### PR TITLE
fix(sdk): Agent tool no longer reports failed subagents as successful

### DIFF
--- a/.changeset/agent-tool-failure-propagation.md
+++ b/.changeset/agent-tool-failure-propagation.md
@@ -1,0 +1,26 @@
+---
+'@namzu/sdk': patch
+---
+
+fix(sdk): Agent tool no longer reports failed subagents as successful
+
+`buildAgentTool` was treating `gateway.waitForTask(handle.taskId)`'s
+returned `state === 'completed'` as proof of success and ignoring
+the underlying `BaseAgentResult.status`. That was wrong: some
+gateways (the SDK's `LocalTaskGateway` for one) forward
+`task.state` directly from the agent manager without re-deriving it
+from the run's `status`, so a subagent run with `status: 'failed'`
+plus a non-empty `lastError` could surface as `state: 'completed'`
+and fool the parent into receiving `success: true` with garbage
+output.
+
+The check now requires BOTH layers to agree before reporting
+success: gateway state must be `'completed'` AND the run's
+`BaseAgentResult.status` (when present) must be `'completed'`. On
+failure the tool surfaces `lastError` and the disagreement state in
+both `error` and `data` so the parent can debug.
+
+Adds three pinned cases in
+`packages/sdk/src/tools/coordinator/__tests__/agent.test.ts`
+covering: both-agree-success, run-status-failed-but-state-completed
+(the regression case), and gateway-state-failed.

--- a/packages/sdk/src/tools/coordinator/__tests__/agent.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/agent.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Behavioural contract for `buildAgentTool`:
+ *
+ * - Reports `success: true` only when BOTH the gateway task state and
+ *   the underlying `BaseAgentResult.status` say completed.
+ * - Reports `success: false` and surfaces `lastError` when either
+ *   layer disagrees — the canonical bug Codex caught was that a
+ *   failed subagent could be reported as successful when the gateway
+ *   forwarded `state: 'completed'` from a manager that did not
+ *   propagate the run's `status: 'failed'`.
+ * - Returns the subagent's `result` string as the tool output on
+ *   success.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import type { TaskGateway, TaskHandle } from '../../../types/agent/gateway.js'
+import type { TaskId } from '../../../types/ids/index.js'
+import type { ToolContext } from '../../../types/tool/index.js'
+import { buildAgentTool } from '../agent.js'
+
+function makeContext(): ToolContext {
+	return {
+		runId: 'run_test' as never,
+		workingDirectory: '/tmp/test',
+		abortSignal: new AbortController().signal,
+		env: {},
+		log: () => {},
+	}
+}
+
+function fakeGateway(handle: TaskHandle, completed: TaskHandle): TaskGateway {
+	return {
+		async createTask() {
+			return handle
+		},
+		async waitForTask() {
+			return completed
+		},
+		async continueTask() {},
+		cancelTask() {},
+		getTask() {
+			return completed
+		},
+		listTasks() {
+			return [completed]
+		},
+		onTaskCompleted() {
+			return () => {}
+		},
+	}
+}
+
+const taskId = 'task_subagent' as TaskId
+
+const launched: TaskHandle = {
+	taskId,
+	agentId: 'sales-strategy',
+	state: 'running',
+	createdAt: 0,
+}
+
+describe('buildAgentTool', () => {
+	it('reports success when both task state and run status say completed', async () => {
+		const gateway = fakeGateway(launched, {
+			...launched,
+			state: 'completed',
+			result: {
+				runId: 'run_inner' as never,
+				status: 'completed',
+				usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } as never,
+				cost: { inputCostUsd: 0, outputCostUsd: 0, totalCostUsd: 0 } as never,
+				iterations: 1,
+				durationMs: 10,
+				messages: [],
+				result: 'final report text',
+			},
+			completedAt: 10,
+		})
+
+		const tool = buildAgentTool({
+			gateway,
+			workingDirectory: '/tmp/test',
+			allowedAgentIds: ['sales-strategy'],
+		})
+
+		const result = await tool.execute(
+			{ description: 'plan', prompt: 'go', subagent_type: 'sales-strategy' },
+			makeContext(),
+		)
+
+		expect(result.success).toBe(true)
+		expect(result.output).toBe('final report text')
+	})
+
+	it('reports failure when run status is failed even though task state is completed', async () => {
+		const gateway = fakeGateway(launched, {
+			...launched,
+			state: 'completed',
+			result: {
+				runId: 'run_inner' as never,
+				status: 'failed',
+				usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } as never,
+				cost: { inputCostUsd: 0, outputCostUsd: 0, totalCostUsd: 0 } as never,
+				iterations: 1,
+				durationMs: 10,
+				messages: [],
+				lastError: 'tool budget exceeded',
+			},
+			completedAt: 10,
+		})
+
+		const tool = buildAgentTool({
+			gateway,
+			workingDirectory: '/tmp/test',
+			allowedAgentIds: ['sales-strategy'],
+		})
+
+		const result = await tool.execute(
+			{ description: 'plan', prompt: 'go', subagent_type: 'sales-strategy' },
+			makeContext(),
+		)
+
+		expect(result.success).toBe(false)
+		expect(result.error).toContain('tool budget exceeded')
+		expect(result.error).toContain('failed')
+	})
+
+	it('reports failure when task state itself is failed', async () => {
+		const gateway = fakeGateway(launched, {
+			...launched,
+			state: 'failed',
+			result: undefined,
+			completedAt: 10,
+		})
+
+		const tool = buildAgentTool({
+			gateway,
+			workingDirectory: '/tmp/test',
+			allowedAgentIds: ['sales-strategy'],
+		})
+
+		const result = await tool.execute(
+			{ description: 'plan', prompt: 'go', subagent_type: 'sales-strategy' },
+			makeContext(),
+		)
+
+		expect(result.success).toBe(false)
+		expect(result.error).toContain('failed')
+	})
+})

