### PR TITLE
feat(sdk)!: rename builtin tools to Claude Code canonical names

### DIFF
--- a/.changeset/canonical-tool-names.md
+++ b/.changeset/canonical-tool-names.md
@@ -1,0 +1,35 @@
+---
+'@namzu/sdk': major
+---
+
+feat(sdk)!: rename builtin tools to Claude Code canonical names
+
+**Breaking change.** Builtin tool names now mirror Claude Code's canonical
+tool table verbatim (per `code.claude.com/docs/en/tools-reference`):
+
+- `bash` → `Bash`
+- `edit` → `Edit`
+- `glob` → `Glob`
+- `grep` → `Grep`
+- `read_file` → `Read`
+- `write_file` → `Write`
+
+`LsTool` and `SearchToolsTool` are still exported but **removed from the
+default `getBuiltinTools()` set**. Claude Code's training distribution
+does not include `LS` (directory listing is `Bash` + `Glob`) and has no
+`search_tools` analogue at all. Including them in the defaults gave the
+model two tools that looked right but degraded alignment. Hosts that
+genuinely want either can register them explicitly.
+
+Why this is breaking and worth it: Namzu is a peer to Claude Code's
+native agentic surface, not a wrapper around the Anthropic Beta Agents
+API. Mirroring the canonical names verbatim means Claude's pretrained
+agentic instincts apply for free — no system-prompt argument needed to
+explain what `Read` or `Bash` does. Idiosyncratic snake_case names threw
+that alignment away on every call.
+
+**Migration:** consumers that hard-code tool-name strings in their
+prompt overlays, friendly-label maps, or per-tool deny rules need to
+update them to the new PascalCase names. The runtime registry contracts
+(register / get / has) are unchanged; only the literal string names of
+the builtin tools moved.

--- a/packages/sdk/src/constants/compaction/index.ts
+++ b/packages/sdk/src/constants/compaction/index.ts
@@ -1,10 +1,14 @@
-export const READ_TOOLS = new Set(['read_file'])
+// Tool-name buckets used by the compaction extractor to classify
+// captured tool results. Names mirror the canonical Claude Code tool
+// table verbatim — see `code.claude.com/docs/en/tools-reference`.
+// `Edit` is grouped with `Write` because both mutate file content.
+export const READ_TOOLS = new Set(['Read'])
 
-export const EDIT_TOOLS = new Set(['write_file'])
+export const EDIT_TOOLS = new Set(['Write', 'Edit'])
 
-export const SHELL_TOOLS = new Set(['bash'])
+export const SHELL_TOOLS = new Set(['Bash'])
 
