### PR TITLE
feat(sdk): lazy provider registration via ProviderRegistry.registerLazy

### DIFF
--- a/.changeset/lazy-provider-registration.md
+++ b/.changeset/lazy-provider-registration.md
@@ -1,0 +1,11 @@
+---
+'@namzu/sdk': minor
+---
+
+Add lazy provider registration: `ProviderRegistry.registerLazy(type, loader, options?)` plus async construction via `ProviderRegistry.createAsync()` / `createProviderAsync()`.
+
+Hosts that must not bundle every provider client into every entrypoint can now register a dynamic-import loader instead of an eagerly imported class — no more hand-rolled construction switches outside the registry. Registration never invokes the loader; the first `createAsync()` awaits it, validates the resolved `{ create }` module, and caches the factory. Concurrent first-creates share a single in-flight load, and only success is cached: a rejected load surfaces as the new `LazyProviderLoadError` (original failure on `cause`) and the next create retries.
+
+Capabilities integrate with capability negotiation: an optional `options.capabilities` hint lets `getCapabilities(type)` answer before the provider is loaded (no hint ⇒ permissive default), the loaded module's declared capabilities replace the hint, and the constructed instance's own `LLMProvider.capabilities` remain what the query runtime negotiates against.
+
+Lazy types are deliberately not constructible through the sync `create()` / `createProvider()` — those throw the new `LazyProviderSyncCreateError` deterministically so sync behavior never depends on load timing. Existing eager `register()` / `create()` behavior is unchanged.

--- a/docs/sdk/provider-integration/registry.md
+++ b/docs/sdk/provider-integration/registry.md
@@ -1,7 +1,7 @@
 ---
 title: Provider Registry
 description: How provider packages register with ProviderRegistry, how to create providers safely, and how to hand them into agents.
-last_updated: 2026-04-18
+last_updated: 2026-07-02
 status: current
 related_packages: ["@namzu/sdk", "@namzu/openai", "@namzu/anthropic", "@namzu/bedrock", "@namzu/openrouter", "@namzu/http", "@namzu/ollama", "@namzu/lmstudio"]
 ---
@@ -87,8 +87,11 @@ That capability object is useful when your application wants to make decisions s
 | Method | Purpose |
 | --- | --- |
 | `register(type, ctor, capabilities, options?)` | Register a provider package manually |
-| `create(config)` | Create `{ provider, capabilities }` in one step |
-| `createProvider(config)` | Create only the provider instance |
+| `registerLazy(type, loader, options?)` | Register a loader without importing the provider implementation |
+| `create(config)` | Create `{ provider, capabilities }` in one step (eager registrations only) |
+| `createAsync(config)` | Async twin of `create()`; works for eager and lazy registrations |
+| `createProvider(config)` | Create only the provider instance (eager registrations only) |
+| `createProviderAsync(config)` | Async twin of `createProvider()`; loads lazy types on first use |
 | `getCapabilities(type)` | Read declared capabilities for a provider type |
 | `isSupported(type)` | Check if a provider type has been registered |
 | `listTypes()` | List currently registered provider types |
@@ -96,7 +99,42 @@ That capability object is useful when your application wants to make decisions s
 
 Most applications only need `register...()` plus `ProviderRegistry.create(...)`.
 
-## 6. Direct Provider Calls vs Agent Runtime
+## 6. Lazy Registration (`registerLazy`)
+
+`register...()` helpers import the provider client eagerly, so an app that registers all seven published providers bundles all seven client SDKs into every entrypoint. Hosts that must avoid that (server routes, edge bundles, serverless cold starts) register a **loader** instead:
+
+```ts
+import { ProviderRegistry } from '@namzu/sdk'
+
+ProviderRegistry.registerLazy(
+  'anthropic',
+  async () => {
+    const m = await import('@namzu/anthropic')
+    return { create: (config) => new m.AnthropicProvider(config), capabilities: m.ANTHROPIC_CAPABILITIES }
+  },
+  { capabilities: { supportsTools: true, supportsStreaming: true, supportsFunctionCalling: true } },
+)
+
+const { provider, capabilities } = await ProviderRegistry.createAsync({
+  type: 'anthropic',
+  apiKey: process.env.ANTHROPIC_API_KEY!,
+})
+```
+
+Semantics:
+
+- registration never invokes the loader; the first `createAsync()` for the type awaits it, validates the resolved `{ create }` module, and caches the factory
+- subsequent creates reuse the cache; concurrent first-creates share a single in-flight load
+- only success is cached — a rejected load surfaces as `LazyProviderLoadError` (with the original failure as `cause`) and the next `createAsync()` retries the loader
+- lazy types are only constructible through `createAsync()` / `createProviderAsync()`; the sync `create()` / `createProvider()` throws `LazyProviderSyncCreateError` deterministically, even after the loader has resolved
+
+Capability precedence (weakest first):
+
+1. `options.capabilities` — a pre-load hint so `getCapabilities(type)` can answer without loading (no hint ⇒ the permissive default, matching how `resolveProviderCapabilities` treats an undeclared provider)
+2. the loaded module's `capabilities` — replaces the hint once loaded
+3. the constructed instance's own `LLMProvider.capabilities` — the query runtime negotiates against the instance, so if it differs from the registry's answer, the instance wins where it matters
+
+## 7. Direct Provider Calls vs Agent Runtime
 
 Direct provider calls are useful for:
 
