### PR TITLE
fix(sdk): make edit validation recoverable

### DIFF
--- a/.changeset/edit-validation-recovery.md
+++ b/.changeset/edit-validation-recovery.md
@@ -1,0 +1,7 @@
+---
+'@namzu/sdk': patch
+---
+
+Add tool-specific validation recovery guidance and use it to show complete,
+safe `edit` call shapes when a model omits `path` or supplies an invalid
+`insertLine`.

--- a/docs/sdk/tools/README.md
+++ b/docs/sdk/tools/README.md
@@ -1,7 +1,7 @@
 ---
 title: SDK Tools
 description: Define tools, register them in ToolRegistry, and understand built-in tool behavior in @namzu/sdk.
-last_updated: 2026-04-18
+last_updated: 2026-07-30
 status: current
 related_packages: ["@namzu/sdk", "@namzu/computer-use"]
 ---
@@ -47,6 +47,7 @@ const summarizeText = defineTool({
 | `name` | Stable snake_case identifier exposed to the model |
 | `description` | Prompt-facing summary of when to use the tool |
 | `inputSchema` | Zod schema used for validation and JSON Schema generation |
+| `validationErrorHint` | Optional model-facing retry guidance for conditional schemas whose accepted shapes are not clear from top-level required fields |
 | `category` | High-level grouping such as `filesystem`, `shell`, `network`, `analysis`, or `custom` |
 | `permissions` | Declared capability list such as `file_read` or `network_access` |
 | `readOnly` | Declares whether the tool should be treated as non-mutating |
@@ -54,6 +55,15 @@ const summarizeText = defineTool({
 | `concurrencySafe` | Signals whether concurrent execution is safe |
 
 If `execute()` throws, the SDK converts that throw into a structured failed tool result instead of leaking an uncaught error through the tool boundary.
+
+When `inputSchema` rejects a call, `ToolRegistry` appends
+`validationErrorHint` to the structured failure. Keep the hint concise and
+include complete safe payloads when a tool supports conditional input shapes:
+
+```ts
+validationErrorHint:
+  'Accepted shapes: {"path":"file.md","insertLine":"end","new_string":"text"} or {"path":"file.md","old_string":"old","new_string":"new"}.',
+```
 
 ## 3. Tool Context
 

--- a/packages/sdk/src/registry/tool/execute.test.ts
+++ b/packages/sdk/src/registry/tool/execute.test.ts
@@ -433,6 +433,20 @@ describe('ToolRegistry — execute', () => {
 		expect(result.error).toContain('Expected string, received number')
 	})
 
+	it('appends a tool-specific recovery hint to validation failures', async () => {
+		const r = new ToolRegistry()
+		r.register(
+			makeTool('strict', {
+				inputSchema: z.object({ required: z.string() }),
+				validationErrorHint: 'Retry with {"required":"value"}.',
+			}),
+		)
+		const result = await r.execute('strict', { required: 123 }, makeContext())
+		expect(result.success).toBe(false)
+		expect(result.error).toContain('Required: required: string.')
+		expect(result.error).toContain('Retry with {"required":"value"}.')
+	})
+
 	it('empty-args validation lists required params with descriptions', async () => {
 		const r = new ToolRegistry()
 		r.register(

--- a/packages/sdk/src/registry/tool/execute.ts
+++ b/packages/sdk/src/registry/tool/execute.ts
@@ -370,10 +370,13 @@ Executable tool names, descriptions, and JSON input schemas are attached through
 						Object.keys(rawInput as Record<string, unknown>).length === 0)
 
 				const requiredHint = describeRequiredInput(tool.inputSchema)
+				const recoveryHint = tool.validationErrorHint?.trim()
+					? ` ${tool.validationErrorHint.trim()}`
+					: ''
 
 				const enrichedMessage = isEmptyInput
-					? `Tool "${toolName}" was called with no arguments. ${requiredHint} Retry the call with the required parameters populated.`
-					: `Validation failed for "${toolName}": ${errorMessage}. ${requiredHint}`
+					? `Tool "${toolName}" was called with no arguments. ${requiredHint}${recoveryHint} Retry the call with the required parameters populated.`
+					: `Validation failed for "${toolName}": ${errorMessage}. ${requiredHint}${recoveryHint}`
 
 				this.log.error(`Tool input validation failed: ${toolName}`, {
 					errors: errorMessage,

--- a/packages/sdk/src/tools/builtins/__tests__/edit.test.ts
+++ b/packages/sdk/src/tools/builtins/__tests__/edit.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { zodToJsonSchema } from 'zod-to-json-schema'
+import { ToolRegistry } from '../../../registry/tool/execute.js'
 import type { ToolContext } from '../../../types/tool/index.js'
 import { EditTool } from '../edit.js'
 
@@ -110,5 +111,23 @@ describe('EditTool', () => {
 			expect(result.error).toBe('insertLine must be a non-negative line number or "end".')
 			expect(readFileSync(join(dir, 'doc.md'), 'utf-8')).toBe('alpha\nbeta\n')
 		}
+	})
+
+	it('returns complete recovery shapes when path is missing and insertLine is invalid', async () => {
+		const registry = new ToolRegistry()
+		registry.register(EditTool)
+
+		const result = await registry.execute(
+			'edit',
+			{ insertLine: '## Progress' },
+			makeContext('/tmp'),
+		)
+
+		expect(result.success).toBe(false)
+		expect(result.error).toContain('Validation failed for "edit":')
+		expect(result.error).toContain('insertLine: Invalid input')
+		expect(result.error).toContain('Required: path: string — Path to the file to edit.')
+		expect(result.error).toContain('{"path":"file.md","insertLine":"end","new_string":"text"}')
+		expect(result.error).toContain('{"path":"file.md","old_string":"old","new_string":"new"}')
 	})
 })

--- a/packages/sdk/src/tools/builtins/edit.ts
+++ b/packages/sdk/src/tools/builtins/edit.ts
@@ -71,6 +71,8 @@ export const EditTool = defineTool({
 	description:
 		'Makes targeted edits to a file using exact string find-and-replace or line insertion. THIS IS THE PREFERRED WAY TO MODIFY AN EXISTING FILE — never reach for `write` to change a file that already exists, because `write` overwrites the whole body and discards earlier work on partial failure. `edit` keeps the rest of the file byte-for-byte intact and is recoverable: if a single edit fails (old_string/oldStr ambiguous, broader restructuring needed), follow up with another `edit` instead of re-emitting the entire file via `write`. The old_string/oldStr must be unique in the file unless replace_all is true. For insertions, pass insertLine plus new_string/newStr; use insertLine: "end" to extend a file at the end. Self-budget new_string/newStr under 12000 characters before emitting the tool call; use repeated bounded edits for long sections. Preserves file formatting and indentation.',
 	inputSchema,
+	validationErrorHint:
+		'Accepted shapes: {"path":"file.md","insertLine":"end","new_string":"text"} or {"path":"file.md","old_string":"old","new_string":"new"}. Always include path; insertLine accepts only a non-negative JSON integer or the exact string "end".',
 	category: 'filesystem',
 	permissions: ['file_write'],
 	readOnly: false,

--- a/packages/sdk/src/tools/defineTool.ts
+++ b/packages/sdk/src/tools/defineTool.ts
@@ -11,6 +11,7 @@ export interface DefineToolOptions<S extends z.ZodType> {
 	name: string
 	description: string
 	inputSchema: S
+	validationErrorHint?: string
 	category: ToolDefinition['category']
 	permissions: ToolPermission[]
 	readOnly: boolean
@@ -29,6 +30,7 @@ export function defineTool<S extends z.ZodType>(
 		name: options.name,
 		description: options.description,
 		inputSchema: options.inputSchema,
+		validationErrorHint: options.validationErrorHint,
 		tier: options.tier,
 		category: options.category,
 		permissions: options.permissions,

--- a/packages/sdk/src/types/tool/index.ts
+++ b/packages/sdk/src/types/tool/index.ts
@@ -64,6 +64,12 @@ export interface ToolDefinition<TInput = unknown> {
 	name: string
 	description: string
 	inputSchema: z.ZodType<TInput, z.ZodTypeDef, unknown>
+	/**
+	 * Concise, model-readable recovery guidance appended when inputSchema
+	 * rejects a call. Use for conditional schemas whose required shapes
+	 * cannot be reconstructed from JSON Schema's top-level `required` list.
+	 */
+	validationErrorHint?: string
 	execute(input: TInput, context: ToolContext): Promise<ToolResult>
 	tier?: string
 	permissions?: ToolPermission[]


### PR DESCRIPTION
## Summary
- add optional tool-specific validation recovery guidance
- teach the built-in edit tool complete insertion and replacement shapes
- preserve generic schema diagnostics and refuse malformed calls before execution

## Verification
- focused SDK tests: 49/49
- SDK build, typecheck, and lint
- full workspace test suite (SDK 1159/1159; all packages green)