### PR TITLE
feat(providers): classify provider failures end to end

### DIFF
--- a/.changeset/provider-error-taxonomy.md
+++ b/.changeset/provider-error-taxonomy.md
@@ -1,0 +1,36 @@
+---
+'@namzu/sdk': minor
+'@namzu/anthropic': patch
+'@namzu/bedrock': patch
+'@namzu/http': patch
+'@namzu/lmstudio': patch
+'@namzu/ollama': patch
+'@namzu/openai': patch
+'@namzu/openrouter': patch
+---
+
+Normalize request-start and mid-stream failures across all seven provider
+drivers with the new public `ProviderRequestError` taxonomy. Errors expose
+`kind` (`throttle`, `network`, `auth`, `context_overflow`, `bad_request`, or
+`server`), `providerId`, and optional `status` / `retryAfterMs`, with
+`isProviderRequestError` available for structural narrowing across package
+copies.
+
+Provider error messages and metadata deliberately omit vendor response bodies,
+URLs, messages, and causes because upstream errors can echo credentials. HTTP
+dialect-mismatch diagnostics now keep only the endpoint origin and status.
+Caller-owned aborts remain unchanged instead of being reclassified.
+
+The runtime preserves the classified error through streaming and publishes its
+safe metadata as `Run.lastProviderError` and
+`run_failed.providerError`. Bedrock stream-exception events and provider
+iterator/SSE failures no longer appear as clean end-of-stream.
+
+`retryAfterMs` is metadata only; this change does not add retries or alter vendor
+SDK retry settings. Provider packages now require `@namzu/sdk >=1.3.0`, the
+first SDK release containing these runtime helpers and types.
+
+Ollama now maps `done_reason: "length"` truthfully so runtime continuation can
+run. LM Studio treats content-free `contextLengthReached` as context overflow,
+while preserving `"length"` after partial content, and creates its WebSocket
+client lazily on first use.

--- a/docs/sdk/provider-integration/operations.md
+++ b/docs/sdk/provider-integration/operations.md
@@ -1,7 +1,7 @@
 ---
 title: Provider Operations
 description: Direct provider usage in @namzu/sdk, including chat, streaming, tool-call inspection, model listing, health checks, and capability-driven routing.
-last_updated: 2026-04-18
+last_updated: 2026-07-30
 status: current
 related_packages: ["@namzu/sdk", "@namzu/openai", "@namzu/anthropic", "@namzu/bedrock", "@namzu/openrouter", "@namzu/http", "@namzu/ollama", "@namzu/lmstudio"]
 ---
@@ -95,7 +95,64 @@ The stream chunks are normalized across providers:
 - `finishReason` tells you why generation ended
 - `usage` may appear near the end of the stream
 
-## 5. Direct Tool-Call Inspection
+## 5. Handle Classified Provider Failures
+
+All published Namzu providers throw the same `ProviderRequestError` shape for
+request-start and mid-stream provider failures. Use the structural guard rather
+than `instanceof`; an application can load more than one copy of the SDK through
+its dependency graph.
+
+```ts
+import { isProviderRequestError } from '@namzu/sdk'
+
+try {
+  for await (const chunk of provider.chatStream({
+    model: 'gpt-4o-mini',
+    messages: [{ role: 'user', content: 'Summarize this document.' }],
+  })) {
+    process.stdout.write(chunk.delta.content ?? '')
+  }
+} catch (error) {
+  if (!isProviderRequestError(error)) {
+    throw error
+  }
+
+  console.error({
+    kind: error.kind,
+    providerId: error.providerId,
+    status: error.status,
+    retryAfterMs: error.retryAfterMs,
+  })
+}
+```
+
+`kind` is one of:
+
+| Kind | Meaning |
+| --- | --- |
+| `throttle` | The provider rate-limited the request |
+| `network` | The provider could not be reached or its stream failed |
+| `auth` | The provider rejected the credentials |
+| `context_overflow` | The prompt exceeded the model context window |
+| `bad_request` | The provider rejected the request as invalid |
+| `server` | The provider failed while handling an otherwise valid request |
+
+`status` and `retryAfterMs` are optional because not every transport exposes an
+HTTP response or preserves retry headers. They are metadata only: Namzu does not
+sleep or retry when constructing the error. In particular, the Ollama client
+discards response headers before its driver sees an error.
+
+Provider errors deliberately omit vendor messages, response bodies, URLs, and
+`cause`. Those surfaces may contain credentials echoed by an upstream service.
+The normalized message and structured fields are safe to record. A caller-owned
+abort remains the caller's original abort error and is not converted into a
+provider failure.
+
+When using `query()` or `drainQuery()`, the same safe metadata also appears on
+failed runs and `run_failed` events; see
+[Low-Level Runtime](../runtime/low-level.md#9-event-streaming-and-sse-mapping).
+
+## 6. Direct Tool-Call Inspection
 
 Direct provider calls do not execute tools for you. They only return normalized tool-call requests when the model chooses them.
 
@@ -143,7 +200,7 @@ Important boundary:
 
 If you need automatic tool execution and iterative reasoning, move back up to `ReactiveAgent` or [Low-Level Runtime](../runtime/low-level.md).
 
-## 6. Optional Provider Methods
+## 7. Optional Provider Methods
 
 Most published providers implement two optional utility methods:
 
@@ -165,7 +222,7 @@ Typical uses:
 - `healthCheck()` before accepting traffic
 - `listModels()` when rendering setup forms or validating config choices
 
-## 7. Capability-Driven Routing
+## 8. Capability-Driven Routing
 
 The capability object returned by `ProviderRegistry.create()` is often enough to decide which runtime shape to use:
 
@@ -177,7 +234,7 @@ The capability object returned by `ProviderRegistry.create()` is often enough to
 
 This lets you branch behavior without hardcoding vendor names.
 
-## 8. Direct Provider Calls vs Agent Runtime
+## 9. Direct Provider Calls vs Agent Runtime
 
 | If you need... | Use |
 | --- | --- |
@@ -186,7 +243,7 @@ This lets you branch behavior without hardcoding vendor names.
 | Health or model discovery | `healthCheck()` / `listModels()` |
 | Tool execution loop, safety policy, and final run assembly | `ReactiveAgent.run()` or `drainQuery()` |
 
-## 9. Common Mistakes
+## 10. Common Mistakes
 
 | Mistake | Why it hurts |
 | --- | --- |
@@ -194,6 +251,7 @@ This lets you branch behavior without hardcoding vendor names.
 | assuming every provider implements `listModels()` and `healthCheck()` | those methods are optional on the shared interface |
 | ignoring `capabilities` and branching by vendor name instead | you lose the main benefit of the provider abstraction |
 | jumping straight into agents before a direct preflight request | setup errors become harder to isolate |
+| logging an unknown vendor error or its `cause` instead of the normalized fields | upstream error text may contain request data or credentials |
 
 ## Related
 

--- a/docs/sdk/runtime/low-level.md
+++ b/docs/sdk/runtime/low-level.md
@@ -1,7 +1,7 @@
 ---
 title: Low-Level Runtime
 description: Use query() and drainQuery() directly in @namzu/sdk when you need sandbox providers, plugin wiring, event streaming, or other query-only runtime controls.
-last_updated: 2026-05-02
+last_updated: 2026-07-30
 status: current
 related_packages: ["@namzu/sdk", "@namzu/openai"]
 ---
@@ -230,6 +230,30 @@ That means stream transport code usually needs both:
 
 1. mapped incremental events during execution
 2. the final `AgentRun` when execution completes
+
+Provider failures carry an additional safe, serializable classification:
+
+```ts
+const run = await drainQuery(params, async (event) => {
+  if (event.type === 'run_failed' && event.providerError) {
+    console.error({
+      kind: event.providerError.kind,
+      providerId: event.providerError.providerId,
+      status: event.providerError.status,
+      retryAfterMs: event.providerError.retryAfterMs,
+    })
+  }
+})
+
+if (run.lastProviderError?.kind === 'throttle') {
+  // A scheduler can use retryAfterMs without parsing an error message.
+}
+```
+
+`providerError` and `lastProviderError` are present only when the failure came
+from a provider as a classified `ProviderRequestError`. Other runtime failures
+continue to use the ordinary `error` / `lastError` fields. The provider metadata
+never includes a response body, vendor message, URL, or error `cause`.
 
 ## 10. Common Mistakes
 

--- a/packages/providers/anthropic/package.json
+++ b/packages/providers/anthropic/package.json
@@ -47,7 +47,7 @@
     "@anthropic-ai/sdk": "^0.89.0"
   },
   "peerDependencies": {
-    "@namzu/sdk": ">=1.0.0"
+    "@namzu/sdk": ">=1.3.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/packages/providers/anthropic/src/__tests__/error-taxonomy.test.ts
+++ b/packages/providers/anthropic/src/__tests__/error-taxonomy.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Provider error taxonomy — Anthropic driver.
+ *
+ * The driver hands the request to the vendor SDK and lets whatever the SDK
+ * rejects with escape verbatim (`RateLimitError`, `BadRequestError`, …).
+ * Those are vendor types: a caller cannot classify them without importing
+ * `@anthropic-ai/sdk`, so nothing downstream can distinguish a throttle
+ * from a context overflow from a bad request.
+ *
+ * Transport seam: `AnthropicConfig.baseURL` — the tests point the SDK at a
+ * loopback server that answers with a scripted status/headers/body. This
+ * exercises the REAL vendor client (including its own internal retries,
+ * which this group must not disturb).
+ */
+
+import { type Server, createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { afterEach, describe, expect, it } from 'vitest'
+import { AnthropicProvider } from '../client.js'
+
+/** Obviously fake, non-functional token — present only as a leak probe. */
+const FAKE_CREDENTIAL = 'sk-ant-FAKE-DO-NOT-USE-0000'
+
+interface ScriptedReply {
+	status: number
+	body: string
+	headers?: Record<string, string>
+}
+
+let server: Server | undefined
+
+afterEach(async () => {
+	if (server) {
+		await new Promise<void>((resolve) => server?.close(() => resolve()))
+		server = undefined
+	}
+})
+
+/** Boot a loopback endpoint that answers every request with `reply`. */
+async function startEndpoint(reply: ScriptedReply): Promise<string> {
+	server = createServer((_req, res) => {
+		res.writeHead(reply.status, {
+			'Content-Type': 'application/json',
+			...(reply.headers ?? {}),
+		})
+		res.end(reply.body)
+	})
+	await new Promise<void>((resolve) => server?.listen(0, '127.0.0.1', () => resolve()))
+	const { port } = server.address() as AddressInfo
+	return `http://127.0.0.1:${port}`
+}
+
+/** Boot a loopback endpoint that streams `frames` as an SSE 200 response. */
+async function startSseEndpoint(frames: string[]): Promise<string> {
+	server = createServer((_req, res) => {
+		res.writeHead(200, {
+			'Content-Type': 'text/event-stream',
+			'Cache-Control': 'no-cache',
+			Connection: 'keep-alive',
+		})
+		res.end(`${frames.join('\n\n')}\n\n`)
+	})
+	await new Promise<void>((resolve) => server?.listen(0, '127.0.0.1', () => resolve()))
+	const { port } = server.address() as AddressInfo
+	return `http://127.0.0.1:${port}`
+}
+
+async function captureChatStreamError(reply: ScriptedReply): Promise<unknown> {
+	const baseURL = await startEndpoint(reply)
+	// maxRetries is deliberately NOT set: this group classifies errors and
+	// must leave the vendor SDK's own retry behaviour exactly as it is.
+	const provider = new AnthropicProvider({
+		apiKey: 'test-key',
+		model: 'claude-sonnet-4-5-20250929',
+		baseURL,
+	})
+	try {
+		for await (const _chunk of provider.chatStream({
+			model: 'claude-sonnet-4-5-20250929',
+			messages: [{ role: 'user', content: 'hi' }],
+		})) {
+			// drain
+		}
+	} catch (err) {
+		return err
+	}
+	throw new Error('expected chatStream to throw')
+}
+
+async function captureProviderError(
+	provider: AnthropicProvider,
+	signal?: AbortSignal,
+): Promise<unknown> {
+	try {
+		for await (const _chunk of provider.chatStream({
+			model: 'claude-sonnet-4-5-20250929',
+			messages: [{ role: 'user', content: 'hi' }],
+			signal,
+		})) {
+			// drain
+		}
+	} catch (err) {
+		return err
+	}
+	throw new Error('expected chatStream to throw')
+}
+
+describe('@namzu/anthropic — provider error taxonomy', () => {
+	it('(a) 429 with `retry-after: 2` throws a throttle-classified error carrying retryAfterMs', async () => {
+		const err = await captureChatStreamError({
+			status: 429,
+			headers: { 'retry-after': '2' },
+			body: JSON.stringify({
+				type: 'error',
+				error: { type: 'rate_limit_error', message: 'slow' },
+			}),
+		})
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'throttle',
+			status: 429,
+			retryAfterMs: 2000,
+			providerId: 'anthropic',
+		})
+	}, 60_000)
+
+	it("(c) 400 whose body says the prompt is too long classifies as 'context_overflow'", async () => {
+		const err = await captureChatStreamError({
+			status: 400,
+			body: JSON.stringify({
+				type: 'error',
+				error: {
+					type: 'invalid_request_error',
+					message: 'prompt is too long: 305231 tokens > 200000 maximum',
+				},
+			}),
+		})
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'context_overflow',
+			status: 400,
+			providerId: 'anthropic',
+		})
+	}, 30_000)
+
+	it("(c) 400 that is not an overflow classifies as 'bad_request'", async () => {
+		const err = await captureChatStreamError({
+			status: 400,
+			body: JSON.stringify({
+				type: 'error',
+				error: {
+					type: 'invalid_request_error',
+					message: 'messages: at least one message required',
+				},
+			}),
+		})
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'bad_request',
+			status: 400,
+			providerId: 'anthropic',
+		})
+	}, 30_000)
+
+	it("(auth) 401 classifies as 'auth'", async () => {
+		const err = await captureChatStreamError({
+			status: 401,
+			body: JSON.stringify({
+				type: 'error',
+				error: { type: 'authentication_error', message: 'invalid x-api-key' },
+			}),
+		})
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'auth',
+			status: 401,
+			providerId: 'anthropic',
+		})
+	}, 30_000)
+
+	it("529 (upstream overload) classifies as 'server'", async () => {
+		const err = await captureChatStreamError({
+			status: 529,
+			body: JSON.stringify({
+				type: 'error',
+				error: { type: 'overloaded_error', message: 'Overloaded' },
+			}),
+		})
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'server',
+			status: 529,
+			providerId: 'anthropic',
+		})
+	}, 60_000)
+
+	it("MID-STREAM: an `event: error` frame after a 200 classifies as 'server'", async () => {
+		// The vendor SDK's SSE reader throws its own `APIError` for an
+		// `event: error` frame (core/streaming: `if (sse.event === 'error')`),
+		// so the driver's event switch never sees it — the vendor error escapes
+		// the driver unclassified, with the frame body interpolated.
+		const baseURL = await startSseEndpoint([
+			'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":5,"output_tokens":0}}}',
+			'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}',
+			'event: error\ndata: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+		])
+		const provider = new AnthropicProvider({
+			apiKey: 'test-key',
+			model: 'claude-sonnet-4-5-20250929',
+			baseURL,
+		})
+
+		let caught: unknown
+		try {
+			for await (const _chunk of provider.chatStream({
+				model: 'claude-sonnet-4-5-20250929',
+				messages: [{ role: 'user', content: 'hi' }],
+			})) {
+				// drain
+			}
+		} catch (err) {
+			caught = err
+		}
+
+		expect(caught).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'server',
+			providerId: 'anthropic',
+		})
+	}, 30_000)
+
+	it('(d) SECURITY: a credential echoed back in a 401 body never reaches the thrown message', async () => {
+		const err = await captureChatStreamError({
+			status: 401,
+			body: JSON.stringify({
+				type: 'error',
+				error: {
+					type: 'authentication_error',
+					message: `invalid x-api-key ${FAKE_CREDENTIAL}`,
+				},
+			}),
+		})
+
+		expect((err as Error).message).not.toContain(FAKE_CREDENTIAL)
+		expect(JSON.stringify(err)).not.toContain(FAKE_CREDENTIAL)
+		expect('cause' in (err as object)).toBe(false)
+	}, 30_000)
+
+	it('preserves the caller abort reason when the SDK replaces the error object', async () => {
+		const controller = new AbortController()
+		const reason = new Error('user stopped')
+		const sdkAbort = Object.assign(new Error('request aborted'), {
+			name: 'APIUserAbortError',
+		})
+		controller.abort(reason)
+		const provider = new AnthropicProvider({
+			apiKey: 'test-key',
+			model: 'claude-sonnet-4-5-20250929',
+		})
+		;(provider as unknown as { client: unknown }).client = {
+			messages: { create: async () => Promise.reject(sdkAbort) },
+		}
+
+		const err = await captureProviderError(provider, controller.signal)
+
+		expect(sdkAbort).not.toBe(reason)
+		expect(err).toBe(reason)
+	})
+})

--- a/packages/providers/anthropic/src/client.ts
+++ b/packages/providers/anthropic/src/client.ts
@@ -10,6 +10,12 @@ import type {
 	TokenUsage,
 	ToolChoice,
 } from '@namzu/sdk'
+import {
+	ProviderRequestError,
+	isCallerAbortError,
+	isProviderRequestError,
+	providerVendorError,
+} from '@namzu/sdk'
 import type { AnthropicConfig } from './types.js'
 
 // Floor for `max_tokens` when neither the request nor the provider
