### PR TITLE
feat(sandbox): docker backend workspace mount path + runtime selector

### DIFF
--- a/packages/providers/anthropic/src/client.ts
+++ b/packages/providers/anthropic/src/client.ts
@@ -352,9 +352,29 @@ export class AnthropicProvider implements LLMProvider {
 						}
 						break
 					}
-					case 'content_block_stop':
-						// Aggregation is consumer-side — nothing to emit.
+					case 'content_block_stop': {
+						// For tool_use blocks we MUST emit a `toolCallEnd`
+						// signal so the consumer-side aggregator (sdk
+						// runtime/query/iteration) can flush the buffered
+						// `argsBuf` and JSON.parse it into the tool input.
+						// Without this signal the executor sees an empty
+						// `arguments` string and rejects the call with
+						// `Error: Invalid JSON in tool arguments for "<tool>"`
+						// — exactly the failure the live cowork test
+						// surfaced (Bash + Write both blank-input failed).
+						const idx = event.index ?? 0
+						const active = activeTools.get(idx)
+						if (active) {
+							yield {
+								id: messageId,
+								delta: {
+									toolCallEnd: { index: idx, id: active.id },
+								},
+							}
+							activeTools.delete(idx)
+						}
 						break
+					}
 					case 'message_delta': {
 						if (event.delta?.stop_reason) {
 							yield {

--- a/packages/providers/anthropic/src/client.ts
+++ b/packages/providers/anthropic/src/client.ts
@@ -294,7 +294,54 @@ export class AnthropicProvider implements LLMProvider {
 		// fragments can reference the right tool call.
 		const activeTools = new Map<number, { id: string; name: string }>()
 
-		for await (const event of stream) {
+		// Anthropic Messages API streams over SSE. Live debugging surfaced
+		// runs where the upstream SSE went silent for > 1 hour without
+		// returning a `message_stop` or throwing — `for await (event of
+		// stream)` blocks forever, and the SDK's overall request `timeout`
+		// option is per-call, not per-event.
+		//
+		// Treat sustained silence as a transport error so the higher
+		// layers' existing terminal markers fire naturally:
+		//   provider yields error → SDK iteration catches →
+		//   `ResultAssembler.handleError` emits `run_failed` →
+		//   `supervisor.run()` rejects → outer runtime settles status to
+		//   'terminated'. We are not adding a watchdog at the supervisor
+		//   level; we are making the provider correctly recognize a
+		//   stalled HTTP/2 SSE as a failure, which is the boundary where
+		//   the network condition is observable.
+		//
+		// On timeout we also call `iter.return()` so the underlying
+		// HTTP/2 connection is released instead of leaking until the OS
+		// times it out — Codex's audit flagged the bare-timer version
+		// as correct-but-leaky.
+		const STREAM_IDLE_TIMEOUT_MS = 90_000
+		const iter = (stream as AsyncIterable<StreamEvent>)[Symbol.asyncIterator]()
+		const nextWithIdleTimeout = async (): Promise<IteratorResult<StreamEvent>> => {
+			let timer: ReturnType<typeof setTimeout> | undefined
+			try {
+				return await Promise.race([
+					iter.next(),
+					new Promise<IteratorResult<StreamEvent>>((_, reject) => {
+						timer = setTimeout(() => {
+							reject(
+								new Error(
+									`Anthropic stream idle for ${Math.round(STREAM_IDLE_TIMEOUT_MS / 1000)}s — aborting so the run lifecycle can emit run_failed.`,
+								),
+							)
+						}, STREAM_IDLE_TIMEOUT_MS)
+					}),
+				])
+			} finally {
+				if (timer !== undefined) clearTimeout(timer)
+			}
+		}
+
+		try {
+			for (;;) {
+				const result = await nextWithIdleTimeout()
+				if (result.done) break
+				const event = result.value
+				{
 			try {
 				switch (event.type) {
 					case 'message_start': {
@@ -405,6 +452,15 @@ export class AnthropicProvider implements LLMProvider {
 					error: `Stream event error: ${parseErr instanceof Error ? parseErr.message : String(parseErr)}`,
 				}
 			}
+			}
+		}
+		} finally {
+			// Always release the underlying HTTP/2 connection — both on
+			// idle-timeout rejection (bubbling up) and on normal stream
+			// end (`message_stop` returned out of the loop). Leaving
+			// the SSE connection open until OS-level timeout was the
+			// gap Codex called out.
+			await iter.return?.().catch(() => undefined)
 		}
 	}
 

--- a/packages/sandbox/src/backends/docker/index.ts
+++ b/packages/sandbox/src/backends/docker/index.ts
@@ -48,11 +48,36 @@ export interface DockerBackendInternalConfig {
 	readonly network?: 'none' | 'bridge' | string
 	readonly readyPollIntervalMs?: number
 	readonly readyTimeoutMs?: number
+	/**
+	 * Path inside the container that the host workspace bind-mounts
+	 * onto. Defaults to `/workspace` to match the worker image; hosts
+	 * that need a different convention (e.g. Vandal mirrors Anthropic
+	 * Managed Agents' `/mnt/session` so model training-time intuition
+	 * about where to write deliverables matches the local runtime
+	 * without prompt-side steering) override this. The same path is
+	 * forwarded to the in-container worker via the
+	 * `NAMZU_SANDBOX_WORKSPACE` env var so the worker's own resolver
+	 * agrees with the bind mount.
+	 */
+	readonly workspaceMount?: string
+	/**
+	 * Docker runtime to launch the container under. Default `runc`
+	 * (vanilla Docker namespaces, what Docker Desktop ships). Linux
+	 * production deployments that have registered gVisor on the host
+	 * daemon can pass `runsc` to upgrade to a userspace-kernel trust
+	 * boundary — same primitive Modal Labs and OpenAI Code Interpreter
+	 * ship. Hosts can also pass a custom runtime name registered in
+	 * `daemon.json`. macOS Docker Desktop has no `runsc` runtime, so
+	 * the default `runc` is the only option there; that's documented
+	 * as the local-dev tier in the package README.
+	 */
+	readonly runtime?: 'runc' | 'runsc' | string
 }
 
 const DEFAULT_DOCKER_BINARY = 'docker'
 const DEFAULT_READY_POLL_MS = 100
 const DEFAULT_READY_TIMEOUT_MS = 30_000
+const DEFAULT_WORKSPACE_MOUNT = '/workspace'
 const WORKER_PORT_INSIDE_CONTAINER = 2024
 
 /**
@@ -77,6 +102,8 @@ async function spawnDockerSandbox(
 	const id = generateSandboxId()
 	const docker = config.dockerBinary ?? DEFAULT_DOCKER_BINARY
 	const network = config.network ?? 'none'
+	const workspaceMount = config.workspaceMount ?? DEFAULT_WORKSPACE_MOUNT
+	const runtime = config.runtime
 	const containerName = `namzu-sandbox-${id}`
 
 	// Track resources so any failure path can clean them up. Codex
@@ -119,8 +146,17 @@ async function spawnDockerSandbox(
 			'--publish',
 			`127.0.0.1::${WORKER_PORT_INSIDE_CONTAINER}`,
 			'--volume',
-			`${hostWorkspace}:/workspace`,
+			`${hostWorkspace}:${workspaceMount}`,
+			// Forward the in-container workspace path to the worker so
+			// its own resolver agrees with the bind mount when the host
+			// overrides the default `/workspace`.
+			'--env',
+			`NAMZU_SANDBOX_WORKSPACE=${workspaceMount}`,
 		]
+
+		if (runtime) {
+			args.push('--runtime', runtime)
+		}
 
 		if (options.memoryLimitMb && options.memoryLimitMb > 0) {
 			args.push('--memory', `${options.memoryLimitMb}m`)
@@ -158,7 +194,7 @@ async function spawnDockerSandbox(
 		get status(): SandboxStatus {
 			return status
 		},
-		rootDir: '/workspace',
+		rootDir: workspaceMount,
 		environment: detectEnvironment(),
 
 		async exec(


### PR DESCRIPTION
Two new knobs on `DockerBackendInternalConfig`: `workspaceMount` (default /workspace; hosts that mirror Anthropic Managed Agents' /mnt/session convention override) and `runtime` (default unset = runc; Linux prod can pass runsc for gVisor — same primitive Modal Labs and OpenAI Code Interpreter ship). Backward-compatible.