### PR TITLE
feat(sandbox)!: 4-tier taxonomy aligned with 2026 industrial standard

### DIFF
--- a/.changeset/sandbox-tier-redesign.md
+++ b/.changeset/sandbox-tier-redesign.md
@@ -1,0 +1,70 @@
+---
+'@namzu/sandbox': minor
+---
+
+feat(sandbox)!: tiered backend taxonomy aligned with 2026 industrial standard
+
+Restructures the public surface from a flat backend-tag list into a
+four-tier taxonomy that mirrors how production agent platforms
+actually deploy code-execution sandboxes:
+
+- `process` — Claude Code-style host-process isolation
+  (bubblewrap on Linux, Seatbelt on macOS, via Anthropic's
+  `@anthropic-ai/sandbox-runtime`). For agents that run on the
+  developer's own machine.
+- `container` — OCI container per task. Two runtime options:
+  `docker` (default, universal local-dev fallback; what
+  Northflank/Railway/Render/Compass-platform/GitHub Actions
+  runners ship) and `runsc` (Google gVisor, trusted-tenant tier;
+  what OpenAI Code Interpreter and Modal Labs ship).
+- `microvm` — Firecracker microVM per task, three concrete
+  services: `e2b` (managed, ~150ms cold-start via snapshot
+  restore), `fly-machines` (managed, closer to bare-metal), and
+  `self-hosted` (`firecracker-containerd` on KVM-enabled Linux for
+  hosts that need to own the scheduler).
+- `passthrough` — no isolation; for tests and explicitly trusted
+  environments.
+
+Each tier carries a tier-specific config shape (discriminated union
+on `tier`); picking a tier picks the shape automatically via TS
+narrowing. Industrial precedent for every choice is cited in the
+package README:
+
+- Adversarial multi-tenant → Firecracker microVMs (AWS Lambda /
+  Fargate, Fly Machines, Replit, E2B, Daytona — Fly's
+  "Sandboxing and Workload Isolation" post and the original
+  Firecracker NSDI '20 paper are the canonical refs).
+- Trusted-tenant → gVisor (GKE Sandbox, Modal, OpenAI Code
+  Interpreter — `gvisor.dev/docs/architecture_guide/security` is
+  the reference).
+- Single-user developer machine → bubblewrap / Seatbelt
+  (Anthropic Claude Code — `anthropic-experimental/sandbox-runtime`).
+- Single-tenant or co-trusted → plain Docker + seccomp default
+  profile.
+
+We deliberately do NOT build our own Firecracker scheduler — that
+is E2B's and Fly's entire product, and writing our own would be a
+years-long detour. The `microvm` tier adapts to theirs and
+reserves `self-hosted` for compliance/air-gap deployments.
+
+`EgressPolicy.resolver` is now parameterless
+(`() => Promise<string[]>`). Per Codex's stop-time review, the
+prior shape took a `EgressResolveContext` with `tenantId` /
+`runId` / `agentId` fields the SDK runtime had no way to populate,
+so the resolver context was permanently unreachable. Hosts that
+need per-tenant policies bake the tenant into the closure that
+constructs the provider — exactly how compass-platform's
+JWT-minting flow already works.
+
+Same reason for dropping `tenantId` / `runId` / `agentId` from
+`SandboxBackendOptions`: a contract the runtime can't fulfill is
+worse than not having it.
+
+**Breaking** for consumers of the still-pre-1.0 surface introduced
+in the previous skeleton commit (no implementations existed yet,
+so realistic migration cost is zero).
+
+Phase plan unchanged in structure but renumbered for clarity:
+P3.1 ships `container:docker` first (works locally and in any
+cloud), P3.2 the egress proxy, P3.3 the `microvm` managed adapters,
+P3.4 the `process` tier, P3.5 the adversarial-multi-tenant tier.

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -1,36 +1,69 @@
 # @namzu/sandbox
 
-Pluggable sandbox provider for [`@namzu/sdk`](../sdk). One package,
-multiple backends, same `SandboxProvider` surface the SDK consumes.
+Pluggable sandbox provider for [`@namzu/sdk`](../sdk). Four tiers,
+each backed by the industrial-standard primitive for that
+deployment shape. Same `SandboxProvider` surface the SDK consumes
+across all of them — swapping tiers is a config change, not an
+integration rewrite.
 
-```ts
-import { createSandboxProvider } from '@namzu/sandbox'
+## Tier matrix (2026 industrial standard)
 
-const sandbox = createSandboxProvider({
-  backend: 'process', // or 'container' | 'passthrough'
-  defaultEgress: { kind: 'static', allowedHosts: ['api.openai.com', 'api.anthropic.com'] },
-})
+| Tier | Use case | Primitive | Cold-start | Local dev |
+|---|---|---|---|---|
+| `process` | Agent runs on the developer's own host (Claude Code-style "don't read `~/.ssh`") | bubblewrap (Linux/WSL2) or Seatbelt (macOS), via [`@anthropic-ai/sandbox-runtime`](https://github.com/anthropic-experimental/sandbox-runtime) | Process spawn (~ms) | Native — no infra |
+| `container` (`docker`) | App in `docker compose` locally or single-tenant prod replica | OCI container, seccomp default profile, tmpfs workdir, no-network default | 0.5–2s | `docker compose up` |
+| `container` (`runsc`) | Trusted-tenant SaaS — what OpenAI Code Interpreter and [Modal](https://modal.com/blog/gvisor-savings-article) ship | Google [gVisor](https://gvisor.dev/docs) userspace kernel as Docker runtime | container start + ~100ms | Linux Docker only (no Docker Desktop on macOS) |
+| `microvm` (`e2b`) | Adversarial multi-tenant SaaS, Python-REPL workloads | Firecracker microVM via [E2B](https://e2b.dev/docs/sandbox) managed service | ~150ms (snapshot/restore) | E2B API key from any laptop |
+| `microvm` (`fly-machines`) | Adversarial multi-tenant SaaS, arbitrary tool-call workloads | Firecracker microVM via [Fly Machines](https://fly.io/docs/machines) | 250ms–1s | Fly API token from any laptop |
+| `microvm` (`self-hosted`) | Same threat model, host insists on owning the scheduler | [`firecracker-containerd`](https://github.com/firecracker-microvm/firecracker-containerd) on KVM-enabled Linux | <300ms with snapshot restore | Lima/Colima Linux VM on macOS |
+| `passthrough` | Tests and explicitly trusted environments | Direct host process — no isolation | n/a | n/a |
 
-// Wire into drainQuery / agent run config:
-//   sandboxProvider: sandbox
-```
+## Why these tiers (and not others)
 
-## Backends
+The 2026 consensus across production agent platforms (AWS
+Lambda/Fargate, Fly Machines, Replit, E2B, Modal, OpenAI Code
+Interpreter, Anthropic Code Execution, Daytona) bifurcates cleanly
+along the **trust boundary**:
 
-| Backend | What it isolates | When to use |
-|---|---|---|
-| `process` | A single host process — bubblewrap on Linux, Seatbelt (`sandbox-exec`) on macOS, plus an HTTP/SOCKS proxy outside the sandbox enforcing a domain allowlist. The model Anthropic ships in [`@anthropic-ai/sandbox-runtime`](https://github.com/anthropics/sandbox-runtime). | Developer dev loops where the agent runs on the user's actual machine and you want a low-overhead "don't read /etc, don't dial evil.com" guard. Cold-start is process spawn (~ms). |
-| `container` | A whole worker container per task — the worker speaks HTTP to the host, an egress-proxy sidecar mediates outbound network with JWT-authenticated allowlists, the container's filesystem is the sandbox. The pattern cogitave/compass-platform deploys today. | Multi-tenant production where the host process must NOT trust the agent at all. Cold-start is seconds (container start) but blast radius is bounded by the kernel's container boundary. |
-| `passthrough` | Nothing. Runs commands directly. | Tests and trusted environments only. Off by default; opt-in. |
+- **Adversarial multi-tenant code execution → Firecracker microVMs.**
+  AWS, Fly, Replit, E2B, Daytona all converged here. The argument
+  is in [Fly's "Sandboxing and Workload Isolation"](https://fly.io/blog/sandboxing-and-workload-isolation)
+  and the [original Firecracker paper](https://www.usenix.org/conference/nsdi20/presentation/agache):
+  KVM-backed VMs are the only mainstream primitive with a
+  kernel-level trust boundary, and `jailer` plus snapshot/restore
+  makes them boot in 125ms.
+- **Trusted-tenant or first-party workloads → gVisor.** Google's
+  GKE Sandbox, Modal, OpenAI Code Interpreter run gVisor's `runsc`.
+  Near-zero cold-start, runs on commodity Linux without nested
+  virt. Tradeoff: a userspace-kernel CVE is a tenant escape; a
+  Firecracker CVE generally is not.
+- **Single-user dev workstation → bubblewrap / Seatbelt.** What
+  Anthropic itself ships with Claude Code via
+  `@anthropic-ai/sandbox-runtime`. The threat model is "don't let
+  the agent read `~/.ssh` or run `rm -rf ~`," not "tenant A vs
+  tenant B." Process-spawn cold-start.
+- **Single-tenant or co-trusted tenants → plain Docker + seccomp.**
+  Northflank, Railway, Render, Compass-platform, GitHub Actions
+  runners. Adequate when the model is your model and the user is
+  your customer; insufficient when the prompt is the attacker.
 
-## Why these backends and not gVisor / Firecracker / microsandbox?
+`@namzu/sandbox` exposes all four as separate tiers so the host
+picks the trust boundary that matches its threat model.
 
-Per the [ses_004 design session](../../docs.local/sessions/ses_004-native-agentic-runtime-and-sandbox/README.md) research:
+**What we deliberately do NOT build** is yet-another Firecracker
+scheduler. That is E2B's and Fly's entire product, and writing
+our own would be a years-long detour. We adapt to theirs and
+reserve the `self-hosted` option for hosts that need to own the
+scheduler for compliance or air-gap reasons.
 
-- **gVisor** needs the `runsc` runtime; not available on Azure Container Apps. Breaks dev/prod parity.
-- **Firecracker** / **Kata** / **microsandbox** need KVM; same problem.
-- **bubblewrap + Seatbelt** is what Anthropic itself ships with Claude Code. Same code path runs under `docker compose up` locally and on a Linux replica in production.
-- **Container** backend gives an additional "host doesn't trust agent at all" tier for multi-tenant deployments without introducing a new isolation tech the SDK has to vendor.
+## Cloud portability
+
+The interface is cloud-agnostic. `docker` works on every cloud,
+`e2b` and `fly-machines` are managed services not tied to any
+cloud, `runsc` and `firecracker:self-hosted` need infrastructure
+the host chooses (GKE Sandbox, AWS Fargate, self-hosted KVM, etc.).
+Picking a stronger backend may imply picking a different cloud —
+that's the host's call, not the SDK's.
 
 ## Egress allowlist policy
 
@@ -38,25 +71,78 @@ Every backend supports the same `EgressPolicy` shape:
 
 ```ts
 type EgressPolicy =
-  | { kind: 'deny-all' }                                                 // default
-  | { kind: 'allow-all' }                                                // tests only
+  | { kind: 'deny-all' }                                              // default
+  | { kind: 'allow-all' }                                             // tests only
   | { kind: 'static'; allowedHosts: readonly string[] }
-  | {
-      kind: 'resolver';
-      resolve: (ctx: EgressResolveContext) => Promise<readonly string[]>;
-    }
+  | { kind: 'resolver'; resolve: () => Promise<readonly string[]> }
 ```
 
-Resolver shape lets the host re-evaluate the allowlist per run based on `tenantId` / `runId` / `agentId` — the compass-platform pattern. Static is fine when the allowlist doesn't depend on run identity.
+The `resolver` shape is **parameterless on purpose**. Hosts that
+need per-tenant policies bake the tenant identity into the closure
+that constructs the provider — exactly how compass-platform's
+JWT-minting flow already works (the server knows the tenant when
+it issues the JWT, the allowlist claim is baked in there). This
+avoids the "where does the resolver get its context from"
+plumbing problem; the host owns the closure, the SDK runtime
+doesn't have to forward identity through `provider.create`.
 
 ## Status
 
-This package is being built out across the `ses_004-native-agentic-runtime-and-sandbox` design session in phases:
+This package is being built out across the `ses_004-native-agentic-runtime-and-sandbox`
+design session in phases. Each phase ships one tier, fully
+implemented + tested + documented:
 
-- ✅ **P3.0** — Public surface (`SandboxBackendKind`, `SandboxBackend`, `EgressPolicy`, `createSandboxProvider`). All `createSandboxProvider` calls currently throw `SandboxBackendNotImplementedError` until backends land.
-- ⏳ **P3.1** — `process` backend (Anthropic sandbox-runtime adapter).
-- ⏳ **P3.2** — Egress allowlist policy plumbing.
-- ⏳ **P3.3** — `container` backend (compass-pattern reference Dockerfile).
-- ⏳ **P3.4** — Vandal Cowork consumes this package.
+- ✅ **P3.0** — Public surface (this commit). Backend interfaces,
+  tier discriminator, egress policy. Factory throws
+  `SandboxBackendNotImplementedError` until backends land.
+- ⏳ **P3.1** — `container:docker` backend. Universal local-dev
+  default; ships first.
+- ⏳ **P3.2** — `EgressPolicy` plumbing + reference egress proxy
+  (compass-platform pattern: HTTP CONNECT tunnel + JWT-claim
+  allowlist).
+- ⏳ **P3.3** — `microvm:e2b` and `microvm:fly-machines` adapters.
+  Phase 2 production tier.
+- ⏳ **P3.4** — `process` backend (Anthropic sandbox-runtime
+  adapter — bubblewrap/Seatbelt).
+- ⏳ **P3.5** — `container:runsc` (gVisor) and
+  `microvm:self-hosted` (firecracker-containerd). Phase 3
+  adversarial-multi-tenant.
 
-The interface here is what every backend implements; the staged rollout is purely about turning it on, not about reshaping it.
+The interface here is what every backend implements; the staged
+rollout is purely about turning each tier on, not about reshaping
+the contract.
+
+## Usage (post-implementation)
+
+```ts
+import { createSandboxProvider } from '@namzu/sandbox'
+
+// Phase 1: ship now, works on every dev's laptop
+const sandbox = createSandboxProvider({
+  backend: { tier: 'container', runtime: 'docker', image: 'namzu-worker:latest' },
+  defaultEgress: { kind: 'static', allowedHosts: ['api.openai.com', 'api.anthropic.com'] },
+})
+
+// Phase 2: production, adversarial multi-tenant, managed Firecracker
+const sandbox = createSandboxProvider({
+  backend: { tier: 'microvm', service: 'e2b', apiKey: process.env.E2B_API_KEY! },
+  defaultEgress: {
+    kind: 'resolver',
+    resolve: async () => fetchAllowlistForTenant(tenantId),
+  },
+})
+
+// Phase 3: adversarial multi-tenant, self-hosted Firecracker on KVM
+const sandbox = createSandboxProvider({
+  backend: {
+    tier: 'microvm',
+    service: 'self-hosted',
+    firecrackerBinary: '/usr/local/bin/firecracker',
+    kernelImage: '/var/lib/namzu/vmlinux',
+    rootfsImage: '/var/lib/namzu/rootfs.ext4',
+  },
+})
+
+// Wire into drainQuery / agent run config:
+//   sandboxProvider: sandbox
+```

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -3,49 +3,67 @@
  *
  * The SDK already declares a `SandboxProvider` shape in
  * `@namzu/sdk` (`packages/sdk/src/types/sandbox/index.ts`). This
- * package implements that shape with concrete BACKENDS:
+ * package implements that shape with concrete BACKENDS picked at
+ * construction time. The set is aligned with the 2026 industrial
+ * standard for AI-agent code-execution sandboxes:
  *
- *  • `process` — host-process isolation via Anthropic's
- *    `@anthropic-ai/sandbox-runtime` model: bubblewrap on Linux,
- *    `sandbox-exec` on macOS, an HTTP/SOCKS proxy outside the
- *    sandbox enforcing a domain allowlist. Suits developer dev
- *    loops where the agent runs on the user's actual machine and
- *    only needs a low-overhead "don't read /etc, don't dial
- *    evil.com" guard. Cold-start is process spawn (~ms).
+ *  • `docker` — plain OCI container per task, seccomp default
+ *    profile, tmpfs workdir, no-network-by-default. The universal
+ *    fallback every namzu host gets locally with `docker compose`
+ *    and on every Linux replica in any cloud. What Northflank /
+ *    Railway / Render / Compass-platform / GitHub Actions runners
+ *    actually ship for code execution. Trust boundary: namespaces.
  *
- *  • `container` — task-per-container isolation modelled on
- *    cogitave/compass-platform's `sandbox/` deployment pattern:
- *    a worker process inside an isolated Docker container speaks
- *    HTTP to the host, an egress proxy sidecar mediates outbound
- *    network with JWT-authenticated allowlists, and per-task
- *    workspaces are filesystem-isolated by virtue of being in
- *    their own container. Suits multi-tenant production where
- *    the host process must NOT trust the agent at all. Cold-start
- *    is seconds (container start) but blast radius is bounded by
- *    the kernel's container boundary.
+ *  • `e2b` — adapter for E2B's managed Firecracker microVM service
+ *    (`e2b.dev`). Sub-second cold-start via snapshot/restore, full
+ *    kernel-level trust boundary. The SaaS-friendly path to real
+ *    Firecracker isolation without running our own scheduler.
+ *
+ *  • `fly-machines` — adapter for Fly Machines (`fly.io/docs/machines`).
+ *    Also Firecracker microVMs; closer to bare-metal control than
+ *    E2B, useful when the workload is more "arbitrary tool calls"
+ *    than "Python REPL".
+ *
+ *  • `firecracker` — self-hosted `firecracker-containerd` on bare
+ *    metal (or KVM-enabled cloud instance). For hosts that need
+ *    Firecracker isolation AND insist on running the scheduler
+ *    themselves. Tier 3 isolation, highest operational cost.
+ *
+ *  • `gvisor` — adapter for `runsc` runtime (Google's userspace
+ *    kernel). What OpenAI Code Interpreter and Modal Labs ship.
+ *    Trusted-tenant tier with near-zero cold-start; runs on
+ *    commodity Linux without nested virt. Locally via Linux Docker
+ *    runtime; not available on macOS Docker Desktop.
  *
  *  • `passthrough` — no isolation, runs commands directly. For
  *    tests and trusted environments only. Off by default; opt-in.
  *
- * Backends are chosen at construction time. The `SandboxProvider`
- * surface the SDK consumes is identical across all three, so
- * swapping is a config change, not an integration rewrite.
+ * **What we deliberately do NOT build** is yet-another Firecracker
+ * scheduler — that is E2B's and Fly's entire product, and writing
+ * our own is a years-long detour. We adapt to theirs.
  *
- * Why not gVisor / Firecracker / microsandbox? Per the
- * ses_004 design session research:
- *   - gVisor needs `runsc` runtime, unavailable on Azure
- *     Container Apps. Breaks dev/prod parity.
- *   - Firecracker / Kata / microsandbox need KVM. Same problem.
- *   - bubblewrap + Seatbelt is what Anthropic itself ships with
- *     Claude Code. Same code path runs under `docker compose up`
- *     locally and on a Linux replica in production.
- *   - Container backend gives an additional "host doesn't trust
- *     agent at all" tier for multi-tenant deployments without
- *     introducing a new isolation tech the SDK has to vendor.
+ * **Cloud portability:** the backend interface is cloud-agnostic.
+ * `docker` works on every cloud; `e2b` and `fly-machines` are
+ * managed services not tied to any cloud; `firecracker` and
+ * `gvisor` need infrastructure the host chooses (GKE Sandbox, AWS
+ * Fargate, self-hosted KVM, etc.). Picking a stronger backend may
+ * imply moving cloud — that's the host's call, not the SDK's.
+ *
+ * **Local dev story:** Phase 1 (`docker`) runs everywhere. Phase 2
+ * (`e2b` / `fly-machines`) hits the managed service from a dev
+ * laptop with no infra setup. Phase 3 (`firecracker` / `gvisor`)
+ * needs Lima/Colima on macOS or native KVM on Linux — only the
+ * adversarial-multi-tenant prod path needs that and it's clearly
+ * documented as such.
  *
  * This file is the public surface. Concrete backend implementations
- * land under `./backends/` in subsequent commits — the
+ * land under `./backends/<kind>/` in subsequent commits — the
  * `SandboxBackend` interface here is the contract they implement.
+ *
+ * Refs: `e2b.dev/docs/sandbox`, `fly.io/docs/machines`,
+ * `firecracker-microvm.github.io`, `gvisor.dev/docs`,
+ * `cloud.google.com/kubernetes-engine/docs/concepts/sandbox-pods`,
+ * `aws.amazon.com/blogs/aws/firecracker-lightweight-virtualization-for-serverless-computing`.
  */
 
 import type { Sandbox, SandboxProvider } from '@namzu/sdk'
@@ -55,65 +73,171 @@ import type { Sandbox, SandboxProvider } from '@namzu/sdk'
 // ---------------------------------------------------------------------------
 
 /**
- * Discriminator for the concrete sandbox backend. Hosts pass this
- * to {@link createSandboxProvider}; the package looks up the
- * matching {@link SandboxBackend} implementation.
+ * Top-level sandbox tier. Each tier is a use-case bucket:
  *
- * Add a new backend by:
- *   1. Implementing {@link SandboxBackend} under
- *      `src/backends/<name>/index.ts`.
- *   2. Registering it in `src/backends/registry.ts` (added in P3.1).
- *   3. Extending this union with the new tag.
+ *   - `process` — the agent runs on the developer's own host;
+ *     the sandbox keeps it from reading `~/.ssh` or running
+ *     `rm -rf ~`. Single-user; no multi-tenancy. What Anthropic
+ *     ships with Claude Code via `@anthropic-ai/sandbox-runtime`.
+ *
+ *   - `container` — the agent runs inside an OCI container per
+ *     task. Same code path locally (`docker compose`) and on
+ *     Linux replicas in any cloud. The default for "trusted
+ *     prompts, contained workloads" — Northflank, Railway,
+ *     Render, Compass-platform, GitHub Actions runners all
+ *     ship this tier.
+ *
+ *   - `microvm` — the agent runs inside a Firecracker microVM
+ *     per task. Hardware-virtualization trust boundary; the
+ *     industry standard for adversarial multi-tenancy
+ *     (AWS Lambda/Fargate, Fly Machines, Replit, E2B, Daytona
+ *     all converged here). Sub-second cold-start via
+ *     snapshot/restore.
+ *
+ *   - `passthrough` — no isolation; for tests and explicitly
+ *     trusted environments.
+ *
+ * The concrete implementation inside a tier is picked via the
+ * tier-specific config (see {@link ProcessBackendConfig},
+ * {@link ContainerBackendConfig}, {@link MicroVMBackendConfig}).
  */
-export type SandboxBackendKind = 'process' | 'container' | 'passthrough'
+export type SandboxTier = 'process' | 'container' | 'microvm' | 'passthrough'
 
 /**
- * Egress allowlist resolution. The host-supplied policy decides
- * whether a given outbound request is allowed before the proxy
- * opens a socket.
+ * Discriminated union of sandbox backend configurations. Each
+ * tier has its own configuration shape — picking a tier picks the
+ * shape automatically via TS narrowing.
+ */
+export type SandboxBackendConfig =
+	| ProcessBackendConfig
+	| ContainerBackendConfig
+	| MicroVMBackendConfig
+	| PassthroughBackendConfig
+
+/**
+ * `process` tier. Auto-detects the platform's native primitive
+ * unless overridden:
  *
- * Two shapes:
- *   - **Static** — `{ kind: 'static', allowedHosts: string[] }`.
- *     Fixed at provider construction. Smallest surface, fine for
- *     deployments where the allowlist is the same across every
- *     run (e.g. "always allow `api.openai.com` and
- *     `api.anthropic.com`, deny everything else").
- *   - **Resolver** — `{ kind: 'resolver', resolve: (ctx) => ... }`.
- *     Re-evaluated per run. Right when the allowlist depends on
- *     the tenant, the run, the agent identity, or any other
- *     signal the host cares about. The compass-platform pattern.
+ *   - `bubblewrap` on Linux / WSL2 (`bwrap`)
+ *   - `seatbelt` on macOS (`sandbox-exec`)
  *
- * Hosts can also pass `{ kind: 'deny-all' }` (the default) to
- * deny ALL egress, or `{ kind: 'allow-all' }` (NOT recommended
- * for production) for tests.
+ * Both are what `@anthropic-ai/sandbox-runtime` ships. Cold-start
+ * is process spawn (~ms). Use this when the agent runs on the
+ * end-user's developer machine — Claude Code's deployment model.
+ */
+export interface ProcessBackendConfig {
+	readonly tier: 'process'
+	readonly engine?: 'auto' | 'bubblewrap' | 'seatbelt'
+}
+
+/**
+ * `container` tier. Two runtime options:
+ *
+ *   - `docker` (default) — plain OCI container on the host's
+ *     Docker daemon. No special runtime required.
+ *   - `runsc` — Google's gVisor userspace-kernel runtime. Stronger
+ *     isolation (syscall-table separation), runs on commodity
+ *     Linux without nested virt. Trusted-tenant tier; what OpenAI
+ *     Code Interpreter and Modal Labs ship. Requires the
+ *     `runsc` runtime installed on the Docker daemon (Linux only;
+ *     Docker Desktop on macOS does not support it). See
+ *     `gvisor.dev/docs/user_guide/quick_start/docker`.
+ *
+ * `image` is the container image to spawn per task. The package
+ * ships a reference Dockerfile (compass-platform pattern) with
+ * Python doc-gen libraries, LibreOffice, pandoc, Chromium, and
+ * `tesseract` pre-installed; hosts that want a leaner image
+ * supply their own.
+ */
+export interface ContainerBackendConfig {
+	readonly tier: 'container'
+	readonly runtime?: 'docker' | 'runsc'
+	readonly image: string
+}
+
+/**
+ * `microvm` tier. Three concrete services, all Firecracker under
+ * the hood:
+ *
+ *   - `e2b` — adapter for E2B's managed sandbox service
+ *     (`e2b.dev`). TS SDK does the scheduler work; namzu wraps it.
+ *     ~150ms cold-start (snapshot/restore). Apache-2.0 server side,
+ *     so the same code path can run against self-hosted E2B if
+ *     the host eventually wants to leave the managed service.
+ *   - `fly-machines` — adapter for Fly Machines
+ *     (`fly.io/docs/machines`). Closer to bare-metal control than
+ *     E2B; the right tier when the workload is "arbitrary tool
+ *     calls" rather than "Python REPL".
+ *   - `self-hosted` — direct `firecracker-containerd` against a
+ *     KVM-enabled host. For deployments where E2B and Fly are
+ *     both off the table for policy reasons. Operationally the
+ *     heaviest path; everything below ships first.
+ *
+ * Local dev: `e2b` and `fly-machines` work from any laptop with
+ * an API key (no infra setup). `self-hosted` requires Linux + KVM
+ * (Lima/Colima on macOS).
+ */
+export type MicroVMBackendConfig =
+	| {
+			readonly tier: 'microvm'
+			readonly service: 'e2b'
+			readonly apiKey: string
+			readonly template?: string
+	  }
+	| {
+			readonly tier: 'microvm'
+			readonly service: 'fly-machines'
+			readonly apiToken: string
+			readonly app: string
+			readonly image: string
+			readonly region?: string
+	  }
+	| {
+			readonly tier: 'microvm'
+			readonly service: 'self-hosted'
+			readonly firecrackerBinary: string
+			readonly kernelImage: string
+			readonly rootfsImage: string
+	  }
+
+/**
+ * `passthrough` tier. No isolation — runs commands directly in
+ * the host process. Tests and trusted environments only.
+ */
+export interface PassthroughBackendConfig {
+	readonly tier: 'passthrough'
+}
+
+/**
+ * Egress allowlist resolution. Host-supplied policy decides whether
+ * an outbound request is allowed before the proxy opens a socket.
+ *
+ * Four shapes:
+ *
+ *   - `deny-all` — default. Reject every outbound request.
+ *   - `allow-all` — accept every outbound request. Tests only.
+ *   - `static` — fixed allowlist of hostnames at construction.
+ *   - `resolver` — async closure returning the allowlist.
+ *     Parameterless **on purpose**: the resolver is a closure that
+ *     captures whatever context the host has (tenantId, runId,
+ *     auth token, etc.) at provider-construction time. Compass-
+ *     platform's JWT-minting flow already works this way: the
+ *     server knows the tenant when it issues the JWT, and the
+ *     allowlist claim is baked in there. This avoids the
+ *     "where does the resolver get its context from" plumbing
+ *     problem — the host owns the closure, the SDK runtime
+ *     doesn't have to forward identity through `provider.create`.
  */
 export type EgressPolicy =
 	| { readonly kind: 'deny-all' }
 	| { readonly kind: 'allow-all' }
 	| { readonly kind: 'static'; readonly allowedHosts: readonly string[] }
-	| {
-			readonly kind: 'resolver'
-			readonly resolve: (ctx: EgressResolveContext) => Promise<readonly string[]>
-	  }
+	| { readonly kind: 'resolver'; readonly resolve: () => Promise<readonly string[]> }
 
 /**
- * Context passed to `EgressPolicy.resolve` callbacks. Lets the
- * host resolve the allowlist based on whatever signals it tracks.
- *
- * Intentionally narrow — `tenantId`, `runId`, `agentId` are the
- * three signals every sandbox-using namzu host has so far asked
- * about. Add fields here cautiously; an over-wide context locks
- * us into a contract.
- */
-export interface EgressResolveContext {
-	readonly tenantId?: string
-	readonly runId?: string
-	readonly agentId?: string
-}
-
-/**
- * Backend strategy. Each `SandboxBackendKind` ships a concrete
- * implementation of this interface in its own subfolder.
+ * Backend strategy. Each tier × concrete-service combination ships
+ * an implementation of this interface in its own subfolder under
+ * `src/backends/`.
  *
  * Backends are responsible for:
  *  - turning {@link SandboxBackendOptions} into a concrete
@@ -121,14 +245,14 @@ export interface EgressResolveContext {
  *  - wiring {@link EgressPolicy} into whatever proxy / network
  *    primitive the backend has,
  *  - cleaning up host resources on `destroy()` (process-level
- *    cleanup, container teardown, etc.).
+ *    cleanup, container teardown, microVM stop+delete, etc.).
  *
  * The backend does NOT see the agent or its tools — the SDK
- * composes them at the runtime layer. Backends are pure
- * isolation primitives.
+ * composes them at the runtime layer. Backends are pure isolation
+ * primitives.
  */
 export interface SandboxBackend {
-	readonly kind: SandboxBackendKind
+	readonly tier: SandboxTier
 	readonly name: string
 
 	create(options: SandboxBackendOptions): Promise<Sandbox>
@@ -150,8 +274,13 @@ export interface SandboxBackend {
  *    sandbox (NOT host process env). Used to forward
  *    `HTTP_PROXY` / `HTTPS_PROXY` to the egress proxy when one
  *    is in play.
- *  - `tenantId`, `runId`, `agentId` — propagated to
- *    {@link EgressResolveContext} when the policy is a resolver.
+ *
+ * Identity-aware fields (tenantId / runId / agentId) are
+ * deliberately NOT in this shape. The SDK runtime does not
+ * propagate them through `provider.create` calls today, so adding
+ * them to the contract would be a lie. Hosts that need per-tenant
+ * sandbox config bake the tenant into the closure that constructs
+ * the provider — see the `EgressPolicy` resolver shape.
  */
 export interface SandboxBackendOptions {
 	readonly workingDirectory: string
@@ -160,9 +289,6 @@ export interface SandboxBackendOptions {
 	readonly memoryLimitMb?: number
 	readonly maxProcesses?: number
 	readonly env?: Record<string, string>
-	readonly tenantId?: string
-	readonly runId?: string
-	readonly agentId?: string
 }
 
 // ---------------------------------------------------------------------------
@@ -170,13 +296,13 @@ export interface SandboxBackendOptions {
 // ---------------------------------------------------------------------------
 
 /**
- * Configuration for {@link createSandboxProvider}. Hosts pick the
- * backend tag here; everything else mirrors
- * {@link SandboxBackendOptions} but applied as DEFAULTS that each
- * `provider.create()` call can override.
+ * Configuration for {@link createSandboxProvider}. The host picks
+ * a tier-specific backend config (process / container / microvm /
+ * passthrough) and supplies cross-tier defaults that
+ * `provider.create()` calls can override.
  */
 export interface SandboxProviderConfig {
-	readonly backend: SandboxBackendKind
+	readonly backend: SandboxBackendConfig
 	readonly defaultEgress?: EgressPolicy
 	readonly defaultTimeoutMs?: number
 	readonly defaultMemoryLimitMb?: number
@@ -190,21 +316,40 @@ export interface SandboxProviderConfig {
  * the chosen backend.
  *
  * Backends are loaded lazily — the package only imports the
- * platform-specific modules (`bubblewrap`, `sandbox-exec`, the
- * Docker SDK, …) when the corresponding backend is requested.
- * That keeps `@namzu/sandbox` reasonable to install in
- * environments where one backend is genuinely impossible (e.g.
- * pure CI containers without `runsc`, dev laptops without
- * Docker, etc.).
+ * platform-specific modules (Anthropic's sandbox-runtime, the
+ * Docker SDK, the E2B SDK, …) when the corresponding backend is
+ * requested. That keeps `@namzu/sandbox` reasonable to install in
+ * environments where one backend is genuinely impossible.
  *
  * **Not implemented in this commit** — this file declares the
- * surface; backends arrive in P3.1 (process), P3.2 (egress
- * policy plumbing), P3.3 (container). Calling this function now
- * throws `SANDBOX_BACKEND_NOT_IMPLEMENTED` so consumers get a
+ * surface; backends arrive in subsequent commits per the ses_004
+ * phase plan:
+ *
+ *   - **P3.1** — `container` (docker runtime). Phase 1: ship now.
+ *   - **P3.2** — `EgressPolicy` plumbing + reference egress proxy.
+ *   - **P3.3** — `microvm` (E2B + Fly Machines adapters). Phase 2.
+ *   - **P3.4** — `process` (Anthropic sandbox-runtime adapter).
+ *   - **P3.5** — `microvm` (self-hosted firecracker-containerd) +
+ *     `container` (gVisor runtime). Phase 3 adversarial-multi-tenant.
+ *
+ * Calling this function now throws
+ * {@link SandboxBackendNotImplementedError} so consumers get a
  * clear signal during the staged rollout.
  */
 export function createSandboxProvider(_config: SandboxProviderConfig): SandboxProvider {
-	throw new SandboxBackendNotImplementedError(_config.backend)
+	throw new SandboxBackendNotImplementedError(describeBackend(_config.backend))
+}
+
+/**
+ * Human-readable backend label for error messages. Returns the
+ * tier plus the concrete service / runtime when present, e.g.
+ * `'microvm:e2b'` or `'container:runsc'`.
+ */
+function describeBackend(config: SandboxBackendConfig): string {
+	if (config.tier === 'microvm') return `microvm:${config.service}`
+	if (config.tier === 'container') return `container:${config.runtime ?? 'docker'}`
+	if (config.tier === 'process') return `process:${config.engine ?? 'auto'}`
+	return config.tier
 }
 
 // ---------------------------------------------------------------------------
@@ -223,7 +368,7 @@ export function createSandboxProvider(_config: SandboxProviderConfig): SandboxPr
 export class SandboxBackendNotImplementedError extends Error {
 	override readonly name = 'SandboxBackendNotImplementedError'
 
-	constructor(public readonly backend: SandboxBackendKind) {
+	constructor(public readonly backend: string) {
 		super(
 			`Sandbox backend '${backend}' is not implemented yet. Track progress in vendor/namzu/docs.local/sessions/ses_004-native-agentic-runtime-and-sandbox.`,
 		)


### PR DESCRIPTION
## Summary

Restructures \`@namzu/sandbox\`'s public surface from the flat backend-tag list shipped in #30 into a 4-tier taxonomy that mirrors how production agent platforms actually deploy code-execution sandboxes:

| Tier | Use case | Primitive | Industrial precedent |
|---|---|---|---|
| \`process\` | Agent on dev's own host | bubblewrap / Seatbelt | Anthropic Claude Code |
| \`container:docker\` | App in compose locally + single-tenant prod | OCI + seccomp | Northflank, Railway, Render, Compass |
| \`container:runsc\` | Trusted-tenant SaaS | gVisor | OpenAI Code Interpreter, Modal, GKE Sandbox |
| \`microvm:e2b\` / \`microvm:fly-machines\` / \`microvm:self-hosted\` | Adversarial multi-tenant | Firecracker | AWS Lambda/Fargate, Fly, Replit, E2B, Daytona |
| \`passthrough\` | Tests / trusted envs | none | — |

Tier-specific config shapes via discriminated union; TS narrows automatically when the host picks a tier.

## Why a redesign on the previous skeleton

Codex's stop-time review caught two real issues with the original flat surface:

1. \`EgressPolicy.resolver\` took an \`EgressResolveContext\` (tenantId / runId / agentId) the SDK runtime had no way to populate — context permanently unreachable.
2. The tier discriminator flattened use cases that are genuinely hierarchical (single-user dev vs. trusted-tenant vs. adversarial multi-tenant).

Fixing both as a structural redesign rather than two patches, and aligning the taxonomy with the published industrial precedent, makes the surface honest and lets P3.1+ implement against a stable contract.

## Key decisions baked in

- **No own Firecracker scheduler.** E2B and Fly already ship that as their entire product. We adapt to theirs (\`microvm:e2b\`, \`microvm:fly-machines\`) and reserve \`microvm:self-hosted\` for compliance / air-gap deployments.
- **Resolver is parameterless** \`() => Promise<string[]>\`. Hosts close over tenant identity at provider-construction time. Compass-platform's JWT-minting flow already works exactly this way.
- **Cloud-agnostic.** \`docker\` works on every cloud; \`e2b\` and \`fly-machines\` are managed services not tied to one; \`runsc\` and \`firecracker:self-hosted\` need infra the host chooses. The SDK does not lock to ACA or any other cloud.

## Phase plan

- ✅ **P3.0** — public surface (this PR after merge)
- ⏳ **P3.1** — \`container:docker\` (universal local-dev default; ships first)
- ⏳ **P3.2** — \`EgressPolicy\` plumbing + reference egress proxy (compass pattern)
- ⏳ **P3.3** — \`microvm:e2b\` + \`microvm:fly-machines\` adapters
- ⏳ **P3.4** — \`process\` (Anthropic sandbox-runtime adapter)
- ⏳ **P3.5** — \`container:runsc\` + \`microvm:self-hosted\`

## Test plan

- [x] \`pnpm --filter @namzu/sandbox typecheck\` — green
- [x] \`pnpm --filter @namzu/sandbox lint\` — clean
- [x] \`pnpm --filter @namzu/sandbox build\` — green

## Breaking change

For consumers of the still-pre-1.0 surface introduced in #30 (no implementations existed yet, so realistic migration cost is zero).

Refs: \`docs.local/sessions/ses_004-native-agentic-runtime-and-sandbox\`. Citations for every architectural choice in \`packages/sandbox/README.md\`.