### PR TITLE
ci(release): use the scoped PAT via GITHUB_TOKEN env for changesets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,10 @@ jobs:
           # the release-pipeline breakage. Falls back to GITHUB_TOKEN when unset.
           github-token: ${{ secrets.CHANGESETS_TOKEN || secrets.GITHUB_TOKEN }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # changesets/action@v1 builds the PR-creating octokit from the
+          # GITHUB_TOKEN ENV (the `github-token` input covers only part of the
+          # path), so the ENV must also be the scoped PAT — otherwise the default
+          # Actions token is used and org policy blocks PR creation.
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN || secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
Follow-up to #44. The `github-token` input alone did not fix PR creation — changesets/action@v1 uses the GITHUB_TOKEN **env** for the octokit that opens the Version Packages PR. This points that env at `CHANGESETS_TOKEN` (fallback to GITHUB_TOKEN), so the scoped PAT is used for both git push and PR creation. Org-wide default stays least-privilege.