### PR TITLE
fix(sdk): compaction stops deleting the turn it is compacting

### DIFF
--- a/.changeset/compaction-cannot-eat-the-live-turn.md
+++ b/.changeset/compaction-cannot-eat-the-live-turn.md
@@ -1,0 +1,41 @@
+---
+'@namzu/sdk': patch
+---
+
+Compaction can no longer delete the turn it is compacting.
+
+The recent-window boundary was snapped FORWARD to avoid splitting a tool pair,
+but that walk skips leading `tool` messages with no stop short of the end of the
+transcript. Whenever the whole suffix from the naive boundary is `tool` messages —
+one assistant turn fanning out at least `keepRecentMessages` parallel calls,
+measured at the start of the very next iteration, which is exactly where the
+compaction check runs — the boundary landed on `messages.length`, the recent
+window came back empty, and the rebuilt transcript held no non-system message at
+all. The model was then asked to answer a conversation whose last turn, including
+the user's own message, had been removed. The existing older-message floor guard
+cannot catch it: in that shape the older half is the whole transcript.
+
+The boundary is now the largest safe one AT OR BELOW naive, so a pass never
+removes more than the naive cut would and at least `keepRecentMessages` original
+messages always survive verbatim. When no safe boundary exists the pass is
+skipped and the transcript is left intact — one iteration of context headroom is
+cheaper than the live turn, and the condition clears itself as soon as the next
+assistant message moves the boundary past the tool block. The same change stops
+the leading system prompts being duplicated into the recent window when the naive
+boundary lands inside the system prefix. `findSafeTrimIndex` is unchanged and is
+reused as the safety predicate.
+
+Two smaller silent losses in the same area:
+
+An empty verification reply is now treated like `COMPLETE`. A truncated turn, a
+refusal, or an exhausted `llmVerificationMaxTokens` produced an empty string,
+which fell through to the append path and stamped a bare
+`## LLM Verification Additions` heading with nothing under it — an empty promise
+that then rode in every subsequent system prompt for the rest of the run.
+
+Every compaction count is `z.number().int().positive()` instead of
+`z.number().positive()`. Zod's base number check rejects only non-numbers and
+`NaN`, so `Infinity` and fractional values both parsed. `Infinity` was the
+dangerous one: it disarms the budget it guards rather than failing, so
+`convoTextBudget: Infinity` made `truncateMessages` a no-op and the entire older
+history was pasted into the verification prompt.

