### PR TITLE
docs(sdk): purge remaining verificationGate-is-low-level claims

### DIFF
--- a/docs/sdk/runtime/low-level.md
+++ b/docs/sdk/runtime/low-level.md
@@ -1,7 +1,7 @@
 ---
 title: Low-Level Runtime
-description: Use query() and drainQuery() directly in @namzu/sdk when you need verification gates, sandbox providers, plugin wiring, event streaming, or query-only runtime controls.
-last_updated: 2026-04-18
+description: Use query() and drainQuery() directly in @namzu/sdk when you need sandbox providers, plugin wiring, event streaming, or other query-only runtime controls.
+last_updated: 2026-05-02
 status: current
 related_packages: ["@namzu/sdk", "@namzu/openai"]
 ---
@@ -14,13 +14,12 @@ related_packages: ["@namzu/sdk", "@namzu/openai"]
 
 Use the low-level runtime when you need:
 
-- `verificationGate` policy before tool execution
 - a `sandboxProvider` that injects a real sandbox into tool context
 - direct `RunEvent` streaming
 - plugin manager, task router, agent bus, or compaction wiring
 - custom resume-handler behavior for HITL review or checkpoints
 
-If you only need messages, tools, provider, IDs, and a final result, stay with `ReactiveAgent.run()`.
+If you only need messages, tools, provider, IDs, and a final result, stay with `ReactiveAgent.run()`. `verificationGate` is also accepted directly on `ReactiveAgentConfig` and `SupervisorAgentConfig`, so a policy gate alone does not require dropping below the high-level surface.
 
 ## 2. `ReactiveAgent.run()` vs `drainQuery()`
 
@@ -172,7 +171,6 @@ Use this pattern when a transport layer or UI needs every incremental event as i
 
 | Field | Purpose |
 | --- | --- |
-| `verificationGate` | Rule-based allow, deny, or review decisions before tool execution |
 | `sandboxProvider` | Create a sandbox for the run and inject it into tool context |
 | `pluginManager` | Run plugin hooks and plugin-contributed runtime behavior |
 | `taskRouter` | Task-specific model routing |
@@ -181,6 +179,8 @@ Use this pattern when a transport layer or UI needs every incremental event as i
 | `contextCache` | Prompt cache and context reuse controls |
 
 That is the main reason this page exists: these are real public runtime features, but they are lower-level than the first-run agent API.
+
+`verificationGate` is intentionally **not** in this table — it is exposed on both `ReactiveAgentConfig` and `SupervisorAgentConfig` and forwarded into `drainQuery` automatically. It still appears in the `drainQuery()` example above because the low-level surface accepts it too; just don't read that as "you have to drop here to use it."
 
 ## 7. Resume Handlers and HITL
 
@@ -203,19 +203,19 @@ Use `autoApproveHandler` only when the runtime should continue automatically.
 
 ## 8. Verification and Sandbox Boundaries
 
-Two low-level runtime fields are easy to confuse:
+Two runtime fields are easy to confuse:
 
-| Field | Role |
-| --- | --- |
-| `verificationGate` | Decide whether a tool call should proceed |
-| `sandboxProvider` | Constrain what sandbox-aware tools can do if the call proceeds |
+| Field | Role | Where exposed |
+| --- | --- | --- |
+| `verificationGate` | Decide whether a tool call should proceed | `ReactiveAgentConfig`, `SupervisorAgentConfig`, and `QueryParams` |
+| `sandboxProvider` | Constrain what sandbox-aware tools can do if the call proceeds | `QueryParams` only (low-level) |
 
 This separation matters operationally:
 
 - verification is policy
 - sandboxing is containment
 
-Both are lower-level runtime concerns, which is why they are wired through `query()` and `drainQuery()` instead of `defineTool()` alone.
+Verification is wired through agent config so a policy gate is a one-line addition; sandbox providers stay at the `query()` / `drainQuery()` layer because they touch tool-context injection that the high-level wrapper doesn't expose.
 
 ## 9. Event Streaming and SSE Mapping
 


### PR DESCRIPTION
Follow-up to #25. Codex stop-time review caught four more places in \`docs/sdk/runtime/low-level.md\` still contradicting the verified \`ReactiveAgentConfig\` surface:

- **frontmatter description** listed \"verification gates\" as a reason to drop to \`query()\` / \`drainQuery()\`
- **Section 1** (\"When to Drop Below \`ReactiveAgent\`\") had \`verificationGate\` as the first bullet
- **Section 6** (\"Query-Only Fields You Do Not Get Through \`ReactiveAgent.run()\`\") table listed \`verificationGate\` as the first row
- **Section 8** (\"Verification and Sandbox Boundaries\") closed with \"Both are lower-level runtime concerns, which is why they are wired through \`query()\` and \`drainQuery()\` instead of \`defineTool()\` alone.\"

Each is corrected. Section 6 now explicitly notes \`verificationGate\`'s absence from the table and explains why it still appears in the \`drainQuery()\` example. Section 8 now lists per-field exposure: \`verificationGate\` is on \`ReactiveAgentConfig\` + \`SupervisorAgentConfig\` + \`QueryParams\`; \`sandboxProvider\` is \`QueryParams\` only.

The page narrative is now consistent across frontmatter, intro, table-of-fields, common-mistakes table, and conceptual section: **drop to \`drainQuery\` for sandbox / plugin / bus / compaction / cache wiring; drop is NOT required just for a policy gate.**

Refs: \`docs.local/sessions/ses_004-native-agentic-runtime-and-sandbox\`.