### PR TITLE
feat(sandbox): host-workspace-dir + per-call container config passthrough

### DIFF
--- a/packages/sandbox/src/backends/docker/index.ts
+++ b/packages/sandbox/src/backends/docker/index.ts
@@ -72,6 +72,24 @@ export interface DockerBackendInternalConfig {
 	 * as the local-dev tier in the package README.
 	 */
 	readonly runtime?: 'runc' | 'runsc' | string
+	/**
+	 * How the SDK consumer reaches the in-container worker:
+	 *
+	 *  - `'host-port'` (default): publish the worker port on the
+	 *    host loopback (`127.0.0.1::<random>`) and connect by host
+	 *    port. Works when the SDK runs ON the docker host (CLI,
+	 *    direct dev). Backward-compatible — the original behaviour.
+	 *
+	 *  - `'container-network'`: skip `--publish` entirely, attach
+	 *    the spawned container to a shared docker bridge that the
+	 *    SDK consumer is also on, and connect by container DNS name
+	 *    (`http://<containerName>:2024`). Required when the SDK
+	 *    runs INSIDE a container (e.g. Vandal's app container
+	 *    spawning sibling sandbox containers via the host's Docker
+	 *    daemon — `127.0.0.1` inside the app is the app, not the
+	 *    sandbox). The shared bridge name comes from `config.network`.
+	 */
+	readonly hostReachability?: 'host-port' | 'container-network'
 }
 
 const DEFAULT_DOCKER_BINARY = 'docker'
