### PR TITLE
docs(sdk): correct verificationGate surface + remaining tool name slip

### DIFF
--- a/docs/sdk/agents/README.md
+++ b/docs/sdk/agents/README.md
@@ -90,8 +90,8 @@ console.log(result.result)
 
 Important boundary:
 
-- `ReactiveAgent.run()` is the high-level entrypoint.
-- If you need `verificationGate`, `sandboxProvider`, custom event streaming, or other query-only fields, drop to [Low-Level Runtime](../runtime/low-level.md).
+- `ReactiveAgent.run()` is the high-level entrypoint and accepts `verificationGate` directly via `ReactiveAgentConfig` (mirrors `SupervisorAgentConfig`).
+- If you need `sandboxProvider`, `pluginManager`, `agentBus`, custom event streaming, or other query-only fields, drop to [Low-Level Runtime](../runtime/low-level.md).
 
 ## 4. `PipelineAgent` Is for Deterministic Stages
 

--- a/docs/sdk/integrations/plugins.md
+++ b/docs/sdk/integrations/plugins.md
@@ -154,8 +154,8 @@ export const hooks = [
   {
     event: 'pre_tool_use',
     async handler(context) {
-      if (context.toolName === 'bash') {
-        return { action: 'skip', reason: 'bash disabled in this environment' }
+      if (context.toolName === 'Bash') {
+        return { action: 'skip', reason: 'Bash disabled in this environment' }
       }
 
       return { action: 'continue' }

--- a/docs/sdk/runtime/configuration.md
+++ b/docs/sdk/runtime/configuration.md
@@ -17,11 +17,11 @@ Every run has two distinct inputs:
 | Input object | Owns |
 | --- | --- |
 | `AgentInput` | messages, working directory, abort signal, task store, runtime tool overrides |
-| `ReactiveAgentConfig` | provider, tools, model, budgets, IDs, persona, skills, advisory config |
+| `ReactiveAgentConfig` | provider, tools, model, budgets, IDs, persona, skills, advisory config, optional `verificationGate` |
 
 This distinction matters because the SDK separates per-invocation message state from runtime policy and dependencies.
 
-It also matters because some low-level runtime fields are intentionally not exposed on `ReactiveAgentConfig` today. If you need `verificationGate`, `sandboxProvider`, `pluginManager`, `taskRouter`, `agentBus`, or `compactionConfig`, use [Low-Level Runtime](./low-level.md).
+It also matters because some low-level runtime fields are intentionally not exposed on `ReactiveAgentConfig` today. If you need `sandboxProvider`, `pluginManager`, `taskRouter`, `agentBus`, or `compactionConfig`, use [Low-Level Runtime](./low-level.md). `verificationGate` is exposed on `ReactiveAgentConfig` directly (mirrors `SupervisorAgentConfig`); pass it there for a sane policy gate without dropping to `drainQuery`.
 
 ## 2. Minimal `ReactiveAgent.run()` Shape
 

--- a/docs/sdk/runtime/low-level.md
+++ b/docs/sdk/runtime/low-level.md
@@ -26,7 +26,7 @@ If you only need messages, tools, provider, IDs, and a final result, stay with `
 
 | Surface | Best for | Notable limits |
 | --- | --- | --- |
-| `ReactiveAgent.run()` | Standard app integrations and quickstarts | Does not expose query-only runtime fields such as `verificationGate` or `sandboxProvider` |
+| `ReactiveAgent.run()` | Standard app integrations and quickstarts | Does not expose query-only runtime fields such as `sandboxProvider` (note: `verificationGate` IS exposed on `ReactiveAgentConfig` and forwarded into `drainQuery`) |
 | `drainQuery()` | Low-level runtime control with a final `AgentRun` result | You supply more runtime wiring yourself |
 | `query()` | Full async-generator control over every emitted event | You manage iteration over the generator directly |
 
@@ -102,7 +102,7 @@ console.log(run.result)
 This example shows the main low-level boundary:
 
 - `runConfig` still carries model, budget, and permission settings
-- query-only fields such as `verificationGate` and `sandboxProvider` live beside that config
+- query-only fields such as `sandboxProvider`, `pluginManager`, and `agentBus` live beside that config; `verificationGate` is also accepted here but is *also* exposed on `ReactiveAgentConfig` and `SupervisorAgentConfig`, so dropping to `drainQuery` is not required just to enable a policy gate
 - `drainQuery()` still returns the same final `AgentRun` shape that high-level agent flows assemble
 
 ## 4. What `drainQuery()` Gives You
@@ -235,7 +235,7 @@ That means stream transport code usually needs both:
 
 | Mistake | Why it breaks |
 | --- | --- |
-| assuming `ReactiveAgent.run()` exposes every runtime field | query-only controls such as `verificationGate` and `sandboxProvider` are lower-level |
+| assuming `ReactiveAgent.run()` exposes every runtime field | query-only controls such as `sandboxProvider`, `pluginManager`, and `agentBus` are lower-level (note: `verificationGate` IS on `ReactiveAgentConfig`) |
 | forgetting `resumeHandler` when calling `query()` | `query()` requires it directly, unlike `drainQuery()` |
 | skipping `workingDirectory` | filesystem tools and path layout lose their stable base path |
 | treating `mapRunToStreamEvent()` as the final result channel | completion still comes from generator completion or `drainQuery()` |


### PR DESCRIPTION
Follow-up to #24. Codex stop-time review caught six remaining doc contradictions vs the actual exported surface on main:

- \`docs/sdk/runtime/configuration.md:24\` — listed \`verificationGate\` as a query-only field. #22 added it to \`ReactiveAgentConfig\`.
- \`docs/sdk/runtime/low-level.md:29\`, \`:105\`, \`:238\` — three separate places called \`verificationGate\` \"query-only\" or \"lower-level\". Same stale claim.
- \`docs/sdk/agents/README.md:94\` — told readers to drop to low-level for \`verificationGate\`. Same stale claim.
- \`docs/sdk/integrations/plugins.md:157\` — example still used pre-rename \`'bash'\` instead of canonical \`'Bash'\`.

Each one corrected to match the surface as of #22 (\`ReactiveAgent\` forwards \`verificationGate\` to \`drainQuery\`) and #23 (tool names are PascalCase canonical).

The narrative is now consistent: \`verificationGate\` is on \`ReactiveAgentConfig\` and \`SupervisorAgentConfig\`; the only fields that still require dropping to \`drainQuery\` are \`sandboxProvider\`, \`pluginManager\`, \`taskRouter\`, \`agentBus\`, and \`compactionConfig\`.

Refs: \`docs.local/sessions/ses_004-native-agentic-runtime-and-sandbox\`.