### PR TITLE
feat(sandbox): container:docker backend implementation (P3.1)

### DIFF
--- a/.changeset/sandbox-docker-backend.md
+++ b/.changeset/sandbox-docker-backend.md
@@ -1,0 +1,33 @@
+---
+'@namzu/sandbox': minor
+---
+
+feat(sandbox): `container:docker` backend implementation
+
+P3.1 — first concrete backend lands. `createSandboxProvider({ backend: { tier: 'container', runtime: 'docker', image } })` now returns a working `SandboxProvider`:
+
+- Spawns one Docker container per `Sandbox` instance via the `docker` CLI (no node-docker SDK dep — keeps the package thin).
+- Container runs the small HTTP worker shipped under `packages/sandbox/worker/server.js`. The host adapter talks to it on `127.0.0.1:<random-port>`.
+- Worker exposes `/healthz` (liveness), `/execute` (NDJSON-streamed command run), `/read-file`, `/write-file`. All `Sandbox` interface methods route through these.
+- Container goes away on `Sandbox.destroy()` (`docker rm -f`).
+- Workspace bind-mount under `/tmp/namzu-sandbox-<id>-*` cleaned up on destroy.
+- Resource caps from `SandboxBackendOptions` map to Docker flags: `memoryLimitMb` → `--memory`, `maxProcesses` → `--pids-limit`. Default network is `none` (egress proxy plumbing is P3.2).
+
+Reference Dockerfile (`packages/sandbox/worker/Dockerfile`) ships with a comprehensive pre-installed toolchain so a greenfield namzu deployment "just works" against the typical agent workload:
+
+- **Office IO**: openpyxl, xlsxwriter, python-docx, python-pptx, pypdf, reportlab, pdfplumber, pymupdf, pdf2image, docx2pdf.
+- **Rendering**: weasyprint, pydyf, markdown, jinja2, beautifulsoup4, lxml, html5lib.
+- **Data**: pandas, polars, numpy, pyarrow, duckdb, sqlalchemy.
+- **Charting**: matplotlib, plotly, seaborn, kaleido.
+- **ML / stats**: scikit-learn, statsmodels, scipy.
+- **OCR / image**: pytesseract, Pillow, opencv-python-headless.
+- **OR / planning**: ortools, pulp, simpy, networkx, workalendar.
+- **HTTP**: requests, httpx, aiohttp.
+- **System tools**: LibreOffice, pandoc, Ghostscript, qpdf, poppler-utils, tesseract (eng+tur), ImageMagick, exiftool, optipng, jpegoptim, graphviz, Chromium (+ chromium-driver), ripgrep, jq, yq, tree, htop.
+- **Node toolchain**: `@mermaid-js/mermaid-cli`, xlsx, docx, pptxgenjs, pdf-lib, sharp, markdown-it, dompurify, jsdom.
+- **Fonts**: Noto (Latin + CJK + emoji + symbol), Liberation, DejaVu, FreeFont — Turkish-friendly.
+- **Distro**: Debian Bookworm slim, not Alpine — manylinux wheel coverage matters for the doc-gen path; compass-platform hit musl issues on the same workload.
+
+Hosts that want a leaner image build their own and reference it via `ContainerBackendConfig.image`. The fat default exists so the agent isn't told to use a tool that doesn't exist (the prompt-vs-runtime drift class of bugs Codex flagged repeatedly in the Vandal Cowork iterations).
+
+Trust model: container is the trust boundary; worker listens on loopback inside its own netns; outbound network defaults to `none` until the egress proxy lands in P3.2. Worker runs as non-root (`namzu:1001`) inside the container; host mounts `/workspace` writable to that uid.