@@ -276,7 +282,13 @@ function applyMessageCacheBreakpoint(messages: AnthropicMessageParam[]): void {
 		if (!msg) continue
 		if (typeof msg.content === 'string') {
 			if (msg.content.length === 0) continue
-			msg.content = [{ type: 'text', text: msg.content, cache_control: { type: 'ephemeral' } }]
+			msg.content = [
+				{
+					type: 'text',
+					text: msg.content,
+					cache_control: { type: 'ephemeral' },
+				},
+			]
 			return
 		}
 		if (msg.content.length > 0) {
@@ -451,7 +463,10 @@ export class AnthropicProvider implements LLMProvider {
 			// line or Anthropic rejects the request. Emit the block-array form
 			// with the identity prefix first; cache breakpoints (if any) stay
 			// on the tagged blocks behind it, so the ordering survives.
-			const ccBlock: AnthropicTextBlock = { type: 'text', text: CLAUDE_CODE_SYSTEM_PREFIX }
+			const ccBlock: AnthropicTextBlock = {
+				type: 'text',
+				text: CLAUDE_CODE_SYSTEM_PREFIX,
+			}
 			body.system = system ? [ccBlock, ...system] : [ccBlock]
 		} else if (system) {
 			body.system = system
@@ -493,7 +508,21 @@ export class AnthropicProvider implements LLMProvider {
 		const createParams = this.buildCreateParams(params, true)
 		const signal = params.signal
 
-		const stream = (await this.createRaw(createParams, { signal })) as AsyncIterable<StreamEvent>
+		let stream: AsyncIterable<StreamEvent>
+		try {
+			stream = (await this.createRaw(createParams, {
+				signal,
+			})) as AsyncIterable<StreamEvent>
+		} catch (err) {
+			// The vendor SDK builds its error message FROM the response body, so a
+			// credential the upstream echoed back is already inside `err.message`
+			// before this code runs (proven with a planted fake token). Classify from
+			// the status and drop the vendor error entirely — no re-throw, no
+			// `cause`, because a `cause` is exactly what a structured logger walks.
+			if (isCallerAbortError(err, signal)) throw signal?.reason ?? err
+			if (isProviderRequestError(err)) throw err
+			throw providerVendorError({ providerId: 'anthropic', error: err })
+		}
 
 		let messageId = ''
 		// Track active tool-use blocks by content_block index so input_json_delta
@@ -521,9 +550,11 @@ export class AnthropicProvider implements LLMProvider {
 					new Promise<IteratorResult<StreamEvent>>((_, reject) => {
 						timer = setTimeout(() => {
 							reject(
-								new Error(
-									`Anthropic stream idle for ${Math.round(streamIdleTimeoutMs / 1000)}s — aborting so the run lifecycle can emit run_failed.`,
-								),
+								new ProviderRequestError({
+									kind: 'network',
+									providerId: 'anthropic',
+									detail: `stream idle for ${Math.round(streamIdleTimeoutMs / 1000)}s — aborting so the run lifecycle can emit run_failed`,
+								}),
 							)
 						}, streamIdleTimeoutMs)
 					}),
@@ -645,13 +676,25 @@ export class AnthropicProvider implements LLMProvider {
 							break
 					}
 				} catch (parseErr) {
-					yield {
-						id: messageId,
-						delta: {},
-						error: `Stream event error: ${parseErr instanceof Error ? parseErr.message : String(parseErr)}`,
-					}
+					if (isProviderRequestError(parseErr)) throw parseErr
+					throw new ProviderRequestError({
+						kind: 'server',
+						providerId: 'anthropic',
+						detail: 'the provider stream returned malformed data',
+					})
 				}
 			}
+		} catch (err) {
+			// A mid-stream failure arrives AFTER a 200, so the create-call wrap above
+			// never sees it: the vendor SDK's SSE reader throws its own APIError for
+			// an `event: error` frame, with the frame body as the message. Same
+			// treatment — classify, then drop.
+			//
+			// An abort is NOT a provider failure: restore the caller's signal.reason
+			// even when the SDK replaced it with its own APIUserAbortError object.
+			if (isCallerAbortError(err, signal)) throw signal?.reason ?? err
+			if (isProviderRequestError(err)) throw err
+			throw providerVendorError({ providerId: 'anthropic', error: err })
 		} finally {
 			// Always release the underlying HTTP/2 connection — both on
 			// idle-timeout rejection (bubbling up) and on normal stream

--- a/packages/providers/bedrock/package.json
+++ b/packages/providers/bedrock/package.json
@@ -47,7 +47,7 @@
     "@aws-sdk/client-bedrock-runtime": "^3.700.0"
   },
   "peerDependencies": {
-    "@namzu/sdk": ">=1.0.0"
+    "@namzu/sdk": ">=1.3.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/packages/providers/bedrock/src/__tests__/error-taxonomy.test.ts
+++ b/packages/providers/bedrock/src/__tests__/error-taxonomy.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Provider error taxonomy — Bedrock driver.
+ *
+ * `chatStream` awaits `this.client.send(command)` with no catch, so an AWS
+ * `BedrockRuntimeServiceException` (`ThrottlingException`,
+ * `ValidationException`, `ServiceUnavailableException`, …) escapes verbatim.
+ * A caller cannot classify it without importing `@aws-sdk/client-bedrock-runtime`.
+ *
+ * Transport seam: `BedrockConfig` exposes no `requestHandler`/`endpoint`, so
+ * unlike the fetch-based drivers there is nothing to inject at the HTTP
+ * layer. The tests substitute the `BedrockRuntimeClient`'s `send` and reject
+ * with the REAL AWS exception classes — which is exactly what the driver
+ * sees from a live call, and the only surface the driver's (currently
+ * absent) error mapping would act on.
+ */
+
+import {
+	AccessDeniedException,
+	ModelErrorException,
+	ServiceQuotaExceededException,
+	ServiceUnavailableException,
+	ThrottlingException,
+	ValidationException,
+} from '@aws-sdk/client-bedrock-runtime'
+import type { ConverseStreamOutput } from '@aws-sdk/client-bedrock-runtime'
+import { describe, expect, it } from 'vitest'
+import { BedrockProvider } from '../client.js'
+
+/** Replace the AWS client's `send` so it rejects with `err`. */
+function providerRejectingWith(err: unknown): BedrockProvider {
+	const provider = new BedrockProvider({ region: 'eu-west-1' })
+	;(provider as unknown as { client: { send: () => Promise<never> } }).client = {
+		send: () => Promise.reject(err),
+	}
+	return provider
+}
+
+function providerStreaming(...events: ConverseStreamOutput[]): BedrockProvider {
+	const provider = new BedrockProvider({ region: 'eu-west-1' })
+	;(provider as unknown as { client: { send: () => Promise<unknown> } }).client = {
+		send: async () => ({
+			$metadata: { requestId: 'bedrock-test' },
+			stream: (async function* () {
+				yield* events
+			})(),
+		}),
+	}
+	return provider
+}
+
+async function captureChatStreamError(
+	provider: BedrockProvider,
+	signal?: AbortSignal,
+): Promise<unknown> {
+	try {
+		for await (const _chunk of provider.chatStream({
+			model: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+			messages: [{ role: 'user', content: 'hi' }],
+			signal,
+		})) {
+			// drain
+		}
+	} catch (err) {
+		return err
+	}
+	throw new Error('expected chatStream to throw')
+}
+
+describe('@namzu/bedrock — provider error taxonomy', () => {
+	it('(a) ThrottlingException with `retry-after: 2` becomes a throttle-classified error carrying retryAfterMs', async () => {
+		const aws = new ThrottlingException({
+			message: 'Too many requests, please wait before trying again.',
+			$metadata: { httpStatusCode: 429 },
+		})
+		;(aws as unknown as { $response: unknown }).$response = {
+			statusCode: 429,
+			headers: { 'retry-after': '2' },
+		}
+
+		const err = await captureChatStreamError(providerRejectingWith(aws))
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'throttle',
+			status: 429,
+			retryAfterMs: 2000,
+			providerId: 'bedrock',
+		})
+	})
+
+	it("(c) a ValidationException reporting too many input tokens classifies as 'context_overflow'", async () => {
+		const aws = new ValidationException({
+			message:
+				'Input is too long for requested model. The input token count exceeds the maximum for this model.',
+			$metadata: { httpStatusCode: 400 },
+		})
+
+		const err = await captureChatStreamError(providerRejectingWith(aws))
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'context_overflow',
+			status: 400,
+			providerId: 'bedrock',
+		})
+	})
+
+	it("(c) a ValidationException that is not an overflow classifies as 'bad_request'", async () => {
+		const aws = new ValidationException({
+			message: 'The value at toolConfig.tools failed to satisfy constraint.',
+			$metadata: { httpStatusCode: 400 },
+		})
+
+		const err = await captureChatStreamError(providerRejectingWith(aws))
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'bad_request',
+			status: 400,
+			providerId: 'bedrock',
+		})
+	})
+
+	it("an AccessDeniedException classifies as 'auth'", async () => {
+		const aws = new AccessDeniedException({
+			message: 'You do not have access to the model with the specified model ID.',
+			$metadata: { httpStatusCode: 403 },
+		})
+
+		const err = await captureChatStreamError(providerRejectingWith(aws))
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'auth',
+			status: 403,
+			providerId: 'bedrock',
+		})
+	})
+
+	it("a ServiceUnavailableException classifies as 'server'", async () => {
+		const aws = new ServiceUnavailableException({
+			message: 'The service is unavailable, try again later.',
+			$metadata: { httpStatusCode: 503 },
+		})
+
+		const err = await captureChatStreamError(providerRejectingWith(aws))
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'server',
+			status: 503,
+			providerId: 'bedrock',
+		})
+	})
+
+	it("a ModelErrorException with HTTP 424 still classifies as 'server'", async () => {
+		const aws = new ModelErrorException({
+			message: 'The model failed while processing the request.',
+			originalStatusCode: 500,
+			$metadata: { httpStatusCode: 424 },
+		})
+
+		const err = await captureChatStreamError(providerRejectingWith(aws))
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'server',
+			status: 424,
+			providerId: 'bedrock',
+		})
+	})
+
+	it("a ServiceQuotaExceededException classifies as 'throttle'", async () => {
+		const aws = new ServiceQuotaExceededException({
+			message: 'Account inference quota exceeded.',
+			$metadata: { httpStatusCode: 400 },
+		})
+
+		const err = await captureChatStreamError(providerRejectingWith(aws))
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'throttle',
+			status: 400,
+			providerId: 'bedrock',
+		})
+	})
+
+	it('classifies a throttling exception delivered as a stream union event', async () => {
+		const aws = new ThrottlingException({
+			message: 'stream quota exceeded',
+			$metadata: { httpStatusCode: 429 },
+		})
+
+		const err = await captureChatStreamError(providerStreaming({ throttlingException: aws }))
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'throttle',
+			status: 429,
+			providerId: 'bedrock',
+		})
+	})
+
+	it('drops a secret-bearing validation stream event without retaining cause', async () => {
+		const secret = 'aws-secret-FAKE-DO-NOT-LOG'
+		const aws = new ValidationException({
+			message: `invalid request echoed ${secret}`,
+			$metadata: { httpStatusCode: 400 },
+		})
+
+		const err = await captureChatStreamError(providerStreaming({ validationException: aws }))
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'bad_request',
+			providerId: 'bedrock',
+		})
+		expect((err as Error).message).not.toContain(secret)
+		expect('cause' in (err as object)).toBe(false)
+	})
+
+	it('preserves the caller abort reason when the SDK replaces the error object', async () => {
+		const controller = new AbortController()
+		const reason = new Error('user stopped')
+		const sdkAbort = Object.assign(new Error('request aborted'), {
+			name: 'AbortError',
+		})
+		controller.abort(reason)
+
+		const err = await captureChatStreamError(providerRejectingWith(sdkAbort), controller.signal)
+
+		expect(sdkAbort).not.toBe(reason)
+		expect(err).toBe(reason)
+	})
+})

--- a/packages/providers/bedrock/src/client.ts
+++ b/packages/providers/bedrock/src/client.ts
@@ -7,6 +7,7 @@ import type {
 	Message as BedrockMessage,
 	ContentBlock,
 	ConversationRole,
+	ConverseStreamCommandOutput,
 	ConverseStreamOutput,
 	SystemContentBlock,
 	Tool,
@@ -22,6 +23,12 @@ import type {
 	StreamChunk,
 	TokenUsage,
 	ToolChoice,
+} from '@namzu/sdk'
+import {
+	ProviderRequestError,
+	isCallerAbortError,
+	isProviderRequestError,
+	providerVendorError,
 } from '@namzu/sdk'
 import type { BedrockConfig } from './types.js'
 
@@ -280,14 +287,29 @@ export class BedrockProvider implements LLMProvider {
 			inferenceConfig,
 		})
 
-		const response = await this.client.send(command, {
-			requestTimeout: this.config.timeout ?? 120_000,
-			// Per-request abort: a Stop tears the in-flight Converse stream down.
-			abortSignal: params.signal,
-		})
+		// AWS models failures as distinct exception CLASSES rather than status
+		// codes (ThrottlingException, ValidationException, AccessDeniedException),
+		// and lets them escape verbatim. Classify from the class name, then drop
+		// the AWS error — no re-throw, no `cause`.
+		let response: ConverseStreamCommandOutput
+		try {
+			response = await this.client.send(command, {
+				requestTimeout: this.config.timeout ?? 120_000,
+				// Per-request abort: a Stop tears the in-flight Converse stream down.
+				abortSignal: params.signal,
+			})
+		} catch (err) {
+			if (isCallerAbortError(err, params.signal)) throw params.signal?.reason ?? err
+			if (isProviderRequestError(err)) throw err
+			throw providerVendorError({ providerId: 'bedrock', error: err })
+		}
 
 		if (!response.stream) {
-			throw new Error('Bedrock returned no stream body')
+			throw new ProviderRequestError({
+				kind: 'server',
+				providerId: 'bedrock',
+				detail: 'the response contained no stream body',
+			})
 		}
 
 		const requestId = response.$metadata.requestId ?? `bedrock-${Date.now()}`