--- a/packages/sdk/src/tools/coordinator/agent.ts
+++ b/packages/sdk/src/tools/coordinator/agent.ts
@@ -94,7 +94,28 @@ export function buildAgentTool(opts: AgentToolOptions): ToolDefinition {
 
 			const completed = await gateway.waitForTask(handle.taskId)
 
-			if (taskStore && planTaskId && completed.state === 'completed') {
+			// Two layers can disagree on whether the subagent succeeded:
+			//
+			// 1. `TaskHandle.state` — the gateway's terminal task state.
+			//    Some gateways (e.g. vandal's) explicitly map
+			//    `result.status !== 'completed'` to `state = 'failed'`,
+			//    others (e.g. SDK's `LocalTaskGateway`) just forward
+			//    whatever the AgentManager set, which does not always
+			//    reflect run-level failure.
+			// 2. `BaseAgentResult.status` — the run's own status. The
+			//    canonical source of truth for whether the agent actually
+			//    finished its work; `lastError` carries the failure
+			//    message when set.
+			//
+			// Treat the subagent as successful only when BOTH agree.
+			// Reporting a failed subagent as successful would silently
+			// hand the parent garbage output and make debugging
+			// impossible, which is what Codex flagged on the first cut.
+			const runStatus = completed.result?.status
+			const succeeded =
+				completed.state === 'completed' && (runStatus === undefined || runStatus === 'completed')
+
+			if (taskStore && planTaskId && succeeded) {
 				await taskStore.update(planTaskId as `task_${string}`, {
 					status: 'completed',
 				})
@@ -103,17 +124,25 @@ export function buildAgentTool(opts: AgentToolOptions): ToolDefinition {
 			const resultText =
 				typeof completed.result?.result === 'string'
 					? completed.result.result
-					: JSON.stringify(completed.result?.result ?? null)
+					: completed.result?.result !== undefined
+						? JSON.stringify(completed.result.result)
+						: ''
 
-			if (completed.state !== 'completed') {
+			if (!succeeded) {
+				const failureLabel =
+					completed.state !== 'completed' ? completed.state : (runStatus ?? 'failed')
+				const detail =
+					completed.result?.lastError ?? resultText ?? '(subagent provided no failure detail)'
 				return {
 					success: false,
 					output: '',
-					error: `Subagent ${subagent_type} ${completed.state}: ${resultText || '(no result)'}`,
+					error: `Subagent ${subagent_type} ${failureLabel}: ${detail}`,
 					data: {
 						task_id: handle.taskId,
 						subagent_type,
 						state: completed.state,
+						status: runStatus,
+						lastError: completed.result?.lastError,
 					},
 				}
 			}
@@ -125,6 +154,7 @@ export function buildAgentTool(opts: AgentToolOptions): ToolDefinition {
 					task_id: handle.taskId,
 					subagent_type,
 					state: completed.state,
+					status: runStatus,
 				},
 			}
 		},


### PR DESCRIPTION
## Summary

Codex stop-time review caught: \`buildAgentTool\` was reporting failed subagents as successful when the gateway's task state said \`completed\` but the underlying \`BaseAgentResult.status\` said \`failed\`. That happens because some gateways (notably the SDK's own \`LocalTaskGateway\`) forward \`task.state\` straight from the agent manager without re-deriving it from the run's \`status\`. A subagent that errored with a populated \`lastError\` could come back as \`state: 'completed'\` and the tool would hand \`success: true\` plus the garbage output to the parent. Hard-to-debug; silent.

The check now requires **both** layers to agree:

- \`completed.state === 'completed'\` (gateway-level)
- \`completed.result?.status\` is \`undefined\` or \`'completed'\` (run-level)

On failure the tool surfaces \`lastError\` and the disagreement state in \`error\` and \`data\` so the parent can debug.

## Test plan

- [x] \`pnpm --filter @namzu/sdk typecheck\` — green
- [x] \`pnpm --filter @namzu/sdk test\` — 968 / 968 (added 3 cases pinning the failure-propagation contract)
- [x] \`pnpm --filter @namzu/sdk lint\` — clean
- [x] \`pnpm --filter @namzu/sdk build\` — green

The three new cases pin: both-agree-success, run-status-failed-but-state-completed (the regression case Codex caught), and gateway-state-failed.

Refs: \`docs.local/sessions/ses_004-native-agentic-runtime-and-sandbox\`.