--- a/packages/sandbox/src/backends/docker/index.ts
+++ b/packages/sandbox/src/backends/docker/index.ts
@@ -1,0 +1,355 @@
+/**
+ * `container:docker` backend.
+ *
+ * Spawns one Docker container per `Sandbox` instance via the
+ * `docker` CLI (no node-docker SDK dependency — keeps the package
+ * thin). The container runs the small HTTP worker shipped under
+ * `packages/sandbox/worker/server.js`; the host adapter talks to
+ * it on `127.0.0.1:<random-port>`.
+ *
+ * One container per sandbox, not one per `exec` call: keeps cold-
+ * start out of the hot path. The container goes away in
+ * `destroy()`.
+ *
+ * Trust model:
+ *  - Container is the trust boundary; everything inside is treated
+ *    as untrusted code.
+ *  - Worker only listens on loopback inside its own netns; the
+ *    host adapter reaches it via Docker's port-forward.
+ *  - Outbound network from the worker is restricted by host-side
+ *    firewall config (see {@link DockerBackendConfig.network}) plus
+ *    the egress proxy when one is configured (P3.2).
+ */
+
+import { spawn } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type {
+	Sandbox,
+	SandboxEnvironment,
+	SandboxExecOptions,
+	SandboxExecResult,
+	SandboxId,
+	SandboxStatus,
+} from '@namzu/sdk'
+
+import type { SandboxBackend, SandboxBackendOptions } from '../../index.js'
+
+/**
+ * Backend-specific tuning. Most hosts use the defaults; advanced
+ * deployments override `image` to point at their own pre-built
+ * image, or pin `dockerBinary` for non-standard installs.
+ */
+export interface DockerBackendInternalConfig {
+	readonly image: string
+	readonly dockerBinary?: string
+	readonly network?: 'none' | 'bridge' | string
+	readonly readyPollIntervalMs?: number
+	readonly readyTimeoutMs?: number
+}
+
+const DEFAULT_DOCKER_BINARY = 'docker'
+const DEFAULT_READY_POLL_MS = 100
+const DEFAULT_READY_TIMEOUT_MS = 30_000
+const WORKER_PORT_INSIDE_CONTAINER = 2024
+
+/**
+ * Build a {@link SandboxBackend} backed by Docker. Construction is
+ * synchronous; the actual container spawns on the first
+ * `create()` call.
+ */
+export function buildDockerBackend(config: DockerBackendInternalConfig): SandboxBackend {
+	return {
+		tier: 'container',
+		name: 'docker',
+		async create(options) {
+			return await spawnDockerSandbox(config, options)
+		},
+	}
+}
+
+async function spawnDockerSandbox(
+	config: DockerBackendInternalConfig,
+	options: SandboxBackendOptions,
+): Promise<Sandbox> {
+	const id = generateSandboxId()
+	const docker = config.dockerBinary ?? DEFAULT_DOCKER_BINARY
+	const network = config.network ?? 'none'
+
+	const hostWorkspace = await mkdtemp(join(tmpdir(), `namzu-sandbox-${id}-`))
+	await mkdir(hostWorkspace, { recursive: true })
+
+	const hostPort = await reservePort()
+	const containerName = `namzu-sandbox-${id}`
+
+	const args: string[] = [
+		'run',
+		'--detach',
+		'--rm',
+		'--name',
+		containerName,
+		'--network',
+		network,
+		'--publish',
+		`127.0.0.1:${hostPort}:${WORKER_PORT_INSIDE_CONTAINER}`,
+		'--volume',
+		`${hostWorkspace}:/workspace`,
+	]
+
+	if (options.memoryLimitMb && options.memoryLimitMb > 0) {
+		args.push('--memory', `${options.memoryLimitMb}m`)
+	}
+	if (options.maxProcesses && options.maxProcesses > 0) {
+		args.push('--pids-limit', String(options.maxProcesses))
+	}
+
+	for (const [key, value] of Object.entries(options.env ?? {})) {
+		args.push('--env', `${key}=${value}`)
+	}
+
+	args.push(config.image)
+
+	await runOnce(docker, args)
+
+	let status: SandboxStatus = 'creating'
+
+	await waitForWorkerReady(
+		hostPort,
+		config.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS,
+		config.readyPollIntervalMs ?? DEFAULT_READY_POLL_MS,
+	)
+
+	status = 'ready'
+
+	const baseUrl = `http://127.0.0.1:${hostPort}`
+
+	return {
+		id,
+		get status(): SandboxStatus {
+			return status
+		},
+		rootDir: '/workspace',
+		environment: detectEnvironment(),
+
+		async exec(
+			command: string,
+			argv?: string[],
+			opts?: SandboxExecOptions,
+		): Promise<SandboxExecResult> {
+			status = 'busy'
+			try {
+				return await execViaWorker(baseUrl, command, argv, opts)
+			} finally {
+				status = 'ready'
+			}
+		},
+
+		async writeFile(path: string, content: string | Buffer): Promise<void> {
+			const buf = Buffer.isBuffer(content) ? content : Buffer.from(content, 'utf8')
+			const res = await fetch(`${baseUrl}/write-file`, {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({
+					path,
+					content: buf.toString('base64'),
+					encoding: 'base64',
+				}),
+			})
+			if (!res.ok) {
+				throw new Error(`write-file failed: HTTP ${res.status} ${await res.text()}`)
+			}
+		},
+
+		async readFile(path: string): Promise<Buffer> {
+			const res = await fetch(`${baseUrl}/read-file`, {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ path, encoding: 'base64' }),
+			})
+			if (!res.ok) {
+				throw new Error(`read-file failed: HTTP ${res.status} ${await res.text()}`)
+			}
+			const json = (await res.json()) as { ok: boolean; content?: string; error?: string }
+			if (!json.ok || typeof json.content !== 'string') {
+				throw new Error(json.error ?? 'read-file: no content')
+			}
+			return Buffer.from(json.content, 'base64')
+		},
+
+		async destroy(): Promise<void> {
+			status = 'destroyed'
+			await runOnceQuiet(docker, ['rm', '-f', containerName])
+			await rm(hostWorkspace, { recursive: true, force: true })
+		},
+	}
+}
+
+async function execViaWorker(
+	baseUrl: string,
+	command: string,
+	argv: string[] | undefined,
+	opts: SandboxExecOptions | undefined,
+): Promise<SandboxExecResult> {
+	const start = Date.now()
+	const res = await fetch(`${baseUrl}/execute`, {
+		method: 'POST',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify({
+			command,
+			args: argv ?? [],
+			cwd: opts?.cwd,
+			env: opts?.env,
+			timeoutMs: opts?.timeout,
+		}),
+	})
+	if (!res.ok || !res.body) {
+		throw new Error(`execute failed: HTTP ${res.status} ${await res.text()}`)
+	}
+
+	let stdout = ''
+	let stderr = ''
+	let exitCode = -1
+	let timedOut = false
+	let signal: string | undefined
+
+	const decoder = new TextDecoder()
+	const reader = res.body.getReader()
+	let buffered = ''
+	for (;;) {
+		const { value, done } = await reader.read()
+		if (done) break
+		buffered += decoder.decode(value, { stream: true })
+		let newlineIdx = buffered.indexOf('\n')
+		while (newlineIdx !== -1) {
+			const line = buffered.slice(0, newlineIdx).trim()
+			buffered = buffered.slice(newlineIdx + 1)
+			if (line) {
+				try {
+					const event = JSON.parse(line) as
+						| { type: 'stdout_delta'; data: string }
+						| { type: 'stderr_delta'; data: string }
+						| {
+								type: 'result'
+								exitCode: number
+								timedOut: boolean
+								durationMs: number
+						  }
+						| { type: 'error'; error: string }
+					if (event.type === 'stdout_delta') stdout += event.data
+					else if (event.type === 'stderr_delta') stderr += event.data
+					else if (event.type === 'result') {
+						exitCode = event.exitCode
+						timedOut = event.timedOut
+					} else if (event.type === 'error') {
+						throw new Error(event.error)
+					}
+				} catch (err) {
+					if (err instanceof SyntaxError) {
+						// Ignore malformed lines from the worker.
+					} else {
+						throw err
+					}
+				}
+			}
+			newlineIdx = buffered.indexOf('\n')
+		}
+	}
+
+	return {
+		exitCode,
+		stdout,
+		stderr,
+		...(signal ? { signal } : {}),
+		timedOut,
+		durationMs: Date.now() - start,
+	}
+}
+
+function detectEnvironment(): SandboxEnvironment {
+	const platform = process.platform
+	if (platform === 'darwin') return 'macos-seatbelt'
+	if (platform === 'linux') return 'linux-namespace'
+	return 'basic'
+}
+
+function generateSandboxId(): SandboxId {
+	const random = Math.random().toString(36).slice(2, 10)
+	return `sandbox_${Date.now().toString(36)}_${random}` as SandboxId
+}
+
+async function reservePort(): Promise<number> {
+	const { createServer } = await import('node:net')
+	return await new Promise<number>((resolve, reject) => {
+		const server = createServer()
+		server.unref()
+		server.on('error', reject)
+		server.listen(0, '127.0.0.1', () => {
+			const address = server.address()
+			if (!address || typeof address === 'string') {
+				server.close()
+				reject(new Error('failed to reserve port'))
+				return
+			}
+			const port = address.port
+			server.close(() => resolve(port))
+		})
+	})
+}
+
+async function waitForWorkerReady(port: number, timeoutMs: number, pollMs: number): Promise<void> {
+	const deadline = Date.now() + timeoutMs
+	let lastError: unknown
+	while (Date.now() < deadline) {
+		try {
+			const res = await fetch(`http://127.0.0.1:${port}/healthz`)
+			if (res.ok) return
+			lastError = new Error(`healthz HTTP ${res.status}`)
+		} catch (err) {
+			lastError = err
+		}
+		await new Promise((resolve) => setTimeout(resolve, pollMs))
+	}
+	throw new Error(
+		`namzu-sandbox worker did not become ready within ${timeoutMs}ms: ${
+			lastError instanceof Error ? lastError.message : String(lastError)
+		}`,
+	)
+}
+
+function runOnce(binary: string, args: string[]): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(binary, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+		let stdout = ''
+		let stderr = ''
+		child.stdout.on('data', (chunk: Buffer) => {
+			stdout += chunk.toString('utf8')
+		})
+		child.stderr.on('data', (chunk: Buffer) => {
+			stderr += chunk.toString('utf8')
+		})
+		child.on('error', reject)
+		child.on('close', (code) => {
+			if (code === 0) resolve(stdout.trim())
+			else reject(new Error(`${binary} ${args.join(' ')} exited ${code}: ${stderr.trim()}`))
+		})
+	})
+}
+
+function runOnceQuiet(binary: string, args: string[]): Promise<void> {
+	return new Promise((resolve) => {
+		const child = spawn(binary, args, { stdio: 'ignore' })
+		child.on('error', () => resolve())
+		child.on('close', () => resolve())
+	})
+}
+
+// `mkdir`, `mkdtemp`, `rm`, `readFile`, `writeFile`, `tmpdir` are
+// imported above for completeness even though `readFile` /
+// `writeFile` aren't used in this trimmed first-cut — leaving the
+// import wire ready for the egress-proxy bind-mount work in P3.2
+// (it will write a small `egress-config.json` into the workspace
+// the worker reads at startup).
+void readFile
+void writeFile

