### PR TITLE
chore: coordinated patch bump across all publishable packages post-telemetry

### DIFF
--- a/.changeset/post-telemetry-compat-patch.md
+++ b/.changeset/post-telemetry-compat-patch.md
@@ -1,0 +1,21 @@
+---
+"@namzu/sdk": patch
+"@namzu/telemetry": patch
+"@namzu/computer-use": patch
+"@namzu/anthropic": patch
+"@namzu/bedrock": patch
+"@namzu/http": patch
+"@namzu/lmstudio": patch
+"@namzu/ollama": patch
+"@namzu/openai": patch
+"@namzu/openrouter": patch
+---
+
+Coordinated patch bump across all publishable packages after the `@namzu/telemetry@0.1.0` extraction landed. No functional changes — this is a compatibility and release-pipeline validation cut to (a) exercise the Trusted Publisher binding for `@namzu/telemetry` that was configured after the 0.1.0 bootstrap publish, and (b) give consumers a single aligned set of patch versions that all know about the new telemetry package.
+
+Resulting versions:
+
+- `@namzu/sdk` → `0.4.1`
+- `@namzu/telemetry` → `0.1.1`
+- `@namzu/computer-use` → `0.2.1`
+- `@namzu/anthropic`, `@namzu/bedrock`, `@namzu/http`, `@namzu/lmstudio`, `@namzu/ollama`, `@namzu/openai`, `@namzu/openrouter` → `0.1.2`

--- a/.github/scripts/verify-consumer-install.sh
+++ b/.github/scripts/verify-consumer-install.sh
@@ -198,8 +198,8 @@ const telemetry = await registerTelemetry({
 })
 
 const inMemory = new InMemorySpanExporter()
-// @ts-ignore — addSpanProcessor exists on NodeTracerProvider.
-telemetry['tracerProvider'].addSpanProcessor(new SimpleSpanProcessor(inMemory))
+const tracerProvider = telemetry['tracerProvider']
+tracerProvider.addSpanProcessor(new SimpleSpanProcessor(inMemory))
 
 // This is THE SDK path: @namzu/sdk's internal getTracer() calls
 // trace.getTracer('namzu'). If it produces a valid span, the SDK's
@@ -209,9 +209,16 @@ const span = tracer.startSpan('verify.sdk.span')
 span.setAttribute('test', true)
 span.end()
 
-await telemetry.shutdown()
+// SimpleSpanProcessor.onEnd fires `void doExport(...)` — fire-and-forget.
+// forceFlush drains pending exports before we read the buffer.
+await tracerProvider.forceFlush()
 
 const collected = inMemory.getFinishedSpans()
+
+// shutdown() AFTER the read: InMemorySpanExporter.shutdown() sets
+// _finishedSpans = []. Reading after shutdown would always return empty.
+await telemetry.shutdown()
+
 if (collected.length === 0) {
   console.error('✗ span-smoke: InMemorySpanExporter captured zero spans')
   console.error('  registerTelemetry must install a real TracerProvider that forwards to attached processors.')


### PR DESCRIPTION
## Summary

Coordinated patch bump across all 10 publishable packages after the `@namzu/telemetry@0.1.0` extraction landed. No functional changes — this cut exists to (a) exercise the Trusted Publisher binding that was configured on npmjs.com for `@namzu/telemetry` AFTER the 0.1.0 bootstrap publish, and (b) give consumers a single aligned patch row.

## Resulting versions

| Package | Before | After |
|---|---|---|
| `@namzu/sdk` | 0.4.0 | 0.4.1 |
| `@namzu/telemetry` | 0.1.0 | 0.1.1 |
| `@namzu/computer-use` | 0.2.0 | 0.2.1 |
| `@namzu/anthropic` | 0.1.1 | 0.1.2 |
| `@namzu/bedrock` | 0.1.1 | 0.1.2 |
| `@namzu/http` | 0.1.1 | 0.1.2 |
| `@namzu/lmstudio` | 0.1.1 | 0.1.2 |
| `@namzu/ollama` | 0.1.1 | 0.1.2 |
| `@namzu/openai` | 0.1.1 | 0.1.2 |
| `@namzu/openrouter` | 0.1.1 | 0.1.2 |

## Test plan

- [x] `pnpm changeset status` lists all 10 packages at patch.
- [ ] Post-merge: changesets/action opens Version Packages PR.
- [ ] Merge that PR → release.yml runs → `pnpm changeset publish` ships all 10 via OIDC with provenance.
- [ ] Critical validation: `@namzu/telemetry@0.1.1` publishes automatically (the 0.1.0 was a manual bootstrap before Trusted Publisher was registered; 0.1.1 is the first full-automated release through that binding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)