@@ -104,6 +122,7 @@ async function spawnDockerSandbox(
 	const network = config.network ?? 'none'
 	const workspaceMount = config.workspaceMount ?? DEFAULT_WORKSPACE_MOUNT
 	const runtime = config.runtime
+	const hostReachability = config.hostReachability ?? 'host-port'
 	const containerName = `namzu-sandbox-${id}`
 
 	// Track resources so any failure path can clean them up. Codex
@@ -143,8 +162,6 @@ async function spawnDockerSandbox(
 			containerName,
 			'--network',
 			network,
-			'--publish',
-			`127.0.0.1::${WORKER_PORT_INSIDE_CONTAINER}`,
 			'--volume',
 			`${hostWorkspace}:${workspaceMount}`,
 			// Forward the in-container workspace path to the worker so
@@ -153,6 +170,15 @@ async function spawnDockerSandbox(
 			'--env',
 			`NAMZU_SANDBOX_WORKSPACE=${workspaceMount}`,
 		]
+
+		// Only publish a host port when the consumer is going to reach
+		// the worker through the docker host's loopback (CLI / direct
+		// dev). For `container-network` reachability we leave the port
+		// unpublished — sibling containers reach the worker by its DNS
+		// name on the shared bridge, no host port required.
+		if (hostReachability === 'host-port') {
+			args.push('--publish', `127.0.0.1::${WORKER_PORT_INSIDE_CONTAINER}`)
+		}
 
 		if (runtime) {
 			args.push('--runtime', runtime)
@@ -174,14 +200,25 @@ async function spawnDockerSandbox(
 		await runOnce(docker, args)
 		containerStarted = true
 
-		hostPort = await readMappedPort(docker, containerName)
-		baseUrl = `http://127.0.0.1:${hostPort}`
-
-		await waitForWorkerReady(
-			hostPort,
-			config.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS,
-			config.readyPollIntervalMs ?? DEFAULT_READY_POLL_MS,
-		)
+		if (hostReachability === 'host-port') {
+			hostPort = await readMappedPort(docker, containerName)
+			baseUrl = `http://127.0.0.1:${hostPort}`
+			await waitForWorkerReady(
+				baseUrl,
+				config.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS,
+				config.readyPollIntervalMs ?? DEFAULT_READY_POLL_MS,
+			)
+		} else {
+			// container-network: connect by container DNS name on the
+			// shared bridge. No host port to read; the SDK consumer is
+			// itself a container on the same bridge.
+			baseUrl = `http://${containerName}:${WORKER_PORT_INSIDE_CONTAINER}`
+			await waitForWorkerReady(
+				baseUrl,
+				config.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS,
+				config.readyPollIntervalMs ?? DEFAULT_READY_POLL_MS,
+			)
+		}
 	} catch (err) {
 		await cleanupOnFailure()
 		throw err
@@ -369,12 +406,16 @@ function generateSandboxId(): SandboxId {
 	return `sandbox_${Date.now().toString(36)}_${random}` as SandboxId
 }
 
-async function waitForWorkerReady(port: number, timeoutMs: number, pollMs: number): Promise<void> {
+async function waitForWorkerReady(
+	baseUrl: string,
+	timeoutMs: number,
+	pollMs: number,
+): Promise<void> {
 	const deadline = Date.now() + timeoutMs
 	let lastError: unknown
 	while (Date.now() < deadline) {
 		try {
-			const res = await fetch(`http://127.0.0.1:${port}/healthz`)
+			const res = await fetch(`${baseUrl}/healthz`)
 			if (res.ok) return
 			lastError = new Error(`healthz HTTP ${res.status}`)
 		} catch (err) {

--- a/packages/sandbox/src/backends/docker/index.ts
+++ b/packages/sandbox/src/backends/docker/index.ts
@@ -131,12 +131,16 @@ async function spawnDockerSandbox(
 	// run` succeeded but `/healthz` polling timed out.
 	let hostWorkspace: string | undefined
 	let containerStarted = false
+	// Host-managed bind sources (provided by the SDK consumer) are
+	// NOT cleaned up on failure — the consumer's lifecycle owns the
+	// directory. Only auto-allocated tmpdir workspaces get rm'd.
+	const hostManagedBind = options.hostWorkspaceDir !== undefined
 
 	async function cleanupOnFailure() {
 		if (containerStarted) {
 			await runOnceQuiet(docker, ['rm', '-f', containerName])
 		}
-		if (hostWorkspace) {
+		if (hostWorkspace && !hostManagedBind) {
 			await rm(hostWorkspace, { recursive: true, force: true })
 		}
 	}
@@ -145,8 +149,26 @@ async function spawnDockerSandbox(
 	let baseUrl: string
 
 	try {
-		hostWorkspace = await mkdtemp(join(tmpdir(), `namzu-sandbox-${id}-`))
-		await mkdir(hostWorkspace, { recursive: true })
+		// Two paths for the host-side workspace bind source:
+		//   1. SDK consumer supplies an explicit `hostWorkspaceDir`
+		//      (e.g. Vandal's per-task `/var/lib/vandal/sessions/<taskId>`).
+		//      The consumer owns the dir lifecycle — backend doesn't
+		//      mkdir/rm it.
+		//   2. No path supplied → mkdtemp under the OS tmpdir; backend
+		//      cleans it up on failure or on `destroy()`.
+		// Path #1 is required when the consumer is itself a container
+		// asking the host's Docker daemon to spawn a sibling: the
+		// daemon resolves bind sources against the host filesystem,
+		// not the consumer container's filesystem, so a dir under
+		// `tmpdir()` of the consumer container is unreachable. Codex
+		// flagged this as the named-volume-sub-path blocker.
+		if (options.hostWorkspaceDir) {
+			hostWorkspace = options.hostWorkspaceDir
+			await mkdir(hostWorkspace, { recursive: true })
+		} else {
+			hostWorkspace = await mkdtemp(join(tmpdir(), `namzu-sandbox-${id}-`))
+			await mkdir(hostWorkspace, { recursive: true })
+		}
 
 		// Let Docker pick the host port instead of pre-reserving one
 		// in this process. The reservePort()-then-publish-fixed-port

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -155,6 +155,33 @@ export interface ContainerBackendConfig {
 	readonly tier: 'container'
 	readonly runtime?: 'docker' | 'runsc'
 	readonly image: string
+	/**
+	 * Path inside the spawned container that the host workspace
+	 * bind-mounts onto. Default `/workspace`. Hosts that mirror
+	 * Anthropic Managed Agents' `/mnt/session/` convention so the
+	 * model's training-time intuition lines up with the local
+	 * runtime override this — typically to `/mnt/session`.
+	 */
+	readonly workspaceMount?: string
+	/**
+	 * How the SDK consumer reaches the in-container worker. Default
+	 * `'host-port'` — the original loopback host-port flow, works
+	 * when the consumer runs ON the docker host. Set
+	 * `'container-network'` when the consumer is itself a container
+	 * spawning siblings via the host's Docker daemon: the worker is
+	 * reachable at `http://<containerName>:2024` over the docker
+	 * bridge named in `network`.
+	 */
+	readonly hostReachability?: 'host-port' | 'container-network'
+	/**
+	 * Docker network the spawned container attaches to. Default
+	 * `'none'` (no inbound or outbound network). Set to a docker
+	 * bridge name when `hostReachability='container-network'` so the
+	 * SDK consumer (also on that bridge) can reach the worker by
+	 * container DNS name. Egress from the sandbox is governed
+	 * separately by `EgressPolicy`.
+	 */
+	readonly network?: 'none' | 'bridge' | string
 }
 
 /**
@@ -291,6 +318,22 @@ export interface SandboxBackendOptions {
 	readonly memoryLimitMb?: number
 	readonly maxProcesses?: number
 	readonly env?: Record<string, string>
+	/**
+	 * Optional host-side directory the backend should bind into the
+	 * container as the workspace. When unset, container backends
+	 * mkdtemp under the OS tmpdir and own the cleanup. When set, the
+	 * SDK consumer owns the dir — the backend will not mkdir/rm it
+	 * beyond best-effort `mkdir -p`. Required when the consumer is
+	 * itself a container asking the host's Docker daemon to spawn a
+	 * sibling: the daemon resolves bind sources against the host
+	 * filesystem, not the consumer container's filesystem, so the
+	 * tmpdir-under-the-consumer path would be unreachable. Hosts
+	 * that mount a per-task host-path bind (e.g.
+	 * `/var/lib/vandal/sessions/<taskId>`) into both their own app
+	 * container and the spawned sandbox container pass that same
+	 * host path here.
+	 */
+	readonly hostWorkspaceDir?: string
 }
 
 // ---------------------------------------------------------------------------
@@ -367,6 +410,9 @@ export function createSandboxProvider(config: SandboxProviderConfig): SandboxPro
 						? { maxProcesses: config.defaultMaxProcesses }
 						: {}),
 				...(perCall?.env !== undefined ? { env: perCall.env } : {}),
+				...(perCall?.hostWorkspaceDir !== undefined
+					? { hostWorkspaceDir: perCall.hostWorkspaceDir }
+					: {}),
 			})
 		},
 	}
@@ -376,6 +422,26 @@ function pickBackend(config: SandboxBackendConfig): SandboxBackend {
 	if (config.tier === 'container' && (config.runtime ?? 'docker') === 'docker') {
 		return buildDockerBackend({
 			image: config.image,
+			...(config.workspaceMount !== undefined
+				? { workspaceMount: config.workspaceMount }
+				: {}),
+			...(config.hostReachability !== undefined
+				? { hostReachability: config.hostReachability }
+				: {}),
+			...(config.network !== undefined ? { network: config.network } : {}),
+		})
+	}
+	if (config.tier === 'container' && config.runtime === 'runsc') {
+		return buildDockerBackend({
+			image: config.image,
+			runtime: 'runsc',
+			...(config.workspaceMount !== undefined
+				? { workspaceMount: config.workspaceMount }
+				: {}),
+			...(config.hostReachability !== undefined
+				? { hostReachability: config.hostReachability }
+				: {}),
+			...(config.network !== undefined ? { network: config.network } : {}),
 		})
 	}
 	throw new SandboxBackendNotImplementedError(describeBackend(config))

--- a/packages/sandbox/worker/server.js
+++ b/packages/sandbox/worker/server.js
@@ -303,6 +303,18 @@ const server = http.createServer(async (req, res) => {
 	writeJson(res, 404, { error: 'not_found' })
 })
 
-server.listen(PORT, '127.0.0.1', () => {
-	console.log(`[namzu-sandbox-worker] listening on 127.0.0.1:${PORT} workspace=${WORKSPACE_ROOT}`)
+// Bind address picks `0.0.0.0` by default so a sibling container
+// (the Vandal app talking to a sandbox spawned via docker.sock on
+// the same host) can reach the worker over a docker bridge network.
+// Overridable via `NAMZU_SANDBOX_BIND` for the dev case where the
+// SDK consumer runs on the docker host itself and prefers loopback.
+//
+// Trust note: the container is the trust boundary. Listening on
+// `0.0.0.0` only matters at the network layer — the docker network
+// the worker is attached to is per-deployment policy (a bridge with
+// no internet egress, or a `network=none` mode where only docker
+// exec talks to the container at all).
+const BIND = process.env.NAMZU_SANDBOX_BIND || '0.0.0.0'
+server.listen(PORT, BIND, () => {
+	console.log(`[namzu-sandbox-worker] listening on ${BIND}:${PORT} workspace=${WORKSPACE_ROOT}`)
 })

--- a/packages/sdk/src/types/sandbox/index.ts
+++ b/packages/sdk/src/types/sandbox/index.ts
@@ -93,6 +93,16 @@ export interface SandboxCreateConfig {
 	readonly timeoutMs?: number
 	readonly memoryLimitMb?: number
 	readonly maxProcesses?: number
+	/**
+	 * Optional host-side directory the backend should bind into the
+	 * container as the workspace. When unset, container backends
+	 * mkdtemp under the OS tmpdir and own the cleanup. When set, the
+	 * SDK consumer owns the dir lifecycle. Required when the consumer
+	 * is itself a container (e.g. Vandal's app container) asking the
+	 * host's Docker daemon to spawn a sibling — the daemon resolves
+	 * bind sources against the host filesystem, not the consumer's.
+	 */
+	readonly hostWorkspaceDir?: string
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Two extensions for hosts spawning sandboxes from inside their own container: (1) `hostWorkspaceDir` on SandboxBackendOptions / SandboxCreateConfig — backend uses this exact host path as bind source instead of mkdtemp under tmpdir (required for sibling-spawn since the daemon resolves bind sources against host fs not consumer container fs); (2) ContainerBackendConfig.workspaceMount/hostReachability/network now flow through createSandboxProvider→pickBackend→buildDockerBackend.