### PR TITLE
chore(sdk): silent test logger + GHA v5 + 0.4.3 changeset

### DIFF
--- a/.changeset/ses_006-pre-freeze-fix.md
+++ b/.changeset/ses_006-pre-freeze-fix.md
@@ -1,0 +1,9 @@
+---
+'@namzu/sdk': patch
+---
+
+Test-side hardening from ses_006 pre-freeze fix.
+
+- **New test: `runtime/query/iteration/phases/advisory.test.ts`** — pins the advisory-phase mutation boundary where fired advisories inject user messages via `runMgr.pushMessage(createUserMessage(...))`. 13 assertions covering early-return paths, happy-path exactly-once calls, envelope format, warnings + decisions rendering, and trigger-selection semantics. Before this test a regression removing the `pushMessage` call at `advisory.ts:154` would pass typecheck, lint, the coverage gate, and every existing `src/advisory/*` test. It now fails deterministically.
+- **`LogLevel` gains `'silent'`** — purely additive; the value short-circuits every `log()` call. Used by the SDK's vitest setup to suppress unmocked `getRootLogger()` stderr writes so GitHub Actions stops annotating `[ERROR]`-level log lines as workflow errors. Consumer impact: zero unless you pass `'silent'` to `configureLogger()` yourself.
+- No runtime behavior change. No public surface additions beyond the one `LogLevel` union member.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,11 @@ jobs:
         node-version: [22, 24]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,11 @@ jobs:
     name: Release (Changesets)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
       - uses: actions/setup-node@v6
         with:

--- a/packages/sdk/src/bridge/a2a/mapper.test.ts
+++ b/packages/sdk/src/bridge/a2a/mapper.test.ts
@@ -281,8 +281,13 @@ describe('mapRunToA2AEvent — explicit null set', () => {
 })
 
 describe('mapSessionToA2AEvent (deprecated alias)', () => {
-	it('behaves identically to mapRunToA2AEvent', () => {
-		const event: RunEvent = { type: 'run_started', runId: RID }
-		expect(mapSessionToA2AEvent(event, 'ctx')).toEqual(mapRunToA2AEvent(event, 'ctx'))
+	it('is the same function reference as mapRunToA2AEvent', () => {
+		// toEqual against paired invocations races the ISO timestamp
+		// inside `statusEvent()` across a millisecond boundary; CI
+		// flaked once with 1 ms drift (see PR #11 Build & Test (22)
+		// 2026-04-22T11:13). Identity check is deterministic and
+		// asserts the deprecation shim strictly — not just a "similar
+		// output" check.
+		expect(mapSessionToA2AEvent).toBe(mapRunToA2AEvent)
 	})
 })

--- a/packages/sdk/src/bridge/sse/mapper.test.ts
+++ b/packages/sdk/src/bridge/sse/mapper.test.ts
@@ -411,8 +411,12 @@ describe('mapRunToStreamEvent — explicit null set', () => {
 })
 
 describe('mapSessionToStreamEvent (deprecated alias)', () => {
-	it('behaves identically to mapRunToStreamEvent', () => {
-		const event: RunEvent = { type: 'run_started', runId: RID }
-		expect(mapSessionToStreamEvent(event, RID)).toEqual(mapRunToStreamEvent(event, RID))
+	it('is the same function reference as mapRunToStreamEvent', () => {
+		// Identity check is deterministic. toEqual on paired calls
+		// would work here (SSE mapper doesn't touch the clock), but
+		// we mirror the a2a mapper test pattern for consistency —
+		// the deprecation shim is literal assignment, so identity is
+		// the strictest possible assertion.
+		expect(mapSessionToStreamEvent).toBe(mapRunToStreamEvent)
 	})
 })

--- a/packages/sdk/src/test-setup.ts
+++ b/packages/sdk/src/test-setup.ts
@@ -1,0 +1,24 @@
+/**
+ * Vitest `setupFiles` entry for `@namzu/sdk`.
+ *
+ * Silences the root logger for the entire test run. Tests that assert on
+ * log output use their own mocked Logger instances (constructed via the
+ * `makeLogger()` helpers colocated with each test) — those are not
+ * affected by the root-level silence.
+ *
+ * The only thing this suppresses is the stderr spam produced by
+ * production code paths that fall through to `getRootLogger()` — e.g.
+ * `ToolRegistry.execute`'s zod-validation and thrown-error branches,
+ * `ConnectorToolRouter.getTools`' per-instance error catch, the
+ * AgentBus listener-throw handler, and every connector's `connect()`
+ * info log. GitHub Actions annotates any `[ERROR]` stderr line as a
+ * workflow error; silencing the root logger during tests keeps the CI
+ * log clean.
+ *
+ * This is test-only configuration. It runs before every test file and
+ * does not affect consumers.
+ */
+
+import { configureLogger } from './utils/logger.js'
+
+configureLogger({ level: 'silent' })

--- a/packages/sdk/src/utils/logger.ts
+++ b/packages/sdk/src/utils/logger.ts
@@ -1,4 +1,4 @@
-export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent'
 
 export type LogContext = Record<string, unknown>
 
@@ -7,6 +7,11 @@ const LOG_LEVELS: Record<LogLevel, number> = {
 	info: 1,
 	warn: 2,
 	error: 3,
+	// `silent` sits above every emit level so the `level < minLevelNum`
+	// guard in `log()` always short-circuits when configured. Used by
+	// test harnesses to suppress unmocked `getRootLogger()` stderr
+	// writes; see packages/sdk/src/test-setup.ts.
+	silent: 4,
 }
 
 export interface Logger {

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
 	test: {
 		include: ['src/**/*.test.ts'],
+		setupFiles: ['./src/test-setup.ts'],
 		coverage: {
 			provider: 'v8',
 			reporter: ['text', 'json-summary', 'lcov'],


### PR DESCRIPTION
## Summary

Post-freeze maintenance from ses_006. Three test-side / infra changes bundled for the **0.4.3 patch** release:

### 1. Silent test logger — kills CI log noise

`LogLevel` gains a `'silent'` member (additive). A new `packages/sdk/src/test-setup.ts` wired through `vitest.config.ts` `setupFiles` calls `configureLogger({ level: 'silent' })` before the suite runs.

**What this fixes:** production code paths that fall through to `getRootLogger()` (e.g. `ToolRegistry.execute`'s zod-validation + thrown-error branches, `ConnectorToolRouter.getTools`' per-instance error catch, every connector's `connect()` info log) write `[ERROR]` lines to stderr during tests. GitHub Actions auto-annotates those as workflow errors even when every test passes — producing lines like:

```
Error: s/sdk test: [2026-04-22T...] [ERROR] [ToolRegistry] Tool execution error: bad
```

**Why this way:** tests that assert on log output use their own mocked `Logger` instances via local `makeLogger()` helpers — those are untouched. Only unmocked fallthrough to the root logger is silenced. Consumer impact: zero unless you call `configureLogger({ level: 'silent' })` yourself in production code.

### 2. GHA actions v4 → v5 (Node 20 deprecation fix)

`actions/checkout` and `pnpm/action-setup` bumped in both `ci.yml` and `release.yml`. Silences the Node.js 20 deprecation warning GitHub started emitting; Node 20 retires from runners 2026-09-16.

### 3. Changeset for @namzu/sdk 0.4.3

`.changeset/ses_006-pre-freeze-fix.md` bumps `@namzu/sdk` patch. Bundles this PR plus the runtime advisory phase test from PR #10 (already on `main` at 9a0a0ce) under a single 0.4.3 release.

## Test plan

- [x] `pnpm --filter @namzu/sdk test` — 898 / 898 pass, zero stderr spam
- [x] `pnpm --filter @namzu/sdk typecheck` — clean
- [x] `pnpm --filter @namzu/sdk lint` — clean
- [x] `pnpm --filter @namzu/sdk build` — `tsc --build` green
- [x] `node .github/scripts/verify-public-surface.mjs` — intact (no new runtime exports; `LogLevel` is type-only)
- [x] Coverage floor + test-presence gates — green
- [ ] CI on PR confirms v5 actions work + Node 20 warning gone

## Merge → release flow

Merging this PR lands the 3 changes on `main`. The Changesets action (`release.yml`) will then open a "chore(release): version packages" PR that versions `@namzu/sdk` to 0.4.3 per the `.changeset/*.md`. Merging that second PR publishes to npm.

If you want to ship 0.4.3 containing ONLY this work + PR #10, no further commits need to land between merging this PR and merging the Changesets release PR.