@@ -295,94 +317,116 @@ export class BedrockProvider implements LLMProvider {
 		const activeToolCalls = new Map<number, { id: string; name: string; args: string }>()
 		let toolCallIndex = 0
 
-		for await (const event of response.stream as AsyncIterable<ConverseStreamOutput>) {
-			// Stop pulling promptly on abort; `for await` calls the stream's
-			// `.return()` on this throw, releasing the connection.
-			params.signal?.throwIfAborted()
-			try {
-				if ('contentBlockDelta' in event && event.contentBlockDelta?.delta) {
-					const delta = event.contentBlockDelta.delta
-					if ('text' in delta && delta.text) {
-						yield {
-							id: requestId,
-							delta: { content: delta.text },
+		try {
+			for await (const event of response.stream as AsyncIterable<ConverseStreamOutput>) {
+				// Stop pulling promptly on abort; `for await` calls the stream's
+				// `.return()` on this throw, releasing the connection.
+				params.signal?.throwIfAborted()
+
+				// Bedrock reports several post-handshake failures as UNION
+				// EVENTS, not thrown exceptions. Ignoring these members makes a
+				// throttled or failed stream look like a clean EOF.
+				const streamFailure =
+					('internalServerException' in event ? event.internalServerException : undefined) ??
+					('modelStreamErrorException' in event ? event.modelStreamErrorException : undefined) ??
+					('validationException' in event ? event.validationException : undefined) ??
+					('throttlingException' in event ? event.throttlingException : undefined) ??
+					('serviceUnavailableException' in event ? event.serviceUnavailableException : undefined)
+				if (streamFailure) {
+					throw providerVendorError({
+						providerId: 'bedrock',
+						error: streamFailure,
+					})
+				}
+
+				try {
+					if ('contentBlockDelta' in event && event.contentBlockDelta?.delta) {
+						const delta = event.contentBlockDelta.delta
+						if ('text' in delta && delta.text) {
+							yield {
+								id: requestId,
+								delta: { content: delta.text },
+							}
+						}
+
+						if ('toolUse' in delta && delta.toolUse) {
+							const idx = event.contentBlockDelta.contentBlockIndex ?? toolCallIndex
+							const active = activeToolCalls.get(idx)
+							if (active) {
+								active.args += delta.toolUse.input ?? ''
+								yield {
+									id: requestId,
+									delta: {
+										toolCalls: [
+											{
+												index: idx,
+												function: { arguments: delta.toolUse.input ?? '' },
+											},
+										],
+									},
+								}
+							}
 						}
 					}
 
-					if ('toolUse' in delta && delta.toolUse) {
-						const idx = event.contentBlockDelta.contentBlockIndex ?? toolCallIndex
-						const active = activeToolCalls.get(idx)
-						if (active) {
-							active.args += delta.toolUse.input ?? ''
+					if ('contentBlockStart' in event && event.contentBlockStart?.start) {
+						const start = event.contentBlockStart.start
+						if ('toolUse' in start && start.toolUse) {
+							const idx = event.contentBlockStart.contentBlockIndex ?? toolCallIndex
+							activeToolCalls.set(idx, {
+								id: start.toolUse.toolUseId ?? `tool-${Date.now()}`,
+								name: start.toolUse.name ?? '',
+								args: '',
+							})
 							yield {
 								id: requestId,
 								delta: {
 									toolCalls: [
 										{
 											index: idx,
-											function: { arguments: delta.toolUse.input ?? '' },
+											id: start.toolUse.toolUseId,
+											type: 'function',
+											function: { name: start.toolUse.name ?? '' },
 										},
 									],
 								},
 							}
+							toolCallIndex = idx + 1
 						}
 					}
-				}
 
-				if ('contentBlockStart' in event && event.contentBlockStart?.start) {
-					const start = event.contentBlockStart.start
-					if ('toolUse' in start && start.toolUse) {
-						const idx = event.contentBlockStart.contentBlockIndex ?? toolCallIndex
-						activeToolCalls.set(idx, {
-							id: start.toolUse.toolUseId ?? `tool-${Date.now()}`,
-							name: start.toolUse.name ?? '',
-							args: '',
-						})
+					if ('contentBlockStop' in event) {
+					}
+
+					if ('messageStop' in event && event.messageStop) {
 						yield {
 							id: requestId,
-							delta: {
-								toolCalls: [
-									{
-										index: idx,
-										id: start.toolUse.toolUseId,
-										type: 'function',
-										function: { name: start.toolUse.name ?? '' },
-									},
-								],
-							},
+							delta: {},
+							finishReason: mapStopReason(event.messageStop.stopReason),
 						}
-						toolCallIndex = idx + 1
 					}
-				}
 
-				if ('contentBlockStop' in event) {
-				}
-
-				if ('messageStop' in event && event.messageStop) {
-					yield {
-						id: requestId,
-						delta: {},
-						finishReason: mapStopReason(event.messageStop.stopReason),
+					if ('metadata' in event && event.metadata?.usage) {
+						const usage = parseUsage(event.metadata.usage as RawBedrockUsage)
+						yield {
+							id: requestId,
+							delta: {},
+							usage,
+						}
 					}
-				}
-
-				if ('metadata' in event && event.metadata?.usage) {
-					const usage = parseUsage(event.metadata.usage as RawBedrockUsage)
-					yield {
-						id: requestId,
-						delta: {},
-						usage,
-					}
-				}
-			} catch (parseErr) {
-				yield {
-					id: requestId,
-					delta: { content: undefined },
-					finishReason: undefined,
-					usage: undefined,
-					error: `Stream parse error: ${parseErr instanceof Error ? parseErr.message : String(parseErr)}`,
+				} catch (parseErr) {
+					if (isProviderRequestError(parseErr)) throw parseErr
+					throw new ProviderRequestError({
+						kind: 'server',
+						providerId: 'bedrock',
+						detail: 'the provider stream returned malformed data',
+					})
 				}
 			}
+		} catch (err) {
+			if (isCallerAbortError(err, params.signal)) throw params.signal?.reason ?? err
+			if (isProviderRequestError(err)) throw err
+			throw providerVendorError({ providerId: 'bedrock', error: err })
 		}
 	}
 

--- a/packages/providers/http/package.json
+++ b/packages/providers/http/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@namzu/sdk": ">=1.0.0"
+    "@namzu/sdk": ">=1.3.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/packages/providers/http/src/__tests__/error-taxonomy.test.ts
+++ b/packages/providers/http/src/__tests__/error-taxonomy.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Provider error taxonomy — generic HTTP driver (both dialects).
+ *
+ * `chatStream`'s `!response.ok` branch interpolates the whole response
+ * body into the thrown message, which is the most likely place an
+ * upstream-echoed credential lands in a log. The failure must instead be
+ * a classified `ProviderRequestError` built from the status line and the
+ * classified kind ONLY.
+ *
+ * Transport seam: the driver calls the global `fetch` directly — the
+ * `vi.stubGlobal('fetch', …)` harness already used by `http.test.ts`.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { HttpProvider } from '../client.js'
+import { DialectMismatchError, type HttpDialect } from '../types.js'
+
+/** Obviously fake, non-functional token — present only as a leak probe. */
+const FAKE_CREDENTIAL = 'sk-ant-FAKE-DO-NOT-USE-0000'
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+function respond(status: number, body: string, headers: Record<string, string> = {}): Response {
+	return new Response(body, {
+		status,
+		headers: { 'Content-Type': 'application/json', ...headers },
+	})
+}
+
+function sseResponse(frames: string[]): Response {
+	return new Response(`${frames.join('\n\n')}\n\n`, {
+		status: 200,
+		headers: { 'Content-Type': 'text/event-stream' },
+	})
+}
+
+function makeProvider(dialect: HttpDialect = 'openai'): HttpProvider {
+	return new HttpProvider({
+		baseURL: 'https://example.test/v1',
+		apiKey: 'test-key',
+		dialect,
+	})
+}
+
+async function captureChatStreamError(
+	provider: HttpProvider,
+	signal?: AbortSignal,
+): Promise<unknown> {
+	try {
+		for await (const _chunk of provider.chatStream({
+			model: 'gpt-4o-mini',
+			messages: [{ role: 'user', content: 'hi' }],
+			signal,
+		})) {
+			// drain
+		}
+	} catch (err) {
+		return err
+	}
+	throw new Error('expected chatStream to throw')
+}
+
+describe('@namzu/http — provider error taxonomy', () => {
+	it('(a) 429 with `retry-after: 2` throws a throttle-classified error carrying retryAfterMs', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				respond(429, JSON.stringify({ error: { message: 'slow down' } }), {
+					'retry-after': '2',
+				}),
+			),
+		)
+
+		const err = await captureChatStreamError(makeProvider())
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'throttle',
+			status: 429,
+			retryAfterMs: 2000,
+			providerId: 'http',
+		})
+	})
+
+	it("(c) 400 whose body says the prompt is too long classifies as 'context_overflow'", async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				respond(
+					400,
+					JSON.stringify({
+						type: 'error',
+						error: {
+							type: 'invalid_request_error',
+							message: 'prompt is too long',
+						},
+					}),
+				),
+			),
+		)
+
+		const err = await captureChatStreamError(makeProvider('anthropic'))
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'context_overflow',
+			status: 400,
+			providerId: 'http',
+		})
+	})
+
+	it("(c) 400 that is not an overflow classifies as 'bad_request'", async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi
+				.fn()
+				.mockResolvedValue(
+					respond(400, JSON.stringify({ error: { message: 'messages: field required' } })),
+				),
+		)
+
+		const err = await captureChatStreamError(makeProvider())
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'bad_request',
+			status: 400,
+			providerId: 'http',
+		})
+	})
+
+	it("529 (upstream overload) classifies as 'server'", async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi
+				.fn()
+				.mockResolvedValue(
+					respond(529, JSON.stringify({ type: 'overloaded_error', message: 'Overloaded' })),
+				),
+		)
+
+		const err = await captureChatStreamError(makeProvider('anthropic'))
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'server',
+			status: 529,
+			providerId: 'http',
+		})
+	})
+
+	it('(d) SECURITY: a credential echoed back in a 401 body never reaches the thrown message', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				respond(
+					401,
+					JSON.stringify({
+						error: { message: `bad x-api-key ${FAKE_CREDENTIAL}` },
+					}),
+				),
+			),
+		)
+
+		const err = await captureChatStreamError(makeProvider('anthropic'))
+
+		expect((err as Error).message).not.toContain(FAKE_CREDENTIAL)
+		expect(JSON.stringify(err)).not.toContain(FAKE_CREDENTIAL)
+		expect('cause' in (err as object)).toBe(false)
+	})
+
+	it('(d) SECURITY: a credential echoed back in a 400 body never reaches the thrown message', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(respond(400, `rejected token ${FAKE_CREDENTIAL}`)),
+		)
+
+		const err = await captureChatStreamError(makeProvider())
+
+		expect((err as Error).message).not.toContain(FAKE_CREDENTIAL)
+	})
+
+	it("classifies a fetch rejection as 'network' without retaining its cause", async () => {
+		const vendor = new Error(`socket failed for ${FAKE_CREDENTIAL}`)
+		vi.stubGlobal('fetch', vi.fn().mockRejectedValue(vendor))
+
+		const err = await captureChatStreamError(makeProvider())
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'network',
+			providerId: 'http',
+		})
+		expect((err as Error).message).not.toContain(FAKE_CREDENTIAL)
+		expect('cause' in (err as object)).toBe(false)
+	})
+
+	it('preserves the caller abort reason when fetch replaces the error object', async () => {
+		const controller = new AbortController()
+		const reason = new Error('user stopped')
+		const fetchAbort = Object.assign(new Error('request aborted'), {
+			name: 'AbortError',
+		})
+		controller.abort(reason)
+		vi.stubGlobal('fetch', vi.fn().mockRejectedValue(fetchAbort))
+
+		const err = await captureChatStreamError(makeProvider(), controller.signal)
+
+		expect(fetchAbort).not.toBe(reason)
+		expect(err).toBe(reason)
+	})
+
+	it('classifies and sanitizes an Anthropic SSE error after the 200 response', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				sseResponse([
+					`event: error\ndata: ${JSON.stringify({
+						type: 'error',
+						error: {
+							type: 'overloaded_error',
+							message: `echoed ${FAKE_CREDENTIAL}`,
+						},
+					})}`,
+				]),
+			),
+		)
+
+		const err = await captureChatStreamError(makeProvider('anthropic'))
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'server',
+			providerId: 'http',
+		})
+		expect((err as Error).message).not.toContain(FAKE_CREDENTIAL)
+		expect(JSON.stringify(err)).not.toContain(FAKE_CREDENTIAL)
+		expect('cause' in (err as object)).toBe(false)
+	})
+
+	it('classifies malformed SSE without retaining the credential-bearing frame', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(sseResponse([`data: ${FAKE_CREDENTIAL} not-json`])),
+		)
+
+		const err = await captureChatStreamError(makeProvider())
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'server',
+			providerId: 'http',
+		})
+		expect((err as Error).message).not.toContain(FAKE_CREDENTIAL)
+		expect(JSON.stringify(err)).not.toContain(FAKE_CREDENTIAL)
+		expect('cause' in (err as object)).toBe(false)
+	})
+
+	it('redacts query strings and response samples from dialect mismatch diagnostics', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				sseResponse([
+					`data: ${JSON.stringify({
+						type: 'message_start',
+						echo: FAKE_CREDENTIAL,
+					})}`,
+				]),
+			),
+		)
+		const provider = new HttpProvider({
+			baseURL: `https://example.test/v1?api_key=${FAKE_CREDENTIAL}`,
+			dialect: 'openai',
+		})
+
+		const err = await captureChatStreamError(provider)
+
+		expect(err).toBeInstanceOf(DialectMismatchError)
+		expect(err).toMatchObject({
+			url: 'https://example.test',
+			sample: '[redacted]',
+			status: 200,
+		})
+		expect((err as Error).message).not.toContain(FAKE_CREDENTIAL)
+		expect(JSON.stringify(err)).not.toContain(FAKE_CREDENTIAL)
+	})
+})

--- a/packages/providers/http/src/client.ts
+++ b/packages/providers/http/src/client.ts
@@ -8,6 +8,12 @@ import type {
 	TokenUsage,
 	ToolChoice,
 } from '@namzu/sdk'
+import {
+	ProviderRequestError,
+	isCallerAbortError,
+	providerHttpError,
+	providerVendorError,
+} from '@namzu/sdk'
 import { DialectMismatchError, type HttpConfig, type HttpDialect } from './types.js'
 
 const DEFAULT_TIMEOUT_MS = 60_000
@@ -347,26 +353,55 @@ export class HttpProvider implements LLMProvider {
 				? formatAnthropicRequest(params, true, this.config.model)
 				: buildOpenAIBody(params, true, this.config.model)
 
-		const response = await fetch(url, {
-			method: 'POST',
-			headers: this.getHeaders(),
-			body: JSON.stringify(body),
-			signal: this.timeoutSignal(params.signal),
-		})
+		let response: Response
+		try {
+			response = await fetch(url, {
+				method: 'POST',
+				headers: this.getHeaders(),
+				body: JSON.stringify(body),
+				signal: this.timeoutSignal(params.signal),
+			})
+		} catch (err) {
+			if (isCallerAbortError(err, params.signal)) throw params.signal?.reason ?? err
+			throw providerVendorError({ providerId: 'http', error: err })
+		}
 
 		if (!response.ok) {
-			const errorBody = await response.text()
-			throw new Error(`HttpProvider error (${response.status}) from ${url}: ${errorBody}`)
+			// Body read to CLASSIFY, then dropped. It used to be interpolated into
+			// the message together with the URL, so a credential the upstream echoed
+			// back — or one embedded in the URL — reached every log that recorded the
+			// failure. Proven with a planted fake token.
+			const errorBody = await response.text().catch(() => '')
+			throw providerHttpError({
+				providerId: 'http',
+				status: response.status,
+				body: errorBody,
+				retryAfter: response.headers.get('retry-after'),
+			})
 		}
 
 		if (!response.body) {
-			throw new Error(`HttpProvider: no stream body from ${url}`)
+			throw new ProviderRequestError({
+				kind: 'server',
+				providerId: 'http',
+				status: response.status,
+				detail: 'the response contained no stream body',
+			})
 		}
 
 		if (this.dialect === 'anthropic') {
 			yield* this.streamAnthropic(response.body, url, response.status, params.signal)
 		} else {
 			yield* this.streamOpenAI(response.body, url, response.status, params.signal)
+		}
+	}
+
+	private async readStream(reader: ReadableStreamDefaultReader<Uint8Array>, signal?: AbortSignal) {
+		try {
+			return await reader.read()
+		} catch (err) {
+			if (isCallerAbortError(err, signal)) throw signal?.reason ?? err
+			throw providerVendorError({ providerId: 'http', error: err })
 		}
 	}
 
