### PR TITLE
ci(release): open the Version Packages PR via a scoped PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,12 @@ jobs:
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
           createGithubReleases: true
+          # Scoped PAT (Contents + Pull requests: write, this repo only) so the
+          # action can OPEN the "Version Packages" PR. The org default GITHUB_TOKEN
+          # is read-only AND org policy forbids Actions from creating PRs, so the
+          # default token can version/commit/push but NOT open the PR — that was
+          # the release-pipeline breakage. Falls back to GITHUB_TOKEN when unset.
+          github-token: ${{ secrets.CHANGESETS_TOKEN || secrets.GITHUB_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fixes the release pipeline's final failing step. After #43 unblocked lint/typecheck/build/test/publint, the changesets action still failed at PR creation:

```
GitHub Actions is not permitted to create or approve pull requests.
```

The cogitave org default `GITHUB_TOKEN` is read-only and org policy forbids Actions from creating PRs. Instead of relaxing that org-wide security posture, this passes a repo-scoped fine-grained PAT (`CHANGESETS_TOKEN`: Contents + Pull requests write, this repo only) as the changesets `github-token`, so only the release job can open the Version Packages PR. Falls back to `GITHUB_TOKEN` when unset. Requires the `CHANGESETS_TOKEN` + `NPM_TOKEN` repo secrets (both present).