### PR TITLE
feat(sandbox): new package — pluggable SandboxProvider for @namzu/sdk

### DIFF
--- a/.changeset/sandbox-package-skeleton.md
+++ b/.changeset/sandbox-package-skeleton.md
@@ -1,0 +1,35 @@
+---
+'@namzu/sandbox': minor
+---
+
+feat(sandbox): new package — pluggable SandboxProvider for @namzu/sdk
+
+Introduces a new workspace package `@namzu/sandbox` that wraps the
+`SandboxProvider` shape `@namzu/sdk` already declares with concrete
+backends. Sandbox is intentionally split off the core SDK because:
+
+- Native dependencies (`bubblewrap` binary, seccomp filter generation,
+  Docker SDK, parent-proxy machinery) shouldn't pollute every namzu
+  consumer.
+- Anthropic itself ships their sandbox runtime as a separate package
+  (`@anthropic-ai/sandbox-runtime`) for the same reason.
+- Hosts that don't need isolation (tests, trusted environments) can
+  skip installing it.
+
+This commit is the **public-surface skeleton** — the package is
+declared, the contract is fixed, but no backend is implemented yet.
+Calling `createSandboxProvider({ backend })` throws
+`SandboxBackendNotImplementedError` for every backend tag. Backends
+arrive in subsequent commits per the
+`ses_004-native-agentic-runtime-and-sandbox` design session:
+
+- **P3.1** — `process` backend (Anthropic sandbox-runtime adapter).
+- **P3.2** — `EgressPolicy` plumbing with the proxy daemon.
+- **P3.3** — `container` backend (compass-platform pattern).
+
+The exported surface freezes:
+- `SandboxBackendKind = 'process' | 'container' | 'passthrough'`
+- `EgressPolicy` (deny-all / allow-all / static / resolver)
+- `SandboxBackend` and `SandboxBackendOptions`
+- `SandboxProviderConfig` and `createSandboxProvider`
+- `SandboxBackendNotImplementedError`

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,0 +1,2 @@
+# @namzu/sandbox
+