@@ -384,7 +419,7 @@ export class HttpProvider implements LLMProvider {
 		try {
 			while (true) {
 				signal?.throwIfAborted()
-				const { done, value } = await reader.read()
+				const { done, value } = await this.readStream(reader, signal)
 				if (done) break
 
 				buffer += decoder.decode(value, { stream: true })
@@ -400,13 +435,22 @@ export class HttpProvider implements LLMProvider {
 					let parsed: unknown
 					try {
 						parsed = JSON.parse(data)
-					} catch (parseErr) {
-						yield {
-							id: '',
-							delta: {},
-							error: `Stream parse error: ${parseErr instanceof Error ? parseErr.message : String(parseErr)}`,
-						}
-						continue
+					} catch {
+						// V8 includes a source snippet in SyntaxError.message. Never
+						// place that message in a chunk or cause: the malformed frame
+						// may contain a credential or request content.
+						throw new ProviderRequestError({
+							kind: 'server',
+							providerId: 'http',
+							detail: 'the provider stream returned malformed JSON',
+						})
+					}
+
+					if (parsed && typeof parsed === 'object' && 'error' in parsed) {
+						throw providerVendorError({
+							providerId: 'http',
+							error: new Error(data),
+						})
 					}
 
 					if (firstFrame) {
@@ -480,7 +524,7 @@ export class HttpProvider implements LLMProvider {
 		try {
 			while (true) {
 				signal?.throwIfAborted()
-				const { done, value } = await reader.read()
+				const { done, value } = await this.readStream(reader, signal)
 				if (done) break
 
 				buffer += decoder.decode(value, { stream: true })
@@ -500,13 +544,14 @@ export class HttpProvider implements LLMProvider {
 					let parsed: unknown
 					try {
 						parsed = JSON.parse(data)
-					} catch (parseErr) {
-						yield {
-							id: messageId,
-							delta: {},
-							error: `Stream parse error: ${parseErr instanceof Error ? parseErr.message : String(parseErr)}`,
-						}
-						continue
+					} catch {
+						// SyntaxError.message may quote the response fragment. Replace
+						// it with an authored diagnostic and drop the raw frame.
+						throw new ProviderRequestError({
+							kind: 'server',
+							providerId: 'http',
+							detail: 'the provider stream returned malformed JSON',
+						})
 					}
 
 					if (!parsed || typeof parsed !== 'object') continue
@@ -614,12 +659,10 @@ export class HttpProvider implements LLMProvider {
 						case 'message_stop':
 							return
 						case 'error': {
-							yield {
-								id: messageId,
-								delta: {},
-								error: `Anthropic stream error: ${JSON.stringify(parsed)}`,
-							}
-							break
+							throw providerVendorError({
+								providerId: 'http',
+								error: new Error(data),
+							})
 						}
 						default:
 							// Unknown / ping events — ignore.

--- a/packages/providers/http/src/types.ts
+++ b/packages/providers/http/src/types.ts
@@ -32,19 +32,34 @@ export interface HttpProviderConfig extends HttpConfig {
  * Thrown when the server's response shape does not match the declared `dialect`.
  *
  * Fail-fast by design: silent coercion between OpenAI and Anthropic response
- * shapes would corrupt tool-call arguments and content deltas. The error carries
- * enough information (URL, status, sample body) to diagnose misconfiguration.
+ * shapes would corrupt tool-call arguments and content deltas. Diagnostics keep
+ * only the endpoint origin and status; query parameters and response samples are
+ * deliberately redacted because both may contain credentials.
  */
 export class DialectMismatchError extends Error {
+	public readonly url: string
+	public readonly sample: string
+
 	constructor(
 		public readonly dialect: HttpDialect,
-		public readonly url: string,
+		url: string,
 		public readonly status: number,
-		public readonly sample: string,
+		_sample: string,
 	) {
+		const safeUrl = redactDiagnosticUrl(url)
 		super(
-			`HttpProvider: response from ${url} (HTTP ${status}) does not match declared dialect '${dialect}'. Check your 'dialect' argument matches the endpoint shape. Known dialects: 'openai' for OpenAI-compat (Ollama, LM Studio, vLLM, Groq, DeepInfra, OpenRouter), 'anthropic' for native Anthropic API. Response sample: ${sample.slice(0, 200)}`,
+			`HttpProvider: response from ${safeUrl} (HTTP ${status}) does not match declared dialect '${dialect}'. Check your 'dialect' argument matches the endpoint shape. Known dialects: 'openai' for OpenAI-compat (Ollama, LM Studio, vLLM, Groq, DeepInfra, OpenRouter), 'anthropic' for native Anthropic API. Response body omitted.`,
 		)
 		this.name = 'DialectMismatchError'
+		this.url = safeUrl
+		this.sample = '[redacted]'
+	}
+}
+
+function redactDiagnosticUrl(raw: string): string {
+	try {
+		return new URL(raw).origin
+	} catch {
+		return '[redacted endpoint]'
 	}
 }

--- a/packages/providers/lmstudio/package.json
+++ b/packages/providers/lmstudio/package.json
@@ -44,7 +44,7 @@
     "prepublishOnly": "pnpm lint && pnpm typecheck && pnpm build"
   },
   "peerDependencies": {
-    "@namzu/sdk": ">=1.0.0"
+    "@namzu/sdk": ">=1.3.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/packages/providers/lmstudio/src/__tests__/error-taxonomy.test.ts
+++ b/packages/providers/lmstudio/src/__tests__/error-taxonomy.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Provider error taxonomy — LM Studio driver.
+ *
+ * `mapStopReason` folds `contextLengthReached` into `finishReason: 'length'`
+ * unconditionally. When the prediction produced NO content, that is not a
+ * truncated answer the runtime can auto-continue — the prompt itself did not
+ * fit, and the turn failed. Today the caller receives a terminal chunk with
+ * `finishReason: 'length'`, empty content, and no error at all: the run reads
+ * as a successful (if empty) turn.
+ *
+ * Transport seam: `LMStudioConfig` exposes no injection point (the SDK owns a
+ * websocket), so these tests substitute the driver's private `clientInstance`
+ * with a stub prediction — the exact surface the mapping code reads.
+ *
+ * That substitution only works because the driver now builds its client on FIRST
+ * USE rather than in the constructor. It used to connect immediately, so the
+ * replacement landed after a socket had already been opened to an LM Studio that
+ * is usually not running, and the connection failure surfaced as an unhandled
+ * rejection that failed the suite while every assertion passed.
+ */
+
+import type { StreamChunk } from '@namzu/sdk'
+import { describe, expect, it, vi } from 'vitest'
+import { LMStudioProvider } from '../client.js'
+
+const clientConstructor = vi.hoisted(() => vi.fn())
+
+vi.mock('@lmstudio/sdk', () => ({
+	LMStudioClient: class {
+		readonly llm = {
+			listLoaded: async () => [],
+		}
+
+		constructor(config: unknown) {
+			clientConstructor(config)
+		}
+	},
+}))
+
+interface FakeStats {
+	stopReason: string
+	promptTokensCount?: number
+	predictedTokensCount?: number
+	totalTokensCount?: number
+}
+
+/**
+ * The SDK's prediction handle is both async-iterable (fragments) and
+ * awaitable (final result) — the driver uses both.
+ */
+function fakePrediction(fragments: string[], stats: FakeStats): AsyncIterable<{ content: string }> {
+	// A REAL promise (so the driver's `await prediction` resolves to the final
+	// result) with an async iterator bolted on (so `for await` walks the
+	// fragments) — rather than a hand-rolled thenable, which is both less
+	// faithful and trips biome's `noThenProperty`.
+	const handle = Promise.resolve({ stats })
+	Object.defineProperty(handle, Symbol.asyncIterator, {
+		value: async function* () {
+			for (const content of fragments) yield { content }
+		},
+	})
+	return handle as unknown as AsyncIterable<{ content: string }>
+}
+
+function providerYielding(fragments: string[], stats: FakeStats): LMStudioProvider {
+	const provider = new LMStudioProvider({ model: 'qwen3-8b' })
+	;(provider as unknown as { clientInstance: unknown }).clientInstance = {
+		llm: {
+			model: async () => ({ respond: () => fakePrediction(fragments, stats) }),
+		},
+	}
+	return provider
+}
+
+async function collectChunks(provider: LMStudioProvider): Promise<StreamChunk[]> {
+	const out: StreamChunk[] = []
+	for await (const chunk of provider.chatStream({
+		model: 'qwen3-8b',
+		messages: [{ role: 'user', content: 'a very long prompt' }],
+	})) {
+		out.push(chunk)
+	}
+	return out
+}
+
+async function captureChatStreamError(
+	provider: LMStudioProvider,
+	signal?: AbortSignal,
+): Promise<unknown> {
+	try {
+		for await (const _chunk of provider.chatStream({
+			model: 'qwen3-8b',
+			messages: [{ role: 'user', content: 'a very long prompt' }],
+			signal,
+		})) {
+			// drain
+		}
+	} catch (err) {
+		return err
+	}
+	throw new Error('expected chatStream to throw')
+}
+
+describe('@namzu/lmstudio — context overflow is a failure, not a finish reason', () => {
+	it("`contextLengthReached` with NO content throws a 'context_overflow' classified error", async () => {
+		const provider = providerYielding([], {
+			stopReason: 'contextLengthReached',
+			promptTokensCount: 200_000,
+			predictedTokensCount: 0,
+		})
+
+		const err = await captureChatStreamError(provider)
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'context_overflow',
+			providerId: 'lmstudio',
+		})
+	})
+
+	it("`contextLengthReached` AFTER content stays a 'length' finish so the runtime can auto-continue", async () => {
+		const provider = providerYielding(['Once upon a time'], {
+			stopReason: 'contextLengthReached',
+			promptTokensCount: 100,
+			predictedTokensCount: 4,
+		})
+
+		const chunks = await collectChunks(provider)
+
+		expect(chunks.at(-1)?.finishReason).toBe('length')
+	})
+})
+
+describe('@namzu/lmstudio — connection lifecycle and provider taxonomy', () => {
+	it('constructs no websocket client until first use, then reuses one normalized client', async () => {
+		clientConstructor.mockClear()
+		const provider = new LMStudioProvider({
+			host: 'https://lmstudio.example.test:1234',
+			model: 'qwen3-8b',
+		})
+
+		expect(clientConstructor).not.toHaveBeenCalled()
+
+		await provider.listModels()
+		await provider.listModels()
+
+		expect(clientConstructor).toHaveBeenCalledTimes(1)
+		expect(clientConstructor).toHaveBeenCalledWith({
+			baseUrl: 'wss://lmstudio.example.test:1234',
+		})
+	})
+
+	it('classifies and sanitizes a raw client failure', async () => {
+		const secret = 'lmstudio-secret-FAKE-DO-NOT-LOG'
+		const provider = new LMStudioProvider({ model: 'qwen3-8b' })
+		;(provider as unknown as { clientInstance: unknown }).clientInstance = {
+			llm: {
+				model: async () => Promise.reject(new Error(`websocket failed for ${secret}`)),
+			},
+		}
+
+		const err = await captureChatStreamError(provider)
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'network',
+			providerId: 'lmstudio',
+		})
+		expect((err as Error).message).not.toContain(secret)
+		expect('cause' in (err as object)).toBe(false)
+	})
+
+	it('returns the caller abort reason while model resolution is still pending', async () => {
+		const controller = new AbortController()
+		const reason = new Error('user stopped')
+		let rejectModel: ((error: unknown) => void) | undefined
+		const modelPromise = new Promise<never>((_resolve, reject) => {
+			rejectModel = reject
+		})
+		const model = vi.fn(async () => modelPromise)
+		const provider = new LMStudioProvider({ model: 'qwen3-8b' })
+		;(provider as unknown as { clientInstance: unknown }).clientInstance = {
+			llm: {
+				model,
+			},
+		}
+
+		const pending = captureChatStreamError(provider, controller.signal)
+		await Promise.resolve()
+		expect(model).toHaveBeenCalledOnce()
+		controller.abort(reason)
+		const err = await pending
+
+		expect(err).toBe(reason)
+
+		// A non-abort vendor error settling after Stop must be owned by the race,
+		// not become an unhandled rejection or replace the caller reason.
+		rejectModel?.(new Error('late websocket failure'))
+		await Promise.resolve()
+	})
+})

--- a/packages/providers/lmstudio/src/client.ts
+++ b/packages/providers/lmstudio/src/client.ts
@@ -9,6 +9,12 @@ import type {
 	StreamChunk,
 	TokenUsage,
 } from '@namzu/sdk'
+import {
+	ProviderRequestError,
+	isCallerAbortError,
+	isProviderRequestError,
+	providerVendorError,
+} from '@namzu/sdk'
 import type { LMStudioConfig } from './types.js'
 
 type StopReason =
@@ -71,6 +77,36 @@ function normalizeBaseUrl(host: string | undefined): string | undefined {
 }
 
 /**
+ * Make the SDK's model-resolution await obey the caller signal too.
+ *
+ * LM Studio accepts a signal only on `model.respond()`, but resolving the model
+ * proxy is itself asynchronous. Without this race, Stop could fire while
+ * `llm.model()` hung and the provider would not return until the vendor did.
+ */
+async function awaitRequestStart<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
+	if (!signal) return operation
+
+	let onAbort: (() => void) | undefined
+	const aborted = new Promise<never>((_resolve, reject) => {
+		if (signal.aborted) {
+			reject(signal.reason)
+			return
+		}
+		onAbort = () => reject(signal.reason)
+		signal.addEventListener('abort', onAbort, { once: true })
+	})
+
+	// The vendor promise can settle after the abort wins. Promise.race installs
+	// a rejection handler, and this explicit sink documents/guards that loser.
+	operation.catch(() => undefined)
+	try {
+		return await Promise.race([operation, aborted])
+	} finally {
+		if (onAbort) signal.removeEventListener('abort', onAbort)
+	}
+}
+
+/**
  * What this DRIVER does, not what LM Studio could do: `chatStream`
  * never reads `params.tools` (tool messages are folded into user text
  * with a `[tool-result]` marker) and `toLMStudioChat` maps text content
@@ -89,13 +125,31 @@ export class LMStudioProvider implements LLMProvider {
 	readonly name = 'LM Studio'
 	readonly capabilities = LMSTUDIO_CAPABILITIES
 
-	private client: LMStudioClient
+	/**
+	 * Built on FIRST USE, not in the constructor.
+	 *
+	 * `new LMStudioClient(...)` opens a websocket to the local LM Studio
+	 * immediately, so constructing this provider — which the registry does for
+	 * every configured provider, used or not — reached out to a service that is
+	 * usually not running, and the connection failure surfaced as an unhandled
+	 * rejection nobody owned. Deferring it means a provider that is never asked
+	 * for a completion never opens a socket.
+	 */
+	private clientInstance?: LMStudioClient
+	private readonly baseUrl?: string
 	private defaultModel?: string
 
 	constructor(config: LMStudioConfig = {}) {
 		const baseUrl = normalizeBaseUrl(config.host ?? process.env.LMSTUDIO_HOST)
-		this.client = new LMStudioClient(baseUrl ? { baseUrl } : {})
+		if (baseUrl) this.baseUrl = baseUrl
 		this.defaultModel = config.model
+	}
+
+	private get client(): LMStudioClient {
+		if (!this.clientInstance) {
+			this.clientInstance = new LMStudioClient(this.baseUrl ? { baseUrl: this.baseUrl } : {})
+		}
+		return this.clientInstance
 	}
 
 	private resolveModel(params: ChatCompletionParams): string {
@@ -110,34 +164,57 @@ export class LMStudioProvider implements LLMProvider {
 
 	async *chatStream(params: ChatCompletionParams): AsyncIterable<StreamChunk> {
 		const modelId = this.resolveModel(params)
-		const model = await this.client.llm.model(modelId)
-		// Pass the caller abort so the SDK sends the real server-side cancel
-		// (LLMPredictionOpts.signal → websocket cancel). `.return()` from the
-		// for-await alone does NOT cancel the prediction, so without this a Stop
-		// leaves the local model generating. No-op when the signal never aborts.
-		const prediction = model.respond(toLMStudioChat(params.messages), {
-			signal: params.signal,
-		})
-
-		const id = randomUUID()
-		for await (const fragment of prediction) {
-			// Cheap promptness check between fragments (the signal above is the
-			// real teardown).
+		try {
 			params.signal?.throwIfAborted()
-			if (fragment.content) {
-				yield {
-					id,
-					delta: { content: fragment.content },
+			const model = await awaitRequestStart(this.client.llm.model(modelId), params.signal)
+			// Pass the caller abort so the SDK sends the real server-side cancel
+			// (LLMPredictionOpts.signal → websocket cancel). `.return()` from the
+			// for-await alone does NOT cancel the prediction, so without this a Stop
+			// leaves the local model generating. No-op when the signal never aborts.
+			const prediction = model.respond(toLMStudioChat(params.messages), {
+				signal: params.signal,
+			})
+
+			const id = randomUUID()
+			let sawContent = false
+			for await (const fragment of prediction) {
+				// Cheap promptness check between fragments (the signal above is the
+				// real teardown).
+				params.signal?.throwIfAborted()
+				if (fragment.content) {
+					sawContent = true
+					yield {
+						id,
+						delta: { content: fragment.content },
+					}
 				}
 			}
-		}
 
-		const result = await prediction
-		yield {
-			id,
-			delta: {},
-			finishReason: mapStopReason(result.stats.stopReason),
-			usage: mapUsage(result.stats),
+			const result = await prediction
+
+			// `contextLengthReached` with NO content is not a truncated answer the
+			// runtime can auto-continue — the PROMPT did not fit, and the turn failed.
+			// Folding it into `finishReason: 'length'` presented it as a successful,
+			// empty turn with no error at all, so a caller parsed "" as the reply.
+			// Truncation AFTER content is genuinely 'length' and must stay that way:
+			// auto-continuation depends on it.
+			if (result.stats.stopReason === 'contextLengthReached' && !sawContent) {
+				throw new ProviderRequestError({
+					kind: 'context_overflow',
+					providerId: 'lmstudio',
+				})
+			}
+
+			yield {
+				id,
+				delta: {},
+				finishReason: mapStopReason(result.stats.stopReason),
+				usage: mapUsage(result.stats),
+			}
+		} catch (err) {
+			if (isCallerAbortError(err, params.signal)) throw params.signal?.reason ?? err
+			if (isProviderRequestError(err)) throw err
+			throw providerVendorError({ providerId: 'lmstudio', error: err })
 		}
 	}
 

--- a/packages/providers/ollama/package.json
+++ b/packages/providers/ollama/package.json
@@ -47,7 +47,7 @@
     "ollama": "^0.5.0"
   },
   "peerDependencies": {
-    "@namzu/sdk": ">=1.0.0"
+    "@namzu/sdk": ">=1.3.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/packages/providers/ollama/src/__tests__/error-taxonomy.test.ts
+++ b/packages/providers/ollama/src/__tests__/error-taxonomy.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Provider error taxonomy + finish-reason truth — Ollama driver.
+ *
+ * Two defects in one file:
+ *
+ *  1. `chatStream` hardcodes `finishReason: 'stop'` on the final chunk, so
+ *     a length-truncated answer is indistinguishable from a finished one.
+ *     The runtime's auto-continuation
+ *     (`packages/sdk/src/runtime/query/iteration/index.ts`, the
+ *     `response.finishReason === 'length'` branch) can therefore NEVER
+ *     fire for Ollama — a truncated answer is silently presented as final.
+ *  2. An HTTP failure surfaces as the ollama SDK's own `ResponseError`,
+ *     which no caller can classify.
+ *
+ * Transport seam: `OllamaConfig.fetch` is already a first-class injection
+ * point on the driver (`new Ollama({ host, fetch })`).
+ */
+
+import type { StreamChunk } from '@namzu/sdk'
+import { describe, expect, it, vi } from 'vitest'
+import { OllamaProvider } from '../client.js'
+
+/** Obviously fake, non-functional token — present only as a leak probe. */
+const FAKE_CREDENTIAL = 'sk-ant-FAKE-DO-NOT-USE-0000'
+
+/** An NDJSON body, the wire shape the ollama SDK's stream parser consumes. */
+function ndjsonResponse(lines: object[]): Response {
+	const text = `${lines.map((l) => JSON.stringify(l)).join('\n')}\n`
+	return new Response(text, {
+		status: 200,
+		headers: { 'Content-Type': 'application/x-ndjson' },
+	})
+}
+
+function jsonResponse(
+	status: number,
+	body: unknown,
+	headers: Record<string, string> = {},
+): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { 'Content-Type': 'application/json', ...headers },
+	})
+}
+
+function providerWithFetch(impl: () => Promise<Response>): OllamaProvider {
+	return new OllamaProvider({
+		host: 'http://ollama.test:11434',
+		model: 'llama3.1',
+		fetch: (async () => impl()) as unknown as typeof fetch,
+	})
+}
+
+async function collectChunks(provider: OllamaProvider): Promise<StreamChunk[]> {
+	const out: StreamChunk[] = []
+	for await (const chunk of provider.chatStream({
+		model: 'llama3.1',
+		messages: [{ role: 'user', content: 'write me a long essay' }],
+	})) {
+		out.push(chunk)
+	}
+	return out
+}
+
+async function captureChatStreamError(
+	provider: OllamaProvider,
+	signal?: AbortSignal,
+): Promise<unknown> {
+	try {
+		for await (const _chunk of provider.chatStream({
+			model: 'llama3.1',
+			messages: [{ role: 'user', content: 'write me a long essay' }],
+			signal,
+		})) {
+			// drain
+		}
+	} catch (err) {
+		return err
+	}
+	throw new Error('expected chatStream to throw')
+}
+
+describe('@namzu/ollama — finish reason truth', () => {
+	it("(b) a final chunk with `done_reason: 'length'` yields finishReason 'length'", async () => {
+		const provider = providerWithFetch(async () =>
+			ndjsonResponse([
+				{
+					model: 'llama3.1',
+					message: { role: 'assistant', content: 'Once upon' },
+					done: false,
+				},
+				{
+					model: 'llama3.1',
+					message: { role: 'assistant', content: '' },
+					done: true,
+					done_reason: 'length',
+					prompt_eval_count: 12,
+					eval_count: 128,
+				},
+			]),
+		)
+
+		const chunks = await collectChunks(provider)
+		const terminal = chunks.at(-1)
+
+		expect(terminal?.finishReason).toBe('length')
+	})
+
+	it("(b) a final chunk with `done_reason: 'stop'` still yields finishReason 'stop'", async () => {
+		const provider = providerWithFetch(async () =>
+			ndjsonResponse([
+				{
+					model: 'llama3.1',
+					message: { role: 'assistant', content: 'Done.' },
+					done: false,
+				},
+				{
+					model: 'llama3.1',
+					message: { role: 'assistant', content: '' },
+					done: true,
+					done_reason: 'stop',
+					prompt_eval_count: 12,
+					eval_count: 3,
+				},
+			]),
+		)
+
+		const chunks = await collectChunks(provider)
+
+		expect(chunks.at(-1)?.finishReason).toBe('stop')
+	})
+})
+
+describe('@namzu/ollama — provider error taxonomy', () => {
+	it('(a) 429 with `retry-after: 2` throws a throttle-classified error carrying retryAfterMs', async () => {
+		const provider = providerWithFetch(async () =>
+			jsonResponse(429, { error: 'too many requests' }, { 'retry-after': '2' }),
+		)
+
+		const err = await captureChatStreamError(provider)
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'throttle',
+			status: 429,
+			providerId: 'ollama',
+		})
+		// `retryAfterMs` is deliberately NOT asserted here, and this is the one
+		// driver where it cannot be. The ollama SDK's `checkOk` builds a
+		// `ResponseError` from the body's `error` field and the status code and
+		// discards the response — headers included — so `retry-after` is gone
+		// before this driver sees the failure. The only way to recover it would be
+		// to wrap the injected `fetch` and stash the header on the provider
+		// instance, which cross-attributes under concurrent requests. An absent
+		// `retryAfterMs` is honest; a possibly-wrong one is not. Ollama is a local
+		// server that does not send the header anyway.
+		expect((err as { retryAfterMs?: number }).retryAfterMs).toBeUndefined()
+	})
+
+	it("(c) 400 whose body says the prompt is too long classifies as 'context_overflow'", async () => {
+		const provider = providerWithFetch(async () =>
+			jsonResponse(400, { error: 'input length exceeds context length' }),
+		)
+
+		const err = await captureChatStreamError(provider)
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'context_overflow',
+			status: 400,
+			providerId: 'ollama',
+		})
+	})
+
+	it('(d) SECURITY: a credential echoed back in a 401 body never reaches the thrown message', async () => {
+		const provider = providerWithFetch(async () =>
+			jsonResponse(401, { error: `unauthorized for ${FAKE_CREDENTIAL}` }),
+		)
+
+		const err = await captureChatStreamError(provider)
+
+		expect((err as Error).message).not.toContain(FAKE_CREDENTIAL)
+		expect(JSON.stringify(err)).not.toContain(FAKE_CREDENTIAL)
+		expect('cause' in (err as object)).toBe(false)
+	})
+
+	it('classifies and sanitizes an iterator failure after streaming began', async () => {
+		const vendor = new Error(`socket failed for ${FAKE_CREDENTIAL}`)
+		const provider = new OllamaProvider({
+			host: 'http://ollama.test:11434',
+			model: 'llama3.1',
+		})
+		const stream = {
+			abort() {},
+			async *[Symbol.asyncIterator]() {
+				yield {
+					model: 'llama3.1',
+					message: { role: 'assistant', content: 'partial' },
+					done: false,
+				}
+				throw vendor
+			},
+		}
+		;(provider as unknown as { client: unknown }).client = {
+			chat: async () => stream,
+		}
+
+		const err = await captureChatStreamError(provider)
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'network',
+			providerId: 'ollama',
+		})
+		expect((err as Error).message).not.toContain(FAKE_CREDENTIAL)
+		expect('cause' in (err as object)).toBe(false)
+	})
+
+	it('returns the caller abort reason while the initial POST is still pending', async () => {
+		const controller = new AbortController()
+		const reason = new Error('user stopped')
+		const abortLateStream = vi.fn()
+		const lateStream = {
+			abort: abortLateStream,
+			async *[Symbol.asyncIterator]() {
+				// no chunks
+			},
+		}
+		let resolveStream: ((stream: typeof lateStream) => void) | undefined
+		const streamPromise = new Promise<typeof lateStream>((resolve) => {
+			resolveStream = resolve
+		})
+		const chat = vi.fn(async () => streamPromise)
+		const provider = new OllamaProvider({
+			host: 'http://ollama.test:11434',
+			model: 'llama3.1',
+		})
+		;(provider as unknown as { client: unknown }).client = {
+			chat,
+		}
+
+		const pending = captureChatStreamError(provider, controller.signal)
+		await Promise.resolve()
+		expect(chat).toHaveBeenCalledOnce()
+		controller.abort(reason)
+		const err = await pending
+
+		expect(err).toBe(reason)
+
+		resolveStream?.(lateStream)
+		await vi.waitFor(() => expect(abortLateStream).toHaveBeenCalledOnce())
+	})
+})

--- a/packages/providers/ollama/src/client.ts
+++ b/packages/providers/ollama/src/client.ts
@@ -7,7 +7,13 @@ import type {
 	StreamChunk,
 	TokenUsage,
 } from '@namzu/sdk'
-import { type ChatResponse, Ollama, type Message as OllamaMessage } from 'ollama'
+import { isCallerAbortError, isProviderRequestError, providerVendorError } from '@namzu/sdk'
+import {
+	type AbortableAsyncIterator,
+	type ChatResponse,
+	Ollama,
+	type Message as OllamaMessage,
+} from 'ollama'
 import type { OllamaConfig } from './types.js'
 
 /**
@@ -40,6 +46,23 @@ function toOllamaMessages(messages: ChatCompletionParams['messages']): OllamaMes
 	}))
 }
 
+/**
+ * Ollama's `done_reason` in the SDK's vocabulary. `length` is the one that
+ * matters: it is what the iteration loop's auto-continuation branch reads.
+ * Anything unrecognised stays 'stop' — the conservative answer, because claiming
+ * a truncation that did not happen would trigger a pointless continuation.
+ */
+function mapDoneReason(reason: string | undefined): StreamChunk['finishReason'] {
+	switch (reason) {
+		case 'length':
+			return 'length'
+		case 'stop':
+			return 'stop'
+		default:
+			return 'stop'
+	}
+}
+
 function buildUsage(resp: Pick<ChatResponse, 'prompt_eval_count' | 'eval_count'>): TokenUsage {
 	const promptTokens = resp.prompt_eval_count ?? 0
 	const completionTokens = resp.eval_count ?? 0
@@ -49,6 +72,44 @@ function buildUsage(resp: Pick<ChatResponse, 'prompt_eval_count' | 'eval_count'>
 		totalTokens: promptTokens + completionTokens,
 		cachedTokens: 0,
 		cacheWriteTokens: 0,
+	}
+}
+
+/**
+ * Race the initial POST/response-handshake against Stop.
+ *
+ * The ollama SDK creates its private AbortController inside the request and
+ * exposes it only on the resolved iterator. If Stop wins before that point, the
+ * caller still returns immediately; when the iterator eventually arrives, abort
+ * it so the late connection is not left generating.
+ */
+async function awaitStreamStart(
+	operation: Promise<AbortableAsyncIterator<ChatResponse>>,
+	signal?: AbortSignal,
+): Promise<AbortableAsyncIterator<ChatResponse>> {
+	if (!signal) return operation
+
+	let onAbort: (() => void) | undefined
+	const aborted = new Promise<never>((_resolve, reject) => {
+		if (signal.aborted) {
+			reject(signal.reason)
+			return
+		}
+		onAbort = () => reject(signal.reason)
+		signal.addEventListener('abort', onAbort, { once: true })
+	})
+
+	void operation.then(
+		(stream) => {
+			if (signal.aborted) stream.abort()
+		},
+		() => undefined,
+	)
+
+	try {
+		return await Promise.race([operation, aborted])
+	} finally {
+		if (onAbort) signal.removeEventListener('abort', onAbort)
 	}
 }
 
@@ -93,12 +154,27 @@ export class OllamaProvider implements LLMProvider {
 		const messages = toOllamaMessages(params.messages)
 		const options = this.buildOptions(params)
 
-		const stream = await this.client.chat({
-			model,
-			messages,
-			stream: true,
-			...(Object.keys(options).length > 0 ? { options } : {}),
-		})
+		// The ollama SDK's `checkOk` promotes the response body's `error` field into
+		// `ResponseError.message`, so an upstream that echoes a credential back has
+		// already put it in the vendor error before this code runs. Classify from
+		// the status, then drop the vendor error entirely — no re-throw, no `cause`.
+		let stream: AbortableAsyncIterator<ChatResponse>
+		try {
+			params.signal?.throwIfAborted()
+			stream = await awaitStreamStart(
+				this.client.chat({
+					model,
+					messages,
+					stream: true,
+					...(Object.keys(options).length > 0 ? { options } : {}),
+				}),
+				params.signal,
+			)
+		} catch (err) {
+			if (isCallerAbortError(err, params.signal)) throw params.signal?.reason ?? err
+			if (isProviderRequestError(err)) throw err
+			throw providerVendorError({ providerId: 'ollama', error: err })
+		}
 
 		// Wire the caller abort to the iterator's real teardown: `stream.abort()`
 		// calls the underlying AbortController so the fetch is cancelled and the
@@ -129,11 +205,21 @@ export class OllamaProvider implements LLMProvider {
 					yield {
 						id,
 						delta: {},
-						finishReason: 'stop',
+						// `done_reason` was ignored and every finish reported as 'stop', so a
+						// length-truncated answer was indistinguishable from a finished one.
+						// The consumer that starves on this is real: the iteration loop's
+						// auto-continuation only fires on `finishReason === 'length'`, so it
+						// could never fire for Ollama. The field is in the vendor's own
+						// typings, so this needs no cast.
+						finishReason: mapDoneReason(chunk.done_reason),
 						usage,
 					}
 				}
 			}
+		} catch (err) {
+			if (isCallerAbortError(err, signal)) throw signal?.reason ?? err
+			if (isProviderRequestError(err)) throw err
+			throw providerVendorError({ providerId: 'ollama', error: err })
 		} finally {
 			signal?.removeEventListener('abort', onAbort)
 		}

--- a/packages/providers/openai/package.json
+++ b/packages/providers/openai/package.json
@@ -47,7 +47,7 @@
     "openai": "^6.0.0"
   },
   "peerDependencies": {
-    "@namzu/sdk": ">=1.0.0"
+    "@namzu/sdk": ">=1.3.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/packages/providers/openai/src/__tests__/error-taxonomy.test.ts
+++ b/packages/providers/openai/src/__tests__/error-taxonomy.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Provider error taxonomy — OpenAI driver.
+ *
+ * Like the Anthropic driver, this one lets the vendor SDK's own error type
+ * escape verbatim (`RateLimitError`, `BadRequestError`, …). Those carry a
+ * status but are vendor classes, so no caller can classify them without
+ * importing `openai` — and their `message` interpolates the response body.
+ *
+ * Transport seam: `OpenAIConfig.baseURL` — a loopback server answering
+ * with a scripted status/headers/body, so the REAL vendor client runs
+ * (including its internal retries, which this group must not disturb).
+ */
+
+import { type Server, createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { afterEach, describe, expect, it } from 'vitest'
+import { OpenAIProvider } from '../client.js'
+
+/** Obviously fake, non-functional token — present only as a leak probe. */
+const FAKE_CREDENTIAL = 'sk-ant-FAKE-DO-NOT-USE-0000'
+
+interface ScriptedReply {
+	status: number
+	body: string
+	headers?: Record<string, string>
+}
+
+let server: Server | undefined
+
+afterEach(async () => {
+	if (server) {
+		await new Promise<void>((resolve) => server?.close(() => resolve()))
+		server = undefined
+	}
+})
+
+async function startEndpoint(reply: ScriptedReply): Promise<string> {
+	server = createServer((_req, res) => {
+		res.writeHead(reply.status, {
+			'Content-Type': 'application/json',
+			...(reply.headers ?? {}),
+		})
+		res.end(reply.body)
+	})
+	await new Promise<void>((resolve) => server?.listen(0, '127.0.0.1', () => resolve()))
+	const { port } = server.address() as AddressInfo
+	return `http://127.0.0.1:${port}/v1`
+}
+
+async function captureChatStreamError(reply: ScriptedReply): Promise<unknown> {
+	const baseURL = await startEndpoint(reply)
+	// maxRetries is deliberately NOT set: this group classifies errors and
+	// must leave the vendor SDK's own retry behaviour exactly as it is.
+	const provider = new OpenAIProvider({
+		apiKey: 'test-key',
+		model: 'gpt-4o-mini',
+		baseURL,
+	})
+	try {
+		for await (const _chunk of provider.chatStream({
+			model: 'gpt-4o-mini',
+			messages: [{ role: 'user', content: 'hi' }],
+		})) {
+			// drain
+		}
+	} catch (err) {
+		return err
+	}
+	throw new Error('expected chatStream to throw')
+}
+
+async function captureProviderError(
+	provider: OpenAIProvider,
+	signal?: AbortSignal,
+): Promise<unknown> {
+	try {
+		for await (const _chunk of provider.chatStream({
+			model: 'gpt-4o-mini',
+			messages: [{ role: 'user', content: 'hi' }],
+			signal,
+		})) {
+			// drain
+		}
+	} catch (err) {
+		return err
+	}
+	throw new Error('expected chatStream to throw')
+}
+
+describe('@namzu/openai — provider error taxonomy', () => {
+	it('(a) 429 with `retry-after: 2` throws a throttle-classified error carrying retryAfterMs', async () => {
+		const err = await captureChatStreamError({
+			status: 429,
+			headers: { 'retry-after': '2' },
+			body: JSON.stringify({
+				error: { message: 'Rate limit reached', type: 'rate_limit_error' },
+			}),
+		})
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'throttle',
+			status: 429,
+			retryAfterMs: 2000,
+			providerId: 'openai',
+		})
+	}, 60_000)
+
+	it("(c) 400 whose body reports a context-length overflow classifies as 'context_overflow'", async () => {
+		const err = await captureChatStreamError({
+			status: 400,
+			body: JSON.stringify({
+				error: {
+					message:
+						"This model's maximum context length is 128000 tokens. However, your messages resulted in 190210 tokens.",
+					type: 'invalid_request_error',
+					code: 'context_length_exceeded',
+				},
+			}),
+		})
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'context_overflow',
+			status: 400,
+			providerId: 'openai',
+		})
+	}, 30_000)
+
+	it("(c) 400 that is not an overflow classifies as 'bad_request'", async () => {
+		const err = await captureChatStreamError({
+			status: 400,
+			body: JSON.stringify({
+				error: {
+					message: "Unrecognized request argument: 'temperture'",
+					type: 'invalid_request_error',
+				},
+			}),
+		})
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'bad_request',
+			status: 400,
+			providerId: 'openai',
+		})
+	}, 30_000)
+
+	it("(auth) 401 classifies as 'auth'", async () => {
+		const err = await captureChatStreamError({
+			status: 401,
+			body: JSON.stringify({
+				error: {
+					message: 'Incorrect API key provided',
+					type: 'invalid_request_error',
+				},
+			}),
+		})
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'auth',
+			status: 401,
+			providerId: 'openai',
+		})
+	}, 30_000)
+
+	it('(d) SECURITY: a credential echoed back in a 401 body never reaches the thrown message', async () => {
+		const err = await captureChatStreamError({
+			status: 401,
+			body: JSON.stringify({
+				error: { message: `Incorrect API key provided: ${FAKE_CREDENTIAL}` },
+			}),
+		})
+
+		expect((err as Error).message).not.toContain(FAKE_CREDENTIAL)
+		expect(JSON.stringify(err)).not.toContain(FAKE_CREDENTIAL)
+		expect('cause' in (err as object)).toBe(false)
+	}, 30_000)
+
+	it('classifies and sanitizes an SDK failure thrown after streaming began', async () => {
+		const vendor = Object.assign(new Error(`overloaded_error ${FAKE_CREDENTIAL}`), {
+			name: 'APIError',
+		})
+		const provider = new OpenAIProvider({
+			apiKey: 'test-key',
+			model: 'gpt-4o-mini',
+		})
+		const stream = {
+			async *[Symbol.asyncIterator]() {
+				yield {
+					id: 'chatcmpl-1',
+					choices: [{ delta: { content: 'partial' }, finish_reason: null }],
+					usage: null,
+				}
+				throw vendor
+			},
+		}
+		;(provider as unknown as { client: unknown }).client = {
+			chat: { completions: { create: async () => stream } },
+		}
+
+		const err = await captureProviderError(provider)
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'server',
+			providerId: 'openai',
+		})
+		expect((err as Error).message).not.toContain(FAKE_CREDENTIAL)
+		expect('cause' in (err as object)).toBe(false)
+	})
+
+	it('preserves the caller abort reason when the SDK replaces the error object', async () => {
+		const controller = new AbortController()
+		const reason = new Error('user stopped')
+		const sdkAbort = Object.assign(new Error('request aborted'), {
+			name: 'APIUserAbortError',
+		})
+		controller.abort(reason)
+		const provider = new OpenAIProvider({
+			apiKey: 'test-key',
+			model: 'gpt-4o-mini',
+		})
+		;(provider as unknown as { client: unknown }).client = {
+			chat: { completions: { create: async () => Promise.reject(sdkAbort) } },
+		}
+
+		const err = await captureProviderError(provider, controller.signal)
+
+		expect(sdkAbort).not.toBe(reason)
+		expect(err).toBe(reason)
+	})
+})

