### PR TITLE
feat(sdk): canonical Agent tool for synchronous subagent delegation

### DIFF
--- a/.changeset/agent-tool-canonical.md
+++ b/.changeset/agent-tool-canonical.md
@@ -1,0 +1,27 @@
+---
+'@namzu/sdk': minor
+---
+
+feat(sdk): canonical `Agent` tool for synchronous subagent delegation
+
+Adds `buildAgentTool({ gateway, workingDirectory, allowedAgentIds, ... })`
+that builds a single tool named `Agent` with the input shape
+`{ description, prompt, subagent_type }`. This mirrors Claude Code's
+training distribution verbatim (per `code.claude.com/docs/en/sub-agents`):
+the parent's tool call BLOCKS on `gateway.waitForTask(handle.taskId)`,
+the subagent runs in its own context window, and the subagent's final
+text comes back as the tool result.
+
+Why this matters: the existing `buildCoordinatorTools` shipped a
+non-blocking `create_task` / `continue_task` / `cancel_task` trio that
+returned immediately and surfaced subagent completion via a
+`<task-notification>` callback. That pattern is useful for fire-and-
+forget multi-task fan-out but is **not** what Claude was trained on.
+Models calling the async coordinator tools waste tokens reasoning
+about whether the task completed yet; with the canonical `Agent`
+tool, the model just receives the result and continues. Free
+alignment, no system-prompt argument needed.
+
+Both surfaces remain available — the coordinator trio is the right
+choice for genuine work-queue surfaces, the `Agent` tool is the
+right choice when the host wants Claude Code parity.