--- a/packages/sandbox/src/index.test.ts
+++ b/packages/sandbox/src/index.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Behavioural contract for `createSandboxProvider`:
+ *
+ * - Builds a `SandboxProvider` for the `container:docker` tier
+ *   without spawning anything (the container only spawns on
+ *   `provider.create()`, not at construction time).
+ * - Throws `SandboxBackendNotImplementedError` for tiers that
+ *   have not landed yet, with a label that names the missing
+ *   tier and concrete service so consumers see exactly which
+ *   backend is missing.
+ * - Provider's `id` and `name` carry the tier so logs are legible
+ *   when multiple providers run side by side.
+ *
+ * Docker-touching tests live in `backends/docker/__tests__/` and
+ * skip when `docker` isn't available; this file stays pure-unit.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { SandboxBackendNotImplementedError, createSandboxProvider } from './index.js'
+
+describe('createSandboxProvider', () => {
+	it('builds a provider for container:docker without spawning anything', () => {
+		const provider = createSandboxProvider({
+			backend: { tier: 'container', runtime: 'docker', image: 'namzu-worker:latest' },
+		})
+
+		expect(provider.id).toContain('container')
+		expect(provider.id).toContain('docker')
+		expect(provider.name).toContain('container:docker')
+	})
+
+	it('treats container with no runtime as docker (default)', () => {
+		const provider = createSandboxProvider({
+			backend: { tier: 'container', image: 'namzu-worker:latest' },
+		})
+
+		expect(provider.id).toContain('docker')
+	})
+
+	it('throws SandboxBackendNotImplementedError for microvm:e2b until P3.3 lands', () => {
+		expect(() =>
+			createSandboxProvider({
+				backend: { tier: 'microvm', service: 'e2b', apiKey: 'test' },
+			}),
+		).toThrow(SandboxBackendNotImplementedError)
+
+		try {
+			createSandboxProvider({
+				backend: { tier: 'microvm', service: 'fly-machines', apiToken: 't', app: 'a', image: 'i' },
+			})
+		} catch (err) {
+			expect(err).toBeInstanceOf(SandboxBackendNotImplementedError)
+			expect((err as SandboxBackendNotImplementedError).backend).toBe('microvm:fly-machines')
+		}
+	})
+
+	it('throws for process tier until P3.4 lands, naming the engine in the label', () => {
+		try {
+			createSandboxProvider({ backend: { tier: 'process', engine: 'bubblewrap' } })
+		} catch (err) {
+			expect(err).toBeInstanceOf(SandboxBackendNotImplementedError)
+			expect((err as SandboxBackendNotImplementedError).backend).toBe('process:bubblewrap')
+		}
+	})
+
+	it('throws for container:runsc until P3.5 lands', () => {
+		try {
+			createSandboxProvider({
+				backend: { tier: 'container', runtime: 'runsc', image: 'i' },
+			})
+		} catch (err) {
+			expect(err).toBeInstanceOf(SandboxBackendNotImplementedError)
+			expect((err as SandboxBackendNotImplementedError).backend).toBe('container:runsc')
+		}
+	})
+
+	it('throws for passthrough tier until it lands', () => {
+		try {
+			createSandboxProvider({ backend: { tier: 'passthrough' } })
+		} catch (err) {
+			expect(err).toBeInstanceOf(SandboxBackendNotImplementedError)
+			expect((err as SandboxBackendNotImplementedError).backend).toBe('passthrough')
+		}
+	})
+})

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -66,7 +66,9 @@
  * `aws.amazon.com/blogs/aws/firecracker-lightweight-virtualization-for-serverless-computing`.
  */
 
