### PR TITLE
docs(sdk): align built-in tool docs to canonical Claude Code names

### DIFF
--- a/docs/sdk/integrations/event-bridges.md
+++ b/docs/sdk/integrations/event-bridges.md
@@ -172,7 +172,7 @@ const card = buildAgentCard(
     name: 'Docs Agent',
     description: 'Answers repository documentation questions.',
     version: '1.0.0',
-    tools: ['read_file', 'grep'],
+    tools: ['Read', 'Grep'],
     capabilities: {
       supportsStreaming: true,
     },

--- a/docs/sdk/observability/README.md
+++ b/docs/sdk/observability/README.md
@@ -65,7 +65,7 @@ const telemetry = await registerTelemetry({
 })
 
 const metrics = createPlatformMetrics()
-metrics.recordToolCall('read_file', true)
+metrics.recordToolCall('Read', true)
 
 // ... application work ...
 
@@ -134,7 +134,7 @@ call order is not under your control.
 const metrics = createPlatformMetrics()
 
 metrics.recordTokenUsage('gpt-4o-mini', 1200, 240)
-metrics.recordToolCall('grep', true)
+metrics.recordToolCall('Grep', true)
 metrics.recordRunDuration('completed', 3.2)
 metrics.recordLLMLatency('gpt-4o-mini', 0.84)
 ```

--- a/docs/sdk/runtime/configuration.md
+++ b/docs/sdk/runtime/configuration.md
@@ -142,13 +142,12 @@ These are more relevant for supervisors, orchestration layers, or manager-driven
 
 `workingDirectory` affects several built-in tools directly:
 
-- `read_file`
-- `write_file`
-- `edit`
-- `ls`
-- `glob`
-- `grep`
-- `bash`
+- `Read`
+- `Write`
+- `Edit`
+- `Glob`
+- `Grep`
+- `Bash`
 
 ## 9. Runtime Defaults at the SDK Level
 

--- a/docs/sdk/tools/README.md
+++ b/docs/sdk/tools/README.md
@@ -83,7 +83,7 @@ const tools = new ToolRegistry()
 tools.register(ReadFileTool)
 tools.register(WriteFileTool, 'deferred')
 
-tools.activate(['write_file'])
+tools.activate(['Write'])
 ```
 
 The registry tracks three availability states:

--- a/docs/sdk/tools/built-in.md
+++ b/docs/sdk/tools/built-in.md
@@ -1,63 +1,62 @@
 ---
 title: Built-In Tools
 description: Reference for the built-in tools exported by @namzu/sdk, including their purpose, safety shape, and common usage patterns.
-last_updated: 2026-04-18
+last_updated: 2026-05-02
 status: current
 related_packages: ["@namzu/sdk", "@namzu/computer-use"]
 ---
 
 # Built-In Tools
 
-The SDK ships a practical built-in tool set for local agent workflows. These tools are important because they are the default capability surface many integrations start with.
+The SDK ships a practical built-in tool set for local agent workflows. Tool **names mirror Claude Code's canonical table verbatim** (`Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`) so Claude's pretrained agentic instincts apply for free — no system-prompt argument needed to explain what `Read` or `Bash` does.
 
 ## 1. What `getBuiltinTools()` Returns
 
 `getBuiltinTools()` returns this core set:
 
-- `ReadFileTool`
-- `WriteFileTool`
-- `EditTool`
 - `BashTool`
+- `EditTool`
 - `GlobTool`
 - `GrepTool`
-- `LsTool`
-- `SearchToolsTool`
+- `ReadFileTool`
+- `WriteFileTool`
 
 It does not include:
 
-- `createStructuredOutputTool()` because that requires a schema per use case
-- `createComputerUseTool()` because that requires a `ComputerUseHost`
+- `LsTool` — Claude Code's canonical table has no `LS`; directory listing is `Bash` + `Glob`. Still exported for hosts that explicitly want it.
+- `SearchToolsTool` — no Claude analogue. Still exported for hosts that explicitly want it.
+- `createStructuredOutputTool()` — requires a schema per use case.
+- `createComputerUseTool()` — requires a `ComputerUseHost`.
 
 ## 2. Built-In Tool Matrix
 
 | Tool | Tool name | Category | Permissions | Read-only | Typical use |
 | --- | --- | --- | --- | --- | --- |
-| `ReadFileTool` | `read_file` | `filesystem` | `file_read` | Yes | Inspect file contents with optional line slicing |
-| `WriteFileTool` | `write_file` | `filesystem` | `file_write` | No | Create or overwrite files |
-| `EditTool` | `edit` | `filesystem` | `file_write` | No | Apply exact-string replacements |
-| `BashTool` | `bash` | `shell` | `shell_execute` | No | Run shell commands |
-| `GlobTool` | `glob` | `filesystem` | `file_read` | Yes | Find files by pattern |
-| `GrepTool` | `grep` | `analysis` | `file_read` | Yes | Search file contents by regex |
-| `LsTool` | `ls` | `filesystem` | `file_read` | Yes | List directory contents |
-| `SearchToolsTool` | `search_tools` | `analysis` | none | Yes | Activate deferred tools by query |
+| `BashTool` | `Bash` | `shell` | `shell_execute` | No | Run shell commands |
+| `ReadFileTool` | `Read` | `filesystem` | `file_read` | Yes | Inspect file contents with optional line slicing |
+| `WriteFileTool` | `Write` | `filesystem` | `file_write` | No | Create or overwrite files |
+| `EditTool` | `Edit` | `filesystem` | `file_write` | No | Apply exact-string replacements |
+| `GlobTool` | `Glob` | `filesystem` | `file_read` | Yes | Find files by pattern |
+| `GrepTool` | `Grep` | `analysis` | `file_read` | Yes | Search file contents by regex |
+| `LsTool` | `Ls` | `filesystem` | `file_read` | Yes | List directory contents (off-canonical, opt-in) |
+| `SearchToolsTool` | `search_tools` | `analysis` | none | Yes | Activate deferred tools by query (off-canonical, opt-in) |
 
 ## 3. Path Resolution Rules
 
-Most filesystem-oriented built-ins resolve paths relative to `workingDirectory`:
+Filesystem-oriented built-ins resolve paths relative to `workingDirectory`:
 
-- `read_file`
-- `write_file`
-- `edit`
-- `glob`
-- `grep`
-- `ls`
-- `bash`
+- `Read`
+- `Write`
+- `Edit`
+- `Glob`
+- `Grep`
+- `Bash`
 
 That means the choice of `workingDirectory` in `AgentInput` is a real execution decision, not a cosmetic field.
 
 ## 4. Tool-by-Tool Notes
 
-### 4.1 `read_file`
+### 4.1 `Read`
 
 Purpose:
 
@@ -69,7 +68,7 @@ Notes:
 - returns numbered lines for easier downstream reasoning
 - uses sandbox file reads when a sandbox is available
 
-### 4.2 `write_file`
+### 4.2 `Write`
 
 Purpose:
 
@@ -82,7 +81,7 @@ Notes:
 - not concurrency-safe
 - sandbox-aware when a sandbox is present
 
-### 4.3 `edit`
+### 4.3 `Edit`
 
 Purpose:
 
@@ -94,7 +93,7 @@ Notes:
 - fails if `old_string` is not unique unless `replace_all` is `true`
 - useful for targeted edits without rewriting entire files
 
-### 4.4 `bash`
+### 4.4 `Bash`
 
 Purpose:
 
@@ -106,7 +105,7 @@ Notes:
 - sandbox execution is used when a sandbox exists
 - command output is returned as `STDOUT` and `STDERR` sections
 
-### 4.5 `glob`
+### 4.5 `Glob`
 
 Purpose:
 
@@ -117,7 +116,7 @@ Notes:
 - auto-expands simple patterns into recursive search
 - caps result count to keep output manageable
 
-### 4.6 `grep`
+### 4.6 `Grep`
 
 Purpose:
 
@@ -129,7 +128,7 @@ Notes:
 - supports context lines
 - returns file path plus line number style output
 
-### 4.7 `ls`
+### 4.7 `Ls` (off-canonical)
 
 Purpose:
 
@@ -137,11 +136,11 @@ Purpose:
 
 Notes:
 
-- supports recursive listing
-- supports hidden files and depth limits
+- not in `getBuiltinTools()` defaults — Claude Code's canonical table has no `LS` (directory listing is `Bash` + `Glob`). Hosts that genuinely want it can register the export explicitly.
+- supports recursive listing, hidden files, and depth limits
 - formats file sizes for readability
 
-### 4.8 `search_tools`
+### 4.8 `search_tools` (off-canonical)
 
 Purpose:
 
@@ -149,6 +148,7 @@ Purpose:
 
 Notes:
 
+- not in `getBuiltinTools()` defaults — no Claude Code analogue. Available via direct export.
 - depends on `toolRegistry` being present in tool context
 - keeps the active tool surface smaller until needed
 
@@ -161,7 +161,7 @@ const tools = new ToolRegistry()
 tools.register(getBuiltinTools())
 ```
 
-You can also mix availability states:
+You can also mix availability states and opt into the off-canonical extras:
 
 ```ts
 import {
@@ -209,11 +209,9 @@ This tool is documented in more detail in the computer-use section because it de
 A practical conservative default for coding or workspace agents is:
 
 1. `ReadFileTool`
-2. `LsTool`
-3. `GlobTool`
-4. `GrepTool`
-5. `SearchToolsTool`
-6. defer `EditTool`, `WriteFileTool`, and `BashTool`
+2. `GlobTool`
+3. `GrepTool`
+4. defer `EditTool`, `WriteFileTool`, and `BashTool`
 
 That setup gives the agent strong discovery capability before granting stronger mutation tools.
 

--- a/docs/sdk/tools/safety.md
+++ b/docs/sdk/tools/safety.md
@@ -93,7 +93,7 @@ const gate = new VerificationGate(
     allowReadOnlyTools: true,
     denyDangerousPatterns: true,
     rules: [
-      { type: 'deny_by_name', toolNames: ['write_file'] },
+      { type: 'deny_by_name', toolNames: ['Write'] },
       { type: 'allow_by_category', categories: ['analysis'] },
     ],
   },
@@ -106,16 +106,16 @@ The important boundary is:
 - verification decides whether the call should proceed
 - sandboxing decides what the call can do if it proceeds
 
-Today, high-level agent helpers such as `ReactiveAgent.run()` do not expose `verificationGate` directly. If you want to turn this on in a real run, wire the config through `query()` or `drainQuery()` as shown in [Low-Level Runtime](../runtime/low-level.md).
+High-level agent helpers (`ReactiveAgent.run()`, `SupervisorAgent.run()`) accept `verificationGate` directly via their config — both forward it through to `drainQuery`. Hosts that just need a sane default can pass the exported `defaultSandboxedGateConfig()` or `defaultSandboxedShellGateConfig()` preset.
 
 ## 7. Sandbox Boundary
 
 Several built-in tools are sandbox-aware:
 
-- `read_file`
-- `write_file`
-- `edit`
-- `bash`
+- `Read`
+- `Write`
+- `Edit`
+- `Bash`
 
 When a sandbox is present in `ToolContext`, those tools route through sandbox APIs instead of touching the host environment directly.
 


### PR DESCRIPTION
## Summary

Follow-up to #23. The SDK rename (\`bash\` → \`Bash\`, \`read_file\` → \`Read\`, \`write_file\` → \`Write\`, \`edit\` → \`Edit\`, \`glob\` → \`Glob\`, \`grep\` → \`Grep\`, plus dropping \`Ls\` + \`search_tools\` from \`getBuiltinTools()\` defaults) shipped without the published docs catching up — codex stop-time review on the consuming Vandal PR caught the contradictory contract.

Updated:

- **\`docs/sdk/tools/built-in.md\`** — full rewrite of the matrix and per-tool sections to canonical names; documents that \`Ls\` and \`search_tools\` are still exported but off-canonical and not in the default set; adds the alignment-by-convention rationale at the top.
- **\`docs/sdk/tools/safety.md\`** — \`deny_by_name\` example uses \`'Write'\`; sandbox-aware tool list updated; corrects the stale claim that \`ReactiveAgent\` doesn't expose \`verificationGate\` (#22 added that forwarding).
- **\`docs/sdk/tools/README.md\`** — \`activate()\` example uses \`'Write'\`.
- **\`docs/sdk/runtime/configuration.md\`** — workingDirectory tool list uses canonical names.
- **\`docs/sdk/integrations/event-bridges.md\`** — example agent declares \`tools: ['Read', 'Grep']\`.
- **\`docs/sdk/observability/README.md\`** — \`recordToolCall\` examples use \`'Read'\` and \`'Grep'\`.

The MCP-namespace example in \`docs/sdk/integrations/plugins.md\` (\`fs-plugin:mcp__fs__read_file\`) is intentionally left as-is — that's a third-party MCP server's tool name, not a namzu builtin.

## Test plan

- [x] No code change; docs-only.
- [x] Verified no remaining stale references to old builtin names in \`docs/\` (excluding the MCP example).

Refs: \`docs.local/sessions/ses_004-native-agentic-runtime-and-sandbox\`.