### PR TITLE
chore(changeset): downgrade v3 bump major→minor (0.5.0 instead of 1.0.0)

### DIFF
--- a/.changeset/ses_001-tool-stream-events.md
+++ b/.changeset/ses_001-tool-stream-events.md
@@ -1,12 +1,12 @@
 ---
-'@namzu/sdk': major
-'@namzu/anthropic': major
-'@namzu/openai': major
-'@namzu/bedrock': major
-'@namzu/openrouter': major
-'@namzu/http': major
-'@namzu/ollama': major
-'@namzu/lmstudio': major
+'@namzu/sdk': minor
+'@namzu/anthropic': minor
+'@namzu/openai': minor
+'@namzu/bedrock': minor
+'@namzu/openrouter': minor
+'@namzu/http': minor
+'@namzu/ollama': minor
+'@namzu/lmstudio': minor
 ---
 
 RunEvent v3 + streaming-only `LLMProvider` (ses_001-tool-stream-events).


### PR DESCRIPTION
Original changeset (#15) marked every package `major`. For 0.x packages, Changesets resolves `major` to 1.0.0 — but the intent was a normal feature bump on the 0.x line. Pinned to `minor` so the next 'chore(release): version packages' PR (#16) refreshes to 0.5.0 across @namzu/sdk + every provider.

Breaking-change migration notes stay in the changeset body; pre-1.0 packages have no stability promise to break.