### PR TITLE
fix(sdk): make runtime tool contracts truthful

### DIFF
--- a/.changeset/runtime-tool-contracts.md
+++ b/.changeset/runtime-tool-contracts.md
@@ -1,0 +1,17 @@
+---
+'@namzu/sdk': patch
+---
+
+Remove the model-facing `cancel_task` coordinator tool from the default
+blocking worker protocol. A supervisor learns a `create_task` id only after
+that worker is terminal, and the old tool manufactured a successful
+"cancelled" result even when the gateway silently ignored a missing or
+terminal id. Host-owned run interruption remains available through the task
+gateway.
+
+Tighten the builtin `edit` contract so `insertLine` accepts only a
+non-negative JSON integer or the exact string `"end"`. Headings, anchors,
+numeric strings, `null`, and empty strings are rejected before execution;
+schema-bypassing callers receive the same refusal. This prevents `null` and
+empty values from being coerced to line `0` and silently inserting content at
+the beginning of a file.

--- a/packages/sdk/src/tools/builtins/__tests__/edit.test.ts
+++ b/packages/sdk/src/tools/builtins/__tests__/edit.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { zodToJsonSchema } from 'zod-to-json-schema'
 import type { ToolContext } from '../../../types/tool/index.js'
 import { EditTool } from '../edit.js'
 
@@ -53,5 +54,61 @@ describe('EditTool', () => {
 
 		expect(result.success).toBe(true)
 		expect(readFileSync(join(dir, 'doc.md'), 'utf-8')).toBe('alpha\nomega\n')
+	})
+
+	it('publishes only the insertLine values the executor can apply', () => {
+		for (const insertLine of ['## Progress', null, '', '1', -1]) {
+			const parsed = EditTool.inputSchema.safeParse({
+				path: 'doc.md',
+				insertLine,
+				newStr: 'inserted',
+			})
+			expect(parsed.success, JSON.stringify(insertLine)).toBe(false)
+		}
+
+		for (const insertLine of [0, 1, 'end']) {
+			const parsed = EditTool.inputSchema.safeParse({
+				path: 'doc.md',
+				insertLine,
+				newStr: 'inserted',
+			})
+			expect(parsed.success, JSON.stringify(insertLine)).toBe(true)
+		}
+
+		const json = zodToJsonSchema(EditTool.inputSchema, {
+			target: 'jsonSchema7',
+			$refStrategy: 'none',
+		}) as {
+			properties?: {
+				insertLine?: {
+					anyOf?: Record<string, unknown>[]
+				}
+			}
+		}
+		expect(json.properties?.insertLine?.anyOf).toEqual([
+			{ type: 'integer', minimum: 0 },
+			{ type: 'string', const: 'end' },
+		])
+	})
+
+	it('refuses invalid insertLine values even when a caller bypasses the schema', async () => {
+		for (const insertLine of ['## Progress', null, '', '1']) {
+			const dir = mkdtempSync(join(tmpdir(), 'namzu-edit-'))
+			writeFileSync(join(dir, 'doc.md'), 'alpha\nbeta\n')
+
+			const result = await EditTool.execute(
+				{
+					path: 'doc.md',
+					insertLine,
+					newStr: 'inserted',
+					replace_all: false,
+				} as never,
+				makeContext(dir),
+			)
+
+			expect(result.success, JSON.stringify(insertLine)).toBe(false)
+			expect(result.error).toBe('insertLine must be a non-negative line number or "end".')
+			expect(readFileSync(join(dir, 'doc.md'), 'utf-8')).toBe('alpha\nbeta\n')
+		}
 	})
 })

--- a/packages/sdk/src/tools/builtins/edit.ts
+++ b/packages/sdk/src/tools/builtins/edit.ts
@@ -29,10 +29,10 @@ const inputSchema = z
 				'Alias for new_string. Also used as inserted content when insertLine is provided. Self-budget this payload under 12000 characters before calling.',
 			),
 		insertLine: z
-			.union([z.coerce.number().int().min(0), z.string().min(1)])
+			.union([z.number().int().min(0), z.literal('end')])
 			.optional()
 			.describe(
-				'Optional line insertion target. Inserts the replacement after this 1-indexed line; 0 inserts before the first line; "end" appends to the file.',
+				'Optional line insertion target. Pass a JSON integer to insert after that 1-indexed line, 0 to insert before the first line, or the exact string "end" to append. Headings, anchors, numeric strings, null, and empty strings are invalid.',
 			),
 		replace_all: z
 			.boolean()