--- a/packages/providers/openai/src/client.ts
+++ b/packages/providers/openai/src/client.ts
@@ -8,6 +8,12 @@ import type {
 	TokenUsage,
 	ToolChoice,
 } from '@namzu/sdk'
+import {
+	ProviderRequestError,
+	isCallerAbortError,
+	isProviderRequestError,
+	providerVendorError,
+} from '@namzu/sdk'
 import OpenAI from 'openai'
 import type {
 	ChatCompletionContentPart,
@@ -188,73 +194,92 @@ export class OpenAIProvider implements LLMProvider {
 	async *chatStream(params: ChatCompletionParams): AsyncIterable<StreamChunk> {
 		const model = this.resolveModel(params)
 
-		const stream = await this.client.chat.completions.create(
-			{
-				model,
-				messages: toOpenAIMessages(params.messages),
-				stream: true,
-				stream_options: { include_usage: true },
-				tools: toOpenAITools(params),
-				tool_choice: formatToolChoice(params.toolChoice),
-				parallel_tool_calls: params.parallelToolCalls,
-				temperature: params.temperature,
-				max_tokens: params.maxTokens,
-				top_p: params.topP,
-				frequency_penalty: params.frequencyPenalty,
-				presence_penalty: params.presencePenalty,
-				stop: params.stop,
-				response_format: params.responseFormat,
-			},
-			// Per-request abort: a Stop tears the in-flight SSE request down.
-			{ signal: params.signal },
-		)
+		let stream: Awaited<ReturnType<typeof this.client.chat.completions.create>>
+		try {
+			stream = await this.client.chat.completions.create(
+				{
+					model,
+					messages: toOpenAIMessages(params.messages),
+					stream: true,
+					stream_options: { include_usage: true },
+					tools: toOpenAITools(params),
+					tool_choice: formatToolChoice(params.toolChoice),
+					parallel_tool_calls: params.parallelToolCalls,
+					temperature: params.temperature,
+					max_tokens: params.maxTokens,
+					top_p: params.topP,
+					frequency_penalty: params.frequencyPenalty,
+					presence_penalty: params.presencePenalty,
+					stop: params.stop,
+					response_format: params.responseFormat,
+				},
+				// Per-request abort: a Stop tears the in-flight SSE request down.
+				{ signal: params.signal },
+			)
+		} catch (err) {
+			// The vendor SDK builds its error message FROM the response body, so a
+			// credential the upstream echoed back is already inside `err.message`
+			// before this code runs (proven with a planted fake token). Classify from
+			// the status and drop the vendor error entirely — no re-throw, no
+			// `cause`, because a `cause` is exactly what a structured logger walks.
+			if (isCallerAbortError(err, params.signal)) throw params.signal?.reason ?? err
+			if (isProviderRequestError(err)) throw err
+			throw providerVendorError({ providerId: 'openai', error: err })
+		}
 
-		for await (const chunk of stream) {
-			// Stop pulling promptly on abort; `for await` calls the stream's
-			// `.return()` on this throw, releasing the connection.
-			params.signal?.throwIfAborted()
-			try {
-				const choice = chunk.choices[0]
-				const delta = choice?.delta
+		try {
+			for await (const chunk of stream) {
+				// Stop pulling promptly on abort; `for await` calls the stream's
+				// `.return()` on this throw, releasing the connection.
+				params.signal?.throwIfAborted()
+				try {
+					const choice = chunk.choices[0]
+					const delta = choice?.delta
 
-				const toolCalls = delta?.tool_calls?.map((tc) => ({
-					index: tc.index,
-					id: tc.id,
-					type: tc.type,
-					function: tc.function
-						? {
-								name: tc.function.name,
-								arguments: tc.function.arguments,
-							}
-						: undefined,
-				}))
+					const toolCalls = delta?.tool_calls?.map((tc) => ({
+						index: tc.index,
+						id: tc.id,
+						type: tc.type,
+						function: tc.function
+							? {
+									name: tc.function.name,
+									arguments: tc.function.arguments,
+								}
+							: undefined,
+					}))
 
-				const hasDelta =
-					(delta?.content !== undefined && delta.content !== null) ||
-					(toolCalls && toolCalls.length > 0)
-				const finishReason = choice?.finish_reason
-					? mapFinishReason(choice.finish_reason)
-					: undefined
-				const usage = chunk.usage ? parseUsage(chunk.usage) : undefined
+					const hasDelta =
+						(delta?.content !== undefined && delta.content !== null) ||
+						(toolCalls && toolCalls.length > 0)
+					const finishReason = choice?.finish_reason
+						? mapFinishReason(choice.finish_reason)
+						: undefined
+					const usage = chunk.usage ? parseUsage(chunk.usage) : undefined
 
-				if (!hasDelta && !finishReason && !usage) continue
+					if (!hasDelta && !finishReason && !usage) continue
 
-				yield {
-					id: chunk.id,
-					delta: {
-						content: delta?.content ?? undefined,
-						toolCalls,
-					},
-					finishReason,
-					usage,
-				}
-			} catch (parseErr) {
-				yield {
-					id: chunk.id ?? '',
-					delta: {},
-					error: `Stream parse error: ${parseErr instanceof Error ? parseErr.message : String(parseErr)}`,
+					yield {
+						id: chunk.id,
+						delta: {
+							content: delta?.content ?? undefined,
+							toolCalls,
+						},
+						finishReason,
+						usage,
+					}
+				} catch (parseErr) {
+					if (isProviderRequestError(parseErr)) throw parseErr
+					throw new ProviderRequestError({
+						kind: 'server',
+						providerId: 'openai',
+						detail: 'the provider stream returned malformed data',
+					})
 				}
 			}
+		} catch (err) {
+			if (isCallerAbortError(err, params.signal)) throw params.signal?.reason ?? err
+			if (isProviderRequestError(err)) throw err
+			throw providerVendorError({ providerId: 'openai', error: err })
 		}
 	}
 

--- a/packages/providers/openrouter/package.json
+++ b/packages/providers/openrouter/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@namzu/sdk": ">=1.0.0"
+    "@namzu/sdk": ">=1.3.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/packages/providers/openrouter/src/__tests__/error-taxonomy.test.ts
+++ b/packages/providers/openrouter/src/__tests__/error-taxonomy.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Provider error taxonomy — OpenRouter driver.
+ *
+ * Every provider failure must reach the caller as a classified
+ * `ProviderRequestError` (kind + status + retryAfterMs + providerId), not
+ * as an opaque vendor string. The message must be built from the status
+ * line and the classified kind ONLY — never from the response body, which
+ * is where a credential echoed back by the upstream would leak into a log.
+ *
+ * Transport seam: the driver calls the global `fetch` directly, so the
+ * existing `vi.stubGlobal('fetch', …)` harness from `http.test.ts` applies
+ * verbatim.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { OpenRouterProvider } from '../client.js'
+
+/**
+ * An obviously fake, non-functional token. Present ONLY to prove the
+ * driver does not interpolate a response body into a thrown message.
+ */
+const FAKE_CREDENTIAL = 'sk-ant-FAKE-DO-NOT-USE-0000'
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+function respond(status: number, body: string, headers: Record<string, string> = {}): Response {
+	return new Response(body, {
+		status,
+		headers: { 'Content-Type': 'application/json', ...headers },
+	})
+}
+
+function sseResponse(frames: string[]): Response {
+	return new Response(`${frames.join('\n\n')}\n\n`, {
+		status: 200,
+		headers: { 'Content-Type': 'text/event-stream' },
+	})
+}
+
+async function captureChatStreamError(
+	provider: OpenRouterProvider,
+	signal?: AbortSignal,
+): Promise<unknown> {
+	try {
+		for await (const _chunk of provider.chatStream({
+			model: 'anthropic/claude-sonnet-4-5',
+			messages: [{ role: 'user', content: 'hi' }],
+			signal,
+		})) {
+			// drain
+		}
+	} catch (err) {
+		return err
+	}
+	throw new Error('expected chatStream to throw')
+}
+
+function makeProvider(): OpenRouterProvider {
+	return new OpenRouterProvider({
+		apiKey: 'test-key',
+		baseUrl: 'https://example.test/api/v1',
+	})
+}
+
+describe('@namzu/openrouter — provider error taxonomy', () => {
+	it('(a) 429 with `retry-after: 2` throws a throttle-classified error carrying retryAfterMs', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				respond(429, JSON.stringify({ error: { message: 'rate limit exceeded' } }), {
+					'retry-after': '2',
+				}),
+			),
+		)
+
+		const err = await captureChatStreamError(makeProvider())
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'throttle',
+			status: 429,
+			retryAfterMs: 2000,
+			providerId: 'openrouter',
+		})
+	})
+
+	it("(c) 400 whose body says the prompt is too long classifies as 'context_overflow'", async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				respond(
+					400,
+					JSON.stringify({
+						error: {
+							type: 'invalid_request_error',
+							message: 'prompt is too long: 305231 tokens > 200000 maximum',
+						},
+					}),
+				),
+			),
+		)
+
+		const err = await captureChatStreamError(makeProvider())
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'context_overflow',
+			status: 400,
+			providerId: 'openrouter',
+		})
+	})
+
+	it("(c) 400 that is not an overflow classifies as 'bad_request'", async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				respond(
+					400,
+					JSON.stringify({
+						error: {
+							type: 'invalid_request_error',
+							message: "unknown field 'temperture'",
+						},
+					}),
+				),
+			),
+		)
+
+		const err = await captureChatStreamError(makeProvider())
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'bad_request',
+			status: 400,
+			providerId: 'openrouter',
+		})
+	})
+
+	it("(a/auth) 401 classifies as 'auth'", async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi
+				.fn()
+				.mockResolvedValue(
+					respond(401, JSON.stringify({ error: { message: 'No auth credentials found' } })),
+				),
+		)
+
+		const err = await captureChatStreamError(makeProvider())
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'auth',
+			status: 401,
+			providerId: 'openrouter',
+		})
+	})
+
+	it('(d) SECURITY: a credential echoed back in a 401 body never reaches the thrown message', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				respond(
+					401,
+					JSON.stringify({
+						error: { message: `invalid api key: ${FAKE_CREDENTIAL}` },
+					}),
+				),
+			),
+		)
+
+		const err = await captureChatStreamError(makeProvider())
+
+		expect(err).toBeInstanceOf(Error)
+		const message = (err as Error).message
+		expect(message).not.toContain(FAKE_CREDENTIAL)
+		expect(JSON.stringify(err)).not.toContain(FAKE_CREDENTIAL)
+		expect('cause' in (err as object)).toBe(false)
+	})
+
+	it('(d) SECURITY: a credential echoed back in a 400 body never reaches the thrown message', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi
+				.fn()
+				.mockResolvedValue(
+					respond(400, `bad request for key ${FAKE_CREDENTIAL}: model not permitted`),
+				),
+		)
+
+		const err = await captureChatStreamError(makeProvider())
+
+		expect((err as Error).message).not.toContain(FAKE_CREDENTIAL)
+	})
+
+	it("classifies a fetch rejection as 'network' without retaining its cause", async () => {
+		const vendor = new Error(`socket failed for ${FAKE_CREDENTIAL}`)
+		vi.stubGlobal('fetch', vi.fn().mockRejectedValue(vendor))
+
+		const err = await captureChatStreamError(makeProvider())
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'network',
+			providerId: 'openrouter',
+		})
+		expect((err as Error).message).not.toContain(FAKE_CREDENTIAL)
+		expect('cause' in (err as object)).toBe(false)
+	})
+
+	it('preserves the caller abort reason when fetch replaces the error object', async () => {
+		const controller = new AbortController()
+		const reason = new Error('user stopped')
+		const fetchAbort = Object.assign(new Error('request aborted'), {
+			name: 'AbortError',
+		})
+		controller.abort(reason)
+		vi.stubGlobal('fetch', vi.fn().mockRejectedValue(fetchAbort))
+
+		const err = await captureChatStreamError(makeProvider(), controller.signal)
+
+		expect(fetchAbort).not.toBe(reason)
+		expect(err).toBe(reason)
+	})
+
+	it('classifies and sanitizes an SSE error after the 200 response', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				sseResponse([
+					`data: ${JSON.stringify({
+						error: {
+							type: 'overloaded_error',
+							message: `echoed ${FAKE_CREDENTIAL}`,
+						},
+					})}`,
+				]),
+			),
+		)
+
+		const err = await captureChatStreamError(makeProvider())
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'server',
+			providerId: 'openrouter',
+		})
+		expect((err as Error).message).not.toContain(FAKE_CREDENTIAL)
+		expect(JSON.stringify(err)).not.toContain(FAKE_CREDENTIAL)
+		expect('cause' in (err as object)).toBe(false)
+	})
+
+	it('classifies malformed SSE without retaining the credential-bearing frame', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(sseResponse([`data: ${FAKE_CREDENTIAL} not-json`])),
+		)
+
+		const err = await captureChatStreamError(makeProvider())
+
+		expect(err).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'server',
+			providerId: 'openrouter',
+		})
+		expect((err as Error).message).not.toContain(FAKE_CREDENTIAL)
+		expect(JSON.stringify(err)).not.toContain(FAKE_CREDENTIAL)
+		expect('cause' in (err as object)).toBe(false)
+	})
+})