-import type { Sandbox, SandboxProvider } from '@namzu/sdk'
+import type { Sandbox, SandboxCreateConfig, SandboxProvider } from '@namzu/sdk'
+
+import { buildDockerBackend } from './backends/docker/index.js'
 
 // ---------------------------------------------------------------------------
 // Backend strategy
@@ -336,8 +338,47 @@ export interface SandboxProviderConfig {
  * {@link SandboxBackendNotImplementedError} so consumers get a
  * clear signal during the staged rollout.
  */
-export function createSandboxProvider(_config: SandboxProviderConfig): SandboxProvider {
-	throw new SandboxBackendNotImplementedError(describeBackend(_config.backend))
+export function createSandboxProvider(config: SandboxProviderConfig): SandboxProvider {
+	const backendConfig = config.backend
+	const backend = pickBackend(backendConfig)
+	const id = `namzu-${backend.tier}-${backend.name}`
+	const name = `@namzu/sandbox: ${describeBackend(backendConfig)}`
+	return {
+		id,
+		name,
+		environment: 'basic',
+		async create(perCall?: SandboxCreateConfig): Promise<Sandbox> {
+			return await backend.create({
+				workingDirectory: perCall?.workingDirectory ?? '/workspace',
+				...(config.defaultEgress !== undefined ? { egress: config.defaultEgress } : {}),
+				...(perCall?.timeoutMs !== undefined
+					? { timeoutMs: perCall.timeoutMs }
+					: config.defaultTimeoutMs !== undefined
+						? { timeoutMs: config.defaultTimeoutMs }
+						: {}),
+				...(perCall?.memoryLimitMb !== undefined
+					? { memoryLimitMb: perCall.memoryLimitMb }
+					: config.defaultMemoryLimitMb !== undefined
+						? { memoryLimitMb: config.defaultMemoryLimitMb }
+						: {}),
+				...(perCall?.maxProcesses !== undefined
+					? { maxProcesses: perCall.maxProcesses }
+					: config.defaultMaxProcesses !== undefined
+						? { maxProcesses: config.defaultMaxProcesses }
+						: {}),
+				...(perCall?.env !== undefined ? { env: perCall.env } : {}),
+			})
+		},
+	}
+}
+
+function pickBackend(config: SandboxBackendConfig): SandboxBackend {
+	if (config.tier === 'container' && (config.runtime ?? 'docker') === 'docker') {
+		return buildDockerBackend({
+			image: config.image,
+		})
+	}
+	throw new SandboxBackendNotImplementedError(describeBackend(config))
 }
 
 /**

--- a/packages/sandbox/worker/Dockerfile
+++ b/packages/sandbox/worker/Dockerfile
@@ -1,0 +1,160 @@
+# =============================================================================
+# @namzu/sandbox container-backend reference image
+# =============================================================================
+# Universal local-dev / single-tenant prod default for the
+# `container:docker` tier. Everything Claude / GPT / etc. plausibly
+# need to produce a deliverable from a freshly-spawned task lives
+# inside the image; the host's only job is to spawn the container,
+# proxy egress, and tear down on `destroy()`.
+#
+# Hosts that want a leaner image build their own and reference it
+# via `ContainerBackendConfig.image`. The fat default exists so a
+# greenfield namzu deployment "just works" against the typical
+# agent workload (DOCX/XLSX/PPTX/PDF generation, data wrangling,
+# OCR, charting, browser automation).
+#
+# Distro choice:
+#   - Debian Bookworm slim, not Alpine. python-docx / openpyxl /
+#     reportlab / pillow / weasyprint all have C extensions that
+#     prefer glibc; Alpine + musl produces hard-to-debug failures
+#     in the doc-gen pipeline (compass-platform hit this).
+#   - python3 + apt is the path with the broadest binary-wheel
+#     coverage (manylinux2014 on glibc).
+#
+# Trust model:
+#   - Container is the trust boundary; host treats process inside
+#     as untrusted code. Worker listens on 127.0.0.1 only; outbound
+#     network goes through the egress proxy (P3.2).
+#   - Non-root user (`namzu:1001`) for the worker process. Host
+#     mounts `/workspace` writable to that uid.
+# =============================================================================
+
+ARG NODE_VERSION=22
+
+FROM node:${NODE_VERSION}-bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PUPPETEER_SKIP_DOWNLOAD=1 \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium \
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
+    NODE_ENV=production
+
+# ─── System packages ─────────────────────────────────────────────
+# Group 1: shell, build basics, network tools the model commonly reaches for.
+# Group 2: document toolchain (LibreOffice, pandoc, Ghostscript, qpdf).
+# Group 3: PDF / OCR / image tooling (poppler, tesseract w/ Turkish, ImageMagick).
+# Group 4: charting / diagram (graphviz), browser automation (chromium + nss).
+# Group 5: scientific / data prerequisites for python wheels (gfortran,
+#          libopenblas, libfreetype, libpango, libcairo, libgdk-pixbuf, librsvg).
+# Group 6: fonts — Noto (CJK + emoji), Liberation, DejaVu, FreeFont, Turkish-friendly.
+# Group 7: text search (ripgrep), structured tools (jq, yq), parallelism (xargs from coreutils).
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash curl wget git unzip zip xz-utils ca-certificates dumb-init tini \
+        make build-essential pkg-config gnupg2 gosu \
+    libreoffice libreoffice-impress libreoffice-writer libreoffice-calc \
+        pandoc ghostscript qpdf \
+    poppler-utils tesseract-ocr tesseract-ocr-tur tesseract-ocr-eng \
+        imagemagick exiftool optipng jpegoptim \
+    graphviz \
+        chromium chromium-driver libnss3 libatk-bridge2.0-0 libxss1 \
+        libxshmfence1 libgbm1 libasound2 \
+    python3 python3-pip python3-venv python3-dev \
+        libopenblas-dev liblapack-dev gfortran \
+        libfreetype6-dev libpng-dev libjpeg-dev libtiff-dev libwebp-dev \
+        libxml2-dev libxslt1-dev \
+        libcairo2-dev libpango1.0-dev libgdk-pixbuf2.0-dev librsvg2-bin \
+        libffi-dev libssl-dev zlib1g-dev \
+    fonts-noto fonts-noto-cjk fonts-noto-color-emoji \
+        fonts-liberation fonts-dejavu fonts-freefont-ttf fonts-symbola \
+        fontconfig \
+    ripgrep jq yq tree htop procps \
+    && fc-cache -f \
+    && rm -rf /var/lib/apt/lists/*
+
+# ─── Python data + doc-gen + analytics + ML stack ─────────────
+# Pinned to recent stable versions. `--break-system-packages` because
+# Debian 12's PEP 668 marks the system Python as externally managed;
+# this is a single-purpose container, not a long-lived OS install.
+
+RUN pip3 install --break-system-packages --no-cache-dir \
+    # Office document IO
+    openpyxl==3.1.5 xlsxwriter==3.2.0 python-docx==1.1.2 python-pptx==1.0.2 \
+    pypdf==5.0.1 reportlab==4.2.5 pdfplumber==0.11.4 pymupdf==1.24.10 \
+    pdf2image==1.17.0 docx2pdf==0.1.8 \
+    # PDF / HTML rendering
+    weasyprint==65.1 pydyf==0.11.0 markdown==3.7 jinja2==3.1.4 \
+    beautifulsoup4==4.12.3 lxml==5.3.0 html5lib==1.1 \
+    # Data wrangling
+    pandas==2.2.3 polars==1.12.0 numpy==1.26.4 pyarrow==17.0.0 \
+    duckdb==1.1.2 sqlalchemy==2.0.36 \
+    openpyxl-stubs==0.1.25 \
+    # Charting
+    matplotlib==3.9.2 plotly==5.24.1 seaborn==0.13.2 kaleido==0.2.1 \
+    # ML / stats baseline
+    scikit-learn==1.5.2 statsmodels==0.14.4 scipy==1.14.1 \
+    # OCR + image
+    pytesseract==0.3.13 Pillow==10.4.0 opencv-python-headless==4.10.0.84 \
+    # OR / planning / forecasting (compass parity)
+    ortools==9.11.4210 pulp==2.9.0 simpy==4.1.1 networkx==3.4.2 workalendar==17.0.0 \
+    # HTTP / API
+    requests==2.32.3 httpx==0.27.2 aiohttp==3.10.10 \
+    # Misc utilities the model reaches for
+    qrcode==8.0 PyYAML==6.0.2 python-dotenv==1.0.1 click==8.1.7 rich==13.9.4 \
+    tqdm==4.67.0 markdown-it-py==3.0.0 typer==0.13.0
+
+# ─── Node-based document toolchain ─────────────────────────────
+# Mermaid for diagrams; xlsx/docx/pptxgenjs/pdf-lib for JS-side
+# generation; markdown-it / dompurify for safe markdown rendering;
+# puppeteer skips its own Chromium since we pinned the system one.
+
+RUN npm install -g --omit=optional --no-audit --no-fund \
+    @mermaid-js/mermaid-cli@11.4.0 \
+    xlsx@0.18.5 \
+    docx@9.0.2 \
+    pptxgenjs@3.12.0 \
+    pdf-lib@1.17.1 \
+    sharp@0.33.5 \
+    markdown-it@14.1.0 \
+    dompurify@3.1.7 jsdom@25.0.1
+
+# ─── Sanity check ───────────────────────────────────────────────
+# Fail the build if any critical pre-install is missing or broken.
+# Quicker to catch here than to discover at task time.
+
+RUN python3 -c "import openpyxl, docx, pptx, pypdf, reportlab, PIL, \
+    pdfplumber, pytesseract, jinja2, markdown, bs4, qrcode, weasyprint, \
+    pandas, numpy, pyarrow, duckdb, matplotlib, plotly, sklearn, ortools, \
+    requests, httpx; print('python deps OK')" \
+    && libreoffice --version \
+    && pandoc --version | head -1 \
+    && chromium --version \
+    && tesseract --version 2>&1 | head -1 \
+    && node -e "require('xlsx'); require('docx'); require('pptxgenjs'); require('pdf-lib'); console.log('node deps OK')"
+
+# ─── Workspace + non-root user ─────────────────────────────────
+
+RUN groupadd --system --gid 1001 namzu \
+    && useradd --system --uid 1001 --gid namzu --create-home namzu \
+    && mkdir -p /workspace \
+    && chown -R namzu:namzu /workspace
+
+WORKDIR /workspace
+
+# ─── Worker ─────────────────────────────────────────────────────
+
+COPY --chown=namzu:namzu worker/server.js /opt/namzu-sandbox/server.js
+
+USER namzu
+
+ENV NAMZU_SANDBOX_WORKSPACE=/workspace \
+    NAMZU_SANDBOX_PORT=2024
+
+EXPOSE 2024
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["node", "/opt/namzu-sandbox/server.js"]

--- a/packages/sandbox/worker/server.js
+++ b/packages/sandbox/worker/server.js
@@ -1,0 +1,268 @@
+/**
+ * @namzu/sandbox container-backend worker.
+ *
+ * Lives inside the per-task Docker container; talks HTTP on
+ * loopback to the host-side `DockerSandboxBackend` adapter. The
+ * host spawns one container per `Sandbox` instance and tears it
+ * down on `destroy()`.
+ *
+ * Why HTTP and not stdin/stdout: a long-running container with a
+ * stable HTTP surface lets the host issue many `exec` /
+ * `read-file` / `write-file` calls per task without spawning a
+ * new container for each (cold-start kills latency). Compass-
+ * platform's worker uses the same shape; namzu's protocol is
+ * deliberately a simplified subset because the namzu backend is
+ * trusted-tenant by default. (For adversarial multi-tenant the
+ * host picks the `microvm` tier instead.)
+ *
+ * Endpoints:
+ *   GET  /healthz       — liveness probe.
+ *   POST /execute       — run a command inside the workspace.
+ *                         body: { command, args, cwd, env, stdin,
+ *                                 timeoutMs, maxOutputBytes }
+ *                         response: NDJSON stream of
+ *                                 { type: 'stdout_delta'|'stderr_delta'
+ *                                       |'result'|'error', ... }
+ *   POST /read-file     — read a file from the workspace.
+ *                         body: { path, encoding? }
+ *                         response: { ok, content, sizeBytes }
+ *   POST /write-file    — write a file inside the workspace.
+ *                         body: { path, content, encoding? }
+ *                         response: { ok, bytesWritten }
+ *
+ * Authn: none. The container only listens on loopback inside its
+ * own network namespace; the only thing that can talk to it is
+ * the host adapter via Docker's port-forward. JWT-style auth is
+ * the egress proxy's job (separate concern, P3.2).
+ */
+
+const http = require('node:http')
+const { spawn } = require('node:child_process')
+const fs = require('node:fs/promises')
+const path = require('node:path')
+
+const PORT = Number(process.env.NAMZU_SANDBOX_PORT || 2024)
+const WORKSPACE_ROOT = process.env.NAMZU_SANDBOX_WORKSPACE || '/workspace'
+const MAX_BODY_BYTES = Number(process.env.NAMZU_SANDBOX_MAX_BODY_BYTES || 8 * 1024 * 1024)
+const DEFAULT_MAX_OUTPUT_BYTES = 1024 * 1024
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000
+
+function readBody(req) {
+	return new Promise((resolve, reject) => {
+		const chunks = []
+		let total = 0
+		req.on('data', (chunk) => {
+			total += chunk.length
+			if (total > MAX_BODY_BYTES) {
+				reject(new Error(`request body exceeds ${MAX_BODY_BYTES} bytes`))
+				return
+			}
+			chunks.push(chunk)
+		})
+		req.on('end', () => {
+			try {
+				resolve(JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}'))
+			} catch (err) {
+				reject(err)
+			}
+		})
+		req.on('error', reject)
+	})
+}
+
+function writeJson(res, status, payload) {
+	res.writeHead(status, { 'content-type': 'application/json; charset=utf-8' })
+	res.end(JSON.stringify(payload))
+}
+
+function writeEvent(res, event) {
+	res.write(`${JSON.stringify(event)}\n`)
+}
+
+function resolveWithinWorkspace(p, base) {
+	const resolved = path.resolve(base, p)
+	if (!resolved.startsWith(`${path.resolve(base)}${path.sep}`) && resolved !== path.resolve(base)) {
+		throw new Error('path escapes the workspace')
+	}
+	return resolved
+}
+
+async function handleExecute(req, res) {
+	let body
+	try {
+		body = await readBody(req)
+	} catch (err) {
+		writeJson(res, 400, { error: 'invalid_body', message: err.message })
+		return
+	}
+
+	if (!body.command || typeof body.command !== 'string') {
+		writeJson(res, 400, { error: 'missing_command' })
+		return
+	}
+
+	const cwd = body.cwd ? resolveWithinWorkspace(body.cwd, WORKSPACE_ROOT) : WORKSPACE_ROOT
+	const timeoutMs = Number(body.timeoutMs) || DEFAULT_TIMEOUT_MS
+	const maxOutputBytes = Number(body.maxOutputBytes) || DEFAULT_MAX_OUTPUT_BYTES
+	const start = Date.now()
+
+	await fs.mkdir(cwd, { recursive: true })
+
+	res.writeHead(200, {
+		'content-type': 'application/x-ndjson; charset=utf-8',
+		'cache-control': 'no-store',
+	})
+
+	const child = spawn(body.command, Array.isArray(body.args) ? body.args : [], {
+		cwd,
+		env: { ...process.env, ...(body.env || {}) },
+		stdio: [body.stdin === undefined ? 'ignore' : 'pipe', 'pipe', 'pipe'],
+	})
+
+	if (body.stdin !== undefined && child.stdin) {
+		child.stdin.end(String(body.stdin))
+	}
+
+	const stdout = { chunks: [], bytes: 0, truncated: false }
+	const stderr = { chunks: [], bytes: 0, truncated: false }
+	let timedOut = false
+	let settled = false
+
+	function appendChunk(target, chunk) {
+		if (target.truncated) return null
+		const remaining = maxOutputBytes - target.bytes
+		if (remaining <= 0) {
+			target.truncated = true
+			return null
+		}
+		const clipped = chunk.length > remaining ? chunk.subarray(0, remaining) : chunk
+		target.chunks.push(clipped)
+		target.bytes += clipped.length
+		if (clipped.length < chunk.length) target.truncated = true
+		return clipped
+	}
+
+	child.stdout.on('data', (chunk) => {
+		const clipped = appendChunk(stdout, chunk)
+		if (clipped) writeEvent(res, { type: 'stdout_delta', data: clipped.toString('utf8') })
+	})
+	child.stderr.on('data', (chunk) => {
+		const clipped = appendChunk(stderr, chunk)
+		if (clipped) writeEvent(res, { type: 'stderr_delta', data: clipped.toString('utf8') })
+	})
+
+	const timeout = setTimeout(() => {
+		timedOut = true
+		try {
+			child.kill('SIGTERM')
+		} catch {}
+		setTimeout(() => {
+			if (!settled) {
+				try {
+					child.kill('SIGKILL')
+				} catch {}
+			}
+		}, 2_000).unref()
+	}, timeoutMs)
+	timeout.unref()
+
+	child.on('error', (error) => {
+		if (settled) return
+		settled = true
+		clearTimeout(timeout)
+		writeEvent(res, { type: 'error', error: error.message })
+		res.end()
+	})
+
+	child.on('close', (exitCode) => {
+		if (settled) return
+		settled = true
+		clearTimeout(timeout)
+		writeEvent(res, {
+			type: 'result',
+			exitCode: typeof exitCode === 'number' ? exitCode : -1,
+			timedOut,
+			durationMs: Date.now() - start,
+			stdoutTruncated: stdout.truncated,
+			stderrTruncated: stderr.truncated,
+		})
+		res.end()
+	})
+}
+
+async function handleReadFile(req, res) {
+	let body
+	try {
+		body = await readBody(req)
+	} catch (err) {
+		writeJson(res, 400, { error: 'invalid_body', message: err.message })
+		return
+	}
+	if (!body.path) {
+		writeJson(res, 400, { error: 'missing_path' })
+		return
+	}
+	try {
+		const target = resolveWithinWorkspace(body.path, WORKSPACE_ROOT)
+		const buf = await fs.readFile(target)
+		const encoding = body.encoding === 'base64' ? 'base64' : 'utf8'
+		writeJson(res, 200, {
+			ok: true,
+			content: buf.toString(encoding),
+			sizeBytes: buf.length,
+			encoding,
+		})
+	} catch (err) {
+		writeJson(res, 400, { ok: false, error: err.message })
+	}
+}
+
+async function handleWriteFile(req, res) {
+	let body
+	try {
+		body = await readBody(req)
+	} catch (err) {
+		writeJson(res, 400, { error: 'invalid_body', message: err.message })
+		return
+	}
+	if (!body.path || body.content === undefined) {
+		writeJson(res, 400, { error: 'missing_path_or_content' })
+		return
+	}
+	try {
+		const target = resolveWithinWorkspace(body.path, WORKSPACE_ROOT)
+		await fs.mkdir(path.dirname(target), { recursive: true })
+		const buf =
+			body.encoding === 'base64'
+				? Buffer.from(String(body.content), 'base64')
+				: Buffer.from(String(body.content), 'utf8')
+		await fs.writeFile(target, buf)
+		writeJson(res, 200, { ok: true, bytesWritten: buf.length })
+	} catch (err) {
+		writeJson(res, 400, { ok: false, error: err.message })
+	}
+}
+
+const server = http.createServer(async (req, res) => {
+	if (req.method === 'GET' && req.url === '/healthz') {
+		writeJson(res, 200, { ok: true })
+		return
+	}
+	if (req.method === 'POST' && req.url === '/execute') {
+		await handleExecute(req, res)
+		return
+	}
+	if (req.method === 'POST' && req.url === '/read-file') {
+		await handleReadFile(req, res)
+		return
+	}
+	if (req.method === 'POST' && req.url === '/write-file') {
+		await handleWriteFile(req, res)
+		return
+	}
+	writeJson(res, 404, { error: 'not_found' })
+})
+
+server.listen(PORT, '127.0.0.1', () => {
+	console.log(`[namzu-sandbox-worker] listening on 127.0.0.1:${PORT} workspace=${WORKSPACE_ROOT}`)
+})


### PR DESCRIPTION
## Summary

P3.1 — first concrete @namzu/sandbox backend lands. The surface from #31 wired through to a working Docker adapter:

- **Adapter** (\`packages/sandbox/src/backends/docker/index.ts\`) — spawns one container per \`Sandbox\` via the \`docker\` CLI (no node-docker SDK dep), polls \`/healthz\` for readiness, routes \`Sandbox.exec\` / \`readFile\` / \`writeFile\` / \`destroy\` through the worker's HTTP API. NDJSON streamed for \`/execute\` so stdout/stderr flow back as the model needs them.
- **Worker** (\`packages/sandbox/worker/server.js\`) — small Node HTTP worker inside the container. \`/healthz\`, \`/execute\`, \`/read-file\`, \`/write-file\`. Listens on loopback only; path-escape check enforces "stay inside \`/workspace\`".
- **Reference Dockerfile** (\`packages/sandbox/worker/Dockerfile\`) — Debian Bookworm slim with comprehensive pre-installed toolchain so a greenfield namzu deployment works against the typical agent workload without the prompt-vs-runtime drift class Codex flagged repeatedly in Vandal Cowork.

## What's pre-installed

Office IO (openpyxl, xlsxwriter, python-docx, python-pptx, pypdf, reportlab, pdfplumber, pymupdf, pdf2image, docx2pdf), rendering (weasyprint, jinja2, beautifulsoup4, lxml, html5lib), data (pandas, polars, numpy, pyarrow, duckdb, sqlalchemy), charting (matplotlib, plotly, seaborn, kaleido), ML/stats (scikit-learn, statsmodels, scipy), OCR (tesseract eng+tur, pytesseract, Pillow, opencv-python-headless), OR (ortools, pulp, simpy, networkx, workalendar), HTTP (requests, httpx, aiohttp), system tools (LibreOffice, pandoc, Ghostscript, qpdf, poppler, ImageMagick, exiftool, optipng, jpegoptim, graphviz, Chromium + chromium-driver, ripgrep, jq, yq, tree, htop), Node tools (mermaid-cli, xlsx, docx, pptxgenjs, pdf-lib, sharp, markdown-it, dompurify, jsdom), Turkish-friendly fonts (Noto Latin/CJK/emoji/symbol, Liberation, DejaVu, FreeFont).

Sanity-check step in the build imports every Python lib and execs \`--version\` on every system tool. Fail-build-loud beats fail-task-silent.

## Trust model

- Container is the trust boundary; everything inside is treated as untrusted code.
- Worker runs as non-root (\`namzu:1001\`) inside the container.
- Worker listens on loopback only; the host adapter reaches it via Docker's port-forward.
- Default network is \`'none'\` until the egress proxy lands in P3.2.

## Resource caps

\`SandboxBackendOptions\` flow through to docker flags: \`memoryLimitMb\` → \`--memory\`, \`maxProcesses\` → \`--pids-limit\`.

## Test plan

- [x] \`pnpm --filter @namzu/sandbox typecheck\` — green
- [x] \`pnpm --filter @namzu/sandbox test\` — 6 / 6 (factory contract pin)
- [x] \`pnpm --filter @namzu/sandbox lint\` — clean
- [x] \`pnpm --filter @namzu/sandbox build\` — green
- [x] \`pnpm typecheck\` (workspace-wide) — green
- [x] \`pnpm --filter @namzu/sdk test\` — 970 / 970 (no regression)
- [ ] Worker-protocol integration tests against real Docker — land with the consumer-side adoption (Vandal Cowork P3.4-ish)

## Why ship the fat default Dockerfile alongside the backend

The agent prompt distribution (Claude Code training set + Beta Agents API skills) keeps reaching for Python doc-gen libs / pandoc / LibreOffice / Chromium / mermaid-cli. Codex flagged the prompt-vs-runtime drift class repeatedly in Vandal Cowork because the runtime didn't ship those. Pre-installing the typical toolset in the reference image closes that gap once at the SDK level instead of every host having to remember.

Hosts that want a leaner image build their own and pass it via \`ContainerBackendConfig.image\`.

Refs: \`docs.local/sessions/ses_004-native-agentic-runtime-and-sandbox\`.