--- a/packages/sdk/src/compaction/__tests__/verifier-empty-reply.test.ts
+++ b/packages/sdk/src/compaction/__tests__/verifier-empty-reply.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The EMPTY VERIFIER REPLY.
+ *
+ * `buildVerifiedSummary` treats only the literal `COMPLETE` as "nothing to add".
+ * Anything else is appended under a `## LLM Verification Additions` heading —
+ * including the empty string, which is what a truncated turn, a refusal, or an
+ * exhausted `llmVerificationMaxTokens` produces. The result is a heading with
+ * nothing under it, and because the summary becomes a leading system message it
+ * then rides in EVERY subsequent prompt of the run.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { CompactionConfigSchema } from '../../config/runtime.js'
+import {
+	type Message,
+	createAssistantMessage,
+	createUserMessage,
+} from '../../types/message/index.js'
+import type { ChatCompletionParams } from '../../types/provider/chat.js'
+import type { LLMProvider } from '../../types/provider/interface.js'
+import type { StreamChunk } from '../../types/provider/stream.js'
+import { WorkingStateManager } from '../manager.js'
+import { buildVerifiedSummary } from '../verifier.js'
+
+const ADDITIONS_HEADING = '## LLM Verification Additions'
+
+function makeProvider(chunks: StreamChunk[]): LLMProvider & { calls: ChatCompletionParams[] } {
+	const calls: ChatCompletionParams[] = []
+	return {
+		id: 'mock',
+		name: 'mock',
+		calls,
+		chatStream(params: ChatCompletionParams): AsyncIterable<StreamChunk> {
+			calls.push(params)
+			return (async function* () {
+				for (const c of chunks) yield c
+			})()
+		},
+	}
+}
+
+function makeManager() {
+	const config = CompactionConfigSchema.parse({ llmVerification: true })
+	const manager = new WorkingStateManager(config)
+	manager.setTask('write the quarterly report')
+	manager.addDecision('built the report as .docx')
+	return { config, manager }
+}
+
+const OLDER: Message[] = [
+	createUserMessage('write the quarterly report'),
+	createAssistantMessage('on it — reading the source numbers first'),
+]
+
+describe('buildVerifiedSummary — empty verifier reply', () => {
+	it('does not append an empty "Additions" section when the verifier returns nothing', async () => {
+		const { config, manager } = makeManager()
+		const provider = makeProvider([])
+
+		const result = await buildVerifiedSummary(manager, OLDER, provider, config)
+
+		expect(result).not.toContain(ADDITIONS_HEADING)
+	})
+
+	it('does not append an empty "Additions" section when the turn is truncated by maxTokens', async () => {
+		const { config, manager } = makeManager()
+		// `length` finish reason with no content — llmVerificationMaxTokens exhausted.
+		const provider = makeProvider([{ id: 'c1', delta: { content: '' }, finishReason: 'length' }])
+
+		const result = await buildVerifiedSummary(manager, OLDER, provider, config)
+
+		expect(result).not.toContain(ADDITIONS_HEADING)
+	})
+
+	it('does not append an "Additions" section for a whitespace-only reply', async () => {
+		const { config, manager } = makeManager()
+		const provider = makeProvider([{ id: 'c1', delta: { content: '   \n\n  ' } }])
+
+		const result = await buildVerifiedSummary(manager, OLDER, provider, config)
+
+		expect(result).not.toContain(ADDITIONS_HEADING)
+	})
+
+	it('still appends real additions', async () => {
+		const { config, manager } = makeManager()
+		const provider = makeProvider([
+			{ id: 'c1', delta: { content: '- the user asked for EUR, not USD' } },
+		])
+
+		const result = await buildVerifiedSummary(manager, OLDER, provider, config)
+
+		expect(result).toContain(ADDITIONS_HEADING)
+		expect(result).toContain('EUR, not USD')
+	})
+})