--- a/packages/providers/openrouter/src/client.ts
+++ b/packages/providers/openrouter/src/client.ts
@@ -7,6 +7,13 @@ import type {
 	TokenUsage,
 	ToolChoice,
 } from '@namzu/sdk'
+import {
+	ProviderRequestError,
+	isCallerAbortError,
+	isProviderRequestError,
+	providerHttpError,
+	providerVendorError,
+} from '@namzu/sdk'
 import type { OpenRouterConfig } from './types.js'
 
 const OPENROUTER_BASE_URL = process.env.OPENROUTER_BASE_URL ?? 'https://openrouter.ai/api/v1'
@@ -160,20 +167,41 @@ export class OpenRouterProvider implements LLMProvider {
 		// prior `AbortSignal.timeout(...)` expression (byte-identical).
 		const signal = params.signal ? AbortSignal.any([timeout, params.signal]) : timeout
 
-		const response = await fetch(`${this.baseUrl}/chat/completions`, {
-			method: 'POST',
-			headers: this.getHeaders(),
-			body: JSON.stringify(body),
-			signal,
-		})
+		let response: Response
+		try {
+			response = await fetch(`${this.baseUrl}/chat/completions`, {
+				method: 'POST',
+				headers: this.getHeaders(),
+				body: JSON.stringify(body),
+				signal,
+			})
+		} catch (err) {
+			if (isCallerAbortError(err, params.signal)) throw params.signal?.reason ?? err
+			throw providerVendorError({ providerId: 'openrouter', error: err })
+		}
 
 		if (!response.ok) {
-			const errorBody = await response.text()
-			throw new Error(`OpenRouter API error (${response.status}): ${errorBody}`)
+			// The body is read to CLASSIFY (a 400 saying "prompt is too long" is a
+			// context overflow, any other 400 is a bad request) and then dropped. It
+			// used to be interpolated straight into the message, which is how a
+			// credential the upstream echoed back reached every log that recorded
+			// the failure — proven with a planted fake token.
+			const errorBody = await response.text().catch(() => '')
+			throw providerHttpError({
+				providerId: 'openrouter',
+				status: response.status,
+				body: errorBody,
+				retryAfter: response.headers.get('retry-after'),
+			})
 		}
 
 		if (!response.body) {
-			throw new Error('OpenRouter returned no stream body')
+			throw new ProviderRequestError({
+				kind: 'server',
+				providerId: 'openrouter',
+				status: response.status,
+				detail: 'the response contained no stream body',
+			})
 		}
 
 		const reader = response.body.getReader()
@@ -199,6 +227,7 @@ export class OpenRouterProvider implements LLMProvider {
 					try {
 						const parsed = JSON.parse(data) as {
 							id: string
+							error?: unknown
 							choices: Array<{
 								delta: {
 									content?: string
@@ -212,6 +241,13 @@ export class OpenRouterProvider implements LLMProvider {
 								finish_reason?: string
 							}>
 							usage?: RawUsage
+						}
+
+						if (parsed.error !== undefined) {
+							throw providerVendorError({
+								providerId: 'openrouter',
+								error: new Error(data),
+							})
 						}
 
 						const choice = parsed.choices[0]
@@ -232,16 +268,21 @@ export class OpenRouterProvider implements LLMProvider {
 							usage: parsed.usage ? parseUsage(parsed.usage) : undefined,
 						}
 					} catch (parseErr) {
-						yield {
-							id: '',
-							delta: { content: undefined },
-							finishReason: undefined,
-							usage: undefined,
-							error: `Stream parse error: ${parseErr instanceof Error ? parseErr.message : String(parseErr)}`,
-						}
+						if (isProviderRequestError(parseErr)) throw parseErr
+						// JSON SyntaxError messages include a source snippet, and
+						// mapping failures may include vendor values. Drop both.
+						throw new ProviderRequestError({
+							kind: 'server',
+							providerId: 'openrouter',
+							detail: 'the provider stream returned malformed data',
+						})
 					}
 				}
 			}
+		} catch (err) {
+			if (isCallerAbortError(err, params.signal)) throw params.signal?.reason ?? err
+			if (isProviderRequestError(err)) throw err
+			throw providerVendorError({ providerId: 'openrouter', error: err })
 		} finally {
 			reader.releaseLock()
 		}

--- a/packages/sdk/src/manager/run/persistence.ts
+++ b/packages/sdk/src/manager/run/persistence.ts
@@ -5,6 +5,7 @@ import { RunDiskStore } from '../../store/run/disk.js'
 import { type CostInfo, type TokenUsage, accumulateTokenUsage } from '../../types/common/index.js'
 import type { RunId, SessionId, TenantId } from '../../types/ids/index.js'
 import type { Message } from '../../types/message/index.js'
+import type { ProviderErrorInfo } from '../../types/provider/index.js'
 import type { CheckpointRunScope, CheckpointStore } from '../../types/run/checkpoint-store.js'
 import type { EmergencySaveData } from '../../types/run/emergency.js'
 import type { Run, RunPersistenceConfig, StopReason } from '../../types/run/index.js'
@@ -164,10 +165,11 @@ export class RunPersistence {
 		this.resolveResult()
 	}
 
-	markFailed(error: string): void {
+	markFailed(error: string, providerError?: ProviderErrorInfo): void {
 		this.run.status = 'failed'
 		this.run.stopReason = 'error'
 		this.run.lastError = error
+		if (providerError) this.run.lastProviderError = providerError
 		this.run.endedAt = Date.now()
 	}
 

--- a/packages/sdk/src/provider/__tests__/errors.test.ts
+++ b/packages/sdk/src/provider/__tests__/errors.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	ProviderRequestError,
+	bodySaysContextOverflow,
+	classifyProviderHttpStatus,
+	isCallerAbortError,
+	isProviderRequestError,
+	parseRetryAfterMs,
+	providerVendorError,
+} from '../errors.js'
+
+describe('provider error taxonomy', () => {
+	it('classifies only context-specific limit messages as context overflow', () => {
+		expect(bodySaysContextOverflow('input token count exceeds the maximum for this model')).toBe(
+			true,
+		)
+		expect(bodySaysContextOverflow('tool count exceeds the maximum allowed')).toBe(false)
+		expect(bodySaysContextOverflow('reduce the tool list length')).toBe(false)
+	})
+
+	it('does not treat a generic HTTP 413 as model context overflow', () => {
+		expect(classifyProviderHttpStatus(413, 'request body too large at reverse proxy')).toBe(
+			'bad_request',
+		)
+		expect(classifyProviderHttpStatus(413, 'prompt is too long for requested model')).toBe(
+			'context_overflow',
+		)
+	})
+
+	it('parses both Retry-After forms and rejects stale or invalid values', () => {
+		expect(parseRetryAfterMs('2', 0)).toBe(2000)
+		expect(parseRetryAfterMs('Thu, 01 Jan 1970 00:00:05 GMT', 1000)).toBe(4000)
+		expect(parseRetryAfterMs('Thu, 01 Jan 1970 00:00:01 GMT', 1000)).toBeUndefined()
+		expect(parseRetryAfterMs('later', 0)).toBeUndefined()
+	})
+
+	it('drops the vendor object and its non-enumerable cause entirely', () => {
+		const secret = 'sk-FAKE-DO-NOT-LOG'
+		const vendor = new Error(`invalid api key ${secret}`, {
+			cause: new Error(`response body ${secret}`),
+		})
+		Object.assign(vendor, { status: 401 })
+
+		const classified = providerVendorError({
+			providerId: 'test-provider',
+			error: vendor,
+		})
+
+		expect(classified).toMatchObject({
+			name: 'ProviderRequestError',
+			kind: 'auth',
+			status: 401,
+			providerId: 'test-provider',
+		})
+		expect(classified.message).not.toContain(secret)
+		expect('cause' in classified).toBe(false)
+	})
+
+	it('recognizes a caller abort only when that signal actually aborted', () => {
+		const controller = new AbortController()
+		const sdkAbort = Object.assign(new Error('request aborted'), {
+			name: 'APIUserAbortError',
+		})
+
+		expect(isCallerAbortError(sdkAbort, controller.signal)).toBe(false)
+		controller.abort(new Error('user stopped'))
+		expect(isCallerAbortError(sdkAbort, controller.signal)).toBe(true)
+		expect(isCallerAbortError(controller.signal.reason, controller.signal)).toBe(true)
+	})
+
+	it('requires the complete structural contract when SDK copies differ', () => {
+		const classified = new ProviderRequestError({
+			kind: 'server',
+			providerId: 'test-provider',
+		})
+		expect(isProviderRequestError(classified)).toBe(true)
+
+		const impostor = Object.assign(new Error('not classified'), {
+			name: 'ProviderRequestError',
+			kind: 'anything',
+		})
+		expect(isProviderRequestError(impostor)).toBe(false)
+	})
+})

--- a/packages/sdk/src/provider/errors.ts
+++ b/packages/sdk/src/provider/errors.ts
@@ -1,0 +1,344 @@
+/**
+ * One classified error for every provider failure.
+ *
+ * Before this, a failure from any of the seven drivers reached the caller as an
+ * opaque string, so nothing downstream could decide whether it was worth
+ * retrying, whether it was the caller's fault, or whether the context window had
+ * simply run out. Two drivers built that string by interpolating the response
+ * body; three more inherited a vendor SDK error whose message IS the response
+ * body. Either way, a credential the upstream echoed back landed in a message
+ * that gets logged.
+ *
+ * So the contract here is deliberately narrow:
+ *
+ *  - the message is built from the STATUS LINE and the classified `kind`. The
+ *    response body is read to classify and then dropped. It is never
+ *    interpolated, never re-thrown, and never attached as `cause` — a `cause`
+ *    survives every logger that serializes an error chain, which defeats the
+ *    point.
+ *  - `retryAfterMs` is DATA. Nothing in this module sleeps, backs off or
+ *    retries. A retry loop inside a driver burns the run's wall clock and hides
+ *    the failure from the layer that should decide.
+ */
+
+import type { ProviderErrorKind, ProviderRequestErrorInit } from '../types/provider/error.js'
+export type {
+	ProviderErrorInfo,
+	ProviderErrorKind,
+	ProviderRequestErrorInit,
+} from '../types/provider/error.js'
+
+const PROVIDER_ERROR_KINDS: readonly ProviderErrorKind[] = [
+	'throttle',
+	'network',
+	'auth',
+	'context_overflow',
+	'bad_request',
+	'server',
+]
+
+/**
+ * A provider request that failed, classified.
+ *
+ * `name` is set explicitly rather than inherited, because the classifier is
+ * matched structurally across a package boundary (a driver in one package throws
+ * it; the runtime in another reads it) and `instanceof` is unreliable when two
+ * copies of the SDK end up in one process.
+ */
+export class ProviderRequestError extends Error {
+	public readonly kind: ProviderErrorKind
+	public readonly providerId: string
+	public readonly status?: number
+	public readonly retryAfterMs?: number
+
+	constructor(init: ProviderRequestErrorInit) {
+		super(buildProviderErrorMessage(init))
+		this.name = 'ProviderRequestError'
+		this.kind = init.kind
+		this.providerId = init.providerId
+		if (init.status !== undefined) this.status = init.status
+		if (init.retryAfterMs !== undefined) this.retryAfterMs = init.retryAfterMs
+	}
+}
+
+/** Is this a classified provider failure, whichever SDK copy threw it? */
+export function isProviderRequestError(err: unknown): err is ProviderRequestError {
+	return (
+		err instanceof Error &&
+		err.name === 'ProviderRequestError' &&
+		typeof (err as { providerId?: unknown }).providerId === 'string' &&
+		PROVIDER_ERROR_KINDS.includes((err as { kind?: ProviderErrorKind }).kind as ProviderErrorKind)
+	)
+}
+
+/**
+ * Did the caller's own AbortSignal terminate this request?
+ *
+ * Provider SDKs do not agree on the object they reject with: some preserve
+ * `signal.reason`, while others replace it with `AbortError` or
+ * `APIUserAbortError`. Reclassifying any of those as a network failure breaks
+ * the runtime's Stop/cancel path, which depends on the abort escaping the
+ * provider boundary.
+ *
+ * The signal must itself be aborted. That condition distinguishes a caller Stop
+ * from an SDK timeout which may also use an `AbortError`-shaped rejection.
+ */
+export function isCallerAbortError(error: unknown, signal?: AbortSignal): boolean {
+	if (!signal?.aborted) return false
+	if (error === signal.reason) return true
+	if (!(error instanceof Error)) return false
+	return error.name === 'AbortError' || error.name === 'APIUserAbortError'
+}
+
+const KIND_SENTENCE: Record<ProviderErrorKind, string> = {
+	throttle: 'rate limited by the provider',
+	network: 'could not reach the provider',
+	auth: 'the provider rejected the request credentials',
+	context_overflow: 'the request exceeded the model context window',
+	bad_request: 'the provider rejected the request as invalid',
+	server: 'the provider failed to complete the request',
+}
+
+function buildProviderErrorMessage(init: ProviderRequestErrorInit): string {
+	const status = init.status !== undefined ? ` (HTTP ${init.status})` : ''
+	const detail = init.detail ? `: ${init.detail}` : ''
+	return `${init.providerId}${status} — ${KIND_SENTENCE[init.kind]}${detail}`
+}
+
+/**
+ * Body fragments that mean "the request did not fit", across the vendors we
+ * drive. Matched case-insensitively against the raw body, which is then
+ * discarded.
+ *
+ * A 400 is otherwise `bad_request`: an overflow is the one 400 a caller can act
+ * on automatically (compact and retry), and mistaking a genuine schema error for
+ * an overflow would send the run into a pointless compaction loop.
+ */
+const OVERFLOW_BODY_PATTERNS: readonly RegExp[] = [
+	/prompt is too long/i,
+	/context[_ ]length[_ ]exceeded/i,
+	/maximum context length/i,
+	/too long for requested model/i,
+	/input is too long/i,
+	/(?:input|prompt|context).{0,80}exceeds the maximum/i,
+	/reduce the (?:input|prompt|context) length/i,
+	// Ollama phrases it the other way round — "input length exceeds context
+	// length" — so a pattern anchored on "exceeded" misses it entirely.
+	/exceeds?\s+(?:the\s+)?(?:model'?s?\s+)?context\s+(?:length|window|size)/i,
+	/context\s+(?:length|window|size)\s+exceed/i,
+]
+
+/** Does this response body say the request did not fit the window? */
+export function bodySaysContextOverflow(body: string | undefined | null): boolean {
+	if (!body) return false
+	return OVERFLOW_BODY_PATTERNS.some((re) => re.test(body))
+}
+
+/**
+ * `Retry-After` in milliseconds. The header is either delta-seconds or an
+ * HTTP-date; both are specified, and vendors use both.
+ *
+ * Returns undefined for anything unparseable or for a date already in the past —
+ * a negative delay is worse than none, because a caller would treat it as
+ * "retry immediately" against a provider that just asked it to wait.
+ */
+export function parseRetryAfterMs(
+	headerValue: string | null | undefined,
+	now: number = Date.now(),
+): number | undefined {
+	if (!headerValue) return undefined
+	const trimmed = headerValue.trim()
+	if (trimmed === '') return undefined
+
+	if (/^\d+(\.\d+)?$/.test(trimmed)) {
+		const seconds = Number(trimmed)
+		if (!Number.isFinite(seconds) || seconds < 0) return undefined
+		return Math.round(seconds * 1000)
+	}
+
+	const at = Date.parse(trimmed)
+	if (Number.isNaN(at)) return undefined
+	const delta = at - now
+	return delta > 0 ? delta : undefined
+}
+
+/**
+ * Classify an HTTP failure. `body` is used ONLY to separate a context overflow
+ * from an ordinary bad request, and is not retained.
+ */
+export function classifyProviderHttpStatus(
+	status: number,
+	body?: string | null,
+): ProviderErrorKind {
+	if (status === 401 || status === 403) return 'auth'
+	if (status === 429) return 'throttle'
+	if (status === 408 || status === 425) return 'network'
+	if (status >= 500) return 'server'
+	if (status === 413) {
+		return bodySaysContextOverflow(body) ? 'context_overflow' : 'bad_request'
+	}
+	if (status >= 400) {
+		return bodySaysContextOverflow(body) ? 'context_overflow' : 'bad_request'
+	}
+	// A non-failure status reaching here is a caller bug, not a provider one.
+	return 'server'
+}
+
+/**
+ * Vendor error TYPES, as the vendors name them in their own payloads. This is a
+ * defined vocabulary, not prose, which is what makes it safe to classify on:
+ * Anthropic sends `{"error":{"type":"overloaded_error"}}` and OpenAI sends
+ * `{"error":{"code":"context_length_exceeded"}}`.
+ *
+ * It matters for MID-STREAM failures above all. Those arrive after a 200, so
+ * there is no status to classify from, and without this an upstream overload
+ * would be filed as `network` — "we could not reach the provider" — when the
+ * provider answered and then gave up. The distinction is the whole point of the
+ * taxonomy: one is worth retrying elsewhere, the other is worth retrying here.
+ */
+const VENDOR_TYPE_KINDS: ReadonlyArray<readonly [RegExp, ProviderErrorKind]> = [
+	[/overloaded_error|api_error|service_unavailable/i, 'server'],
+	[/rate_limit_error|rate_limit_exceeded/i, 'throttle'],
+	[/authentication_error|permission_error|invalid_api_key|unauthorized/i, 'auth'],
+	[/timeout_error|connection_error/i, 'network'],
+]
+
+/** The kind a vendor's own error-type vocabulary implies, if it says one. */
+function vendorTypeKind(message: string): ProviderErrorKind | undefined {
+	for (const [re, kind] of VENDOR_TYPE_KINDS) {
+		if (re.test(message)) return kind
+	}
+	return undefined
+}
+
+/**
+ * Status code off a vendor SDK's own error object, whatever it calls the field.
+ * Anthropic and OpenAI use `status`; the ollama client uses `status_code`; AWS
+ * puts it under `$metadata.httpStatusCode`.
+ */
+function vendorErrorStatus(err: unknown): number | undefined {
+	if (typeof err !== 'object' || err === null) return undefined
+	const e = err as {
+		status?: unknown
+		statusCode?: unknown
+		status_code?: unknown
+		$metadata?: { httpStatusCode?: unknown }
+	}
+	for (const candidate of [e.status, e.statusCode, e.status_code, e.$metadata?.httpStatusCode]) {
+		if (typeof candidate === 'number' && Number.isFinite(candidate)) return candidate
+	}
+	return undefined
+}
+
+/**
+ * `retry-after` off a vendor SDK error's captured response headers. The
+ * Anthropic and OpenAI clients both attach them (as a `Headers` instance or a
+ * plain object depending on version); the ollama client throws them away, which
+ * is why `retryAfterMs` is genuinely unavailable on that driver.
+ */
+function vendorRetryAfter(err: unknown): string | undefined {
+	if (typeof err !== 'object' || err === null) return undefined
+	// AWS keeps the response one level down, on `$response`; the Anthropic and
+	// OpenAI clients attach `headers` directly.
+	const headers =
+		(err as { headers?: unknown }).headers ??
+		(err as { $response?: { headers?: unknown } }).$response?.headers
+	if (!headers) return undefined
+	if (typeof (headers as Headers).get === 'function') {
+		return (headers as Headers).get('retry-after') ?? undefined
+	}
+	const record = headers as Record<string, unknown>
+	for (const key of ['retry-after', 'Retry-After', 'retryAfter']) {
+		const value = record[key]
+		if (typeof value === 'string') return value
+	}
+	return undefined
+}
+
+/**
+ * Classify an error thrown by a vendor SDK and replace it.
+ *
+ * This exists because wrapping our OWN `!response.ok` throws is not enough. The
+ * Anthropic, OpenAI and ollama clients each build their error message FROM the
+ * response body, so a credential the upstream echoed back is already inside
+ * `err.message` before our code sees it. Proven with a planted fake token on all
+ * three.
+ *
+ * So the vendor error is read for its status and scanned for an overflow
+ * signature, and then **dropped entirely** — not re-thrown, not wrapped, and not
+ * attached as `cause`. A `cause` is exactly what a structured logger walks, so
+ * keeping one for debuggability would reintroduce the leak it is meant to close.
+ *
+ * `name` is checked too, because AWS models its failures as distinct classes
+ * (`ThrottlingException`, `ValidationException`, `AccessDeniedException`) rather
+ * than as status codes.
+ */
+export function providerVendorError(input: {
+	readonly providerId: string
+	readonly error: unknown
+	readonly retryAfter?: string | null
+	readonly now?: number
+}): ProviderRequestError {
+	const { error } = input
+	const status = vendorErrorStatus(error)
+	const name = error instanceof Error ? error.name : ''
+	const message = error instanceof Error ? error.message : ''
+
+	let kind: ProviderErrorKind
+	if (/ThrottlingException|TooManyRequests|ServiceQuotaExceeded/i.test(name)) {
+		kind = 'throttle'
+	} else if (/AccessDenied|Unauthorized|Forbidden|Authentication/i.test(name)) {
+		kind = 'auth'
+	} else if (/ValidationException/i.test(name)) {
+		kind = bodySaysContextOverflow(message) ? 'context_overflow' : 'bad_request'
+	} else if (
+		/ServiceUnavailable|InternalServer|ModelTimeout|ModelStreamError|ModelError|ModelNotReady/i.test(
+			name,
+		)
+	) {
+		kind = 'server'
+	} else if (status !== undefined) {
+		kind = classifyProviderHttpStatus(status, message)
+	} else if (bodySaysContextOverflow(message)) {
+		kind = 'context_overflow'
+	} else {
+		// No status: a mid-stream failure, or a transport error. The vendor's own
+		// error-type vocabulary is the only signal left; absent that, the request
+		// genuinely did not get an answer.
+		kind = vendorTypeKind(message) ?? 'network'
+	}
+
+	const retryAfterMs = parseRetryAfterMs(
+		input.retryAfter ?? vendorRetryAfter(error),
+		input.now ?? Date.now(),
+	)
+	return new ProviderRequestError({
+		kind,
+		providerId: input.providerId,
+		...(status !== undefined ? { status } : {}),
+		...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+	})
+}
+
+/**
+ * Build a classified error from a failed HTTP response.
+ *
+ * Callers pass the body they already read for classification; this function
+ * does not return it, store it, or put it in the message.
+ */
+export function providerHttpError(input: {
+	readonly providerId: string
+	readonly status: number
+	readonly body?: string | null
+	readonly retryAfter?: string | null
+	readonly now?: number
+}): ProviderRequestError {
+	const kind = classifyProviderHttpStatus(input.status, input.body)
+	const retryAfterMs = parseRetryAfterMs(input.retryAfter, input.now ?? Date.now())
+	return new ProviderRequestError({
+		kind,
+		providerId: input.providerId,
+		status: input.status,
+		...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+	})
+}

--- a/packages/sdk/src/provider/index.ts
+++ b/packages/sdk/src/provider/index.ts
@@ -1,4 +1,19 @@
 export {
+	ProviderRequestError,
+	isCallerAbortError,
+	isProviderRequestError,
+	classifyProviderHttpStatus,
+	bodySaysContextOverflow,
+	parseRetryAfterMs,
+	providerHttpError,
+	providerVendorError,
+} from './errors.js'
+export type {
+	ProviderErrorInfo,
+	ProviderErrorKind,
+	ProviderRequestErrorInit,
+} from './errors.js'
+export {
 	ProviderRegistry,
 	UnknownProviderError,
 	DuplicateProviderError,

--- a/packages/sdk/src/public-runtime.ts
+++ b/packages/sdk/src/public-runtime.ts
@@ -47,11 +47,19 @@ export * from './utils/id.js'
 
 // ─── utility helpers ─────────────────────────────────────────────────────
 
-export { accumulateCost, calculateCost, formatCost, ZERO_COST } from './utils/cost.js'
+export {
+	accumulateCost,
+	calculateCost,
+	formatCost,
+	ZERO_COST,
+} from './utils/cost.js'
 export { toErrorMessage } from './utils/error.js'
 export { configureLogger, getRootLogger, Logger } from './utils/logger.js'
 export { buildToolResultHashes, hashToolResult } from './utils/hash.js'
-export { compressShellOutput, compressShellOutputFull } from './utils/shell-compress.js'
+export {
+	compressShellOutput,
+	compressShellOutputFull,
+} from './utils/shell-compress.js'
 export { createChildAbortController } from './utils/abort.js'
 export { memoizeAsync } from './utils/memoize.js'
 export { extractFinalResponse } from './utils/conversation.js'
@@ -61,7 +69,10 @@ export { extractFinalResponse } from './utils/conversation.js'
 export { resolveTaskModel } from './router/task-router.js'
 export { drainQuery, query } from './runtime/query/index.js'
 export { ContextCache } from './runtime/query/context-cache.js'
-export { CheckpointManager, projectEmergencyToCheckpoint } from './runtime/query/checkpoint.js'
+export {
+	CheckpointManager,
+	projectEmergencyToCheckpoint,
+} from './runtime/query/checkpoint.js'
 export { prepareReplayState } from './runtime/query/replay/prepare.js'
 export { listCheckpoints } from './runtime/query/replay/list.js'
 export { DecisionParser, FallbackResolver } from './runtime/decision/index.js'
@@ -73,8 +84,17 @@ export {
 
 // ─── personas, skills, advisory ──────────────────────────────────────────
 
-export { assembleSystemPrompt, mergePersonas, withSessionContext } from './persona/index.js'
-export { discoverSkills, loadSkill, resolveSkillChain, SkillRegistry } from './skills/index.js'
+export {
+	assembleSystemPrompt,
+	mergePersonas,
+	withSessionContext,
+} from './persona/index.js'
+export {
+	discoverSkills,
+	loadSkill,
+	resolveSkillChain,
+	SkillRegistry,
+} from './skills/index.js'
 export {
 	AdvisorRegistry,
 	AdvisoryContext,
@@ -144,19 +164,30 @@ export { LocalTaskGateway } from './gateway/local.js'
 // ─── providers, sandbox, vault ───────────────────────────────────────────
 
 export {
+	bodySaysContextOverflow,
+	classifyProviderHttpStatus,
 	DuplicateProviderError,
+	isCallerAbortError,
+	isProviderRequestError,
 	LazyProviderLoadError,
 	LazyProviderSyncCreateError,
 	MOCK_CAPABILITIES,
 	MockLLMProvider,
+	parseRetryAfterMs,
 	PERMISSIVE_PROVIDER_CAPABILITIES,
+	providerHttpError,
+	providerVendorError,
 	ProviderRegistry,
+	ProviderRequestError,
 	registerMock,
 	resolveProviderCapabilities,
 	UnknownProviderError,
 } from './provider/index.js'
 
-export { LocalSandboxProvider, SandboxProviderFactory } from './sandbox/index.js'
+export {
+	LocalSandboxProvider,
+	SandboxProviderFactory,
+} from './sandbox/index.js'
 
 export { InMemoryCredentialVault } from './vault/index.js'
 
@@ -222,7 +253,10 @@ export {
 	runToA2ATask,
 } from './bridge/a2a/index.js'
 
-export { mapRunToStreamEvent, mapSessionToStreamEvent } from './bridge/sse/index.js'
+export {
+	mapRunToStreamEvent,
+	mapSessionToStreamEvent,
+} from './bridge/sse/index.js'
 
 // ─── bus, verification ───────────────────────────────────────────────────
 
@@ -355,10 +389,19 @@ export {
 // ─── runtime helpers colocated with shapes under `types/` (§1.5) ─────────
 
 export { A2AProtocolError } from './types/a2a/index.js'
-export { isTerminalActivityStatus, resolveActivityTracking } from './types/activity/index.js'
+export {
+	isTerminalActivityStatus,
+	resolveActivityTracking,
+} from './types/activity/index.js'
 export { isTerminalAgentTaskState } from './types/agent/task.js'
-export { accumulateTokenUsage, isTerminalStatus } from './types/common/index.js'
-export { assertComputerUseActionType, assertDisplayServer } from './types/computer-use/index.js'
+export {
+	accumulateTokenUsage,
+	isTerminalStatus,
+} from './types/common/index.js'
+export {
+	assertComputerUseActionType,
+	assertDisplayServer,
+} from './types/computer-use/index.js'
 export { isConnectorActive } from './types/connector/core.js'
 export { CONNECTOR_SCOPE_ORDER } from './types/connector/scope.js'
 export { RoutingResponseSchema } from './types/decision/index.js'

--- a/packages/sdk/src/runtime/query/__tests__/stream-recovery.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/stream-recovery.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 
+import { ProviderRequestError } from '../../../provider/errors.js'
 import { ToolRegistry } from '../../../registry/tool/execute.js'
 import type { SessionId, TenantId } from '../../../types/ids/index.js'
 import { createUserMessage } from '../../../types/message/index.js'
@@ -72,6 +73,22 @@ class IdleDuringToolInputProvider implements LLMProvider {
 	}
 }
 
+class ClassifiedFailureProvider implements LLMProvider {
+	readonly id = 'classified-failure'
+	readonly name = 'Classified Failure Provider'
+
+	async *chatStream(): AsyncIterable<StreamChunk> {
+		yield await Promise.reject(
+			new ProviderRequestError({
+				kind: 'throttle',
+				providerId: 'classified-failure',
+				status: 429,
+				retryAfterMs: 2000,
+			}),
+		)
+	}
+}
+
 describe('query stream recovery', () => {
 	let workdirs: string[] = []
 
@@ -82,7 +99,10 @@ describe('query stream recovery', () => {
 
 	it('turns an idle stream with partial tool JSON into retryable tool feedback', async () => {
 		const provider = new IdleDuringToolInputProvider()
-		const actualWrite = vi.fn(async () => ({ success: true, output: 'should not run' }))
+		const actualWrite = vi.fn(async () => ({
+			success: true,
+			output: 'should not run',
+		}))
 		const tools = new ToolRegistry()
 		tools.register({
 			name: 'write_file',
@@ -152,5 +172,48 @@ describe('query stream recovery', () => {
 		expect(completedTool?.type === 'tool_completed' ? completedTool.result : '').toContain(
 			'extend it with edit using insertLine',
 		)
+	})
+
+	it('preserves classified provider metadata through the primary run boundary', async () => {
+		const workingDirectory = await mkdtemp(join(tmpdir(), 'namzu-provider-error-'))
+		workdirs.push(workingDirectory)
+		const events: RunEvent[] = []
+
+		const run = await drainQuery(
+			{
+				provider: new ClassifiedFailureProvider(),
+				tools: new ToolRegistry(),
+				runConfig: {
+					model: 'mock-model',
+					timeoutMs: 5_000,
+					tokenBudget: 100_000,
+					maxIterations: 1,
+					maxResponseTokens: 256,
+				},
+				agentId: 'agent_test',
+				agentName: 'Test Agent',
+				messages: [createUserMessage('fail with classified metadata')],
+				workingDirectory,
+				sessionId: 'ses_provider_error' as SessionId,
+				threadId: 'thd_provider_error' as ThreadId,
+				projectId: 'prj_provider_error' as ProjectId,
+				tenantId: 'tnt_provider_error' as TenantId,
+			},
+			(event) => {
+				events.push(event)
+			},
+		)
+
+		expect(run.status).toBe('failed')
+		expect(run.lastProviderError).toEqual({
+			kind: 'throttle',
+			providerId: 'classified-failure',
+			status: 429,
+			retryAfterMs: 2000,
+		})
+		expect(events.find((event) => event.type === 'run_failed')).toMatchObject({
+			type: 'run_failed',
+			providerError: run.lastProviderError,
+		})
 	})
 })

--- a/packages/sdk/src/runtime/query/iteration/stream-turn.ts
+++ b/packages/sdk/src/runtime/query/iteration/stream-turn.ts
@@ -1,3 +1,4 @@
+import { isProviderRequestError } from '../../../provider/errors.js'
 import { mergeTokenUsage } from '../../../types/common/index.js'
 import type { ToolUseId } from '../../../types/ids/index.js'
 import type {
@@ -111,9 +112,12 @@ export async function* streamProviderTurn(
 			inputTruncated: boolean
 		}
 	>()
-	let streamError: string | undefined
+	let streamError: Error | undefined
 
-	const stream = provider.chatStream({ ...params, stream: true }) as AsyncIterable<StreamChunk>
+	const stream = provider.chatStream({
+		...params,
+		stream: true,
+	}) as AsyncIterable<StreamChunk>
 
 	// Drive the stream manually so each `.next()` can be RACED against the run
 	// abort: a Stop tears the in-flight model request down (the provider got
@@ -145,7 +149,7 @@ export async function* streamProviderTurn(
 			if (res.done) break
 			const chunk = res.value
 			if (chunk.error) {
-				streamError = chunk.error
+				streamError = new Error(`Provider stream error: ${chunk.error}`)
 				break
 			}
 			if (!id && chunk.id) id = chunk.id
@@ -252,7 +256,7 @@ export async function* streamProviderTurn(
 		// run as cancelled rather than recording a normal (errored) turn. Any
 		// other stream error is captured into the synthesized response as before.
 		if (signal?.aborted) throw err
-		streamError = err instanceof Error ? err.message : String(err)
+		streamError = err instanceof Error ? err : new Error(String(err))
 	} finally {
 		if (onAbort) signal?.removeEventListener('abort', onAbort)
 		// Release the underlying connection on every exit (natural end, error,
@@ -355,7 +359,7 @@ export async function* streamProviderTurn(
 		log.warn('provider stream failed after tool input; surfacing tool call to executor', {
 			runId,
 			iteration,
-			error: streamError,
+			error: streamError?.message ?? 'provider stream failed',
 			toolCallCount: toolCalls.length,
 		})
 	}
@@ -378,7 +382,8 @@ export async function* streamProviderTurn(
 	yield* drainPending()
 
 	if (streamError && !recoveredToolInputFromStreamError) {
-		throw new Error(`Provider stream error: ${streamError}`)
+		if (isProviderRequestError(streamError)) throw streamError
+		throw new Error(`Provider stream error: ${streamError.message}`)
 	}
 
 	const response: ChatCompletionResponse = {

--- a/packages/sdk/src/runtime/query/result.ts
+++ b/packages/sdk/src/runtime/query/result.ts
@@ -1,6 +1,7 @@
 import { type Span, SpanStatusCode } from '@opentelemetry/api'
 import type { PlanManager } from '../../manager/plan/lifecycle.js'
 import type { RunPersistence } from '../../manager/run/persistence.js'
+import { isProviderRequestError } from '../../provider/errors.js'
 import type { ActivityStore } from '../../store/activity/memory.js'
 import { GENAI, NAMZU } from '../../telemetry/attributes.js'
 import type { Run, RunEvent } from '../../types/run/index.js'
@@ -61,7 +62,15 @@ export class ResultAssembler {
 	async *handleError(err: unknown, rootSpan: Span): AsyncGenerator<RunEvent> {
 		const { runMgr, planManager, log, emitEvent, drainPending } = this.config
 		const errorMessage = toErrorMessage(err)
-		runMgr.markFailed(errorMessage)
+		const providerError = isProviderRequestError(err)
+			? {
+					kind: err.kind,
+					providerId: err.providerId,
+					...(err.status !== undefined ? { status: err.status } : {}),
+					...(err.retryAfterMs !== undefined ? { retryAfterMs: err.retryAfterMs } : {}),
+				}
+			: undefined
+		runMgr.markFailed(errorMessage, providerError)
 
 		if (planManager.isActive) {
 			planManager.failPlan(errorMessage)
@@ -71,6 +80,7 @@ export class ResultAssembler {
 			type: 'run_failed',
 			runId: runMgr.id,
 			error: errorMessage,
+			...(providerError ? { providerError } : {}),
 		})
 		yield* drainPending()
 

--- a/packages/sdk/src/types/provider/error.ts
+++ b/packages/sdk/src/types/provider/error.ts
@@ -1,0 +1,29 @@
+/** What went wrong, at the coarsest granularity a caller can act on. */
+export type ProviderErrorKind =
+	| 'throttle'
+	| 'network'
+	| 'auth'
+	| 'context_overflow'
+	| 'bad_request'
+	| 'server'
+
+/**
+ * Serializable provider-failure metadata carried by failed runs and events.
+ *
+ * No response body, vendor message, URL, or `cause` belongs here.
+ */
+export interface ProviderErrorInfo {
+	readonly kind: ProviderErrorKind
+	readonly providerId: string
+	readonly status?: number
+	readonly retryAfterMs?: number
+}
+
+export interface ProviderRequestErrorInit extends ProviderErrorInfo {
+	/**
+	 * Optional extra clause for the message. MUST be text this codebase
+	 * authored — never a fragment of a response body, a header, or a vendor
+	 * error.
+	 */
+	readonly detail?: string
+}

--- a/packages/sdk/src/types/provider/index.ts
+++ b/packages/sdk/src/types/provider/index.ts
@@ -9,6 +9,11 @@ export type { StreamChunk } from './stream.js'
 export type { ModelInfo } from './model.js'
 export type { LLMProvider } from './interface.js'
 export type {
+	ProviderErrorInfo,
+	ProviderErrorKind,
+	ProviderRequestErrorInit,
+} from './error.js'
+export type {
 	ProviderConfigRegistry,
 	ProviderType,
 	MockProviderConfig,

--- a/packages/sdk/src/types/run/entity.ts
+++ b/packages/sdk/src/types/run/entity.ts
@@ -1,6 +1,7 @@
 import type { AgentStatus, CostInfo, TokenUsage } from '../common/index.js'
 import type { RunId } from '../ids/index.js'
 import type { Message } from '../message/index.js'
+import type { ProviderErrorInfo } from '../provider/index.js'
 import type { AgentRunConfig } from './config.js'
 import type { ReplayAttribution } from './replay.js'
 import type { StopReason } from './stop-reason.js'
@@ -37,6 +38,7 @@ export interface Run {
 	endedAt?: number
 	stopReason?: StopReason
 	lastError?: string
+	lastProviderError?: ProviderErrorInfo
 	result?: string
 
 	parentRunId?: RunId

--- a/packages/sdk/src/types/run/events.ts
+++ b/packages/sdk/src/types/run/events.ts
@@ -14,6 +14,7 @@ import type {
 } from '../ids/index.js'
 import type { PlanStep } from '../plan/index.js'
 import type { PluginHookEvent, PluginHookResult } from '../plugin/index.js'
+import type { ProviderErrorInfo } from '../provider/index.js'
 import type { TaskStatus } from '../task/index.js'
 import type { Lineage } from './lineage.js'
 import type { MessageStopReason } from './stop-reason.js'
@@ -98,7 +99,12 @@ type CoreRunEvent =
 			fromCheckpointId: CheckpointId
 	  }
 	| { type: 'run_completed'; runId: RunId; result: string }
-	| { type: 'run_failed'; runId: RunId; error: string }
+	| {
+			type: 'run_failed'
+			runId: RunId
+			error: string
+			providerError?: ProviderErrorInfo
+	  }
 	// Additive 2026-07 (provider capability negotiation): emitted once per
 	// run when the request asks for something the provider DRIVER declared
 	// it cannot do — tools registered against a no-tools driver (tool


### PR DESCRIPTION
## Summary

- add one SDK-owned provider failure taxonomy and public ProviderRequestError contract
- normalize Anthropic, Bedrock, HTTP, LM Studio, Ollama, OpenAI, and OpenRouter failures without retaining unsafe vendor response bodies or causes
- preserve caller abort identity and carry safe ProviderErrorInfo through run events and persisted run state
- make LM Studio client creation lazy and close request-start abort races in LM Studio and Ollama
- document operational recovery and publish provider package changesets

## Verification

- pnpm lint
- pnpm typecheck
- pnpm test: 1,697 passed, 10 skipped
- pnpm build
- Vandal integration: architecture 39/39, unit 8,219/8,219, typecheck and production build

## Security

Credential-bearing vendor messages are classified at the provider boundary and then dropped. They are not attached as causes where structured logging could recover them.