### PR TITLE
feat(sdk): SupervisorAgent forwards resumeHandler + verificationGate to drainQuery

### DIFF
--- a/.changeset/supervisor-hitl-hooks.md
+++ b/.changeset/supervisor-hitl-hooks.md
@@ -1,0 +1,30 @@
+---
+'@namzu/sdk': minor
+---
+
+`SupervisorAgentConfig` accepts `resumeHandler` and `verificationGate`.
+
+The supervisor's existing tool-review pipeline (drainQuery's
+`runToolReview` phase) was reachable only by callers that constructed
+`drainQuery` arguments by hand — `SupervisorAgent.run` ignored them
+entirely and always fell back to `autoApproveHandler`. Hosts that
+wanted "Ask before acting" semantics had no way to plug in.
+
+`SupervisorAgent.run` now forwards both fields verbatim to
+`drainQuery` when the caller supplies them. Behaviour is unchanged
+for callers that omit them — the SDK still defaults to auto-approve.
+
+Migration:
+
+```ts
+new SupervisorAgent({...}).run(input, {
+  ...config,
+  // surface tool_review_requested events to the user; resolve when
+  // they approve / modify / reject.
+  resumeHandler: async ({ runId, toolCalls, ... }) => {
+    return await waitForUserDecision(runId, toolCalls)
+  },
+  // optionally pre-classify tools so trivial reads bypass review.
+  verificationGate: { enabled: true, rules: [...] },
+})
+```

--- a/packages/sdk/src/agents/SupervisorAgent.ts
+++ b/packages/sdk/src/agents/SupervisorAgent.ts
@@ -158,6 +158,12 @@ export class SupervisorAgent extends AbstractAgent<SupervisorAgentConfig, Superv
 				launchedTasks,
 				advisory: config.advisory,
 				invocationState: childInvocationState,
+				// HITL surface: forward optional review-time hooks so hosts can
+				// run "Ask before acting" supervisors instead of the default
+				// auto-approve. drainQuery falls back to autoApproveHandler
+				// when resumeHandler is omitted (= same behaviour as before).
+				...(config.resumeHandler ? { resumeHandler: config.resumeHandler } : {}),
+				...(config.verificationGate ? { verificationGate: config.verificationGate } : {}),
 			},
 			listener,
 		)

--- a/packages/sdk/src/types/agent/supervisor.ts
+++ b/packages/sdk/src/types/agent/supervisor.ts
@@ -1,6 +1,8 @@
 import type { AdvisoryConfig } from '../advisory/index.js'
+import type { ResumeHandler } from '../hitl/index.js'
 import type { LLMProvider } from '../provider/index.js'
 import type { TaskRouterConfig } from '../router/index.js'
+import type { VerificationGateConfig } from '../verification/index.js'
 import type { BaseAgentConfig, BaseAgentResult } from './base.js'
 import type { AgentFactoryOptions } from './factory.js'
 import type { TaskGateway } from './gateway.js'
@@ -23,6 +25,33 @@ export interface SupervisorAgentConfig extends BaseAgentConfig {
 	factoryOptions?: AgentFactoryOptions
 
 	advisory?: AdvisoryConfig
+
+	/**
+	 * Optional human-in-the-loop hook for tool review and run-pause
+	 * decisions. When omitted, the supervisor delegates to drainQuery's
+	 * built-in `autoApproveHandler`, which approves every tool call
+	 * without prompting — matching Anthropic's "Act without asking"
+	 * cowork mode.
+	 *
+	 * Hosts that want "Ask before acting" behaviour pass a custom
+	 * handler that surfaces the `tool_review_requested` RunEvent to
+	 * the user and resolves the returned promise once the user
+	 * approves, rejects, or modifies the call.
+	 */
+	resumeHandler?: ResumeHandler
+
+	/**
+	 * Optional declarative gate evaluated before tool execution. When
+	 * the gate marks all calls in a batch as `allow`, they execute
+	 * without round-tripping through the resumeHandler. Mixed or all-
+	 * deny outcomes fall through to review (and the resumeHandler).
+	 *
+	 * Use it to express deterministic policy (e.g. "internal
+	 * read-only tools always allow; destructive shell calls always
+	 * review") so the resumeHandler only fires for the truly
+	 * non-deterministic cases.
+	 */
+	verificationGate?: VerificationGateConfig
 }
 
 export interface AgentTaskResult {


### PR DESCRIPTION
Closes the integration gap where SupervisorAgent ignored the SDK's existing tool-review pipeline. The runToolReview phase was reachable only via direct drainQuery construction; SupervisorAgent.run always fell back to autoApproveHandler, so hosts couldn't run an 'Ask before acting' supervisor.

SupervisorAgentConfig grows two optional fields, forwarded only when supplied:
- `resumeHandler?: ResumeHandler`
- `verificationGate?: VerificationGateConfig`

Behaviour unchanged for existing callers (auto-approve default kept). Minor bump because the public config surface gained new optional fields.