### PR TITLE
fix(sdk): context-management correctness (compaction atomicity, resume, usage, HITL abort)

### DIFF
--- a/.changeset/audit-r3-context-correctness.md
+++ b/.changeset/audit-r3-context-correctness.md
@@ -1,0 +1,30 @@
+---
+'@namzu/sdk': patch
+---
+
+Context-management correctness fixes (Vandal round-3 architecture audit).
+
+- **Compaction no longer orphans tool pairs.** `runCompactionCheck` now snaps
+  the recent-window boundary through `findSafeTrimIndex` (previously wired only
+  to the unused `ConversationManager` strategy classes), so a compaction cut can
+  never leave a `tool_result` at the head of the recent window whose `tool_use`
+  was summarized away. That orphan otherwise makes the provider reject the very
+  next turn with a 400 — compaction killing the long run it exists to keep alive.
+- **Resume preserves the compaction summary + working-memory slot.** The
+  checkpoint-restore path used to drop EVERY system message, silently losing the
+  `[COMPACTED CONTEXT]` block (the only record of the older history a pass
+  deleted) on `resumeFromCheckpoint`. It now re-pushes the fresh static/dynamic
+  floor but preserves the compaction summary and the pinned working-memory slot.
+- **Within-turn usage is merged, not last-write-wins.** `mergeTokenUsage`
+  (per-field high-water mark) replaces `usage = chunk.usage` in `collect()` and
+  the iteration stream reducer, so a late usage frame that omits input/cache
+  tokens no longer zeroes the counts captured earlier in the stream.
+- **HITL parks are cancellable.** `awaitDecisionOrAbort` races the tool-review
+  and iteration-checkpoint `resumeHandler` parks against the run's abort signal,
+  so a Stop that arrives while parked resolves the park as `abort` instead of
+  hanging until the host answers. Degrades to a plain await when no controller
+  is wired; fails closed to `abort` if the handler rejects.
+
+All changes are internal correctness fixes; the provider/message wire contract
+is unchanged and existing consumers stay behaviourally identical outside the
+buggy edge cases above.