-export const SEARCH_TOOLS = new Set(['glob', 'search_tools'])
+export const SEARCH_TOOLS = new Set(['Glob', 'Grep'])
 
 export const SECTION_HEADERS = {
 	task: '## Task',

--- a/packages/sdk/src/constants/tools/index.ts
+++ b/packages/sdk/src/constants/tools/index.ts
@@ -31,4 +31,4 @@ export const DANGEROUS_PATTERNS = [
 	/\beval\s+["'`$]/,
 ]
 
-export const FILESYSTEM_TOOLS = new Set(['glob', 'read_file', 'write_file', 'bash'])
+export const FILESYSTEM_TOOLS = new Set(['Glob', 'Read', 'Write', 'Bash'])

--- a/packages/sdk/src/tools/builtins/bash.ts
+++ b/packages/sdk/src/tools/builtins/bash.ts
@@ -20,7 +20,7 @@ function isDangerousCommand(command: string): boolean {
 }
 
 export const BashTool = defineTool({
-	name: 'bash',
+	name: 'Bash',
 	description:
 		'Executes a bash command and returns stdout/stderr output. Command timeout is configurable.',
 	inputSchema,

--- a/packages/sdk/src/tools/builtins/edit.ts
+++ b/packages/sdk/src/tools/builtins/edit.ts
@@ -18,7 +18,7 @@ const inputSchema = z.object({
 type EditInput = z.infer<typeof inputSchema>
 
 export const EditTool = defineTool({
-	name: 'edit',
+	name: 'Edit',
 	description:
 		'Makes targeted edits to a file using exact string find-and-replace. The old_string must be unique in the file unless replace_all is true. Preserves file formatting and indentation.',
 	inputSchema,

--- a/packages/sdk/src/tools/builtins/glob.ts
+++ b/packages/sdk/src/tools/builtins/glob.ts
@@ -36,7 +36,7 @@ function extractGlobBaseDirectory(pattern: string): {
 }
 
 export const GlobTool = defineTool({
-	name: 'glob',
+	name: 'Glob',
 	description: 'Searches for files using a glob pattern. Returns matching file paths.',
 	inputSchema,
 	category: 'filesystem',

--- a/packages/sdk/src/tools/builtins/grep.ts
+++ b/packages/sdk/src/tools/builtins/grep.ts
@@ -40,7 +40,7 @@ function isBinaryContent(buffer: Buffer): boolean {
 }
 
 export const GrepTool = defineTool({
-	name: 'grep',
+	name: 'Grep',
 	description:
 		'Searches file contents using a regular expression. Returns matching lines with file paths, line numbers, and optional context lines. Skips binary files.',
 	inputSchema,

--- a/packages/sdk/src/tools/builtins/index.ts
+++ b/packages/sdk/src/tools/builtins/index.ts
@@ -14,22 +14,19 @@ import { BashTool } from './bash.js'
 import { EditTool } from './edit.js'
 import { GlobTool } from './glob.js'
 import { GrepTool } from './grep.js'
-import { LsTool } from './ls.js'
 import { ReadFileTool } from './read-file.js'
-import { SearchToolsTool } from './search-tools.js'
 import { WriteFileTool } from './write-file.js'
 // Note: createStructuredOutputTool is not included in getBuiltinTools()
-// because it requires a schema parameter and is created per-use case
+// because it requires a schema parameter and is created per-use case.
+//
+// `LsTool` and `SearchToolsTool` are still exported for direct use but
+// are NOT in the default builtin set. Claude Code's training distribution
+// (per `code.claude.com/docs/en/tools-reference`) does NOT include `LS`
+// — directory listing is canonical `Bash` + `Glob`. `search_tools`
+// has no Claude analogue at all. Including either in the defaults gives
+// the model two tools that look right but degrade alignment. Hosts that
+// genuinely want them can still register them explicitly.
 
 export function getBuiltinTools(): ToolDefinition[] {
-	return [
-		ReadFileTool,
-		WriteFileTool,
-		EditTool,
-		BashTool,
-		GlobTool,
-		GrepTool,
-		LsTool,
-		SearchToolsTool,
-	]
+	return [BashTool, EditTool, GlobTool, GrepTool, ReadFileTool, WriteFileTool]
 }

--- a/packages/sdk/src/tools/builtins/read-file.ts
+++ b/packages/sdk/src/tools/builtins/read-file.ts
@@ -15,7 +15,7 @@ const inputSchema = z.object({
 })
 
 export const ReadFileTool = defineTool({
-	name: 'read_file',
+	name: 'Read',
 	description:
 		'Reads a file and returns its contents with line numbers. Supports offset and limit parameters for large files.',
 	inputSchema,

--- a/packages/sdk/src/tools/builtins/write-file.ts
+++ b/packages/sdk/src/tools/builtins/write-file.ts
@@ -9,7 +9,7 @@ const inputSchema = z.object({
 })
 
 export const WriteFileTool = defineTool({
-	name: 'write_file',
+	name: 'Write',
 	description:
 		'Writes content to a file. Creates the file if it does not exist, overwrites if it does. Creates intermediate directories as needed.',
 	inputSchema,


### PR DESCRIPTION
## Summary

**Breaking change.** Builtin tool names now mirror Claude Code's canonical table verbatim:

- \`bash\` → \`Bash\`
- \`edit\` → \`Edit\`
- \`glob\` → \`Glob\`
- \`grep\` → \`Grep\`
- \`read_file\` → \`Read\`
- \`write_file\` → \`Write\`

\`LsTool\` and \`SearchToolsTool\` are still exported but dropped from the default \`getBuiltinTools()\` set. Per [tools-reference](https://code.claude.com/docs/en/tools-reference), Claude Code has no \`LS\` (directory listing is canonical \`Bash\` + \`Glob\`) and no \`search_tools\` analogue. Including either in defaults gave the model two tools that looked right but degraded alignment.

## Why

Namzu is a peer to Claude Code's *native* agentic surface, not a wrapper around the Anthropic Beta Agents API. Mirroring the canonical names verbatim means Claude's pretrained agentic instincts apply for free — no system-prompt argument needed to explain what \`Read\` or \`Bash\` does. Idiosyncratic snake_case names threw that alignment away on every tool call.

This is the gating change for everything in \`docs.local/sessions/ses_004-native-agentic-runtime-and-sandbox\` Phase 2+. Subagent specs, prompt templates, and deny-rule lists all reference tool names; landing the rename first means we don't have to translate twice.

## Test plan

- [x] \`pnpm --filter @namzu/sdk typecheck\` — green
- [x] \`pnpm --filter @namzu/sdk test\` — 965 / 965 passing
- [x] \`pnpm --filter @namzu/sdk lint\` — clean (2 pre-existing warnings on \`streaming/coalesce.test.ts\`)
- [x] \`pnpm --filter @namzu/sdk build\` — green
- [ ] Vandal follow-up: \`app/api/cowork/tasks/[taskId]/stream/route.ts\` \`friendlyToolName\` switch updates to PascalCase + bump submodule pointer (separate PR)

## Migration

Consumers that hard-code tool-name strings (in prompt overlays, friendly-label maps, per-tool deny rules) need to update them to the new PascalCase names. Runtime registry contracts (register / get / has) are unchanged.

Refs the design session: \`namzu/docs.local/sessions/ses_004-native-agentic-runtime-and-sandbox\`.