--- a/packages/sandbox/LICENSE.md
+++ b/packages/sandbox/LICENSE.md
@@ -1,0 +1,110 @@
+# Functional Source License, Version 1.1, MIT Future License
+
+## Abbreviation
+
+FSL-1.1-MIT
+
+## Notice
+
+Copyright 2026 Cogitave
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the MIT license that is effective on the second anniversary of the date we make
+the Software available. On or after that date, you may use the Software under
+the MIT license, in which case the following will apply:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -1,0 +1,62 @@
+# @namzu/sandbox
+
+Pluggable sandbox provider for [`@namzu/sdk`](../sdk). One package,
+multiple backends, same `SandboxProvider` surface the SDK consumes.
+
+```ts
+import { createSandboxProvider } from '@namzu/sandbox'
+
+const sandbox = createSandboxProvider({
+  backend: 'process', // or 'container' | 'passthrough'
+  defaultEgress: { kind: 'static', allowedHosts: ['api.openai.com', 'api.anthropic.com'] },
+})
+
+// Wire into drainQuery / agent run config:
+//   sandboxProvider: sandbox
+```
+
+## Backends
+
+| Backend | What it isolates | When to use |
+|---|---|---|
+| `process` | A single host process — bubblewrap on Linux, Seatbelt (`sandbox-exec`) on macOS, plus an HTTP/SOCKS proxy outside the sandbox enforcing a domain allowlist. The model Anthropic ships in [`@anthropic-ai/sandbox-runtime`](https://github.com/anthropics/sandbox-runtime). | Developer dev loops where the agent runs on the user's actual machine and you want a low-overhead "don't read /etc, don't dial evil.com" guard. Cold-start is process spawn (~ms). |
+| `container` | A whole worker container per task — the worker speaks HTTP to the host, an egress-proxy sidecar mediates outbound network with JWT-authenticated allowlists, the container's filesystem is the sandbox. The pattern cogitave/compass-platform deploys today. | Multi-tenant production where the host process must NOT trust the agent at all. Cold-start is seconds (container start) but blast radius is bounded by the kernel's container boundary. |
+| `passthrough` | Nothing. Runs commands directly. | Tests and trusted environments only. Off by default; opt-in. |
+
+## Why these backends and not gVisor / Firecracker / microsandbox?
+
+Per the [ses_004 design session](../../docs.local/sessions/ses_004-native-agentic-runtime-and-sandbox/README.md) research:
+
+- **gVisor** needs the `runsc` runtime; not available on Azure Container Apps. Breaks dev/prod parity.
+- **Firecracker** / **Kata** / **microsandbox** need KVM; same problem.
+- **bubblewrap + Seatbelt** is what Anthropic itself ships with Claude Code. Same code path runs under `docker compose up` locally and on a Linux replica in production.
+- **Container** backend gives an additional "host doesn't trust agent at all" tier for multi-tenant deployments without introducing a new isolation tech the SDK has to vendor.
+
+## Egress allowlist policy
+
+Every backend supports the same `EgressPolicy` shape:
+
+```ts
+type EgressPolicy =
+  | { kind: 'deny-all' }                                                 // default
+  | { kind: 'allow-all' }                                                // tests only
+  | { kind: 'static'; allowedHosts: readonly string[] }
+  | {
+      kind: 'resolver';
+      resolve: (ctx: EgressResolveContext) => Promise<readonly string[]>;
+    }
+```
+
+Resolver shape lets the host re-evaluate the allowlist per run based on `tenantId` / `runId` / `agentId` — the compass-platform pattern. Static is fine when the allowlist doesn't depend on run identity.
+
+## Status
+
+This package is being built out across the `ses_004-native-agentic-runtime-and-sandbox` design session in phases:
+
+- ✅ **P3.0** — Public surface (`SandboxBackendKind`, `SandboxBackend`, `EgressPolicy`, `createSandboxProvider`). All `createSandboxProvider` calls currently throw `SandboxBackendNotImplementedError` until backends land.
+- ⏳ **P3.1** — `process` backend (Anthropic sandbox-runtime adapter).
+- ⏳ **P3.2** — Egress allowlist policy plumbing.
+- ⏳ **P3.3** — `container` backend (compass-pattern reference Dockerfile).
+- ⏳ **P3.4** — Vandal Cowork consumes this package.
+
+The interface here is what every backend implements; the staged rollout is purely about turning it on, not about reshaping it.

--- a/packages/sandbox/biome.json
+++ b/packages/sandbox/biome.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedImports": "warn",
+        "noUnusedVariables": "warn"
+      },
+      "style": {
+        "useConst": "error",
+        "noNonNullAssertion": "warn",
+        "useTemplate": "warn",
+        "useNodejsImportProtocol": "error",
+        "noParameterAssign": "error",
+        "useConsistentArrayType": {
+          "level": "error",
+          "options": { "syntax": "shorthand" }
+        }
+      },
+      "suspicious": {
+        "noExplicitAny": "warn",
+        "noConsole": "warn"
+      },
+      "complexity": {
+        "noForEach": "warn",
+        "useFlatMap": "warn",
+        "noStaticOnlyClass": "off"
+      },
+      "performance": {
+        "noAccumulatingSpread": "warn",
+        "noDelete": "warn",
+        "noBarrelFile": "off"
+      }
+    }
+  },
+  "organizeImports": {
+    "enabled": true
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "tab",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "asNeeded"
+    }
+  },
+  "files": {
+    "include": ["src/**/*.ts"]
+  },
+  "overrides": [
+    {
+      "include": ["src/**/__tests__/**/*.ts"],
+      "linter": {
+        "rules": {
+          "complexity": {
+            "useLiteralKeys": "off"
+          },
+          "suspicious": {
+            "noExplicitAny": "off"
+          },
+          "style": {
+            "noNonNullAssertion": "off"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@namzu/sandbox",
+  "version": "0.0.0",
+  "description": "Pluggable sandbox provider for @namzu/sdk. Process-level isolation (bubblewrap on Linux, Seatbelt on macOS, via @anthropic-ai/sandbox-runtime) for developer dev loops; container-level isolation (HTTP worker + JWT-authenticated egress proxy) for multi-tenant production. Backend selected at construction time; the SDK consumes both through the same SandboxProvider interface.",
+  "license": "FSL-1.1-MIT",
+  "type": "module",
+  "homepage": "https://github.com/cogitave/namzu#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cogitave/namzu.git",
+    "directory": "packages/sandbox"
+  },
+  "bugs": {
+    "url": "https://github.com/cogitave/namzu/issues"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "LICENSE.md",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "tsc --build",
+    "dev": "tsc --build --watch",
+    "lint": "biome check src/",
+    "lint:fix": "biome check --write src/",
+    "format": "biome format --write src/",
+    "test": "vitest run --passWithNoTests",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "pnpm lint && pnpm typecheck && pnpm build"
+  },
+  "peerDependencies": {
+    "@namzu/sdk": ">=0.1.6 <1.0.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "@namzu/sdk": "workspace:^",
+    "@types/node": "^22.19.17",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -1,0 +1,231 @@
+/**
+ * @namzu/sandbox — pluggable sandbox provider for @namzu/sdk.
+ *
+ * The SDK already declares a `SandboxProvider` shape in
+ * `@namzu/sdk` (`packages/sdk/src/types/sandbox/index.ts`). This
+ * package implements that shape with concrete BACKENDS:
+ *
+ *  • `process` — host-process isolation via Anthropic's
+ *    `@anthropic-ai/sandbox-runtime` model: bubblewrap on Linux,
+ *    `sandbox-exec` on macOS, an HTTP/SOCKS proxy outside the
+ *    sandbox enforcing a domain allowlist. Suits developer dev
+ *    loops where the agent runs on the user's actual machine and
+ *    only needs a low-overhead "don't read /etc, don't dial
+ *    evil.com" guard. Cold-start is process spawn (~ms).
+ *
+ *  • `container` — task-per-container isolation modelled on
+ *    cogitave/compass-platform's `sandbox/` deployment pattern:
+ *    a worker process inside an isolated Docker container speaks
+ *    HTTP to the host, an egress proxy sidecar mediates outbound
+ *    network with JWT-authenticated allowlists, and per-task
+ *    workspaces are filesystem-isolated by virtue of being in
+ *    their own container. Suits multi-tenant production where
+ *    the host process must NOT trust the agent at all. Cold-start
+ *    is seconds (container start) but blast radius is bounded by
+ *    the kernel's container boundary.
+ *
+ *  • `passthrough` — no isolation, runs commands directly. For
+ *    tests and trusted environments only. Off by default; opt-in.
+ *
+ * Backends are chosen at construction time. The `SandboxProvider`
+ * surface the SDK consumes is identical across all three, so
+ * swapping is a config change, not an integration rewrite.
+ *
+ * Why not gVisor / Firecracker / microsandbox? Per the
+ * ses_004 design session research:
+ *   - gVisor needs `runsc` runtime, unavailable on Azure
+ *     Container Apps. Breaks dev/prod parity.
+ *   - Firecracker / Kata / microsandbox need KVM. Same problem.
+ *   - bubblewrap + Seatbelt is what Anthropic itself ships with
+ *     Claude Code. Same code path runs under `docker compose up`
+ *     locally and on a Linux replica in production.
+ *   - Container backend gives an additional "host doesn't trust
+ *     agent at all" tier for multi-tenant deployments without
+ *     introducing a new isolation tech the SDK has to vendor.
+ *
+ * This file is the public surface. Concrete backend implementations
+ * land under `./backends/` in subsequent commits — the
+ * `SandboxBackend` interface here is the contract they implement.
+ */
+
+import type { Sandbox, SandboxProvider } from '@namzu/sdk'
+
+// ---------------------------------------------------------------------------
+// Backend strategy
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminator for the concrete sandbox backend. Hosts pass this
+ * to {@link createSandboxProvider}; the package looks up the
+ * matching {@link SandboxBackend} implementation.
+ *
+ * Add a new backend by:
+ *   1. Implementing {@link SandboxBackend} under
+ *      `src/backends/<name>/index.ts`.
+ *   2. Registering it in `src/backends/registry.ts` (added in P3.1).
+ *   3. Extending this union with the new tag.
+ */
+export type SandboxBackendKind = 'process' | 'container' | 'passthrough'
+
+/**
+ * Egress allowlist resolution. The host-supplied policy decides
+ * whether a given outbound request is allowed before the proxy
+ * opens a socket.
+ *
+ * Two shapes:
+ *   - **Static** — `{ kind: 'static', allowedHosts: string[] }`.
+ *     Fixed at provider construction. Smallest surface, fine for
+ *     deployments where the allowlist is the same across every
+ *     run (e.g. "always allow `api.openai.com` and
+ *     `api.anthropic.com`, deny everything else").
+ *   - **Resolver** — `{ kind: 'resolver', resolve: (ctx) => ... }`.
+ *     Re-evaluated per run. Right when the allowlist depends on
+ *     the tenant, the run, the agent identity, or any other
+ *     signal the host cares about. The compass-platform pattern.
+ *
+ * Hosts can also pass `{ kind: 'deny-all' }` (the default) to
+ * deny ALL egress, or `{ kind: 'allow-all' }` (NOT recommended
+ * for production) for tests.
+ */
+export type EgressPolicy =
+	| { readonly kind: 'deny-all' }
+	| { readonly kind: 'allow-all' }
+	| { readonly kind: 'static'; readonly allowedHosts: readonly string[] }
+	| {
+			readonly kind: 'resolver'
+			readonly resolve: (ctx: EgressResolveContext) => Promise<readonly string[]>
+	  }
+
+/**
+ * Context passed to `EgressPolicy.resolve` callbacks. Lets the
+ * host resolve the allowlist based on whatever signals it tracks.
+ *
+ * Intentionally narrow — `tenantId`, `runId`, `agentId` are the
+ * three signals every sandbox-using namzu host has so far asked
+ * about. Add fields here cautiously; an over-wide context locks
+ * us into a contract.
+ */
+export interface EgressResolveContext {
+	readonly tenantId?: string
+	readonly runId?: string
+	readonly agentId?: string
+}
+
+/**
+ * Backend strategy. Each `SandboxBackendKind` ships a concrete
+ * implementation of this interface in its own subfolder.
+ *
+ * Backends are responsible for:
+ *  - turning {@link SandboxBackendOptions} into a concrete
+ *    {@link Sandbox} instance the SDK can use,
+ *  - wiring {@link EgressPolicy} into whatever proxy / network
+ *    primitive the backend has,
+ *  - cleaning up host resources on `destroy()` (process-level
+ *    cleanup, container teardown, etc.).
+ *
+ * The backend does NOT see the agent or its tools — the SDK
+ * composes them at the runtime layer. Backends are pure
+ * isolation primitives.
+ */
+export interface SandboxBackend {
+	readonly kind: SandboxBackendKind
+	readonly name: string
+
+	create(options: SandboxBackendOptions): Promise<Sandbox>
+}
+
+/**
+ * Options handed to a backend's `create()`. Covers the host-
+ * provided knobs every backend needs:
+ *
+ *  - `workingDirectory` — the per-task root where the sandbox is
+ *    rooted (e.g. `/tmp/<tenant>/<run>/`). Backends bind-mount or
+ *    chroot this depending on platform.
+ *  - `egress` — the allowlist policy applied to outbound network
+ *    inside the sandbox. Backends translate this into proxy /
+ *    iptables / domain-allowlist plumbing.
+ *  - `timeoutMs`, `memoryLimitMb`, `maxProcesses` — resource caps
+ *    applied per spawned process inside the sandbox.
+ *  - `env` — environment variables added to the inside of the
+ *    sandbox (NOT host process env). Used to forward
+ *    `HTTP_PROXY` / `HTTPS_PROXY` to the egress proxy when one
+ *    is in play.
+ *  - `tenantId`, `runId`, `agentId` — propagated to
+ *    {@link EgressResolveContext} when the policy is a resolver.
+ */
+export interface SandboxBackendOptions {
+	readonly workingDirectory: string
+	readonly egress?: EgressPolicy
+	readonly timeoutMs?: number
+	readonly memoryLimitMb?: number
+	readonly maxProcesses?: number
+	readonly env?: Record<string, string>
+	readonly tenantId?: string
+	readonly runId?: string
+	readonly agentId?: string
+}
+
+// ---------------------------------------------------------------------------
+// Provider factory (public)
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration for {@link createSandboxProvider}. Hosts pick the
+ * backend tag here; everything else mirrors
+ * {@link SandboxBackendOptions} but applied as DEFAULTS that each
+ * `provider.create()` call can override.
+ */
+export interface SandboxProviderConfig {
+	readonly backend: SandboxBackendKind
+	readonly defaultEgress?: EgressPolicy
+	readonly defaultTimeoutMs?: number
+	readonly defaultMemoryLimitMb?: number
+	readonly defaultMaxProcesses?: number
+}
+
+/**
+ * Build a {@link SandboxProvider} the SDK can wire into
+ * `drainQuery`'s `sandboxProvider` field. Selects the backend at
+ * construction time; subsequent `provider.create()` calls all use
+ * the chosen backend.
+ *
+ * Backends are loaded lazily — the package only imports the
+ * platform-specific modules (`bubblewrap`, `sandbox-exec`, the
+ * Docker SDK, …) when the corresponding backend is requested.
+ * That keeps `@namzu/sandbox` reasonable to install in
+ * environments where one backend is genuinely impossible (e.g.
+ * pure CI containers without `runsc`, dev laptops without
+ * Docker, etc.).
+ *
+ * **Not implemented in this commit** — this file declares the
+ * surface; backends arrive in P3.1 (process), P3.2 (egress
+ * policy plumbing), P3.3 (container). Calling this function now
+ * throws `SANDBOX_BACKEND_NOT_IMPLEMENTED` so consumers get a
+ * clear signal during the staged rollout.
+ */
+export function createSandboxProvider(_config: SandboxProviderConfig): SandboxProvider {
+	throw new SandboxBackendNotImplementedError(_config.backend)
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown by the factory when a backend is requested before its
+ * implementation has landed. Makes the staged rollout legible —
+ * consumers see exactly which backend is missing rather than a
+ * generic `TypeError: foo is not a function`.
+ *
+ * Subclasses Error so existing host error handling (instanceof
+ * checks, JSON.stringify, etc.) keeps working.
+ */
+export class SandboxBackendNotImplementedError extends Error {
+	override readonly name = 'SandboxBackendNotImplementedError'
+
+	constructor(public readonly backend: SandboxBackendKind) {
+		super(
+			`Sandbox backend '${backend}' is not implemented yet. Track progress in vendor/namzu/docs.local/sessions/ses_004-native-agentic-runtime-and-sandbox.`,
+		)
+	}
+}

--- a/packages/sandbox/tsconfig.json
+++ b/packages/sandbox/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "references": [
+    { "path": "../sdk" }
+  ],
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,16 +61,6 @@ importers:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@22.19.17)
 
-  packages/contracts:
-    dependencies:
-      zod:
-        specifier: ^3.23.0
-        version: 3.25.76
-    devDependencies:
-      typescript:
-        specifier: ^5.5.0
-        version: 5.9.3
-
   packages/providers/anthropic:
     dependencies:
       '@anthropic-ai/sdk':
@@ -207,6 +197,24 @@ importers:
       '@namzu/sdk':
         specifier: workspace:^
         version: link:../../sdk
+      '@types/node':
+        specifier: ^22.19.17
+        version: 22.19.17
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@22.19.17)
+
+  packages/sandbox:
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^1.9.4
+        version: 1.9.4
+      '@namzu/sdk':
+        specifier: workspace:^
+        version: link:../sdk
       '@types/node':
         specifier: ^22.19.17
         version: 22.19.17


### PR DESCRIPTION
## Summary

Introduces \`@namzu/sandbox\` as a separate workspace package, wraps the \`SandboxProvider\` shape \`@namzu/sdk\` already declares with concrete backends. Pluggable: hosts pick process-level (bubblewrap+Seatbelt), container-level (worker+egress-proxy), or passthrough at construction time.

## Why a separate package

- Native deps (bubblewrap binary, seccomp filter generation, Docker SDK, parent-proxy machinery) shouldn't pollute every namzu consumer.
- Anthropic itself ships sandbox separately (\`@anthropic-ai/sandbox-runtime\`).
- Hosts that don't need isolation can skip installing it.

## Why these backends, not gVisor / Firecracker

- gVisor needs \`runsc\` runtime → unavailable on Azure Container Apps → breaks dev/prod parity.
- Firecracker / Kata / microsandbox need KVM → same problem.
- bubblewrap + Seatbelt is what Anthropic itself ships with Claude Code → same code path runs locally and in production.
- Container backend gives the multi-tenant tier without inventing a new isolation tech.

## Status

This commit ships the **public-surface skeleton** only. \`createSandboxProvider()\` throws \`SandboxBackendNotImplementedError\` on every backend tag. The contract is frozen so backends in P3.1–P3.3 are pure implementation work, not contract revisits.

Backends in subsequent PRs:
- **P3.1** — \`process\` backend (Anthropic sandbox-runtime adapter).
- **P3.2** — \`EgressPolicy\` plumbing with HTTP/SOCKS proxy daemon.
- **P3.3** — \`container\` backend (compass-platform pattern, worker Dockerfile with python + libreoffice + pandoc + chromium pre-installed).

## Public surface

- \`SandboxBackendKind = 'process' | 'container' | 'passthrough'\`
- \`EgressPolicy\` (\`deny-all\` / \`allow-all\` / \`static\` / \`resolver\`)
- \`SandboxBackend\` strategy interface + \`SandboxBackendOptions\`
- \`SandboxProviderConfig\` and \`createSandboxProvider()\`
- \`SandboxBackendNotImplementedError\`

## Test plan

- [x] \`pnpm typecheck\` (workspace-wide) — green
- [x] \`pnpm --filter @namzu/sandbox typecheck\` — green
- [x] \`pnpm --filter @namzu/sandbox lint\` — clean
- [x] \`pnpm --filter @namzu/sandbox build\` — green
- [x] \`pnpm --filter @namzu/sdk test\` — 969 / 969 (no regression)

Refs: \`docs.local/sessions/ses_004-native-agentic-runtime-and-sandbox\`.