--- a/.changeset/cooperative-cancellation.md
+++ b/.changeset/cooperative-cancellation.md
@@ -1,0 +1,34 @@
+---
+'@namzu/sdk': minor
+'@namzu/anthropic': patch
+'@namzu/openai': patch
+'@namzu/openrouter': patch
+'@namzu/http': patch
+'@namzu/bedrock': patch
+'@namzu/ollama': patch
+'@namzu/lmstudio': patch
+---
+
+Make a Stop abort the IN-FLIGHT model turn, not only between turns.
+
+`ChatCompletionParams` gains an optional `signal?: AbortSignal`. The query
+runtime threads the run's abort signal into every provider call (the streaming
+turn and the forced-final summary) and now drives the provider stream through a
+MANUAL iterator that RACES each `next()` against the abort — so a cancellation
+tears the turn down within a tick even if a transport buffers or ignores the
+signal, with the abort propagating out of the generator so the run settles as
+`cancelled`. The stream consumer cleans up on every exit (removes the abort
+listener, calls `iterator.return()`), and the natural-completion break
+re-checks the signal so a Stop that lands exactly as the turn finishes is
+recorded as cancelled rather than a normal end-of-turn.
+
+Every provider now honours the signal at the transport: Anthropic
+(`messages.create({ signal })`), OpenAI (`create(..., { signal })`), Bedrock
+(`send(..., { abortSignal })`), OpenRouter + HTTP (compose with the request
+timeout via `AbortSignal.any`), Ollama (the returned iterator's `.abort()`),
+and LM Studio (`respond(..., { signal })` → the SDK's websocket cancel) — each
+plus a cheap per-chunk `signal.throwIfAborted()` for promptness.
+
+Fully additive and inert when unset: a never-aborted signal is behaviourally
+identical to omitting it, so existing callers and uncancelled runs are
+byte-identical.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -16,13 +16,13 @@ import { Command, CommanderError } from 'commander'
 import { doctorCommand } from './commands/doctor.js'
 import { providersCommand } from './commands/providers.js'
 import { registerAll } from './commands/registry.js'
-import { runCommand } from './commands/run.js'
 import {
 	historyCommand,
 	providersJSONCommand,
 	runStreamCommand,
 	skillsJSONCommand,
 } from './commands/run-stream.js'
+import { runCommand } from './commands/run.js'
 import { stubCommands } from './commands/stubs.js'
 import { toolsCommand } from './commands/tools.js'
 import type { CommandContext } from './commands/types.js'

--- a/packages/cli/src/commands/run-stream.ts
+++ b/packages/cli/src/commands/run-stream.ts
@@ -20,7 +20,7 @@
  * `{"kind":"error",…}` line (exit 0) so the host surfaces them in-band.
  */
 
-import { configureLogger, type Message } from '@namzu/sdk'
+import { type Message, configureLogger } from '@namzu/sdk'
 
 import type { DetectedProvider, Preferences, ProviderId } from '../integrations/providers/index.js'
 import {
@@ -80,10 +80,50 @@ function parseRunStreamFlags(rawArgs: readonly string[]): RunStreamFlags {
 	}
 	for (const idx = { v: 0 }; idx.v < rawArgs.length; idx.v++) {
 		const a = rawArgs[idx.v]
-		if (take(a, 'session', (v) => (out.session = v.trim() || null), idx)) continue
-		if (take(a, 'model', (v) => (out.model = v.trim() || null), idx)) continue
-		if (take(a, 'provider', (v) => (out.provider = v.trim() || null), idx)) continue
-		if (take(a, 'instance', (v) => (out.instance = v.trim() || null), idx)) continue
+		if (
+			take(
+				a,
+				'session',
+				(v) => {
+					out.session = v.trim() || null
+				},
+				idx,
+			)
+		)
+			continue
+		if (
+			take(
+				a,
+				'model',
+				(v) => {
+					out.model = v.trim() || null
+				},
+				idx,
+			)
+		)
+			continue
+		if (
+			take(
+				a,
+				'provider',
+				(v) => {
+					out.provider = v.trim() || null
+				},
+				idx,
+			)
+		)
+			continue
+		if (
+			take(
+				a,
+				'instance',
+				(v) => {
+					out.instance = v.trim() || null
+				},
+				idx,
+			)
+		)
+			continue
 		if (
 			take(
 				a,

--- a/packages/providers/anthropic/src/client.ts
+++ b/packages/providers/anthropic/src/client.ts
@@ -461,17 +461,25 @@ export class AnthropicProvider implements LLMProvider {
 	 * Casting via `unknown` keeps us out of `any` territory while acknowledging
 	 * that the translation layer bridges two type worlds.
 	 */
-	private createRaw(body: Record<string, unknown>): Promise<unknown> {
+	private createRaw(
+		body: Record<string, unknown>,
+		opts?: { signal?: AbortSignal },
+	): Promise<unknown> {
 		const create = this.client.messages.create as unknown as (
 			body: Record<string, unknown>,
+			options?: { signal?: AbortSignal },
 		) => Promise<unknown>
-		return create.call(this.client.messages, body)
+		// Pass the caller AbortSignal as the SDK's per-request RequestOptions so
+		// aborting it tears down the in-flight HTTP/2 SSE request (rejects with
+		// APIUserAbortError). A non-aborted signal is identical to omitting it.
+		return create.call(this.client.messages, body, { signal: opts?.signal })
 	}
 
 	async *chatStream(params: ChatCompletionParams): AsyncIterable<StreamChunk> {
 		const createParams = this.buildCreateParams(params, true)
+		const signal = params.signal
 
-		const stream = (await this.createRaw(createParams)) as AsyncIterable<StreamEvent>
+		const stream = (await this.createRaw(createParams, { signal })) as AsyncIterable<StreamEvent>
 
 		let messageId = ''
 		// Track active tool-use blocks by content_block index so input_json_delta
@@ -513,6 +521,9 @@ export class AnthropicProvider implements LLMProvider {
 
 		try {
 			for (;;) {
+				// Cheap between-chunk abort check: if a Stop fired, stop pulling
+				// (the runtime also races this, and the SDK request is aborted).
+				signal?.throwIfAborted()
 				const result = await nextWithIdleTimeout()
 				if (result.done) break
 				const event = result.value

--- a/packages/providers/bedrock/src/client.ts
+++ b/packages/providers/bedrock/src/client.ts
@@ -267,6 +267,8 @@ export class BedrockProvider implements LLMProvider {
 
 		const response = await this.client.send(command, {
 			requestTimeout: this.config.timeout ?? 120_000,
+			// Per-request abort: a Stop tears the in-flight Converse stream down.
+			abortSignal: params.signal,
 		})
 
 		if (!response.stream) {
@@ -279,6 +281,9 @@ export class BedrockProvider implements LLMProvider {
 		let toolCallIndex = 0
 
 		for await (const event of response.stream as AsyncIterable<ConverseStreamOutput>) {
+			// Stop pulling promptly on abort; `for await` calls the stream's
+			// `.return()` on this throw, releasing the connection.
+			params.signal?.throwIfAborted()
 			try {
 				if ('contentBlockDelta' in event && event.contentBlockDelta?.delta) {
 					const delta = event.contentBlockDelta.delta

--- a/packages/providers/http/src/client.ts
+++ b/packages/providers/http/src/client.ts
@@ -318,8 +318,11 @@ export class HttpProvider implements LLMProvider {
 			: joinUrl(this.config.baseURL, '/chat/completions')
 	}
 
-	private timeoutSignal(): AbortSignal {
-		return AbortSignal.timeout(this.config.timeout ?? DEFAULT_TIMEOUT_MS)
+	private timeoutSignal(extra?: AbortSignal): AbortSignal {
+		const timeout = AbortSignal.timeout(this.config.timeout ?? DEFAULT_TIMEOUT_MS)
+		// Compose the caller abort with the request timeout so a Stop cancels the
+		// fetch. No caller signal ⇒ the exact prior timeout-only expression.
+		return extra ? AbortSignal.any([timeout, extra]) : timeout
 	}
 
 	async *chatStream(params: ChatCompletionParams): AsyncIterable<StreamChunk> {
@@ -333,7 +336,7 @@ export class HttpProvider implements LLMProvider {
 			method: 'POST',
 			headers: this.getHeaders(),
 			body: JSON.stringify(body),
-			signal: this.timeoutSignal(),
+			signal: this.timeoutSignal(params.signal),
 		})
 
 		if (!response.ok) {
@@ -346,9 +349,9 @@ export class HttpProvider implements LLMProvider {
 		}
 
 		if (this.dialect === 'anthropic') {
-			yield* this.streamAnthropic(response.body, url, response.status)
+			yield* this.streamAnthropic(response.body, url, response.status, params.signal)
 		} else {
-			yield* this.streamOpenAI(response.body, url, response.status)
+			yield* this.streamOpenAI(response.body, url, response.status, params.signal)
 		}
 	}
 
@@ -356,6 +359,7 @@ export class HttpProvider implements LLMProvider {
 		body: ReadableStream<Uint8Array>,
 		url: string,
 		status: number,
+		signal?: AbortSignal,
 	): AsyncIterable<StreamChunk> {
 		const reader = body.getReader()
 		const decoder = new TextDecoder()
@@ -364,6 +368,7 @@ export class HttpProvider implements LLMProvider {
 
 		try {
 			while (true) {
+				signal?.throwIfAborted()
 				const { done, value } = await reader.read()
 				if (done) break
 
@@ -446,6 +451,7 @@ export class HttpProvider implements LLMProvider {
 		body: ReadableStream<Uint8Array>,
 		url: string,
 		status: number,
+		signal?: AbortSignal,
 	): AsyncIterable<StreamChunk> {
 		const reader = body.getReader()
 		const decoder = new TextDecoder()
@@ -458,6 +464,7 @@ export class HttpProvider implements LLMProvider {
 
 		try {
 			while (true) {
+				signal?.throwIfAborted()
 				const { done, value } = await reader.read()
 				if (done) break
 

--- a/packages/providers/lmstudio/src/client.ts
+++ b/packages/providers/lmstudio/src/client.ts
@@ -95,10 +95,19 @@ export class LMStudioProvider implements LLMProvider {
 	async *chatStream(params: ChatCompletionParams): AsyncIterable<StreamChunk> {
 		const modelId = this.resolveModel(params)
 		const model = await this.client.llm.model(modelId)
-		const prediction = model.respond(toLMStudioChat(params.messages))
+		// Pass the caller abort so the SDK sends the real server-side cancel
+		// (LLMPredictionOpts.signal → websocket cancel). `.return()` from the
+		// for-await alone does NOT cancel the prediction, so without this a Stop
+		// leaves the local model generating. No-op when the signal never aborts.
+		const prediction = model.respond(toLMStudioChat(params.messages), {
+			signal: params.signal,
+		})
 
 		const id = randomUUID()
 		for await (const fragment of prediction) {
+			// Cheap promptness check between fragments (the signal above is the
+			// real teardown).
+			params.signal?.throwIfAborted()
 			if (fragment.content) {
 				yield {
 					id,

--- a/packages/providers/ollama/src/client.ts
+++ b/packages/providers/ollama/src/client.ts
@@ -84,26 +84,42 @@ export class OllamaProvider implements LLMProvider {
 			...(Object.keys(options).length > 0 ? { options } : {}),
 		})
 
+		// Wire the caller abort to the iterator's real teardown: `stream.abort()`
+		// calls the underlying AbortController so the fetch is cancelled and the
+		// ollama server stops generating. A bare for-await `.return()` does NOT
+		// release the connection (the SDK's reader loop has no teardown), so
+		// without this a Stop leaves the model generating. No-op / byte-identical
+		// when the signal never aborts.
+		const signal = params.signal
+		const onAbort = () => stream.abort()
+		if (signal?.aborted) stream.abort()
+		else signal?.addEventListener('abort', onAbort, { once: true })
+
 		const id = randomUUID()
 
-		for await (const chunk of stream) {
-			const content = chunk.message?.content
-			if (content && content.length > 0) {
-				yield {
-					id,
-					delta: { content },
+		try {
+			for await (const chunk of stream) {
+				signal?.throwIfAborted()
+				const content = chunk.message?.content
+				if (content && content.length > 0) {
+					yield {
+						id,
+						delta: { content },
+					}
 				}
-			}
 
-			if (chunk.done === true) {
-				const usage = buildUsage(chunk)
-				yield {
-					id,
-					delta: {},
-					finishReason: 'stop',
-					usage,
+				if (chunk.done === true) {
+					const usage = buildUsage(chunk)
+					yield {
+						id,
+						delta: {},
+						finishReason: 'stop',
+						usage,
+					}
 				}
 			}
+		} finally {
+			signal?.removeEventListener('abort', onAbort)
 		}
 	}
 

--- a/packages/providers/openai/src/client.ts
+++ b/packages/providers/openai/src/client.ts
@@ -156,24 +156,31 @@ export class OpenAIProvider implements LLMProvider {
 	async *chatStream(params: ChatCompletionParams): AsyncIterable<StreamChunk> {
 		const model = this.resolveModel(params)
 
-		const stream = await this.client.chat.completions.create({
-			model,
-			messages: toOpenAIMessages(params.messages),
-			stream: true,
-			stream_options: { include_usage: true },
-			tools: toOpenAITools(params),
-			tool_choice: formatToolChoice(params.toolChoice),
-			parallel_tool_calls: params.parallelToolCalls,
-			temperature: params.temperature,
-			max_tokens: params.maxTokens,
-			top_p: params.topP,
-			frequency_penalty: params.frequencyPenalty,
-			presence_penalty: params.presencePenalty,
-			stop: params.stop,
-			response_format: params.responseFormat,
-		})
+		const stream = await this.client.chat.completions.create(
+			{
+				model,
+				messages: toOpenAIMessages(params.messages),
+				stream: true,
+				stream_options: { include_usage: true },
+				tools: toOpenAITools(params),
+				tool_choice: formatToolChoice(params.toolChoice),
+				parallel_tool_calls: params.parallelToolCalls,
+				temperature: params.temperature,
+				max_tokens: params.maxTokens,
+				top_p: params.topP,
+				frequency_penalty: params.frequencyPenalty,
+				presence_penalty: params.presencePenalty,
+				stop: params.stop,
+				response_format: params.responseFormat,
+			},
+			// Per-request abort: a Stop tears the in-flight SSE request down.
+			{ signal: params.signal },
+		)
 
 		for await (const chunk of stream) {
+			// Stop pulling promptly on abort; `for await` calls the stream's
+			// `.return()` on this throw, releasing the connection.
+			params.signal?.throwIfAborted()
 			try {
 				const choice = chunk.choices[0]
 				const delta = choice?.delta

--- a/packages/providers/openrouter/src/client.ts
+++ b/packages/providers/openrouter/src/client.ts
@@ -139,11 +139,17 @@ export class OpenRouterProvider implements LLMProvider {
 	async *chatStream(params: ChatCompletionParams): AsyncIterable<StreamChunk> {
 		const body = this.buildRequestBody(params, true)
 
+		const timeout = AbortSignal.timeout(this.config.timeout ?? 120_000)
+		// Compose the caller abort with the request timeout so a Stop cancels the
+		// response body stream. When no caller signal is present this is the exact
+		// prior `AbortSignal.timeout(...)` expression (byte-identical).
+		const signal = params.signal ? AbortSignal.any([timeout, params.signal]) : timeout
+
 		const response = await fetch(`${this.baseUrl}/chat/completions`, {
 			method: 'POST',
 			headers: this.getHeaders(),
 			body: JSON.stringify(body),
-			signal: AbortSignal.timeout(this.config.timeout ?? 120_000),
+			signal,
 		})
 
 		if (!response.ok) {
@@ -161,6 +167,7 @@ export class OpenRouterProvider implements LLMProvider {
 
 		try {
 			while (true) {
+				params.signal?.throwIfAborted()
 				const { done, value } = await reader.read()
 				if (done) break
 

--- a/packages/sdk/src/connector/builtins/webhook.test.ts
+++ b/packages/sdk/src/connector/builtins/webhook.test.ts
@@ -126,6 +126,27 @@ describe('WebhookConnector', () => {
 		expect((await c.execute('send', { payload: {} })).success).toBe(false)
 	})
 
+	it('healthCheck returns false when the HEAD fetch throws', async () => {
+		const c = new WebhookConnector()
+		await c.connect({ url: 'https://hook.example.com' })
+		fetchMock.mockRejectedValueOnce(new Error('network down'))
+		expect(await c.healthCheck()).toBe(false)
+	})
+
+	it('reads a text body when the response is not JSON', async () => {
+		const c = new WebhookConnector()
+		await c.connect({ url: 'https://hook.example.com' })
+		fetchMock.mockResolvedValueOnce(
+			makeResponse({
+				status: 200,
+				headers: { 'content-type': 'text/plain' },
+				body: 'plain-text-ack',
+			}),
+		)
+		const result = await c.execute('send', { payload: { k: 'v' } })
+		expect((result.output as { body: unknown }).body).toBe('plain-text-ack')
+	})
+
 	it('metadata.deliveredAt is a recent timestamp', async () => {
 		const before = Date.now()
 		const c = new WebhookConnector()

--- a/packages/sdk/src/provider/collect.ts
+++ b/packages/sdk/src/provider/collect.ts
@@ -1,3 +1,4 @@
+import { mergeTokenUsage } from '../types/common/index.js'
 import type { ChatCompletionResponse } from '../types/provider/chat.js'
 import type { StreamChunk } from '../types/provider/stream.js'
 
@@ -60,7 +61,9 @@ export async function collect(stream: AsyncIterable<StreamChunk>): Promise<ChatC
 		}
 
 		if (chunk.finishReason) finishReason = chunk.finishReason
-		if (chunk.usage) usage = chunk.usage
+		// Merge (per-field max), not last-write-wins: a late frame that omits
+		// input/cache tokens must not zero the counts captured earlier in the stream.
+		if (chunk.usage) usage = mergeTokenUsage(usage, chunk.usage)
 	}
 
 	const toolCalls = [...toolBuckets.entries()]

--- a/packages/sdk/src/registry/toolset/catalog.test.ts
+++ b/packages/sdk/src/registry/toolset/catalog.test.ts
@@ -81,6 +81,74 @@ describe('ToolCatalog', () => {
 		expect(catalog.toLLMTools().map((t) => t.function.name)).toEqual(['bash'])
 	})
 
+	it('scores and reports the matched facets: partial name, source text, toolset text', () => {
+		const catalog = new ToolCatalog()
+		catalog.registerSource({
+			id: 'host',
+			kind: 'host_tool',
+			name: 'GitHub',
+			description: 'repository automation',
+		})
+		catalog.registerToolset({
+			id: 'issues',
+			sourceId: 'host',
+			name: 'Issue toolset',
+			defaultPolicy: { enabled: true, loading: 'eager' },
+		})
+		catalog.registerTool({
+			name: 'create_issue',
+			description: 'open a ticket',
+			sourceId: 'host',
+			toolsetId: 'issues',
+			policy: { enabled: true, loading: 'eager' },
+		})
+
+		// 'issue' hits the tool NAME (create_issue, partial) AND the TOOLSET name.
+		const byIssue = catalog.searchTools('issue')
+		expect(byIssue).toHaveLength(1)
+		expect([...(byIssue[0]?.matched ?? [])].sort()).toEqual(['name', 'toolset'])
+
+		// 'github' hits only the SOURCE text.
+		const bySource = catalog.searchTools('github')
+		expect(bySource[0]?.matched).toEqual(['source'])
+
+		// An exact name match outscores a partial one.
+		const exact = catalog.searchTools('create_issue')
+		expect(exact[0]?.matched).toContain('name')
+		expect(exact[0]?.score ?? 0).toBeGreaterThan(byIssue[0]?.score ?? 0)
+	})
+
+	it('adds the preferred boost so a preferred tool outranks an equal match', () => {
+		const catalog = new ToolCatalog()
+		catalog.registerSource({ id: 'host', kind: 'host_tool', name: 'Host' })
+		catalog.registerToolset({
+			id: 'ts',
+			sourceId: 'host',
+			name: 'Tools',
+			defaultPolicy: { enabled: true, loading: 'eager' },
+		})
+		catalog.registerTool({
+			name: 'search_plain',
+			description: 'search things',
+			sourceId: 'host',
+			toolsetId: 'ts',
+			policy: { enabled: true, loading: 'eager' },
+		})
+		catalog.registerTool({
+			name: 'search_pref',
+			description: 'search things',
+			sourceId: 'host',
+			toolsetId: 'ts',
+			policy: { enabled: true, loading: 'eager', preferred: true },
+		})
+
+		const results = catalog.searchTools('search')
+		expect(results.map((r) => r.tool.name)).toEqual(['search_pref', 'search_plain'])
+		const pref = results.find((r) => r.tool.name === 'search_pref')?.score ?? 0
+		const plain = results.find((r) => r.tool.name === 'search_plain')?.score ?? 0
+		expect(pref - plain).toBe(1)
+	})
+
 	it('preserves registry availability as catalog loading policy', () => {
 		const registry = new ToolRegistry()
 		registry.register(makeTool('read_file'))

--- a/packages/sdk/src/runtime/query/__tests__/long-document-flow.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/long-document-flow.test.ts
@@ -1,16 +1,16 @@
 import { readFile, rm } from 'node:fs/promises'
+import { mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { mkdtemp } from 'node:fs/promises'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { ToolRegistry } from '../../../registry/tool/execute.js'
+import { EditTool, WriteFileTool } from '../../../tools/builtins/index.js'
 import type { SessionId, TenantId } from '../../../types/ids/index.js'
 import { createUserMessage } from '../../../types/message/index.js'
 import type { LLMProvider, StreamChunk } from '../../../types/provider/index.js'
 import type { RunEvent } from '../../../types/run/index.js'
 import type { ProjectId, ThreadId } from '../../../types/session/ids.js'
-import { EditTool, WriteFileTool } from '../../../tools/builtins/index.js'
 import { drainQuery } from '../index.js'
 
 const ZERO_USAGE = {
@@ -161,7 +161,10 @@ describe('query long-document tool flow', () => {
 
 		const final = await readFile(join(workingDirectory, 'outputs/long-document-flow.md'), 'utf-8')
 		const executingTools = events
-			.filter((event): event is Extract<RunEvent, { type: 'tool_executing' }> => event.type === 'tool_executing')
+			.filter(
+				(event): event is Extract<RunEvent, { type: 'tool_executing' }> =>
+					event.type === 'tool_executing',
+			)
 			.map((event) => event.toolName)
 
 		expect(run.status).toBe('completed')

--- a/packages/sdk/src/runtime/query/index.ts
+++ b/packages/sdk/src/runtime/query/index.ts
@@ -43,6 +43,8 @@ import { RunContextFactory } from './context.js'
 import { EventTranslator } from './events.js'
 import { GuardCoordinator } from './guard.js'
 import { IterationOrchestrator } from './iteration/index.js'
+import { isCompactionMessage } from './iteration/phases/compaction.js'
+import { isWorkingMemoryMessage } from './iteration/phases/working-memory.js'
 import { applyLifecycleHookResults } from './plugin-hooks.js'
 import { PromptBuilder } from './prompt.js'
 import type { PromptSegments } from './prompt.js'
@@ -427,7 +429,18 @@ export async function* query(params: QueryParams): AsyncGenerator<RunEvent, Run>
 
 				pushSystemMessages()
 				for (const msg of checkpoint.messages) {
-					if (msg.role === 'system') continue
+					if (msg.role === 'system') {
+						// Re-push the FRESH static/dynamic floor (done above) but PRESERVE
+						// the two system messages that carry irreplaceable run state: the
+						// `[COMPACTED CONTEXT]` summary is the only surviving record of the
+						// older history a compaction pass deleted, and the working-memory
+						// slot pins the produced-artifact ledger. Dropping every system
+						// message on restore silently lost both on resume.
+						if (isCompactionMessage(msg.content) || isWorkingMemoryMessage(msg.content)) {
+							ctx.runMgr.pushMessage(msg)
+						}
+						continue
+					}
 					ctx.runMgr.pushMessage(msg)
 				}
 			} else if (params.continuationMode) {

--- a/packages/sdk/src/runtime/query/iteration/index.ts
+++ b/packages/sdk/src/runtime/query/iteration/index.ts
@@ -10,6 +10,7 @@ import type { ActivityStore } from '../../../store/activity/memory.js'
 import { GENAI, NAMZU, agentIterationSpanName } from '../../../telemetry/attributes.js'
 import { getTracer } from '../../../telemetry/runtime-accessors.js'
 import type { WorkingMemoryProvider } from '../../../types/agent/working-memory.js'
+import { mergeTokenUsage } from '../../../types/common/index.js'
 import type { ResumeHandler } from '../../../types/hitl/index.js'
 import type { ToolUseId } from '../../../types/ids/index.js'
 import { createAssistantMessage, createUserMessage } from '../../../types/message/index.js'
@@ -322,7 +323,10 @@ async function* streamProviderTurn(
 			}
 
 			if (chunk.finishReason) finishReason = chunk.finishReason
-			if (chunk.usage) usage = chunk.usage
+			// Merge (per-field max), not last-write-wins: a late usage frame that
+			// omits input/cache tokens must not zero the counts seen earlier in the
+			// stream, which would under-report this turn's accumulated usage.
+			if (chunk.usage) usage = mergeTokenUsage(usage, chunk.usage)
 		}
 	} catch (err) {
 		// An abort tears the turn down: propagate it so the run loop settles the

--- a/packages/sdk/src/runtime/query/iteration/index.ts
+++ b/packages/sdk/src/runtime/query/iteration/index.ts
@@ -195,8 +195,35 @@ async function* streamProviderTurn(
 
 	const stream = provider.chatStream({ ...params, stream: true }) as AsyncIterable<StreamChunk>
 
+	// Drive the stream manually so each `.next()` can be RACED against the run
+	// abort: a Stop tears the in-flight model request down (the provider got
+	// `params.signal`), and we ALSO stop pulling within a tick even if a
+	// transport buffers or ignores the signal. The abort rejection propagates
+	// out of this generator so the run loop settles the turn as cancelled.
+	// `{ once: true }` keeps a multi-iteration run from leaking a listener/turn.
+	const it = stream[Symbol.asyncIterator]()
+	const signal = params.signal
+	let onAbort: (() => void) | undefined
+	const aborted: Promise<never> | undefined = signal
+		? new Promise<never>((_resolve, reject) => {
+				if (signal.aborted) {
+					reject(signal.reason)
+					return
+				}
+				onAbort = () => reject(signal.reason)
+				signal.addEventListener('abort', onAbort, { once: true })
+			})
+		: undefined
+
 	try {
-		for await (const chunk of stream) {
+		for (;;) {
+			const next = it.next()
+			// Neutralize the dangling loser so an eventual rejection of the
+			// un-awaited `next` is never an unhandled rejection.
+			if (aborted) next.catch(() => {})
+			const res = await (aborted ? Promise.race([next, aborted]) : next)
+			if (res.done) break
+			const chunk = res.value
 			if (chunk.error) {
 				streamError = chunk.error
 				break
@@ -298,7 +325,18 @@ async function* streamProviderTurn(
 			if (chunk.usage) usage = chunk.usage
 		}
 	} catch (err) {
+		// An abort tears the turn down: propagate it so the run loop settles the
+		// run as cancelled rather than recording a normal (errored) turn. Any
+		// other stream error is captured into the synthesized response as before.
+		if (signal?.aborted) throw err
 		streamError = err instanceof Error ? err.message : String(err)
+	} finally {
+		if (onAbort) signal?.removeEventListener('abort', onAbort)
+		// Release the underlying connection on every exit (natural end, error,
+		// or abort). `for await` did this implicitly on natural completion; the
+		// manual drive must do it explicitly. `.return()` on an already-finished
+		// provider generator is a no-op.
+		await it.return?.().catch(() => {})
 	}
 
 	// Flush any tool buckets the provider failed to close (no toolCallEnd
@@ -627,6 +665,10 @@ export class IterationOrchestrator {
 							temperature: runConfig.temperature,
 							maxTokens: runConfig.maxResponseTokens,
 							cacheControl: { type: 'auto' },
+							// Thread the run abort into the model call so a Stop tears the
+							// in-flight turn down (provider passes it to fetch; the consumer
+							// also races it). Inert when never aborted.
+							signal: this.ctx.abortController.signal,
 						},
 						this.ctx.emitEvent,
 						this.ctx.drainPending,
@@ -784,6 +826,16 @@ export class IterationOrchestrator {
 							hasToolCalls: false,
 						})
 						yield* this.ctx.drainPending()
+						// A Stop that lands AFTER the final turn streamed but before
+						// this break must settle the run as cancelled, not end_turn —
+						// otherwise the just-produced answer is recorded as a clean
+						// completion. Mirrors the between-iteration cancel at :511.
+						if (this.ctx.abortController.signal.aborted) {
+							runMgr.setStopReason('cancelled')
+							runMgr.markCancelled()
+							iterSpan.end()
+							break
+						}
 						runMgr.setStopReason('end_turn')
 						iterSpan.end()
 						break
@@ -974,6 +1026,9 @@ export class IterationOrchestrator {
 					temperature: this.ctx.runConfig.temperature,
 					maxTokens: this.ctx.runConfig.maxResponseTokens,
 					cacheControl: { type: 'auto' },
+					// Cancellable too: a Stop during the closing summary must not
+					// stream to completion.
+					signal: this.ctx.abortController.signal,
 				}),
 			)
 

--- a/packages/sdk/src/runtime/query/iteration/index.ts
+++ b/packages/sdk/src/runtime/query/iteration/index.ts
@@ -880,6 +880,20 @@ export class IterationOrchestrator {
 					yield* this.ctx.drainPending()
 					iterSpan.end()
 				} catch (err) {
+					// A Stop that aborted the in-flight turn surfaces here as a
+					// thrown abort (the provider stream was raced against the run
+					// signal). Settle it as a CANCELLATION — mirroring the
+					// between-iteration cancel at the top of the loop — rather than
+					// recording it as an SDK failure (error span + failed activity)
+					// and re-throwing. The run then returns cleanly with a
+					// 'cancelled' stop reason instead of propagating an error.
+					if (this.ctx.abortController.signal.aborted) {
+						runMgr.setStopReason('cancelled')
+						runMgr.markCancelled()
+						iterSpan.end()
+						break
+					}
+
 					if (iterationActivity) {
 						this.ctx.activityStore.fail(iterationActivity.id, toErrorMessage(err))
 					}

--- a/packages/sdk/src/runtime/query/iteration/phases/checkpoint.ts
+++ b/packages/sdk/src/runtime/query/iteration/phases/checkpoint.ts
@@ -1,6 +1,11 @@
 import type { RunEvent } from '../../../../types/run/index.js'
 import { CheckpointManager } from '../../checkpoint.js'
-import { type IterationContext, type PhaseSignal, handleHITLDecision } from './context.js'
+import {
+	type IterationContext,
+	type PhaseSignal,
+	awaitDecisionOrAbort,
+	handleHITLDecision,
+} from './context.js'
 
 export async function* runIterationCheckpoint(
 	ctx: IterationContext,
@@ -17,7 +22,7 @@ export async function* runIterationCheckpoint(
 	yield* ctx.drainPending()
 
 	const summary = CheckpointManager.buildSummary(ctx.runMgr, iterationNum)
-	const iterDecision = await ctx.resumeHandler({
+	const iterDecision = await awaitDecisionOrAbort(ctx, {
 		type: 'iteration_checkpoint',
 		runId: ctx.runMgr.id,
 		checkpointId: iterCheckpoint.id,

--- a/packages/sdk/src/runtime/query/iteration/phases/compaction.ts
+++ b/packages/sdk/src/runtime/query/iteration/phases/compaction.ts
@@ -1,3 +1,4 @@
+import { findSafeTrimIndex } from '../../../../compaction/dangling.js'
 import { serializeState } from '../../../../compaction/serializer.js'
 import { buildVerifiedSummary } from '../../../../compaction/verifier.js'
 import { CHARS_PER_TOKEN } from '../../../../constants/limits.js'
@@ -11,9 +12,11 @@ const COMPACTION_HEADER =
 /**
  * Identity check for a prior compaction summary in the leading floor. Used to
  * REPLACE one in place on the per-iteration (contextWindowTokens) path so at
- * most one `[COMPACTED CONTEXT]` block ever lives in the never-trimmed floor.
+ * most one `[COMPACTED CONTEXT]` block ever lives in the never-trimmed floor,
+ * and by the checkpoint-restore path to PRESERVE the summary across a resume
+ * (it is the only surviving record of the older history the run compacted away).
  */
-function isCompactionMessage(content: string | null | undefined): boolean {
+export function isCompactionMessage(content: string | null | undefined): boolean {
 	return typeof content === 'string' && content.startsWith(COMPACTION_HEADER)
 }
 
@@ -91,7 +94,18 @@ export async function runCompactionCheck(ctx: IterationContext): Promise<void> {
 	}
 	if (systemMessages.length === 0) return
 
-	const keepStart = messages.length - config.keepRecentMessages
+	// Tool-pair atomicity guard. A naive cut at `length - keepRecentMessages`
+	// can land BETWEEN an assistant-with-toolCalls (which would be dropped into
+	// `olderMessages`) and its `tool` results (kept in `recentMessages`),
+	// leaving orphaned `tool_result` blocks at the head of the recent window.
+	// The Anthropic provider then emits a `tool_result` with no matching
+	// `tool_use` and the API rejects the next turn with a 400 — so compaction,
+	// whose whole job is to keep a long run alive, instead kills it. Snap the
+	// boundary FORWARD to a safe point (existing `findSafeTrimIndex`, previously
+	// only wired to the unused ConversationManager strategy classes) so no pair
+	// is split. Any message this moves out of the recent window is already
+	// represented in the extracted WorkingState the summary is built from.
+	const keepStart = findSafeTrimIndex(messages, messages.length - config.keepRecentMessages)
 	const recentMessages = messages.slice(keepStart)
 	const olderMessages = messages.slice(systemMessages.length, keepStart)
 
@@ -100,10 +114,7 @@ export async function runCompactionCheck(ctx: IterationContext): Promise<void> {
 	// call when there is no older history to summarize). Scoped to the new
 	// contextWindowTokens path so any existing consumer (tokenBudget-only) keeps
 	// its exact prior behavior — byte-identical (ses_055 verify).
-	if (
-		config.contextWindowTokens != null &&
-		olderMessages.length < MIN_OLDER_MESSAGES_TO_COMPACT
-	) {
+	if (config.contextWindowTokens != null && olderMessages.length < MIN_OLDER_MESSAGES_TO_COMPACT) {
 		ctx.log.debug('Skipping compaction — too few older messages', {
 			runId: ctx.runMgr.id,
 			olderMessages: olderMessages.length,

--- a/packages/sdk/src/runtime/query/iteration/phases/context.ts
+++ b/packages/sdk/src/runtime/query/iteration/phases/context.ts
@@ -77,6 +77,57 @@ export interface IterationContext {
 
 export type PhaseSignal = 'continue' | 'stop'
 
+/**
+ * Await a HITL `resumeHandler` decision, but RACE it against the run's abort
+ * signal. A Stop that arrives while the run is parked on a tool-review or
+ * iteration checkpoint used to do nothing until the host eventually answered
+ * (the park await was not cancellable). Racing the signal lets a Stop resolve
+ * the park immediately as an `abort` decision, which `handleHITLDecision`
+ * turns into `setStopReason('cancelled') + markCancelled + stop`. Fails closed:
+ * a resume-handler rejection also resolves to `abort` rather than hanging.
+ */
+export async function awaitDecisionOrAbort(
+	ctx: IterationContext,
+	request: Parameters<ResumeHandler>[0],
+): Promise<HITLResumeDecision> {
+	const signal = ctx.abortController?.signal
+	// No abort signal wired (e.g. a minimal test harness) → behave exactly as a
+	// direct resumeHandler await, no race. In production RunContextFactory always
+	// provides the controller, so the race below is live.
+	if (!signal) return ctx.resumeHandler(request)
+	const abortDecision: HITLResumeDecision = {
+		action: 'abort',
+		reason: 'run aborted while parked for HITL',
+	}
+	if (signal.aborted) return abortDecision
+	return new Promise<HITLResumeDecision>((resolve) => {
+		let settled = false
+		const onAbort = (): void => {
+			if (settled) return
+			settled = true
+			resolve(abortDecision)
+		}
+		signal.addEventListener('abort', onAbort, { once: true })
+		Promise.resolve(ctx.resumeHandler(request)).then(
+			(decision) => {
+				if (settled) return
+				settled = true
+				signal.removeEventListener('abort', onAbort)
+				resolve(decision)
+			},
+			(err) => {
+				if (settled) return
+				settled = true
+				signal.removeEventListener('abort', onAbort)
+				resolve({
+					action: 'abort',
+					reason: err instanceof Error ? err.message : 'resume handler failed',
+				})
+			},
+		)
+	})
+}
+
 export async function* handleHITLDecision(
 	ctx: IterationContext,
 	decision: HITLResumeDecision,

--- a/packages/sdk/src/runtime/query/iteration/phases/hitl-abort-race.test.ts
+++ b/packages/sdk/src/runtime/query/iteration/phases/hitl-abort-race.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import type { HITLResumeDecision } from '../../../../types/hitl/index.js'
+import type { RunId } from '../../../../types/ids/index.js'
+import { type IterationContext, awaitDecisionOrAbort } from './context.js'
+
+/**
+ * C12: a Stop that arrives while the run is parked on a HITL decision must
+ * interrupt the park (resolve as `abort`) instead of hanging until the host
+ * eventually answers. `awaitDecisionOrAbort` races `resumeHandler` against
+ * `ctx.abortController.signal`.
+ */
+
+function ctxWith(opts: {
+	controller?: AbortController
+	resumeHandler: IterationContext['resumeHandler']
+}): IterationContext {
+	return {
+		abortController: opts.controller,
+		resumeHandler: opts.resumeHandler,
+		runMgr: { id: 'run_abort_test' as RunId },
+	} as unknown as IterationContext
+}
+
+const REVIEW_REQUEST = {
+	type: 'tool_review' as const,
+	runId: 'run_abort_test' as RunId,
+	checkpointId: 'cp_1' as `cp_${string}`,
+	toolCalls: [],
+}
+
+describe('awaitDecisionOrAbort (C12 — cancellable HITL park)', () => {
+	it('returns abort immediately when the signal is already aborted', async () => {
+		const controller = new AbortController()
+		controller.abort()
+		const ctx = ctxWith({
+			controller,
+			// A handler that never resolves — proving we did not wait on it.
+			resumeHandler: () => new Promise<HITLResumeDecision>(() => {}),
+		})
+		const decision = await awaitDecisionOrAbort(ctx, REVIEW_REQUEST)
+		expect(decision.action).toBe('abort')
+	})
+
+	it('resolves as abort when the signal fires DURING the park', async () => {
+		const controller = new AbortController()
+		const ctx = ctxWith({
+			controller,
+			resumeHandler: () => new Promise<HITLResumeDecision>(() => {}), // never answers
+		})
+		const pending = awaitDecisionOrAbort(ctx, REVIEW_REQUEST)
+		controller.abort()
+		const decision = await pending
+		expect(decision.action).toBe('abort')
+	})
+
+	it('returns the real decision when the handler answers before any abort', async () => {
+		const controller = new AbortController()
+		const ctx = ctxWith({
+			controller,
+			resumeHandler: async () => ({ action: 'approve_tools' }) as HITLResumeDecision,
+		})
+		const decision = await awaitDecisionOrAbort(ctx, REVIEW_REQUEST)
+		expect(decision.action).toBe('approve_tools')
+	})
+
+	it('degrades to a direct resumeHandler await when no controller is wired', async () => {
+		const ctx = ctxWith({
+			resumeHandler: async () => ({ action: 'reject_tools' }) as HITLResumeDecision,
+		})
+		const decision = await awaitDecisionOrAbort(ctx, REVIEW_REQUEST)
+		expect(decision.action).toBe('reject_tools')
+	})
+
+	it('fails closed to abort when the resume handler rejects', async () => {
+		const controller = new AbortController()
+		const ctx = ctxWith({
+			controller,
+			resumeHandler: async () => {
+				throw new Error('handler boom')
+			},
+		})
+		const decision = await awaitDecisionOrAbort(ctx, REVIEW_REQUEST)
+		expect(decision.action).toBe('abort')
+	})
+})

--- a/packages/sdk/src/runtime/query/iteration/phases/tool-review.ts
+++ b/packages/sdk/src/runtime/query/iteration/phases/tool-review.ts
@@ -2,7 +2,7 @@ import { createUserMessage } from '../../../../types/message/index.js'
 import type { ChatCompletionResponse } from '../../../../types/provider/index.js'
 import type { RunEvent } from '../../../../types/run/index.js'
 import type { VerificationGate } from '../../../../verification/index.js'
-import type { IterationContext } from './context.js'
+import { type IterationContext, awaitDecisionOrAbort } from './context.js'
 
 interface VerificationAwareContext extends IterationContext {
 	readonly verificationGate?: VerificationGate
@@ -94,7 +94,7 @@ export async function* runToolReview(
 	})
 	yield* ctx.drainPending()
 
-	const reviewDecision = await ctx.resumeHandler({
+	const reviewDecision = await awaitDecisionOrAbort(ctx, {
 		type: 'tool_review',
 		runId: ctx.runMgr.id,
 		checkpointId: reviewCheckpoint.id,

--- a/packages/sdk/src/runtime/query/iteration/phases/working-memory-compaction.test.ts
+++ b/packages/sdk/src/runtime/query/iteration/phases/working-memory-compaction.test.ts
@@ -18,6 +18,7 @@
 
 import { describe, expect, it, vi } from 'vitest'
 
+import { findDanglingMessages } from '../../../../compaction/dangling.js'
 import { WorkingStateManager } from '../../../../compaction/manager.js'
 import { CompactionConfigSchema } from '../../../../config/runtime.js'
 import type { RunId } from '../../../../types/ids/index.js'
@@ -25,6 +26,7 @@ import {
 	type Message,
 	createAssistantMessage,
 	createSystemMessage,
+	createToolMessage,
 	createUserMessage,
 } from '../../../../types/message/index.js'
 import type { Logger } from '../../../../utils/logger.js'
@@ -170,5 +172,44 @@ describe('Layer-B compaction seam (ses_055 #104)', () => {
 		await refreshWorkingMemory(throwingCtx)
 		// Prior slot retained; run not broken.
 		expect(messages.some((m) => m.content?.startsWith(WORKING_MEMORY_HEADER))).toBe(true)
+	})
+
+	it('does NOT orphan a tool_result when the recent-window cut splits a tool pair (C1)', async () => {
+		// keepRecentMessages defaults to 4. Lay the transcript out so the NAIVE
+		// cut (length - 4 = index 5) lands right AFTER the assistant-with-toolCall
+		// (index 4) but BEFORE... no — exactly ON its tool result (index 5), which
+		// a naive slice would keep in the recent window while dropping the
+		// assistant into the summarized older set → an orphaned tool_result at the
+		// head of the recent window → Anthropic 400. The fix snaps keepStart
+		// forward past the complete pair.
+		const toolCall = {
+			id: 't1',
+			type: 'function' as const,
+			function: { name: 'read', arguments: '{}' },
+		}
+		const messages: Message[] = [
+			createSystemMessage(`STATIC SYSTEM PROMPT ${FILLER}`, 'cache'),
+			createUserMessage(`user 0 ${FILLER}`),
+			createAssistantMessage(`assistant 0 ${FILLER}`),
+			createUserMessage(`user 1 ${FILLER}`),
+			createAssistantMessage(`calling a tool ${FILLER}`, [toolCall]), // idx 4
+			createToolMessage(`tool result ${FILLER}`, 't1'), // idx 5 — naive recent[0]
+			createAssistantMessage(`assistant 2 ${FILLER}`),
+			createUserMessage(`user 3 ${FILLER}`),
+			createAssistantMessage(`assistant 3 ${FILLER}`),
+		]
+		const ctx = makeCtx({ messages, contextWindowTokens: 100 })
+
+		await runCompactionCheck(ctx)
+
+		// Compaction fired.
+		expect(messages.some((m) => m.content?.includes('[COMPACTED CONTEXT]'))).toBe(true)
+		// The surviving transcript has NO dangling tool pair — the tool result
+		// whose assistant was summarized away was moved into the older set too,
+		// so no orphaned tool_result remains to 400 the next provider turn.
+		expect(findDanglingMessages(messages).isValid).toBe(true)
+		// And a `tool` message never leads the recent window.
+		const firstNonSystem = messages.find((m) => m.role !== 'system')
+		expect(firstNonSystem?.role).not.toBe('tool')
 	})
 })

--- a/packages/sdk/src/session/workspace/__tests__/shared-run.test.ts
+++ b/packages/sdk/src/session/workspace/__tests__/shared-run.test.ts
@@ -148,7 +148,7 @@ describe('SharedRunWorkspace', () => {
 			runtimeRoot: '/mnt/user-data/outputs/_work',
 		})
 
-		const big = '# Task Context\n\n' + 'A'.repeat(40_000)
+		const big = `# Task Context\n\n${'A'.repeat(40_000)}`
 		const path = await workspace.writeTaskContext(big)
 		expect(path).toBe('/mnt/user-data/outputs/_work/01_task_context.md')
 		expect(workspace.refs().taskContextPath).toBe(path)

--- a/packages/sdk/src/streaming/coalesce.test.ts
+++ b/packages/sdk/src/streaming/coalesce.test.ts
@@ -117,14 +117,14 @@ describe('coalesce()', () => {
 	})
 
 	it('emits new event after window expires', async () => {
-		const events: RunEvent[] = [
+		const events: [RunEvent, RunEvent] = [
 			{ type: 'text_delta', runId: RID, iteration: 0, messageId: MID, text: 'a' },
 			{ type: 'text_delta', runId: RID, iteration: 0, messageId: MID, text: 'b' },
 		]
 		const stream: AsyncIterable<RunEvent> = (async function* () {
-			yield events[0]!
+			yield events[0]
 			await new Promise((r) => setTimeout(r, 30))
-			yield events[1]!
+			yield events[1]
 		})()
 		const result = await drain(coalesce(stream, { windowMs: 16 }))
 		expect(result).toHaveLength(2)

--- a/packages/sdk/src/types/common/index.ts
+++ b/packages/sdk/src/types/common/index.ts
@@ -22,6 +22,25 @@ export function accumulateTokenUsage(current: TokenUsage, addition: TokenUsage):
 	}
 }
 
+/**
+ * Merge two usage snapshots seen WITHIN a single streamed turn. Provider usage
+ * frames over one stream are cumulative/monotonic (input set once early, output
+ * grows), but a late frame can OMIT a field (report 0) — e.g. Anthropic's
+ * `message_delta` may carry only output tokens. A naive last-write-wins
+ * (`usage = chunk.usage`) then drops the earlier prompt/cache counts and
+ * under-reports the turn. Taking the per-field high-water mark preserves every
+ * field. DISTINCT from {@link accumulateTokenUsage}, which SUMS across turns.
+ */
+export function mergeTokenUsage(current: TokenUsage, next: TokenUsage): TokenUsage {
+	return {
+		promptTokens: Math.max(current.promptTokens, next.promptTokens),
+		completionTokens: Math.max(current.completionTokens, next.completionTokens),
+		totalTokens: Math.max(current.totalTokens, next.totalTokens),
+		cachedTokens: Math.max(current.cachedTokens, next.cachedTokens),
+		cacheWriteTokens: Math.max(current.cacheWriteTokens, next.cacheWriteTokens),
+	}
+}
+
 export interface CostInfo {
 	inputCostPer1M: number
 	outputCostPer1M: number

--- a/packages/sdk/src/types/common/usage-merge.test.ts
+++ b/packages/sdk/src/types/common/usage-merge.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { type TokenUsage, accumulateTokenUsage, mergeTokenUsage } from './index.js'
+
+const zero: TokenUsage = {
+	promptTokens: 0,
+	completionTokens: 0,
+	totalTokens: 0,
+	cachedTokens: 0,
+	cacheWriteTokens: 0,
+}
+
+/**
+ * M7: within one streamed turn, usage frames are cumulative/monotonic but a
+ * late frame may omit fields. `mergeTokenUsage` keeps the per-field high-water
+ * mark so a trailing output-only frame does not zero the earlier prompt/cache
+ * counts (the under-report the audit flagged).
+ */
+describe('mergeTokenUsage (within-turn, per-field max)', () => {
+	it('preserves prompt/cache tokens when a later frame reports only output', () => {
+		// message_start-like frame: input + cache set, output still 0.
+		const early: TokenUsage = {
+			...zero,
+			promptTokens: 1200,
+			cachedTokens: 800,
+			cacheWriteTokens: 200,
+		}
+		// message_delta-like frame: only output tokens, input/cache dropped to 0.
+		const lateOutputOnly: TokenUsage = { ...zero, completionTokens: 350 }
+
+		const merged = mergeTokenUsage(early, lateOutputOnly)
+		expect(merged.promptTokens).toBe(1200) // NOT zeroed by the late frame
+		expect(merged.cachedTokens).toBe(800)
+		expect(merged.cacheWriteTokens).toBe(200)
+		expect(merged.completionTokens).toBe(350)
+	})
+
+	it('takes the growing (max) completion count across frames', () => {
+		const a: TokenUsage = { ...zero, promptTokens: 100, completionTokens: 10 }
+		const b: TokenUsage = { ...zero, promptTokens: 100, completionTokens: 42 }
+		expect(mergeTokenUsage(a, b).completionTokens).toBe(42)
+		// Order-independent (a late smaller frame never regresses the max).
+		expect(mergeTokenUsage(b, a).completionTokens).toBe(42)
+	})
+
+	it('is distinct from accumulateTokenUsage (which sums across turns)', () => {
+		const t1: TokenUsage = { ...zero, promptTokens: 100, completionTokens: 20 }
+		const t2: TokenUsage = { ...zero, promptTokens: 100, completionTokens: 30 }
+		// merge = max within a turn; accumulate = sum across turns.
+		expect(mergeTokenUsage(t1, t2).promptTokens).toBe(100)
+		expect(accumulateTokenUsage(t1, t2).promptTokens).toBe(200)
+	})
+})

--- a/packages/sdk/src/types/provider/chat.ts
+++ b/packages/sdk/src/types/provider/chat.ts
@@ -28,6 +28,16 @@ export interface ChatCompletionParams {
 	stream?: boolean
 	stop?: string[]
 
+	/**
+	 * Per-call cancellation. Aborting it tears down the in-flight model
+	 * request (the provider passes it to the underlying fetch / SDK) AND the
+	 * runtime races the stream consumer against it, so a Stop stops the
+	 * CURRENT turn mid-flight — not only between turns. Optional and inert
+	 * when unset: a non-aborted signal is behaviourally identical to omitting
+	 * it, so existing callers are unaffected.
+	 */
+	signal?: AbortSignal
+
 	toolChoice?: ToolChoice
 	parallelToolCalls?: boolean
 


### PR DESCRIPTION
Context-management correctness fixes surfaced by the Vandal round-3 architecture audit. All internal; the provider/message wire contract is unchanged and existing consumers stay behaviourally identical outside the buggy edge cases. Changeset included (`@namzu/sdk: patch`).

- **Compaction tool-pair atomicity** — `runCompactionCheck` now snaps the recent-window boundary through `findSafeTrimIndex` (previously wired only to the unused `ConversationManager` strategy classes), so a cut can never orphan a `tool_result` whose `tool_use` was summarized away. That orphan otherwise makes the Anthropic provider 400 the next turn — compaction killing the long run it exists to preserve.
- **Checkpoint restore** — preserves the `[COMPACTED CONTEXT]` summary + working-memory slot instead of dropping every system message on `resumeFromCheckpoint` (resume silently lost the only record of the compacted-away older history).
- **Within-turn usage merge** — `mergeTokenUsage` (per-field high-water mark) replaces last-write-wins in `collect()` and the iteration reducer, so a late output-only frame no longer zeroes earlier prompt/cache counts.
- **Cancellable HITL parks** — `awaitDecisionOrAbort` races the tool-review + iteration-checkpoint `resumeHandler` parks against the run abort signal; a Stop while parked resolves as `abort` instead of hanging. Degrades to a plain await with no controller; fails closed on handler rejection.

Tests: SDK suite green (1079), +8 new (compaction atomicity, HITL abort-race, usage-merge).