--- a/packages/sdk/src/compaction/verifier.ts
+++ b/packages/sdk/src/compaction/verifier.ts
@@ -86,7 +86,16 @@ export async function buildVerifiedSummary(
 
 	const responseText = response.message.content?.trim() ?? ''
 
-	if (responseText === 'COMPLETE') {
+	// `COMPLETE` is the verifier saying it found nothing to add. An EMPTY reply
+	// says the same thing by accident — a turn truncated at
+	// `llmVerificationMaxTokens`, a refusal, or a provider that returned no
+	// content at all — and used to fall through to the append below, stamping a
+	// bare `## LLM Verification Additions` heading with nothing under it. That
+	// empty promise then rides in the compaction summary, and therefore in every
+	// subsequent system prompt, for the rest of the run. A heading with no body
+	// is not a verification result; treat a silent verifier the same as one that
+	// had nothing to say.
+	if (responseText === 'COMPLETE' || responseText.length === 0) {
 		return serialized
 	}
 

--- a/packages/sdk/src/config/__tests__/compaction-budget-schema.test.ts
+++ b/packages/sdk/src/config/__tests__/compaction-budget-schema.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The BUDGET SCHEMA.
+ *
+ * Every compaction count used to be `z.number().positive()`. Zod's base number
+ * check rejects only non-numbers and `NaN`, so `Infinity` and `0.5` both parsed.
+ * These are counts of messages, characters, sentences and tokens: a non-integer
+ * is meaningless, and `Infinity` does something worse than being meaningless —
+ * it turns a bound into a no-op rather than an error. `truncateMessages` compares
+ * `charCount > budget`, never true against `Infinity`, so the WHOLE older history
+ * was pasted into the verification prompt.
+ *
+ * They are `.int().positive()` now. `Number.isInteger` is false for `Infinity`
+ * and for any fraction, so one validator closes both. These tests are the guard:
+ * every count is checked against both illegal shapes, and the documented
+ * defaults are pinned so tightening the validator cannot have moved them.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { WorkingStateManager } from '../../compaction/manager.js'
+import { buildVerifiedSummary } from '../../compaction/verifier.js'
+import { type Message, createUserMessage } from '../../types/message/index.js'
+import type { ChatCompletionParams } from '../../types/provider/chat.js'
+import type { LLMProvider } from '../../types/provider/interface.js'
+import type { StreamChunk } from '../../types/provider/stream.js'
+import { CompactionConfigSchema, RuntimeConfigSchema } from '../runtime.js'
+
+/** Every integer count on CompactionConfigSchema. */
+const COUNT_FIELDS = [
+	'contextWindowTokens',
+	'keepRecentMessages',
+	'maxToolResults',
+	'maxListSize',
+	'llmVerificationMaxTokens',
+	'richStateThreshold',
+	'convoTextBudget',
+	'maxSentencesPerTurn',
+	'maxCharsPerNote',
+	'maxCharsPerRequirement',
+	'maxCharsPerTask',
+] as const
+
+describe('CompactionConfigSchema — count fields', () => {
+	for (const field of COUNT_FIELDS) {
+		it(`rejects Infinity for ${field}`, () => {
+			expect(() => CompactionConfigSchema.parse({ [field]: Number.POSITIVE_INFINITY })).toThrow()
+		})
+
+		it(`rejects a fractional value for ${field}`, () => {
+			expect(() => CompactionConfigSchema.parse({ [field]: 0.5 })).toThrow()
+		})
+	}
+
+	it('rejects Infinity through the RuntimeConfigSchema envelope', () => {
+		expect(() =>
+			RuntimeConfigSchema.parse({ compaction: { convoTextBudget: Number.POSITIVE_INFINITY } }),
+		).toThrow()
+	})
+
+	it('still accepts the documented defaults', () => {
+		const parsed = CompactionConfigSchema.parse({})
+		expect(parsed.convoTextBudget).toBe(12_000)
+		expect(parsed.keepRecentMessages).toBe(4)
+	})
+})
+
+/**
+ * Why the schema is the only defence, and what that leaves open.
+ *
+ * `truncateMessages` bounds the verification prompt with `charCount > budget`,
+ * which is never true against `Infinity` — that is the consequence the schema
+ * fix above exists to prevent, and it can no longer be reached THROUGH the
+ * schema. It is still reachable by a host that hand-builds a `CompactionConfig`
+ * object literal, because the inferred type is plain `number`; that is a stated
+ * limitation, not a covered case. No silent clamp was added inside
+ * `truncateMessages` — a budget that quietly repairs an illegal value hides the
+ * caller's bug instead of surfacing it, and the schema is where the boundary
+ * belongs.
+ *
+ * What this test does pin: with a LEGAL budget the prompt really is bounded, so
+ * the truncation the schema now guarantees is actually performed.
+ */
+describe('truncateMessages bounds the verification prompt at a legal budget', () => {
+	it('does not paste the entire older history into the verification prompt', async () => {
+		const config = CompactionConfigSchema.parse({
+			llmVerification: true,
+			convoTextBudget: 12_000,
+		})
+		const manager = new WorkingStateManager(config)
+		manager.setTask('write the quarterly report')
+
+		const calls: ChatCompletionParams[] = []
+		const provider: LLMProvider = {
+			id: 'mock',
+			name: 'mock',
+			chatStream(params: ChatCompletionParams): AsyncIterable<StreamChunk> {
+				calls.push(params)
+				return (async function* () {
+					yield { id: 'c1', delta: { content: 'COMPLETE' } } as StreamChunk
+				})()
+			},
+		}
+
+		// ~200 KB of older history — far past any sane verification budget.
+		const older: Message[] = Array.from({ length: 200 }, (_, i) =>
+			createUserMessage(`turn ${i} ${'y'.repeat(1000)}`),
+		)
+
+		await buildVerifiedSummary(manager, older, provider, config)
+
+		const promptChars = (calls[0]?.messages ?? []).reduce((n, m) => n + (m.content?.length ?? 0), 0)
+		expect(promptChars).toBeLessThan(100_000)
+	})
+})

--- a/packages/sdk/src/config/runtime.ts
+++ b/packages/sdk/src/config/runtime.ts
@@ -26,20 +26,29 @@ export const CompactionConfigSchema = z.object({
 	 * `tokenBudget` unlimited (0) set this so compaction fires on
 	 * window-pressure instead of being a silent no-op.
 	 */
-	contextWindowTokens: z.number().positive().optional(),
+	// Every field below counts something — tokens, messages, characters,
+	// sentences. `z.number().positive()` was the wrong validator for all of them:
+	// Zod's base number check rejects only non-numbers and NaN, so `Infinity` and
+	// `0.5` both passed. `Infinity` is the dangerous one, because it turns a bound
+	// into a no-op rather than an error — `convoTextBudget: Infinity` makes the
+	// verifier's `charCount > budget` test never true, so `truncateMessages` stops
+	// truncating and the WHOLE history is pasted into the verification prompt.
+	// A fraction is merely nonsense (`keepRecentMessages: 2.5`). `.int()` rejects
+	// both: `Number.isInteger` is false for Infinity and for any fraction.
+	contextWindowTokens: z.number().int().positive().optional(),
 	triggerThreshold: z.number().min(0).max(1).default(0.7),
 	resetThreshold: z.number().min(0).max(1).default(0.4),
-	keepRecentMessages: z.number().positive().default(4),
-	maxToolResults: z.number().positive().default(30),
-	maxListSize: z.number().positive().default(25),
+	keepRecentMessages: z.number().int().positive().default(4),
+	maxToolResults: z.number().int().positive().default(30),
+	maxListSize: z.number().int().positive().default(25),
 	llmVerification: z.boolean().default(true),
-	llmVerificationMaxTokens: z.number().positive().default(2048),
-	richStateThreshold: z.number().positive().default(15),
-	convoTextBudget: z.number().positive().default(12_000),
-	maxSentencesPerTurn: z.number().positive().default(5),
-	maxCharsPerNote: z.number().positive().default(500),
-	maxCharsPerRequirement: z.number().positive().default(300),
-	maxCharsPerTask: z.number().positive().default(400),
+	llmVerificationMaxTokens: z.number().int().positive().default(2048),
+	richStateThreshold: z.number().int().positive().default(15),
+	convoTextBudget: z.number().int().positive().default(12_000),
+	maxSentencesPerTurn: z.number().int().positive().default(5),
+	maxCharsPerNote: z.number().int().positive().default(500),
+	maxCharsPerRequirement: z.number().int().positive().default(300),
+	maxCharsPerTask: z.number().int().positive().default(400),
 })
 
 export type CompactionConfig = z.infer<typeof CompactionConfigSchema>

--- a/packages/sdk/src/runtime/query/iteration/phases/compaction-safe-cut.test.ts
+++ b/packages/sdk/src/runtime/query/iteration/phases/compaction-safe-cut.test.ts
@@ -1,0 +1,186 @@
+/**
+ * The UNBOUNDED CUT.
+ *
+ * `runCompactionCheck` snaps the naive recent-window boundary
+ * (`messages.length - keepRecentMessages`) FORWARD via `findSafeTrimIndex` so a
+ * tool pair is never split. But `findSafeTrimIndex` only ever walks forward, and
+ * its leading-`tool`-message skip has no stop short of `messages.length` — so
+ * whenever the whole suffix from the naive index to the end is `tool` messages,
+ * the cut lands ON `messages.length`, `recentMessages` comes back EMPTY, and
+ * `[...preservedSystem, compactionMessage]` replaces the ENTIRE recent window.
+ * What is left is a transcript with no non-system message at all.
+ *
+ * The shape that produces it: ONE assistant turn that fans out
+ * `>= keepRecentMessages` parallel tool calls, measured at the START of the next
+ * iteration — which is exactly where `runCompactionCheck` runs (iteration/index.ts,
+ * after `refreshWorkingMemory`, before the model call), i.e. immediately after
+ * those results were appended.
+ *
+ * The `olderMessages.length < 1` guard at :117 cannot fire: `olderMessages` is
+ * the whole transcript in exactly this situation.
+ *
+ * Symmetrically, when the naive index lands BELOW `systemMessages.length` the
+ * cut sits inside the system prefix and the leading prompts are duplicated into
+ * `recentMessages`.
+ *
+ * The invariant these tests pin is the one a cut taken AT OR BELOW naive gives
+ * for free: a pass never removes more than the naive cut would, so at least
+ * `keepRecentMessages` original messages survive verbatim — or, when no safe cut
+ * exists at all, the pass is skipped and the transcript is untouched.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { WorkingStateManager } from '../../../../compaction/manager.js'
+import { CompactionConfigSchema } from '../../../../config/runtime.js'
+import type { RunId } from '../../../../types/ids/index.js'
+import {
+	type Message,
+	createAssistantMessage,
+	createSystemMessage,
+	createToolMessage,
+	createUserMessage,
+} from '../../../../types/message/index.js'
+import type { Logger } from '../../../../utils/logger.js'
+import { runCompactionCheck } from './compaction.js'
+import type { IterationContext } from './context.js'
+
+function makeLogger(): Logger {
+	const self = {
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+		child: vi.fn(),
+	} as unknown as Logger
+	;(self as { child: (ctx: unknown) => Logger }).child = vi.fn(() => self)
+	return self
+}
+
+/** Long enough that a handful of messages overflow a tiny budget. */
+const FILLER = 'x'.repeat(200)
+
+const KEEP_RECENT = 4
+
+function makeCtx(opts: {
+	messages: Message[]
+	contextWindowTokens?: number
+	tokenBudget?: number
+}): IterationContext {
+	const config = CompactionConfigSchema.parse({
+		strategy: 'structured',
+		llmVerification: false,
+		keepRecentMessages: KEEP_RECENT,
+		...(opts.contextWindowTokens !== undefined
+			? { contextWindowTokens: opts.contextWindowTokens }
+			: {}),
+	})
+	const manager = new WorkingStateManager(config)
+	manager.addDecision('built the report as .docx')
+
+	return {
+		runConfig: { tokenBudget: opts.tokenBudget ?? 0 },
+		compactionConfig: config,
+		workingStateManager: manager,
+		log: makeLogger(),
+		runMgr: {
+			id: 'run_1' as RunId,
+			currentIteration: 3,
+			messages: opts.messages,
+		},
+	} as unknown as IterationContext
+}
+
+function toolCall(id: string) {
+	return { id, type: 'function' as const, function: { name: 'read', arguments: '{}' } }
+}
+
+/** How many of the ORIGINAL messages survived the pass, by identity. */
+function survivorCount(before: readonly Message[], after: readonly Message[]): number {
+	const kept = new Set<Message>(after)
+	return before.filter((m) => kept.has(m)).length
+}
+
+/**
+ * The exact shape the iteration loop holds when `runCompactionCheck` runs: the
+ * user's turn, one assistant that fanned out four parallel tool calls, and the
+ * four results that just landed. The next thing that happens is the model call —
+ * with whatever this function leaves behind.
+ */
+function buildParallelFanOutTail(): Message[] {
+	return [
+		createSystemMessage(`STATIC SYSTEM PROMPT ${FILLER}`, 'cache'),
+		createUserMessage(`please rename the heading to Q3 ${FILLER}`),
+		createAssistantMessage(`reading the sources ${FILLER}`, [
+			toolCall('a'),
+			toolCall('b'),
+			toolCall('c'),
+			toolCall('d'),
+		]),
+		createToolMessage(`result a ${FILLER}`, 'a'),
+		createToolMessage(`result b ${FILLER}`, 'b'),
+		createToolMessage(`result c ${FILLER}`, 'c'),
+		createToolMessage(`result d ${FILLER}`, 'd'),
+	]
+}
+
+describe('compaction — the unbounded cut', () => {
+	it('keeps at least keepRecentMessages messages verbatim when the tail is a parallel tool fan-out', async () => {
+		const messages = buildParallelFanOutTail()
+		const before = [...messages]
+		const ctx = makeCtx({ messages, contextWindowTokens: 100 })
+
+		await runCompactionCheck(ctx)
+
+		expect(survivorCount(before, messages)).toBeGreaterThanOrEqual(KEEP_RECENT)
+	})
+
+	it('never leaves a system-only transcript (nothing for the next turn to answer)', async () => {
+		const messages = buildParallelFanOutTail()
+		const ctx = makeCtx({ messages, contextWindowTokens: 100 })
+
+		await runCompactionCheck(ctx)
+
+		const nonSystem = messages.filter((m) => m.role !== 'system')
+		expect(nonSystem.length).toBeGreaterThan(0)
+	})
+
+	it('skips the pass, leaving the transcript intact, when no safe cut exists at or below naive', async () => {
+		// System prefix, then a single assistant fanning out six parallel calls.
+		// Every candidate boundary at or below naive splits that one pair-set, so
+		// there is nothing safe to cut to — skipping beats deleting the turn.
+		const ids = ['a', 'b', 'c', 'd', 'e', 'f']
+		const messages: Message[] = [
+			createSystemMessage(`STATIC SYSTEM PROMPT ${FILLER}`, 'cache'),
+			createAssistantMessage(`fanning out ${FILLER}`, ids.map(toolCall)),
+			...ids.map((id) => createToolMessage(`result ${id} ${FILLER}`, id)),
+		]
+		const before = [...messages]
+		const ctx = makeCtx({ messages, contextWindowTokens: 100 })
+
+		await runCompactionCheck(ctx)
+
+		expect(messages).toEqual(before)
+	})
+
+	it('does not duplicate the leading system prompts when the naive cut lands inside them', async () => {
+		// Legacy (tokenBudget) path: five leading system messages and only three
+		// conversational ones, so naive = 8 - 4 = 4 < systemMessages.length = 5.
+		const messages: Message[] = [
+			createSystemMessage(`SYS-1 ${FILLER}`, 'cache'),
+			createSystemMessage(`SYS-2 ${FILLER}`),
+			createSystemMessage(`SYS-3 ${FILLER}`),
+			createSystemMessage(`SYS-4 ${FILLER}`),
+			createSystemMessage(`SYS-5 UNIQUE-MARKER ${FILLER}`),
+			createUserMessage(`user 0 ${FILLER}`),
+			createAssistantMessage(`assistant 0 ${FILLER}`),
+			createUserMessage(`user 1 ${FILLER}`),
+		]
+		const ctx = makeCtx({ messages, tokenBudget: 100 })
+
+		await runCompactionCheck(ctx)
+
+		const marker = messages.filter((m) => m.content?.includes('UNIQUE-MARKER'))
+		expect(marker).toHaveLength(1)
+	})
+})

--- a/packages/sdk/src/runtime/query/iteration/phases/compaction.ts
+++ b/packages/sdk/src/runtime/query/iteration/phases/compaction.ts
@@ -94,18 +94,60 @@ export async function runCompactionCheck(ctx: IterationContext): Promise<void> {
 	}
 	if (systemMessages.length === 0) return
 
-	// Tool-pair atomicity guard. A naive cut at `length - keepRecentMessages`
-	// can land BETWEEN an assistant-with-toolCalls (which would be dropped into
-	// `olderMessages`) and its `tool` results (kept in `recentMessages`),
-	// leaving orphaned `tool_result` blocks at the head of the recent window.
-	// The Anthropic provider then emits a `tool_result` with no matching
-	// `tool_use` and the API rejects the next turn with a 400 — so compaction,
-	// whose whole job is to keep a long run alive, instead kills it. Snap the
-	// boundary FORWARD to a safe point (existing `findSafeTrimIndex`, previously
-	// only wired to the unused ConversationManager strategy classes) so no pair
-	// is split. Any message this moves out of the recent window is already
-	// represented in the extracted WorkingState the summary is built from.
-	const keepStart = findSafeTrimIndex(messages, messages.length - config.keepRecentMessages)
+	// Tool-pair atomicity guard, taken DOWNWARD.
+	//
+	// A naive cut at `length - keepRecentMessages` can land BETWEEN an
+	// assistant-with-toolCalls (dropped into `olderMessages`) and its `tool`
+	// results (kept in `recentMessages`), leaving orphaned `tool_result` blocks at
+	// the head of the recent window. The Anthropic provider then emits a
+	// `tool_result` with no matching `tool_use` and the API rejects the next turn
+	// with a 400 — so compaction, whose whole job is to keep a long run alive,
+	// instead kills it.
+	//
+	// Snapping FORWARD via `findSafeTrimIndex` fixes the orphan and introduces a
+	// worse failure. That walk skips leading `tool` messages with no stop short of
+	// `messages.length`, so whenever the entire suffix from the naive index is
+	// `tool` messages, the boundary lands ON `messages.length`: `recentMessages`
+	// comes back EMPTY and `[...preservedSystem, compactionMessage]` replaces the
+	// whole recent window. The model is then asked to answer a conversation whose
+	// last turn — including the user's own message — was deleted, and it answers a
+	// question nobody asked. The shape is routine, not exotic: one assistant turn
+	// fanning out `>= keepRecentMessages` parallel tool calls, measured at the
+	// start of the very next iteration, which is exactly where this runs. The
+	// `olderMessages` floor guard below cannot catch it either — in that shape
+	// `olderMessages` is the whole transcript.
+	//
+	// So take the LARGEST safe boundary AT OR BELOW naive instead. A cut that low
+	// removes no more than the naive cut would, so at least `keepRecentMessages`
+	// original messages always survive verbatim, and the transcript can never be
+	// reduced to system messages alone. `findSafeTrimIndex(m, k) === k` is the
+	// safety predicate — reused rather than reimplemented, so the function itself
+	// (public API, other callers) is untouched.
+	const naiveKeepStart = messages.length - config.keepRecentMessages
+	let keepStart = -1
+	for (let candidate = naiveKeepStart; candidate > systemMessages.length; candidate--) {
+		if (findSafeTrimIndex(messages, candidate) === candidate) {
+			keepStart = candidate
+			break
+		}
+	}
+
+	// No safe boundary at or below naive. Either every candidate splits a pair-set
+	// (one assistant fanning out more calls than the recent window holds), or naive
+	// itself sits inside the leading system prefix — which would otherwise
+	// duplicate those prompts into `recentMessages`. Skipping costs one iteration's
+	// worth of context headroom; cutting anyway costs the live turn. The condition
+	// is self-clearing: the next assistant message moves naive past the tool block.
+	if (keepStart < 0) {
+		ctx.log.debug('Skipping compaction — no safe cut at or below the naive boundary', {
+			runId: ctx.runMgr.id,
+			naiveKeepStart,
+			systemMessages: systemMessages.length,
+			messageCount: messages.length,
+		})
+		return
+	}
+
 	const recentMessages = messages.slice(keepStart)
 	const olderMessages = messages.slice(systemMessages.length, keepStart)
 


### PR DESCRIPTION
Three fixes in the compaction path. The first one is a live correctness bug: a
compaction pass could delete the message the user had just typed.

## The recent-window boundary was taken in the wrong direction

The boundary is snapped away from the naive `length - keepRecentMessages` so a
tool pair is never split — an orphaned `tool_result` at the head of the recent
window makes the next Anthropic request a 400, which would mean compaction, whose
whole job is to keep a long run alive, kills it instead.

But it snapped **forward**, via `findSafeTrimIndex`, whose leading-`tool`-message
skip has no stop short of `messages.length`. So whenever the entire suffix from
the naive boundary is `tool` messages, the boundary landed **on**
`messages.length`: `recentMessages` came back empty and
`[...preservedSystem, compactionMessage]` replaced the whole recent window. What
was left had no non-system message at all, and the model was asked to answer a
conversation whose last turn — including the user's own message — had been
removed.

The shape is routine, not exotic: **one assistant turn fanning out at least
`keepRecentMessages` parallel tool calls**, measured at the start of the very next
iteration, which is exactly where the compaction check runs. The existing
older-message floor guard cannot catch it either — in that shape the older half is
the whole transcript.

The boundary is now the **largest safe one at or below naive**. A cut that low
removes no more than the naive cut would, so at least `keepRecentMessages`
original messages always survive verbatim and the transcript can never be reduced
to system messages alone. When no safe boundary exists the pass is **skipped and
the transcript left intact** — one iteration of context headroom is cheaper than
the live turn, and the condition clears itself as soon as the next assistant
message moves the boundary past the tool block.

The same change stops the leading system prompts being duplicated into the recent
window when the naive boundary lands inside the system prefix.

`findSafeTrimIndex` is **unchanged** and reused as the safety predicate
(`findSafeTrimIndex(m, k) === k`), so its other, public callers keep their exact
behaviour.

## An empty verification reply stamped an empty promise

`buildVerifiedSummary` tested only `responseText === 'COMPLETE'`. An empty string
— a turn truncated at `llmVerificationMaxTokens`, a refusal, or a provider that
returned no content — fell through to the append path and wrote a bare
`## LLM Verification Additions` heading with nothing under it. That heading then
rode in the compaction summary, and therefore in every subsequent system prompt,
for the rest of the run. A silent verifier now means the same thing as one that
had nothing to say.

## `Infinity` disarmed the budget it was guarding

Every compaction count was `z.number().positive()`. Zod's base number check
rejects only non-numbers and `NaN`, so `Infinity` and `0.5` both parsed. A
fraction is merely meaningless; `Infinity` is worse, because it turns a bound into
a **no-op rather than an error** — `convoTextBudget: Infinity` makes
`truncateMessages`' `charCount > budget` test never true, so the whole older
history was pasted into the verification prompt.

All eleven counts are `.int().positive()` now: `Number.isInteger` is false for
`Infinity` and for any fraction, so one validator closes both.

**No clamp was added inside `truncateMessages`.** A budget that quietly repairs an
illegal value hides the caller's bug instead of surfacing it, and the schema is
where the boundary belongs. A host that hand-builds a `CompactionConfig` object
literal still bypasses it, because the inferred type is plain `number` — that is
stated in the test as a limitation rather than papered over.

## Proof

**Red before green, 19 failing assertions** across three new suites — 4 on the
cut, 3 on the verifier, 12 on the schema. The sharpest one:

    × never leaves a system-only transcript (nothing for the next turn to answer)
      → expected 0 to be greater than 0

Zero non-system messages, which is the bug stated as a number.

After: **169 passed (169)** across the compaction, config and `runtime/query`
suites — 24 test files, no regressions. `biome check` clean, `tsc --noEmit` clean.

The host-side gate on the consuming application, with the submodule pointer moved:
`lint` 0 errors · `test:architecture` 37/37 · `lint:unused` unchanged ·
`typecheck` clean · `test:unit` **8179/8179** · `build` ✓.

## Provenance

These three carry the *intent* of commits `9fa3f38`, `b56cab6` and `3e73108` from
`feat/sdk-0.5-reliability-safety-durable-pause`. They are not cherry-picks and
cannot be: that branch is 210 commits behind `main` and patches files that no
longer exist, having been rewritten by the chatStream-only provider change. Each
fix here is written against today's files.