@@ -154,7 +192,7 @@ const result = await agent.run(
 console.log(result.result)
 ```
 
-## 7. Registration Lifetime
+## 8. Registration Lifetime
 
 The recommended application pattern is:
 
@@ -163,16 +201,18 @@ The recommended application pattern is:
 
 Do not call `register...()` before every request. Registration is process-level catalog setup, not per-run work.
 
-## 8. Common Errors
+## 9. Common Errors
 
 | Error | Meaning | Fix |
 | --- | --- | --- |
 | `Unsupported provider type` | The provider package was never registered | Call `registerOpenAI()` or the matching helper before `create()` |
 | `Provider type "x" is already registered` | The same provider was registered twice | Register once, or pass `{ replace: true }` intentionally |
+| `Provider type "x" is registered lazily` | Sync `create()`/`createProvider()` was called for a `registerLazy()` type | Use `createAsync()` / `createProviderAsync()` |
+| `Failed to load lazy provider "x"` | The lazy loader rejected or resolved an invalid module | Inspect `cause`; fix the import mapping — the next `createAsync()` retries |
 | provider-specific missing credential error | Required config such as `apiKey` was not supplied | Fix the package config before creating the provider |
 | missing model error on `chat()` | Neither provider config nor `chat()` params supplied a model | Set a default model in config or pass `model` per call |
 
-## 9. Optional Provider Methods
+## 10. Optional Provider Methods
 
 The `LLMProvider` contract always requires:
 
@@ -192,7 +232,7 @@ That makes the registry useful beyond agent runtime. You can use the same provid
 
 Read [Provider Operations](./operations.md) if you want concrete direct-call patterns for those optional methods.
 
-## 10. Related Decisions
+## 11. Related Decisions
 
 Use the registry layer when:
 

--- a/packages/sdk/src/provider/__tests__/registry.test.ts
+++ b/packages/sdk/src/provider/__tests__/registry.test.ts
@@ -1,9 +1,16 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import type { LLMProvider, ProviderCapabilities } from '../../types/provider/index.js'
+import type {
+	LLMProvider,
+	LazyProviderModule,
+	ProviderCapabilities,
+} from '../../types/provider/index.js'
+import { PERMISSIVE_PROVIDER_CAPABILITIES, resolveProviderCapabilities } from '../capabilities.js'
 import { registerMock } from '../mock-register.js'
 import { MockLLMProvider } from '../mock.js'
 import {
 	DuplicateProviderError,
+	LazyProviderLoadError,
+	LazyProviderSyncCreateError,
 	ProviderRegistry,
 	UnknownProviderError,
 	__resetProviderRegistryInternal,
@@ -16,9 +23,15 @@ interface TestProviderConfig {
 	value?: string
 }
 
+interface LazyTestProviderConfig {
+	type: 'lazytest'
+	value?: string
+}
+
 declare module '../../types/provider/config.js' {
 	interface ProviderConfigRegistry {
 		test: TestProviderConfig
+		lazytest: LazyTestProviderConfig
 	}
 }
 
@@ -50,6 +63,41 @@ const TEST_CAPS: ProviderCapabilities = {
 	supportsTools: false,
 	supportsStreaming: true,
 	supportsFunctionCalling: false,
+}
+
+class LazyTestProvider implements LLMProvider {
+	readonly id = 'lazytest'
+	readonly name = 'Lazy Test'
+	constructor(
+		public readonly config: LazyTestProviderConfig,
+		readonly capabilities?: ProviderCapabilities,
+	) {}
+	async *chatStream() {
+		yield { id: 'x', delta: { content: 'ok' } }
+	}
+}
+
+const HINT_CAPS: ProviderCapabilities = {
+	supportsTools: false,
+	supportsStreaming: false,
+	supportsFunctionCalling: false,
+}
+
+const MODULE_CAPS: ProviderCapabilities = {
+	supportsTools: true,
+	supportsStreaming: true,
+	supportsFunctionCalling: true,
+	supportsVision: false,
+}
+
+function deferred<T>() {
+	let resolve!: (value: T) => void
+	let reject!: (reason?: unknown) => void
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res
+		reject = rej
+	})
+	return { promise, resolve, reject }
 }
 
 describe('ProviderRegistry', () => {
@@ -150,6 +198,223 @@ describe('ProviderRegistry', () => {
 			const err = new DuplicateProviderError('bar')
 			expect(err.providerType).toBe('bar')
 			expect(err.name).toBe('DuplicateProviderError')
+		})
+	})
+
+	describe('registerLazy', () => {
+		it('does not invoke the loader at registration time', () => {
+			let calls = 0
+			ProviderRegistry.registerLazy('lazytest', async () => {
+				calls++
+				return { create: (config) => new LazyTestProvider(config) }
+			})
+
+			expect(calls).toBe(0)
+			expect(ProviderRegistry.isSupported('lazytest')).toBe(true)
+			expect(ProviderRegistry.listTypes()).toContain('lazytest')
+		})
+
+		it('throws DuplicateProviderError over an existing eager registration', () => {
+			ProviderRegistry.register('test', TestProvider, TEST_CAPS)
+			expect(() =>
+				ProviderRegistry.registerLazy('test', async () => ({
+					create: (config) => new TestProvider(config),
+				})),
+			).toThrowError(DuplicateProviderError)
+		})
+
+		it('throws DuplicateProviderError over an existing lazy registration', () => {
+			const loader = async (): Promise<LazyProviderModule<LazyTestProviderConfig>> => ({
+				create: (config) => new LazyTestProvider(config),
+			})
+			ProviderRegistry.registerLazy('lazytest', loader)
+			expect(() => ProviderRegistry.registerLazy('lazytest', loader)).toThrowError(
+				DuplicateProviderError,
+			)
+		})
+
+		it('replace: true swaps between eager and lazy registrations', async () => {
+			ProviderRegistry.register('lazytest', LazyTestProvider, TEST_CAPS)
+			ProviderRegistry.registerLazy(
+				'lazytest',
+				async () => ({ create: (config) => new LazyTestProvider(config) }),
+				{ replace: true },
+			)
+			expect(() => ProviderRegistry.createProvider({ type: 'lazytest' })).toThrowError(
+				LazyProviderSyncCreateError,
+			)
+
+			ProviderRegistry.register('lazytest', LazyTestProvider, TEST_CAPS, { replace: true })
+			expect(ProviderRegistry.createProvider({ type: 'lazytest' })).toBeInstanceOf(LazyTestProvider)
+		})
+
+		it('sync create()/createProvider() always throws for lazy types, even after load', async () => {
+			ProviderRegistry.registerLazy('lazytest', async () => ({
+				create: (config) => new LazyTestProvider(config),
+			}))
+
+			expect(() => ProviderRegistry.create({ type: 'lazytest' })).toThrowError(
+				LazyProviderSyncCreateError,
+			)
+
+			await ProviderRegistry.createAsync({ type: 'lazytest' })
+			expect(() => ProviderRegistry.createProvider({ type: 'lazytest' })).toThrowError(
+				LazyProviderSyncCreateError,
+			)
+		})
+
+		it('unregister removes a lazy registration', () => {
+			ProviderRegistry.registerLazy('lazytest', async () => ({
+				create: (config) => new LazyTestProvider(config),
+			}))
+			expect(ProviderRegistry.unregister('lazytest')).toBe(true)
+			expect(ProviderRegistry.isSupported('lazytest')).toBe(false)
+		})
+	})
+
+	describe('createAsync', () => {
+		it('first create invokes the loader once; subsequent creates reuse the cached factory', async () => {
+			let calls = 0
+			ProviderRegistry.registerLazy('lazytest', async () => {
+				calls++
+				return { create: (config) => new LazyTestProvider(config) }
+			})
+
+			const first = await ProviderRegistry.createAsync({ type: 'lazytest', value: 'a' })
+			const second = await ProviderRegistry.createAsync({ type: 'lazytest', value: 'b' })
+
+			expect(calls).toBe(1)
+			expect(first.provider).toBeInstanceOf(LazyTestProvider)
+			expect(second.provider).toBeInstanceOf(LazyTestProvider)
+			expect((second.provider as LazyTestProvider).config.value).toBe('b')
+		})
+
+		it('concurrent first-creates share a single loader invocation', async () => {
+			let calls = 0
+			const gate = deferred<void>()
+			ProviderRegistry.registerLazy('lazytest', async () => {
+				calls++
+				await gate.promise
+				return { create: (config) => new LazyTestProvider(config) }
+			})
+
+			const a = ProviderRegistry.createAsync({ type: 'lazytest' })
+			const b = ProviderRegistry.createAsync({ type: 'lazytest' })
+			gate.resolve()
+
+			const [ra, rb] = await Promise.all([a, b])
+			expect(calls).toBe(1)
+			expect(ra.provider).toBeInstanceOf(LazyTestProvider)
+			expect(rb.provider).toBeInstanceOf(LazyTestProvider)
+		})
+
+		it('loader rejection surfaces as LazyProviderLoadError and the next create retries', async () => {
+			let calls = 0
+			ProviderRegistry.registerLazy('lazytest', async () => {
+				calls++
+				if (calls === 1) {
+					throw new Error('transient network failure')
+				}
+				return { create: (config) => new LazyTestProvider(config) }
+			})
+
+			const failure = await ProviderRegistry.createAsync({ type: 'lazytest' }).catch(
+				(err: unknown) => err,
+			)
+			expect(failure).toBeInstanceOf(LazyProviderLoadError)
+			expect((failure as LazyProviderLoadError).providerType).toBe('lazytest')
+			expect(((failure as LazyProviderLoadError).cause as Error).message).toBe(
+				'transient network failure',
+			)
+
+			const { provider } = await ProviderRegistry.createAsync({ type: 'lazytest' })
+			expect(calls).toBe(2)
+			expect(provider).toBeInstanceOf(LazyTestProvider)
+		})
+
+		it('rejects with LazyProviderLoadError when the loader resolves an invalid module shape', async () => {
+			ProviderRegistry.registerLazy(
+				'lazytest',
+				async () => ({}) as unknown as LazyProviderModule<LazyTestProviderConfig>,
+			)
+			await expect(ProviderRegistry.createAsync({ type: 'lazytest' })).rejects.toThrowError(
+				LazyProviderLoadError,
+			)
+		})
+
+		it('works for eagerly registered types too', async () => {
+			const { provider, capabilities } = await ProviderRegistry.createAsync({
+				type: 'mock',
+				model: 'test-model',
+			})
+			expect(provider).toBeInstanceOf(MockLLMProvider)
+			expect(capabilities.supportsStreaming).toBe(true)
+		})
+
+		it('rejects with UnknownProviderError for unregistered types', async () => {
+			await expect(
+				ProviderRegistry.createAsync({ type: 'nonexistent' } as unknown as { type: 'mock' }),
+			).rejects.toThrowError(UnknownProviderError)
+		})
+	})
+
+	describe('lazy capabilities', () => {
+		it('answers with the registration hint before load, without invoking the loader', () => {
+			let calls = 0
+			ProviderRegistry.registerLazy(
+				'lazytest',
+				async () => {
+					calls++
+					return { create: (config) => new LazyTestProvider(config) }
+				},
+				{ capabilities: HINT_CAPS },
+			)
+
+			expect(ProviderRegistry.getCapabilities('lazytest')).toEqual(HINT_CAPS)
+			expect(calls).toBe(0)
+		})
+
+		it('answers permissively before load when no hint was given', () => {
+			ProviderRegistry.registerLazy('lazytest', async () => ({
+				create: (config) => new LazyTestProvider(config),
+			}))
+			expect(ProviderRegistry.getCapabilities('lazytest')).toEqual(PERMISSIVE_PROVIDER_CAPABILITIES)
+		})
+
+		it('module capabilities replace the hint after load', async () => {
+			ProviderRegistry.registerLazy(
+				'lazytest',
+				async () => ({
+					create: (config) => new LazyTestProvider(config),
+					capabilities: MODULE_CAPS,
+				}),
+				{ capabilities: HINT_CAPS },
+			)
+
+			const { capabilities } = await ProviderRegistry.createAsync({ type: 'lazytest' })
+			expect(capabilities).toEqual(MODULE_CAPS)
+			expect(ProviderRegistry.getCapabilities('lazytest')).toEqual(MODULE_CAPS)
+		})
+
+		it('the constructed instance own capabilities win at run time over any hint', async () => {
+			const instanceCaps: ProviderCapabilities = {
+				supportsTools: true,
+				supportsStreaming: true,
+				supportsFunctionCalling: false,
+				supportsVision: false,
+			}
+			ProviderRegistry.registerLazy(
+				'lazytest',
+				async () => ({ create: (config) => new LazyTestProvider(config, instanceCaps) }),
+				{ capabilities: HINT_CAPS },
+			)
+
+			const { provider } = await ProviderRegistry.createAsync({ type: 'lazytest' })
+			// The query runtime negotiates against the instance, not the registry:
+			const resolved = resolveProviderCapabilities(provider)
+			expect(resolved.supportsTools).toBe(true)
+			expect(resolved.supportsFunctionCalling).toBe(false)
+			expect(resolved.supportsVision).toBe(false)
 		})
 	})
 })

--- a/packages/sdk/src/provider/index.ts
+++ b/packages/sdk/src/provider/index.ts
@@ -1,4 +1,10 @@
-export { ProviderRegistry, UnknownProviderError, DuplicateProviderError } from './registry.js'
+export {
+	ProviderRegistry,
+	UnknownProviderError,
+	DuplicateProviderError,
+	LazyProviderLoadError,
+	LazyProviderSyncCreateError,
+} from './registry.js'
 export { MockLLMProvider } from './mock.js'
 export { registerMock, MOCK_CAPABILITIES } from './mock-register.js'
 export {

--- a/packages/sdk/src/provider/registry.ts
+++ b/packages/sdk/src/provider/registry.ts
@@ -1,13 +1,17 @@
 import type {
 	LLMProvider,
 	LLMProviderConstructor,
+	LazyProviderLoader,
+	LazyProviderModule,
 	ProviderCapabilities,
 	ProviderConfigRegistry,
 	ProviderFactoryConfig,
 	ProviderFactoryResult,
 	ProviderType,
+	RegisterLazyOptions,
 	RegisterOptions,
 } from '../types/provider/index.js'
+import { PERMISSIVE_PROVIDER_CAPABILITIES } from './capabilities.js'
 
 export class UnknownProviderError extends Error {
 	readonly providerType: string
@@ -31,9 +35,99 @@ export class DuplicateProviderError extends Error {
 	}
 }
 
+/**
+ * The loader passed to `ProviderRegistry.registerLazy()` rejected (or
+ * resolved to something without a `create(config)` function). Wraps the
+ * original failure as `cause`. The failed load is NOT cached — the next
+ * `createAsync()` for the type re-invokes the loader, so a transient
+ * failure (network hiccup during a dynamic import) does not permanently
+ * poison the type.
+ */
+export class LazyProviderLoadError extends Error {
+	readonly providerType: string
+
+	constructor(providerType: string, cause: unknown) {
+		const detail = cause instanceof Error ? cause.message : String(cause)
+		super(`Failed to load lazy provider "${providerType}": ${detail}`, { cause })
+		this.name = 'LazyProviderLoadError'
+		this.providerType = providerType
+	}
+}
+
+/**
+ * A synchronous `create()`/`createProvider()` was called for a type
+ * registered via `registerLazy()`. Lazy types are only constructible
+ * through the async path — deterministically, even after the loader has
+ * resolved, so calling code never depends on load-order timing.
+ */
+export class LazyProviderSyncCreateError extends Error {
+	readonly providerType: string
+
+	constructor(providerType: string) {
+		super(
+			`Provider type "${providerType}" is registered lazily; synchronous create()/createProvider() cannot load it. Use ProviderRegistry.createAsync() or createProviderAsync().`,
+		)
+		this.name = 'LazyProviderSyncCreateError'
+		this.providerType = providerType
+	}
+}
+
+interface LazyProviderEntry {
+	loader: LazyProviderLoader<unknown>
+	/** In-flight load shared by concurrent first-creates (dedupe). */
+	loading?: Promise<LazyProviderModule<unknown>>
+	/** Cached module — set only on SUCCESS, so failures retry. */
+	module?: LazyProviderModule<unknown>
+}
+
 // Module-private state. Only the exported functions below can read/mutate.
 const providers = new Map<string, LLMProviderConstructor<unknown>>()
 const capabilities = new Map<string, ProviderCapabilities>()
+const lazyProviders = new Map<string, LazyProviderEntry>()
+
+async function loadLazyModule(
+	type: string,
+	entry: LazyProviderEntry,
+): Promise<LazyProviderModule<unknown>> {
+	if (entry.module) {
+		return entry.module
+	}
+	let inflight = entry.loading
+	if (!inflight) {
+		// Promise.resolve().then(...) also catches loaders that throw synchronously.
+		inflight = Promise.resolve()
+			.then(() => entry.loader())
+			.then((mod) => {
+				if (typeof mod?.create !== 'function') {
+					throw new TypeError(
+						'loader resolved to a value without a create(config) function — map your dynamic import to { create: (config) => new Provider(config) }',
+					)
+				}
+				return mod
+			})
+		entry.loading = inflight
+	}
+	try {
+		const mod = await inflight
+		entry.module = mod
+		if (entry.loading === inflight) {
+			entry.loading = undefined
+		}
+		// The loaded module's declaration is authoritative at the type level:
+		// it replaces any registration-time hint for future getCapabilities().
+		if (mod.capabilities) {
+			capabilities.set(type, mod.capabilities)
+		}
+		return mod
+	} catch (cause) {
+		// Clear only OUR in-flight promise; a retry started by another caller
+		// after an earlier failure must not be dropped.
+		if (entry.loading === inflight) {
+			entry.loading = undefined
+		}
+		throw new LazyProviderLoadError(type, cause)
+	}
+}
 
 /**
  * Central registry for LLM providers.
@@ -56,6 +150,23 @@ const capabilities = new Map<string, ProviderCapabilities>()
  *   region: 'us-east-1',
  * })
  * ```
+ *
+ * Hosts that must not eagerly bundle every provider client register a
+ * LOADER instead and construct through the async path:
+ *
+ * @example
+ * ```ts
+ * ProviderRegistry.registerLazy(
+ *   'anthropic',
+ *   async () => {
+ *     const m = await import('@namzu/anthropic')
+ *     return { create: (c) => new m.AnthropicProvider(c), capabilities: m.ANTHROPIC_CAPABILITIES }
+ *   },
+ *   { capabilities: { supportsTools: true, supportsStreaming: true, supportsFunctionCalling: true } },
+ * )
+ *
+ * const { provider } = await ProviderRegistry.createAsync({ type: 'anthropic', apiKey })
+ * ```
  */
 export class ProviderRegistry {
 	static register<K extends ProviderType>(
@@ -64,11 +175,52 @@ export class ProviderRegistry {
 		caps: ProviderCapabilities,
 		options?: RegisterOptions,
 	): void {
-		if (providers.has(type) && !options?.replace) {
+		if ((providers.has(type) || lazyProviders.has(type)) && !options?.replace) {
 			throw new DuplicateProviderError(type)
 		}
+		lazyProviders.delete(type)
 		providers.set(type, ctor as LLMProviderConstructor<unknown>)
 		capabilities.set(type, caps)
+	}
+
+	/**
+	 * Register a provider type WITHOUT importing its implementation. The
+	 * loader is not invoked here; the first `createAsync()` for the type
+	 * awaits it, validates the resolved `{ create }` module, and caches it.
+	 * Subsequent creates reuse the cached factory. Only SUCCESS is cached:
+	 * a rejected load surfaces as `LazyProviderLoadError` and the next
+	 * `createAsync()` retries the loader. Concurrent first-creates share a
+	 * single in-flight load.
+	 *
+	 * Capability precedence (weakest first):
+	 * 1. `options.capabilities` — pre-load HINT so `getCapabilities(type)`
+	 *    answers without loading (absent hint ⇒ permissive default, matching
+	 *    `resolveProviderCapabilities`'s treatment of undeclared providers).
+	 * 2. the loaded module's `capabilities` — replaces the hint on load.
+	 * 3. the constructed instance's own `LLMProvider.capabilities` — the
+	 *    query runtime negotiates against the INSTANCE
+	 *    (`resolveProviderCapabilities(provider)`), so if it differs from
+	 *    both of the above, the instance wins where it matters.
+	 *
+	 * Lazy types are deliberately NOT constructible via the sync
+	 * `create()`/`createProvider()` (throws `LazyProviderSyncCreateError`),
+	 * even after the loader has resolved — sync behavior must not depend on
+	 * whether some earlier call happened to load the module.
+	 */
+	static registerLazy<K extends ProviderType>(
+		type: K,
+		loader: LazyProviderLoader<ProviderConfigRegistry[K]>,
+		options?: RegisterLazyOptions,
+	): void {
+		if ((providers.has(type) || lazyProviders.has(type)) && !options?.replace) {
+			throw new DuplicateProviderError(type)
+		}
+		providers.delete(type)
+		capabilities.delete(type)
+		lazyProviders.set(type, { loader: loader as LazyProviderLoader<unknown> })
+		if (options?.capabilities) {
+			capabilities.set(type, options.capabilities)
+		}
 	}
 
 	static create(config: ProviderFactoryConfig): ProviderFactoryResult {
@@ -77,33 +229,75 @@ export class ProviderRegistry {
 		return { provider, capabilities: caps }
 	}
 
+	/**
+	 * Async twin of `create()`. Works for BOTH eager and lazy registrations,
+	 * so hosts can use one code path; for lazy types it performs the
+	 * load-on-first-use described on `registerLazy()`.
+	 */
+	static async createAsync(config: ProviderFactoryConfig): Promise<ProviderFactoryResult> {
+		const provider = await ProviderRegistry.createProviderAsync(config)
+		// Read capabilities AFTER construction so a lazily-loaded module's
+		// authoritative declaration (set during load) is what gets returned.
+		const caps = ProviderRegistry.getCapabilities(config.type)
+		return { provider, capabilities: caps }
+	}
+
 	static createProvider(config: ProviderFactoryConfig): LLMProvider {
 		const Ctor = providers.get(config.type)
 		if (!Ctor) {
+			if (lazyProviders.has(config.type)) {
+				throw new LazyProviderSyncCreateError(config.type)
+			}
 			throw new UnknownProviderError(config.type)
 		}
 		return new Ctor(config)
 	}
 
+	static async createProviderAsync(config: ProviderFactoryConfig): Promise<LLMProvider> {
+		const Ctor = providers.get(config.type)
+		if (Ctor) {
+			return new Ctor(config)
+		}
+		const entry = lazyProviders.get(config.type)
+		if (!entry) {
+			throw new UnknownProviderError(config.type)
+		}
+		const mod = await loadLazyModule(config.type, entry)
+		return mod.create(config)
+	}
+
+	/**
+	 * Type-level capabilities. For a lazily-registered type this answers
+	 * WITHOUT invoking the loader: the registration hint if one was given,
+	 * otherwise the permissive default (assume everything — consistent with
+	 * how `resolveProviderCapabilities` treats an undeclared provider). Once
+	 * loaded, a module-shipped declaration replaces the hint. Note the query
+	 * runtime negotiates against the constructed INSTANCE's own
+	 * `capabilities`, which wins over anything stored here.
+	 */
 	static getCapabilities(type: string): ProviderCapabilities {
 		const caps = capabilities.get(type)
-		if (!caps) {
-			throw new UnknownProviderError(type)
+		if (caps) {
+			return caps
 		}
-		return caps
+		if (lazyProviders.has(type)) {
+			return PERMISSIVE_PROVIDER_CAPABILITIES
+		}
+		throw new UnknownProviderError(type)
 	}
 
 	static isSupported(type: string): type is ProviderType {
-		return providers.has(type)
+		return providers.has(type) || lazyProviders.has(type)
 	}
 
 	static unregister(type: ProviderType): boolean {
 		capabilities.delete(type)
-		return providers.delete(type)
+		const hadLazy = lazyProviders.delete(type)
+		return providers.delete(type) || hadLazy
 	}
 
 	static listTypes(): ProviderType[] {
-		return Array.from(providers.keys()) as ProviderType[]
+		return Array.from(new Set([...providers.keys(), ...lazyProviders.keys()])) as ProviderType[]
 	}
 }
 
@@ -115,4 +309,5 @@ export class ProviderRegistry {
 export function __resetProviderRegistryInternal(): void {
 	providers.clear()
 	capabilities.clear()
+	lazyProviders.clear()
 }

--- a/packages/sdk/src/public-runtime.ts
+++ b/packages/sdk/src/public-runtime.ts
@@ -145,6 +145,8 @@ export { LocalTaskGateway } from './gateway/local.js'
 
 export {
 	DuplicateProviderError,
+	LazyProviderLoadError,
+	LazyProviderSyncCreateError,
 	MOCK_CAPABILITIES,
 	MockLLMProvider,
 	PERMISSIVE_PROVIDER_CAPABILITIES,

--- a/packages/sdk/src/types/provider/config.ts
+++ b/packages/sdk/src/types/provider/config.ts
@@ -70,4 +70,40 @@ export interface RegisterOptions {
 	replace?: boolean
 }
 
+/**
+ * What a lazy loader must resolve to: a factory that constructs the
+ * provider, plus (optionally) the provider package's authoritative
+ * capability declaration resolved at load time.
+ *
+ * Designed so a host can map a dynamic import in one line:
+ *
+ * ```ts
+ * ProviderRegistry.registerLazy('anthropic', async () => {
+ *   const m = await import('@namzu/anthropic')
+ *   return { create: (c) => new m.AnthropicProvider(c), capabilities: m.ANTHROPIC_CAPABILITIES }
+ * })
+ * ```
+ */
+export interface LazyProviderModule<C = unknown> {
+	create: (config: C) => LLMProvider
+	/**
+	 * Authoritative type-level capabilities shipped by the loaded module.
+	 * When present, replaces any registration-time hint in the registry.
+	 */
+	capabilities?: ProviderCapabilities
+}
+
+export type LazyProviderLoader<C = unknown> = () => Promise<LazyProviderModule<C>>
+
+export interface RegisterLazyOptions extends RegisterOptions {
+	/**
+	 * Pre-load capability HINT so `ProviderRegistry.getCapabilities(type)`
+	 * can answer without triggering the loader. Precedence (weakest first):
+	 * this hint → the loaded module's `capabilities` → the constructed
+	 * instance's own `LLMProvider.capabilities` (what the query runtime
+	 * resolves via `resolveProviderCapabilities` and actually respects).
+	 */
+	capabilities?: ProviderCapabilities
+}
+
 export type LLMProviderConstructor<C = unknown> = new (config: C) => LLMProvider

--- a/packages/sdk/src/types/provider/index.ts
+++ b/packages/sdk/src/types/provider/index.ts
@@ -16,5 +16,8 @@ export type {
 	ProviderCapabilities,
 	ProviderFactoryResult,
 	RegisterOptions,
+	LazyProviderModule,
+	LazyProviderLoader,
+	RegisterLazyOptions,
 	LLMProviderConstructor,
 } from './config.js'


### PR DESCRIPTION
Hosts that want lazy provider loading (avoid bundling 7 provider clients into every route) were forced to bypass the registry and hand-roll construction — Vandal does exactly that with a 413-line switch. This gives the registry a first-class lazy path.

- `registerLazy(type, loader, opts?)`: stores the loader WITHOUT invoking it; new `createAsync()/createProviderAsync()` work for both eager and lazy registrations (existing sync API untouched for eager types).
- First `createAsync` awaits the loader once; concurrent first-creates share one in-flight load; **only success is cached** — a transient loader failure retries on the next create.
- Deterministic sync semantics: sync `create()` for a lazy type ALWAYS throws `LazyProviderSyncCreateError` (never "works if something loaded it earlier").
- Capability precedence integrated with the negotiation seam: `opts.capabilities` is a pre-load HINT answering `getCapabilities(type)` without loading; the constructed instance's own capabilities win post-load; unloaded+no-hint returns the permissive default (consistent with `resolveProviderCapabilities`).
- Duplicate/replace/unregister/isSupported/listTypes unified across eager+lazy.
- 28 registry tests; full repo gate green (sdk 1114, cli 251, all providers/files/sandbox, build). Changeset: minor `@namzu/sdk`.

First consumer: Vandal's `lib/namzu/runtime/provider.ts` adoption (follow-up PR host-side).