@@ -166,18 +166,16 @@ function normalizeEditInput(
 }
 
 function normalizeInsertLine(
-	value: string | number,
+	value: unknown,
 ): { success: true; value: number | 'end' } | { success: false; error: string } {
-	if (typeof value === 'string') {
-		if (value.trim().toLowerCase() === 'end') return { success: true, value: 'end' }
-		const parsed = Number(value)
-		if (Number.isInteger(parsed) && parsed >= 0) return { success: true, value: parsed }
-		return {
-			success: false,
-			error: 'insertLine must be a non-negative line number or "end".',
-		}
+	if (value === 'end') return { success: true, value: 'end' }
+	if (typeof value === 'number' && Number.isInteger(value) && value >= 0) {
+		return { success: true, value }
 	}
-	return { success: true, value }
+	return {
+		success: false,
+		error: 'insertLine must be a non-negative line number or "end".',
+	}
 }
 
 function applyEdit(

--- a/packages/sdk/src/tools/coordinator/__tests__/task-list.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/task-list.test.ts
@@ -179,4 +179,20 @@ describe('coordinator agent_task_list tool', () => {
 		expect(names).toContain('agent_task_list')
 		expect(names).not.toContain('task_list')
 	})
+
+	it('does not advertise per-task cancellation on the blocking coordinator surface', () => {
+		const coordinatorTools = buildCoordinatorTools({
+			gateway: gatewayWith([]),
+			workingDirectory: '/tmp/test',
+			allowedAgentIds: ['solution-architecture'],
+		})
+		const names = coordinatorTools.map((tool) => tool.name)
+
+		// create_task returns only after the worker is terminal, so the
+		// supervisor cannot know a live task id in a later model turn.
+		// Keeping cancel_task here only manufactured success for missing
+		// or terminal ids because every gateway cancellation is a void
+		// no-op in those states.
+		expect(names).not.toContain('cancel_task')
+	})
 })

--- a/packages/sdk/src/tools/coordinator/agent.ts
+++ b/packages/sdk/src/tools/coordinator/agent.ts
@@ -19,14 +19,12 @@ import type { TaskLaunchedCallback } from './index.js'
  * subagent tool calls are isolated — only the summary surfaces to
  * the parent.
  *
- * This is **NOT** the same shape as the legacy `create_task` /
- * `continue_task` / `cancel_task` trio that this package ships
- * alongside it: those are non-blocking and use a `<task-notification>`
- * callback model. The async pattern is useful for hosts that want a
- * work-queue surface, but it is not what Claude Code trained against.
- * For free agentic alignment, prefer the canonical `Agent` tool; keep
- * the legacy coordinator tools only when you genuinely need
- * fire-and-forget multi-task fan-out.
+ * This is **NOT** the same shape as the coordinator `create_task`
+ * tool that this package ships alongside it. That tool exposes
+ * Namzu's task IDs and optional planning integration, while still
+ * returning results synchronously. For free agentic alignment,
+ * prefer the canonical `Agent` tool; use the coordinator tool when
+ * the host needs task tracking.
  */
 export interface AgentToolOptions {
 	gateway: TaskGateway

--- a/packages/sdk/src/tools/coordinator/index.ts
+++ b/packages/sdk/src/tools/coordinator/index.ts
@@ -227,28 +227,6 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 		},
 	})
 
-	const cancelTask = defineTool({
-		name: 'cancel_task',
-		description:
-			'Cancel a running agent task. Only use this with a task_id from a previous create_task.',
-		inputSchema: z.object({
-			task_id: z.string().describe('Agent task ID from a previous create_task'),
-		}),
-		category: 'custom',
-		permissions: [],
-		readOnly: false,
-		destructive: false,
-		concurrencySafe: true,
-		async execute({ task_id }) {
-			gateway.cancelTask(task_id as TaskId)
-			return {
-				success: true,
-				output: `Task ${task_id} cancelled`,
-				data: { task_id },
-			}
-		},
-	})
-
 	const agentTaskList = defineTool({
 		name: 'agent_task_list',
 		description:
@@ -305,19 +283,18 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 		},
 	})
 
-	// `continue_task` was a follow-up channel for a still-alive worker
-	// task. With `create_task` now blocking + tool_result returning
-	// the worker's final output, every worker reaches a terminal
-	// state by the time the supervisor wants to follow up — and the
-	// agent manager rejects `continue` on terminal tasks. The
-	// industrial pattern is to issue a fresh `create_task` that
-	// references the prior worker's output path, so we drop
-	// `continue_task` from the registered surface entirely. The
-	// definition stays in this file for now in case a future
-	// non-default gateway (one that keeps the worker process alive
-	// for follow-ups) wants to re-register it.
+	// `continue_task` and model-facing per-task cancellation both
+	// belonged to the old non-blocking worker protocol. With
+	// `create_task` now blocking + tool_result returning the worker's
+	// final output, every worker is terminal by the time a later model
+	// turn learns its task id. The old cancel tool additionally called
+	// a void/no-op gateway method and manufactured "cancelled" even for
+	// a missing id. Host-owned run interruption still uses the gateway
+	// cancellation contract directly; it does not need a model tool.
+	// Keep only the follow-up definition for a future non-default
+	// gateway that deliberately preserves live workers between turns.
 	void continueTask
-	const tools: ToolDefinition[] = [createTask, cancelTask, agentTaskList]
+	const tools: ToolDefinition[] = [createTask, agentTaskList]
 
 	if (getPlanManager) {
 		const approvePlan = defineTool({


### PR DESCRIPTION
## Summary

- remove the model-facing cancel_task tool from the blocking coordinator while preserving host-owned whole-run cancellation
- restrict edit insertLine to non-negative JSON integers or the exact literal "end"
- reject schema-bypassing invalid insertion targets without mutating files
- add coordinator-surface, executor, and published JSON Schema regressions

## Testing

- pnpm lint
- pnpm typecheck
- pnpm test (1,692 tests)
- pnpm build

Stacked on #55.