### PR TITLE
feat(sdk): ReactiveAgent forwards verificationGate to drainQuery

### DIFF
--- a/.changeset/reactive-agent-verification-gate.md
+++ b/.changeset/reactive-agent-verification-gate.md
@@ -1,0 +1,15 @@
+---
+'@namzu/sdk': minor
+---
+
+feat(sdk): ReactiveAgent forwards verificationGate to drainQuery
+
+Adds an optional `verificationGate?: VerificationGateConfig` field on
+`ReactiveAgentConfig` and forwards it through `ReactiveAgent.run()` into
+`drainQuery`, mirroring the existing `SupervisorAgentConfig.verificationGate`
+plumbing. Without this, child agents running under `ReactiveAgent` could not
+opt into the same capability-aware deny/allow rules the supervisor already
+uses — the only path was `drainQuery`'s `autoApproveHandler` default, which
+approves every tool call silently. Hosts that want defense-in-depth at the
+child level (deny dangerous shell patterns, restrict by category) can now
+pass the same preset they pass to the supervisor.

--- a/packages/sdk/src/agents/ReactiveAgent.ts
+++ b/packages/sdk/src/agents/ReactiveAgent.ts
@@ -46,6 +46,7 @@ export class ReactiveAgent extends AbstractAgent<ReactiveAgentConfig, ReactiveAg
 				basePrompt: config.basePrompt,
 				provider: config.provider,
 				tools: config.tools,
+				...(config.verificationGate ? { verificationGate: config.verificationGate } : {}),
 				runConfig: {
 					model: config.model,
 					tokenBudget: config.tokenBudget,

--- a/packages/sdk/src/types/agent/reactive.ts
+++ b/packages/sdk/src/types/agent/reactive.ts
@@ -3,6 +3,7 @@ import type { AgentPersona } from '../persona/index.js'
 import type { LLMProvider } from '../provider/index.js'
 import type { Skill } from '../skills/index.js'
 import type { ToolRegistryContract } from '../tool/index.js'
+import type { VerificationGateConfig } from '../verification/index.js'
 import type { BaseAgentConfig, BaseAgentResult } from './base.js'
 
 export interface ReactiveAgentConfig extends BaseAgentConfig {
@@ -17,6 +18,18 @@ export interface ReactiveAgentConfig extends BaseAgentConfig {
 	tools: ToolRegistryContract
 
 	advisory?: AdvisoryConfig
+
+	/**
+	 * Optional capability-aware deny/allow gate for child tool calls.
+	 * Mirrors the same field on `SupervisorAgentConfig`; when omitted,
+	 * `drainQuery` falls back to its `autoApproveHandler` default
+	 * (every tool call auto-approves, no policy applied). Hosts that
+	 * trust their sandbox should still pass at least
+	 * `{ enabled: true, denyDangerousPatterns: true, ... }` so the
+	 * canonical brick patterns hard-deny instead of executing
+	 * silently.
+	 */
+	verificationGate?: VerificationGateConfig
 }
 
 export interface ReactiveAgentResult extends BaseAgentResult {


### PR DESCRIPTION
## Summary

Closes the asymmetry between \`SupervisorAgentConfig\` and \`ReactiveAgentConfig\` w.r.t. \`verificationGate\`. Both now forward the optional gate config into \`drainQuery\`; one-line forwarding mirrors \`SupervisorAgent.ts:166\`.

Without this, child agents running under \`ReactiveAgent\` could not opt into the same capability-aware deny/allow rules the supervisor already uses — the only path was \`drainQuery\`'s \`autoApproveHandler\` default, which approves every tool call silently. Hosts that want defense-in-depth at the child level (deny dangerous shell patterns, restrict by category) can now pass the same preset they pass to the supervisor.

Driven by Vandal Cowork's stop-time review (Codex flagged \"restored bash is unreviewed host shell access\"): child specialists had no policy gate, so \`rm -rf /\` would auto-execute even though the SDK ships the deny rule.

## Test plan

- [x] \`pnpm --filter @namzu/sdk typecheck\` — green
- [x] \`pnpm --filter @namzu/sdk test\` — 965 / 965
- [x] \`pnpm --filter @namzu/sdk lint\` — clean
- [x] \`pnpm --filter @namzu/sdk build\` — green
- [ ] Vandal Cowork passes \`defaultSandboxedShellGateConfig()\` to child runs — separate PR