--- a/packages/sdk/src/public-tools.ts
+++ b/packages/sdk/src/public-tools.ts
@@ -44,6 +44,7 @@ export {
 export { buildAdvisoryTools } from './tools/advisory/index.js'
 export { buildMemoryTools } from './tools/memory/index.js'
 export { buildCoordinatorTools } from './tools/coordinator/index.js'
+export { buildAgentTool, type AgentToolOptions } from './tools/coordinator/agent.js'
 
 // ─── RAG tool builder ────────────────────────────────────────────────────
 

--- a/packages/sdk/src/tools/coordinator/agent.ts
+++ b/packages/sdk/src/tools/coordinator/agent.ts
@@ -1,0 +1,132 @@
+import { z } from 'zod'
+
+import type { AgentRuntimeContext } from '../../types/agent/base.js'
+import type { TaskGateway } from '../../types/agent/gateway.js'
+import type { RunId } from '../../types/ids/index.js'
+import type { TaskStore } from '../../types/task/index.js'
+import type { ToolDefinition } from '../../types/tool/index.js'
+import { defineTool } from '../defineTool.js'
+
+import type { TaskLaunchedCallback } from './index.js'
+
+/**
+ * Build the canonical Claude Code `Agent` tool — synchronous subagent
+ * delegation that mirrors what Claude is trained against in
+ * `code.claude.com/docs/en/sub-agents`.
+ *
+ * Semantics: parent calls `Agent({ description, prompt, subagent_type })`,
+ * the runtime spawns the chosen subagent with its own context window,
+ * the parent's tool call BLOCKS until the subagent finishes, and the
+ * subagent's final text comes back as the tool result. Intermediate
+ * subagent tool calls are isolated — only the summary surfaces to
+ * the parent.
+ *
+ * This is **NOT** the same shape as the legacy `create_task` /
+ * `continue_task` / `cancel_task` trio that this package ships
+ * alongside it: those are non-blocking and use a `<task-notification>`
+ * callback model. The async pattern is useful for hosts that want a
+ * work-queue surface, but it is not what Claude Code trained against.
+ * For free agentic alignment, prefer the canonical `Agent` tool; keep
+ * the legacy coordinator tools only when you genuinely need
+ * fire-and-forget multi-task fan-out.
+ */
+export interface AgentToolOptions {
+	gateway: TaskGateway
+	workingDirectory: string
+	runtimeContext?: AgentRuntimeContext
+	allowedAgentIds: string[]
+
+	taskStore?: TaskStore
+
+	runId?: RunId
+
+	onTaskLaunched?: TaskLaunchedCallback
+}
+
+export function buildAgentTool(opts: AgentToolOptions): ToolDefinition {
+	const { gateway, allowedAgentIds: agentIds, taskStore, runId, onTaskLaunched } = opts
+	const cwd = opts.workingDirectory
+
+	const subagentTypeEnum =
+		agentIds.length > 0 ? z.enum(agentIds as [string, ...string[]]) : z.string()
+
+	return defineTool({
+		name: 'Agent',
+		description: `Delegate a task to a specialized subagent. BLOCKING: returns when the subagent has finished, with the subagent's final text as the tool result. The subagent runs in its own context window and cannot see your conversation — include all necessary context in the prompt. Available subagents: ${agentIds.join(', ')}. To run multiple subagents in parallel, call this tool multiple times in a single response.`,
+		inputSchema: z.object({
+			description: z.string().describe('Short label for tracking (shown to the user)'),
+			prompt: z
+				.string()
+				.describe('Self-contained task description with all context the subagent needs'),
+			subagent_type: subagentTypeEnum.describe('Which subagent to run'),
+		}),
+		category: 'custom',
+		permissions: [],
+		readOnly: false,
+		destructive: false,
+		concurrencySafe: true,
+		async execute({ description, prompt, subagent_type }) {
+			let planTaskId: string | undefined
+
+			if (taskStore && runId) {
+				const planTask = await taskStore.create({
+					runId,
+					subject: description,
+					activeForm: description,
+					owner: subagent_type,
+				})
+				await taskStore.update(planTask.id, { status: 'in_progress' })
+				planTaskId = planTask.id
+			}
+
+			const handle = await gateway.createTask({
+				agentId: subagent_type,
+				prompt,
+				workingDirectory: cwd,
+				runtimeContext: opts.runtimeContext,
+			})
+
+			onTaskLaunched?.(handle.taskId, {
+				agentId: subagent_type,
+				description,
+				planTaskId,
+			})
+
+			const completed = await gateway.waitForTask(handle.taskId)
+
+			if (taskStore && planTaskId && completed.state === 'completed') {
+				await taskStore.update(planTaskId as `task_${string}`, {
+					status: 'completed',
+				})
+			}
+
+			const resultText =
+				typeof completed.result?.result === 'string'
+					? completed.result.result
+					: JSON.stringify(completed.result?.result ?? null)
+
+			if (completed.state !== 'completed') {
+				return {
+					success: false,
+					output: '',
+					error: `Subagent ${subagent_type} ${completed.state}: ${resultText || '(no result)'}`,
+					data: {
+						task_id: handle.taskId,
+						subagent_type,
+						state: completed.state,
+					},
+				}
+			}
+
+			return {
+				success: true,
+				output: resultText || '(subagent returned no text)',
+				data: {
+					task_id: handle.taskId,
+					subagent_type,
+					state: completed.state,
+				},
+			}
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Adds \`buildAgentTool({ gateway, workingDirectory, allowedAgentIds, ... })\` — a single tool named \`Agent\` with input shape \`{ description, prompt, subagent_type }\`. Mirrors Claude Code's training distribution verbatim (per [sub-agents](https://code.claude.com/docs/en/sub-agents)):

- **Blocking semantics**: \`await gateway.waitForTask(handle.taskId)\`. The parent's tool call doesn't return until the subagent finishes.
- **Isolation**: subagent runs in its own context window; only the final text bubbles back.
- **Final-text-as-tool-result**: parent receives the subagent's result string directly as the tool output; no \`<task-notification>\` callback dance.

## Why

The existing \`buildCoordinatorTools\` trio (\`create_task\` / \`continue_task\` / \`cancel_task\`) is non-blocking and surfaces completion via a \`<task-notification>\` callback. Useful for fire-and-forget multi-task fan-out, but **not** what Claude was trained against. Models calling the async coordinator tools waste tokens reasoning about whether the task completed yet; with the canonical \`Agent\` tool the model just receives the result and continues. Free alignment, no system-prompt argument needed.

Both surfaces remain available:
- \`buildCoordinatorTools\` — async work-queue, when the host wants fan-out.
- \`buildAgentTool\` — synchronous Claude Code parity, when the host wants free alignment.

## Test plan

- [x] \`pnpm --filter @namzu/sdk typecheck\` — green
- [x] \`pnpm --filter @namzu/sdk test\` — 965 / 965 (no new tests; thin wrapper over \`gateway.createTask\` + \`gateway.waitForTask\` which are already covered by manager/agent lifecycle tests; a focused integration test belongs with the consumer-side adoption commit)
- [x] \`pnpm --filter @namzu/sdk lint\` — clean
- [x] \`pnpm --filter @namzu/sdk build\` — green

## Notes for downstream consumers

\`SupervisorAgent\` currently mounts the coordinator trio internally; switching the supervisor to mount \`Agent\` instead is a follow-up the SDK can take in P3 (sandbox / permission pipeline session). Hosts that want to use \`Agent\` directly today can build it via \`buildAgentTool\` and register it on whichever tool registry they pass into \`drainQuery\`.

The on-disk \`.namzu/agents/<name>.md\` markdown loader (Phase 2.b in the design session) is **not** in this PR — Vandal authors specs as TS objects today, the alignment win is the tool surface alone, and the loader is purely an authoring ergonomic.

Refs: \`docs.local/sessions/ses_004-native-agentic-runtime-and-sandbox\` (D3 updated to use \`.namzu/agents/\` instead of \`.claude/agents/\` per discussion: the literal path is a config-file convention, not training distribution; sharing the namespace would collide with Claude Code IDE settings on the same project).