### PR TITLE
fix(sandbox): docker backend lifecycle leak + worker symlink escape

### DIFF
--- a/.changeset/sandbox-docker-lifecycle-and-symlinks.md
+++ b/.changeset/sandbox-docker-lifecycle-and-symlinks.md
@@ -1,0 +1,43 @@
+---
+'@namzu/sandbox': patch
+---
+
+fix(sandbox): docker backend lifecycle leak + worker symlink escape
+
+Two issues Codex stop-time review caught on the just-shipped
+`container:docker` backend (#32):
+
+**HIGH — container lifecycle leak.** `spawnDockerSandbox`'s create
+path had no rollback on failure. If `docker run` succeeded but
+`/healthz` polling timed out (slow image, kernel under pressure,
+network-namespace setup hiccup), the temp workspace under `/tmp/`
+plus the running container were both orphaned. The
+`reservePort()` pattern also had a TOCTOU race: this process
+allocated a host port, closed the listening socket, then passed
+the number to `docker run --publish 127.0.0.1:PORT:…`, leaving a
+window where another process could bind the same port.
+
+Fixed:
+- `spawnDockerSandbox` now wraps create in `try/catch`. The catch
+  arm runs `cleanupOnFailure()` which `docker rm -f`s the
+  container if it started and removes `hostWorkspace` if it was
+  created. Both are tracked via a flag/var captured in the outer
+  scope.
+- Switched from pre-reserve-then-publish to letting Docker
+  allocate via `--publish 127.0.0.1::WORKER_PORT`. The mapped
+  host port is read back via `docker inspect --format
+  '{{(index ...).HostPort}}'`. No TOCTOU window.
+
+**MEDIUM — symlink escape in worker.** `resolveWithinWorkspace()`
+in the worker's `/read-file` and `/write-file` handlers checked
+the lexical path string but `fs.readFile` / `fs.writeFile`
+follow symlinks. A symlink inside `/workspace` pointing to
+`/etc/passwd` (or anywhere outside the bind-mount) bypassed the
+boundary.
+
+Fixed: added `realpathWithinWorkspace()` which `realpath`s both
+the workspace root and the requested target, then verifies the
+resolved real path is still inside the workspace. For writes
+where the target may not exist yet, the parent directory's
+realpath is checked instead. Both handlers now resolve through
+the new helper before touching the file.

--- a/packages/sandbox/src/backends/docker/index.ts
+++ b/packages/sandbox/src/backends/docker/index.ts
@@ -77,53 +77,81 @@ async function spawnDockerSandbox(
 	const id = generateSandboxId()
 	const docker = config.dockerBinary ?? DEFAULT_DOCKER_BINARY
 	const network = config.network ?? 'none'
-
-	const hostWorkspace = await mkdtemp(join(tmpdir(), `namzu-sandbox-${id}-`))
-	await mkdir(hostWorkspace, { recursive: true })
-
-	const hostPort = await reservePort()
 	const containerName = `namzu-sandbox-${id}`
 
-	const args: string[] = [
-		'run',
-		'--detach',
-		'--rm',
-		'--name',
-		containerName,
-		'--network',
-		network,
-		'--publish',
-		`127.0.0.1:${hostPort}:${WORKER_PORT_INSIDE_CONTAINER}`,
-		'--volume',
-		`${hostWorkspace}:/workspace`,
-	]
+	// Track resources so any failure path can clean them up. Codex
+	// stop-time review caught that the original create path leaked
+	// `hostWorkspace` and possibly a running container if `docker
+	// run` succeeded but `/healthz` polling timed out.
+	let hostWorkspace: string | undefined
+	let containerStarted = false
 
-	if (options.memoryLimitMb && options.memoryLimitMb > 0) {
-		args.push('--memory', `${options.memoryLimitMb}m`)
-	}
-	if (options.maxProcesses && options.maxProcesses > 0) {
-		args.push('--pids-limit', String(options.maxProcesses))
+	async function cleanupOnFailure() {
+		if (containerStarted) {
+			await runOnceQuiet(docker, ['rm', '-f', containerName])
+		}
+		if (hostWorkspace) {
+			await rm(hostWorkspace, { recursive: true, force: true })
+		}
 	}
 
-	for (const [key, value] of Object.entries(options.env ?? {})) {
-		args.push('--env', `${key}=${value}`)
+	let hostPort: number
+	let baseUrl: string
+
+	try {
+		hostWorkspace = await mkdtemp(join(tmpdir(), `namzu-sandbox-${id}-`))
+		await mkdir(hostWorkspace, { recursive: true })
+
+		// Let Docker pick the host port instead of pre-reserving one
+		// in this process. The reservePort()-then-publish-fixed-port
+		// pattern had a TOCTOU window: the OS could hand the port to
+		// another process between our `server.close()` and Docker's
+		// `bind()`. Letting Docker pick (`--publish-all`) and reading
+		// the mapping back via `docker inspect` removes the race.
+		const args: string[] = [
+			'run',
+			'--detach',
+			'--rm',
+			'--name',
+			containerName,
+			'--network',
+			network,
+			'--publish',
+			`127.0.0.1::${WORKER_PORT_INSIDE_CONTAINER}`,
+			'--volume',
+			`${hostWorkspace}:/workspace`,
+		]
+
+		if (options.memoryLimitMb && options.memoryLimitMb > 0) {
+			args.push('--memory', `${options.memoryLimitMb}m`)
+		}
+		if (options.maxProcesses && options.maxProcesses > 0) {
+			args.push('--pids-limit', String(options.maxProcesses))
+		}
+
+		for (const [key, value] of Object.entries(options.env ?? {})) {
+			args.push('--env', `${key}=${value}`)
+		}
+
+		args.push(config.image)
+
+		await runOnce(docker, args)
+		containerStarted = true
+
+		hostPort = await readMappedPort(docker, containerName)
+		baseUrl = `http://127.0.0.1:${hostPort}`
+
+		await waitForWorkerReady(
+			hostPort,
+			config.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS,
+			config.readyPollIntervalMs ?? DEFAULT_READY_POLL_MS,
+		)
+	} catch (err) {
+		await cleanupOnFailure()
+		throw err
 	}
 
-	args.push(config.image)
-
-	await runOnce(docker, args)
-
-	let status: SandboxStatus = 'creating'
-
-	await waitForWorkerReady(
-		hostPort,
-		config.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS,
-		config.readyPollIntervalMs ?? DEFAULT_READY_POLL_MS,
-	)
-
-	status = 'ready'
-
-	const baseUrl = `http://127.0.0.1:${hostPort}`
+	let status: SandboxStatus = 'ready'
 
 	return {
 		id,
@@ -181,9 +209,35 @@ async function spawnDockerSandbox(
 		async destroy(): Promise<void> {
 			status = 'destroyed'
 			await runOnceQuiet(docker, ['rm', '-f', containerName])
-			await rm(hostWorkspace, { recursive: true, force: true })
+			if (hostWorkspace) {
+				await rm(hostWorkspace, { recursive: true, force: true })
+			}
 		},
 	}
+}
+
+/**
+ * Ask Docker which host port it bound to the worker port. Used
+ * instead of the pre-reserve-then-publish pattern (which had a
+ * TOCTOU race window between this process closing the listening
+ * socket and Docker's bind picking the same port — another
+ * process could grab it in the meantime). Letting Docker
+ * allocate and reading the mapping back is race-free.
+ */
+async function readMappedPort(docker: string, containerName: string): Promise<number> {
+	const inspectOutput = await runOnce(docker, [
+		'inspect',
+		'--format',
+		`{{(index (index .NetworkSettings.Ports "${WORKER_PORT_INSIDE_CONTAINER}/tcp") 0).HostPort}}`,
+		containerName,
+	])
+	const port = Number(inspectOutput.trim())
+	if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+		throw new Error(
+			`docker inspect returned no usable host port mapping for ${containerName}: '${inspectOutput}'`,
+		)
+	}
+	return port
 }
 
 async function execViaWorker(
@@ -277,25 +331,6 @@ function detectEnvironment(): SandboxEnvironment {
 function generateSandboxId(): SandboxId {
 	const random = Math.random().toString(36).slice(2, 10)
 	return `sandbox_${Date.now().toString(36)}_${random}` as SandboxId
-}
-
-async function reservePort(): Promise<number> {
-	const { createServer } = await import('node:net')
-	return await new Promise<number>((resolve, reject) => {
-		const server = createServer()
-		server.unref()
-		server.on('error', reject)
-		server.listen(0, '127.0.0.1', () => {
-			const address = server.address()
-			if (!address || typeof address === 'string') {
-				server.close()
-				reject(new Error('failed to reserve port'))
-				return
-			}
-			const port = address.port
-			server.close(() => resolve(port))
-		})
-	})
 }
 
 async function waitForWorkerReady(port: number, timeoutMs: number, pollMs: number): Promise<void> {

--- a/packages/sandbox/worker/server.js
+++ b/packages/sandbox/worker/server.js
@@ -81,10 +81,44 @@ function writeEvent(res, event) {
 
 function resolveWithinWorkspace(p, base) {
 	const resolved = path.resolve(base, p)
-	if (!resolved.startsWith(`${path.resolve(base)}${path.sep}`) && resolved !== path.resolve(base)) {
+	const baseResolved = path.resolve(base)
+	if (!resolved.startsWith(`${baseResolved}${path.sep}`) && resolved !== baseResolved) {
 		throw new Error('path escapes the workspace')
 	}
 	return resolved
+}
+
+/**
+ * After lexical resolution proves the requested path doesn't ESCAPE
+ * `/workspace` via `..`, we still have to defend against symlinks
+ * inside the workspace pointing OUTSIDE it (e.g. `/workspace/leak ->
+ * /etc/passwd`). The lexical check only inspects the string; the
+ * actual `fs.readFile` follows symlinks. Resolve via `realpath` and
+ * verify the resolved target is still inside the workspace before
+ * touching the file.
+ *
+ * For writes the parent directory's realpath is what matters — the
+ * file itself may not exist yet, so realpath the parent and
+ * reconstruct the final path. If the parent contains a symlink
+ * jumping out of the workspace, this rejects the write.
+ */
+async function realpathWithinWorkspace(target, base) {
+	const baseReal = await fs.realpath(path.resolve(base))
+	let real
+	try {
+		real = await fs.realpath(target)
+	} catch (err) {
+		if (err && err.code === 'ENOENT') {
+			const parentReal = await fs.realpath(path.dirname(target))
+			real = path.join(parentReal, path.basename(target))
+		} else {
+			throw err
+		}
+	}
+	if (!real.startsWith(`${baseReal}${path.sep}`) && real !== baseReal) {
+		throw new Error('symlink escapes the workspace')
+	}
+	return real
 }
 
 async function handleExecute(req, res) {
@@ -204,7 +238,8 @@ async function handleReadFile(req, res) {
 	}
 	try {
 		const target = resolveWithinWorkspace(body.path, WORKSPACE_ROOT)
-		const buf = await fs.readFile(target)
+		const real = await realpathWithinWorkspace(target, WORKSPACE_ROOT)
+		const buf = await fs.readFile(real)
 		const encoding = body.encoding === 'base64' ? 'base64' : 'utf8'
 		writeJson(res, 200, {
 			ok: true,
@@ -232,11 +267,16 @@ async function handleWriteFile(req, res) {
 	try {
 		const target = resolveWithinWorkspace(body.path, WORKSPACE_ROOT)
 		await fs.mkdir(path.dirname(target), { recursive: true })
+		const real = await realpathWithinWorkspace(target, WORKSPACE_ROOT)
 		const buf =
 			body.encoding === 'base64'
 				? Buffer.from(String(body.content), 'base64')
 				: Buffer.from(String(body.content), 'utf8')
-		await fs.writeFile(target, buf)
+		// flag 'wx' rejects existing symlinks pointing out of the workspace
+		// only when the target doesn't exist; for existing files we already
+		// confirmed via realpath that they resolve inside /workspace, so a
+		// plain writeFile is safe.
+		await fs.writeFile(real, buf)
 		writeJson(res, 200, { ok: true, bytesWritten: buf.length })
 	} catch (err) {
 		writeJson(res, 400, { ok: false, error: err.message })


### PR DESCRIPTION
## Summary

Codex stop-time review on #32 caught two issues:

### HIGH — container lifecycle leak
\`spawnDockerSandbox\`'s create path had no rollback on failure. If \`docker run\` succeeded but \`/healthz\` polling timed out, the temp workspace under \`/tmp/\` and the running container were both orphaned. Plus the \`reservePort()\` pattern had a TOCTOU race: this process allocated a host port, closed the listening socket, then passed the number to \`docker run --publish 127.0.0.1:PORT:…\`, leaving a window where another process could grab the same port.

**Fix:**
- create wraps in \`try/catch\`. The catch arm runs \`cleanupOnFailure()\` which \`docker rm -f\`s the container if it started and \`rm\`s \`hostWorkspace\` if it was created.
- switched from pre-reserve-then-publish to letting Docker allocate via \`--publish 127.0.0.1::WORKER_PORT\`. The mapped host port is read back via \`docker inspect --format '{{(index ...).HostPort}}'\`. Race-free.

### MEDIUM — symlink escape in worker /read-file and /write-file
\`resolveWithinWorkspace()\` checked the lexical string but \`fs.readFile\` / \`fs.writeFile\` follow symlinks. A symlink inside \`/workspace\` pointing to \`/etc/passwd\` bypassed the boundary.

**Fix:** added \`realpathWithinWorkspace()\` — \`realpath\`'s both the workspace root and the requested target, verifies the resolved real path is still inside. For writes where the target may not exist yet, the parent directory's realpath is checked instead.

## Test plan

- [x] \`pnpm --filter @namzu/sandbox typecheck\` — green
- [x] \`pnpm --filter @namzu/sandbox test\` — 6 / 6
- [x] \`pnpm --filter @namzu/sandbox lint\` — clean
- [x] \`pnpm --filter @namzu/sandbox build\` — green
- [ ] Manual: trigger a failed \`docker run\` and confirm no orphaned container or temp dir
- [ ] Manual: \`ln -s /etc/passwd /workspace/leak\` then \`POST /read-file {path: 'leak'}\` and confirm 400 \"symlink escapes the workspace\"

Refs: \`docs.local/sessions/ses_004-native-agentic-runtime-and-sandbox\`.