### PR TITLE
fix(sdk): enforce canonical tool input schemas

### DIFF
--- a/.changeset/calm-tools-listen.md
+++ b/.changeset/calm-tools-listen.md
@@ -1,0 +1,11 @@
+---
+"@namzu/sdk": minor
+"@namzu/anthropic": minor
+"@namzu/http": minor
+---
+
+Separate runtime tool validation from canonical model-facing JSON Schema,
+propagate constrained-input hints through the agent loop, and map reviewed
+schemas to Anthropic strict tool use with capability-aware overrides. The
+built-in edit tool now advertises only canonical arguments while retaining
+legacy aliases for direct runtime callers.

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -1,7 +1,7 @@
 ---
 title: Anthropic Provider
 description: Configure @namzu/anthropic for the Anthropic Messages API through Namzu.
-last_updated: 2026-04-18
+last_updated: 2026-07-30
 status: current
 related_packages: ["@namzu/sdk", "@namzu/anthropic"]
 ---
@@ -102,6 +102,7 @@ const result = await agent.run(
 | `timeout` | No | Request timeout in milliseconds |
 | `defaultHeaders` | No | Extra headers appended to every request |
 | `maxTokens` | No | Default `max_tokens` value; Anthropic requires this field at request time |
+| `strictToolUse` | No | Constrained tool-input policy: `auto` (default), `on`, or `off` |
 
 ## 8. Capability Snapshot
 
@@ -118,6 +119,8 @@ The package exports `ANTHROPIC_CAPABILITIES`:
 ## 9. Operational Notes
 
 - Anthropic requires `max_tokens`, so setting `maxTokens` at provider creation time is a good default.
+- In `auto` mode, tools marked with `enforceModelInput: true` are sent with `strict: true` on recognized Claude 4.5+ model identifiers. Use `on` only for a compatible proxy alias, or `off` to disable constrained tool inputs.
+- Strict generation narrows model output, but `ToolRegistry` still applies the tool's runtime Zod schema before execution.
 - `baseURL` can point at proxies or gateways, but for Bedrock-hosted Anthropic models [`@namzu/bedrock`](./bedrock.md) is the better fit.
 - The provider also implements `listModels()` and `healthCheck()`.
 

--- a/docs/providers/http.md
+++ b/docs/providers/http.md
@@ -1,7 +1,7 @@
 ---
 title: HTTP Provider
 description: Use @namzu/http as the generic zero-dependency provider for OpenAI- or Anthropic-compatible HTTP endpoints.
-last_updated: 2026-04-18
+last_updated: 2026-07-30
 status: current
 related_packages: ["@namzu/sdk", "@namzu/http"]
 ---
@@ -91,6 +91,7 @@ const { provider } = ProviderRegistry.create({
 | `dialect` | No | `openai` or `anthropic`; defaults to `openai` |
 | `headers` | No | Extra HTTP headers |
 | `model` | No | Default model when omitted from chat params |
+| `strictToolUse` | No | Anthropic-dialect constrained tool-input policy: `auto` (default), `on`, or `off` |
 | `timeout` | No | Request timeout in milliseconds |
 
 ## 7. Capability Snapshot
@@ -111,6 +112,8 @@ The actual endpoint still has to support those features correctly.
 
 - The package exports `DialectMismatchError`, which is thrown when the declared dialect does not match the actual response shape.
 - Use `dialect: 'anthropic'` only for native Anthropic-style endpoints.
+- With `dialect: 'anthropic'`, `auto` maps tools marked with `enforceModelInput: true` to `strict: true` on recognized Claude 4.5+ identifiers. Use `on` only for a compatible proxy alias, or `off` to disable the mapping.
+- `strictToolUse` has no effect on the OpenAI dialect. The Namzu enforcement hint is never serialized as an HTTP request field.
 - This package is a good fit for self-hosted gateways, vLLM, TGI, Groq-style OpenAI-compatible APIs, and similar targets.
 - The provider also implements `listModels()` and `healthCheck()`.
 

--- a/docs/sdk/provider-integration/operations.md
+++ b/docs/sdk/provider-integration/operations.md
@@ -167,6 +167,13 @@ tools.register(
     name: 'echo_text',
     description: 'Return the provided text.',
     inputSchema: z.object({ text: z.string() }),
+    modelInputSchema: {
+      type: 'object',
+      properties: { text: { type: 'string' } },
+      required: ['text'],
+      additionalProperties: false,
+    },
+    enforceModelInput: true,
     category: 'analysis',
     permissions: [],
     readOnly: true,
@@ -187,6 +194,11 @@ const response = await provider.chat({
     },
   ],
   tools: tools.toLLMTools(),
+  // Optional non-wire provider hint for tools with a reviewed
+  // modelInputSchema. The agent runtime derives this automatically.
+  // This OpenAI example ignores the hint; Anthropic transports map it
+  // to strict tool use when the selected model supports that feature.
+  enforceToolInputSchema: ['echo_text'],
   toolChoice: 'auto',
 })
 
@@ -197,6 +209,9 @@ Important boundary:
 
 - providers return tool-call intent
 - `ToolRegistry.execute()` or the agent runtime performs the actual tool execution
+- `enforceToolInputSchema` is a Namzu provider hint, not a JSON request field;
+  custom providers must map or strip it instead of spreading the whole params
+  object into a wire payload
 
 If you need automatic tool execution and iterative reasoning, move back up to `ReactiveAgent` or [Low-Level Runtime](../runtime/low-level.md).
 

--- a/docs/sdk/tools/README.md
+++ b/docs/sdk/tools/README.md
@@ -46,7 +46,9 @@ const summarizeText = defineTool({
 | --- | --- |
 | `name` | Stable snake_case identifier exposed to the model |
 | `description` | Prompt-facing summary of when to use the tool |
-| `inputSchema` | Zod schema used for validation and JSON Schema generation |
+| `inputSchema` | Zod schema used for runtime validation and default JSON Schema generation |
+| `modelInputSchema` | Optional canonical JSON Schema shown to models instead of the runtime compatibility schema |
+| `enforceModelInput` | Requests constrained input generation on capable providers; requires `modelInputSchema` |
 | `validationErrorHint` | Optional model-facing retry guidance for conditional schemas whose accepted shapes are not clear from top-level required fields |
 | `category` | High-level grouping such as `filesystem`, `shell`, `network`, `analysis`, or `custom` |
 | `permissions` | Declared capability list such as `file_read` or `network_access` |
@@ -64,6 +66,71 @@ include complete safe payloads when a tool supports conditional input shapes:
 validationErrorHint:
   'Accepted shapes: {"path":"file.md","insertLine":"end","new_string":"text"} or {"path":"file.md","old_string":"old","new_string":"new"}.',
 ```
+
+### Separate runtime compatibility from the model contract
+
+Use `modelInputSchema` when direct callers need compatibility aliases or
+runtime-only constraints that should not become choices in the model's tool
+schema. `ToolRegistry` publishes this override through `toLLMTools()` while
+continuing to validate execution with `inputSchema`:
+
+```ts
+const editLike = defineTool({
+  name: 'edit_like',
+  description: 'Replace exact text in a file.',
+  inputSchema: z.object({
+    path: z.string(),
+    old_string: z.string().optional(),
+    oldStr: z.string().optional(), // legacy runtime alias
+    new_string: z.string().optional(),
+    newStr: z.string().optional(), // legacy runtime alias
+  }),
+  modelInputSchema: {
+    type: 'object',
+    properties: {
+      path: { type: 'string' },
+      old_string: { type: 'string' },
+      new_string: { type: 'string' },
+    },
+    required: ['path', 'old_string', 'new_string'],
+    additionalProperties: false,
+  },
+  enforceModelInput: true,
+  category: 'filesystem',
+  permissions: ['file_write'],
+  readOnly: false,
+  destructive: false,
+  concurrencySafe: false,
+  async execute(input) {
+    // Runtime execution may normalize oldStr/newStr for compatibility.
+    return { success: true, output: input.path }
+  },
+})
+```
+
+`enforceModelInput: true` without an explicit `modelInputSchema` is rejected at
+registration. Namzu does not assume a Zod-generated schema is compatible with
+every provider's constrained-decoding subset.
+
+The agent runtime carries enforced tool names to providers through
+`ChatCompletionParams.enforceToolInputSchema`. This property is a non-wire
+provider hint: custom `LLMProvider` implementations must consume or strip it
+instead of serializing `ChatCompletionParams` wholesale.
+
+Native Anthropic and the HTTP provider's Anthropic dialect enable strict tool
+use for documented Claude 4.5+ model identifiers. Their `strictToolUse`
+configuration accepts:
+
+- `"auto"` (default): enable only for recognized compatible models
+- `"on"`: opt a compatible proxy/model alias in
+- `"off"`: disable constrained tool inputs
+
+Runtime validation always remains authoritative. Anthropic's strict JSON
+Schema subset does not grammar-enforce constraints such as `minimum`, so those
+constraints belong in descriptions and the runtime decoder. Anthropic also
+limits one request to 20 strict tools, 24 optional parameters, and 16 union
+parameters. Compiled schemas are cached for up to 24 hours; do not place PHI
+in schema property names, enum/const values, or regex patterns.
 
 ## 3. Tool Context
 

--- a/docs/sdk/tools/built-in.md
+++ b/docs/sdk/tools/built-in.md
@@ -1,7 +1,7 @@
 ---
 title: Built-In Tools
 description: Reference for the built-in tools exported by @namzu/sdk, including their purpose, safety shape, and common usage patterns.
-last_updated: 2026-05-02
+last_updated: 2026-07-30
 status: current
 related_packages: ["@namzu/sdk", "@namzu/computer-use"]
 ---
@@ -85,11 +85,14 @@ Notes:
 
 Purpose:
 
-- apply exact-string replacements
+- apply exact-string replacements or insert text after a numbered line or at the end
 
 Notes:
 
-- fails if `old_string` is missing
+- models see only the canonical `old_string` / `new_string` keys; legacy `oldStr` / `newStr` aliases remain runtime-only compatibility inputs
+- replacement requires `path`, `old_string`, and `new_string`
+- insertion requires `path`, `insertLine`, and `new_string`; `insertLine` is a non-negative JSON integer or the parsed JSON string `"end"`
+- rejects a string containing quote characters such as `"\"end\""`
 - fails if `old_string` is not unique unless `replace_all` is `true`
 - useful for targeted edits without rewriting entire files
 

--- a/packages/providers/anthropic/README.md
+++ b/packages/providers/anthropic/README.md
@@ -68,10 +68,20 @@ ProviderRegistry.create({
   type: 'anthropic',
   apiKey: process.env.ANTHROPIC_API_KEY!,
   baseURL: 'https://anthropic-proxy.example.com',
+  // Use 'on' only when a proxy alias supports Anthropic strict tool use.
+  strictToolUse: 'auto',
   defaultHeaders: { 'x-team': 'platform' },
   timeout: 120_000,
 })
 ```
+
+### Strict tool inputs
+
+Tools declared with both `modelInputSchema` and `enforceModelInput: true` are
+sent with Anthropic `strict: true` on recognized Claude 4.5+ models.
+`strictToolUse` defaults to `auto`; set it to `on` for a compatible proxy model
+alias or `off` to disable constrained input generation. Runtime Zod validation
+still runs for every tool call.
 
 ### Max tokens
 

--- a/packages/providers/anthropic/src/__tests__/anthropic.test.ts
+++ b/packages/providers/anthropic/src/__tests__/anthropic.test.ts
@@ -64,7 +64,7 @@ describe('@namzu/anthropic', () => {
 		})
 
 		it('throws when constructed without an apiKey or authToken', () => {
-			expect(() => new AnthropicProvider({} as any)).toThrow(/apiKey.*or.*authToken.*required/)
+			expect(() => new AnthropicProvider({})).toThrow(/apiKey.*or.*authToken.*required/)
 		})
 
 		it('accepts an authToken instead of an apiKey (OAuth path)', () => {
@@ -88,7 +88,7 @@ describe('@namzu/anthropic', () => {
 				apiKey: 'test-key',
 				model: 'claude-sonnet-4-5-20250929',
 			})
-			;(provider as any).client = {
+			;(provider as unknown as { client: unknown }).client = {
 				messages: {
 					create: async () => delayedAnthropicStream(10),
 				},
@@ -112,7 +112,7 @@ describe('@namzu/anthropic', () => {
 				model: 'claude-sonnet-4-5-20250929',
 				streamIdleTimeoutMs: 1,
 			})
-			;(provider as any).client = {
+			;(provider as unknown as { client: unknown }).client = {
 				messages: {
 					create: async () => delayedAnthropicStream(20),
 				},
@@ -134,24 +134,43 @@ describe('@namzu/anthropic', () => {
 })
 
 describe('AnthropicProvider — buildCreateParams', () => {
+	type AnthropicRequestBody = Record<string, unknown> & {
+		tools?: Record<string, unknown>[]
+	}
+
 	const buildParams = (
 		provider: AnthropicProvider,
 		params: ChatCompletionParams,
 		stream = false,
-	): Record<string, any> =>
-		(provider as any).buildCreateParams(params, stream) as Record<string, any>
+	): AnthropicRequestBody =>
+		(
+			provider as unknown as {
+				buildCreateParams(input: ChatCompletionParams, useStream: boolean): AnthropicRequestBody
+			}
+		).buildCreateParams(params, stream)
 
 	const makeProvider = () =>
-		new AnthropicProvider({ apiKey: 'test-key', model: 'claude-sonnet-4-5-20250929' })
+		new AnthropicProvider({
+			apiKey: 'test-key',
+			model: 'claude-sonnet-4-5-20250929',
+		})
 
 	const tools: LLMToolSchema[] = [
 		{
 			type: 'function',
-			function: { name: 'alpha', description: 'first', parameters: { type: 'object' } },
+			function: {
+				name: 'alpha',
+				description: 'first',
+				parameters: { type: 'object' },
+			},
 		},
 		{
 			type: 'function',
-			function: { name: 'beta', description: 'second', parameters: { type: 'object' } },
+			function: {
+				name: 'beta',
+				description: 'second',
+				parameters: { type: 'object' },
+			},
 		},
 	]
 
@@ -204,7 +223,154 @@ describe('AnthropicProvider — buildCreateParams', () => {
 				tools,
 				parallelToolCalls: false,
 			})
-			expect(body.tool_choice).toEqual({ type: 'auto', disable_parallel_tool_use: true })
+			expect(body.tool_choice).toEqual({
+				type: 'auto',
+				disable_parallel_tool_use: true,
+			})
+		})
+	})
+
+	describe('strict tool input mapping', () => {
+		const base = (model: string): ChatCompletionParams => ({
+			model,
+			messages: [{ role: 'user', content: 'hi' }],
+			tools,
+			enforceToolInputSchema: ['alpha'],
+		})
+
+		it.each([
+			'claude-haiku-4-5-20251001',
+			'claude-sonnet-4-6',
+			'claude-opus-5',
+			'anthropic/claude-fable-5',
+			'claude-mythos-preview',
+		])('enables only named tools for supported model %s', (model) => {
+			const body = buildParams(makeProvider(), base(model))
+			expect(body.tools?.[0]).toMatchObject({ name: 'alpha', strict: true })
+			expect(body.tools?.[1]).toEqual({
+				name: 'beta',
+				description: 'second',
+				input_schema: { type: 'object' },
+			})
+		})
+
+		it.each([
+			'claude-3-5-sonnet-20241022',
+			'proxy-production-alias',
+			'proxy-production-claude-opus-5-legacy',
+			'not-claude-sonnet-4-5-compatible',
+			'claude-mythos-preview-shadow',
+		])('falls back to runtime validation for unsupported or unknown model %s', (model) => {
+			const body = buildParams(makeProvider(), base(model))
+			expect(JSON.stringify(body.tools)).not.toContain('"strict"')
+		})
+
+		it('uses the per-call model instead of the configured default in auto mode', () => {
+			const provider = new AnthropicProvider({
+				apiKey: 'test-key',
+				model: 'claude-opus-5',
+			})
+			const body = buildParams(provider, base('proxy-production-alias'))
+			expect(JSON.stringify(body.tools)).not.toContain('"strict"')
+		})
+
+		it('supports explicit on/off overrides for compatible aliases and proxies', () => {
+			const on = new AnthropicProvider({
+				apiKey: 'test-key',
+				model: 'proxy-production-alias',
+				strictToolUse: 'on',
+			})
+			expect(
+				buildParams(on, {
+					...base(''),
+					model: '',
+				}).tools?.[0],
+			).toMatchObject({ strict: true })
+
+			const off = new AnthropicProvider({
+				apiKey: 'test-key',
+				model: 'claude-opus-5',
+				strictToolUse: 'off',
+			})
+			expect(JSON.stringify(buildParams(off, base('claude-opus-5')).tools)).not.toContain(
+				'"strict"',
+			)
+		})
+
+		it('ignores empty and unknown enforcement names', () => {
+			for (const names of [[], ['unknown_tool']]) {
+				const body = buildParams(makeProvider(), {
+					...base('claude-opus-5'),
+					enforceToolInputSchema: names,
+				})
+				expect(JSON.stringify(body.tools)).not.toContain('"strict"')
+			}
+		})
+
+		it('serializes the reviewed model schema unchanged without unsupported constraints', () => {
+			const schema = {
+				type: 'object',
+				properties: {
+					path: { type: 'string' },
+					new_string: { type: 'string' },
+					insertLine: {
+						anyOf: [{ type: 'integer' }, { type: 'string', const: 'end' }],
+					},
+				},
+				required: ['path', 'new_string'],
+				additionalProperties: false,
+				anyOf: [
+					{
+						type: 'object',
+						properties: {
+							path: { type: 'string' },
+							insertLine: {
+								anyOf: [{ type: 'integer' }, { type: 'string', const: 'end' }],
+							},
+							new_string: { type: 'string' },
+						},
+						required: ['path', 'insertLine', 'new_string'],
+						additionalProperties: false,
+					},
+				],
+			}
+			const body = buildParams(makeProvider(), {
+				model: 'claude-opus-5',
+				messages: [{ role: 'user', content: 'append' }],
+				tools: [
+					{
+						type: 'function',
+						function: {
+							name: 'edit',
+							description: 'Edit',
+							parameters: schema,
+						},
+					},
+				],
+				enforceToolInputSchema: ['edit'],
+			})
+
+			expect(body.tools?.[0]).toEqual({
+				name: 'edit',
+				description: 'Edit',
+				input_schema: schema,
+				strict: true,
+			})
+			expect(JSON.stringify(body.tools)).not.toContain('"minimum"')
+		})
+
+		it('coexists with cache_control on the tools-array tail', () => {
+			const body = buildParams(makeProvider(), {
+				...base('claude-opus-5'),
+				enforceToolInputSchema: ['beta'],
+				cacheControl: { type: 'auto' },
+			})
+			expect(body.tools?.[0]).not.toHaveProperty('strict')
+			expect(body.tools?.[1]).toMatchObject({
+				name: 'beta',
+				strict: true,
+				cache_control: { type: 'ephemeral' },
+			})
 		})
 	})
 
@@ -235,7 +401,11 @@ describe('AnthropicProvider — buildCreateParams', () => {
 		it('preserves system segment boundaries and marks only the cache-tagged block', () => {
 			const body = buildParams(makeProvider(), cachedParams())
 			expect(body.system).toEqual([
-				{ type: 'text', text: 'STATIC PREFIX', cache_control: { type: 'ephemeral' } },
+				{
+					type: 'text',
+					text: 'STATIC PREFIX',
+					cache_control: { type: 'ephemeral' },
+				},
 				{ type: 'text', text: 'DYNAMIC SEGMENT' },
 			])
 		})
@@ -261,7 +431,11 @@ describe('AnthropicProvider — buildCreateParams', () => {
 					role: 'assistant',
 					content: null,
 					toolCalls: [
-						{ id: 'tu_1', type: 'function', function: { name: 'alpha', arguments: '{}' } },
+						{
+							id: 'tu_1',
+							type: 'function',
+							function: { name: 'alpha', arguments: '{}' },
+						},
 					],
 				},
 				{ role: 'tool', content: 'tool says hi', toolCallId: 'tu_1' },
@@ -281,7 +455,10 @@ describe('AnthropicProvider — buildCreateParams', () => {
 		it('keeps the Claude Code identity block FIRST on the OAuth path', () => {
 			const provider = new AnthropicProvider({ authToken: 'cc-oauth-token' })
 			const body = buildParams(provider, cachedParams())
-			const system = body.system as Array<{ text: string; cache_control?: unknown }>
+			const system = body.system as Array<{
+				text: string
+				cache_control?: unknown
+			}>
 			expect(system[0]?.text).toMatch(/^You are Claude Code/)
 			expect(system[0]?.cache_control).toBeUndefined()
 			expect(system[1]).toEqual({

--- a/packages/providers/anthropic/src/client.ts
+++ b/packages/providers/anthropic/src/client.ts
@@ -106,6 +106,7 @@ interface AnthropicToolParam {
 	name: string
 	description: string
 	input_schema: unknown
+	strict?: boolean
 	cache_control?: AnthropicCacheControl
 }
 
@@ -233,13 +234,19 @@ function toAnthropicMessages(messages: ChatCompletionParams['messages']): Anthro
 function toAnthropicTools(
 	params: ChatCompletionParams,
 	cachingEnabled: boolean,
+	strictToolUseEnabled: boolean,
 ): AnthropicToolParam[] | undefined {
 	if (!params.tools || params.tools.length === 0) return undefined
-	const tools: AnthropicToolParam[] = params.tools.map((t) => ({
-		name: t.function.name,
-		description: t.function.description ?? '',
-		input_schema: t.function.parameters ?? { type: 'object' },
-	}))
+	const enforcedNames = new Set(params.enforceToolInputSchema ?? [])
+	const tools: AnthropicToolParam[] = params.tools.map((t) => {
+		const strict = strictToolUseEnabled && enforcedNames.has(t.function.name)
+		return {
+			name: t.function.name,
+			description: t.function.description ?? '',
+			input_schema: t.function.parameters ?? { type: 'object' },
+			...(strict ? { strict: true } : {}),
+		}
+	})
 	if (cachingEnabled) {
 		// Breakpoint on the tools-array tail: tools render at position 0 of
 		// the cache prefix, so this caches every tool schema even when the
@@ -248,6 +255,24 @@ function toAnthropicTools(
 		if (tail) tail.cache_control = { type: 'ephemeral' }
 	}
 	return tools
+}
+
+function shouldUseStrictToolInputs(
+	model: string,
+	mode: AnthropicConfig['strictToolUse'] = 'auto',
+): boolean {
+	if (mode === 'on') return true
+	if (mode === 'off') return false
+
+	const normalized = model.toLowerCase()
+	if (/^(?:anthropic\/)?claude-mythos-preview$/.test(normalized)) return true
+	const version = normalized.match(
+		/^(?:anthropic\/)?claude-(?:haiku|sonnet|opus|fable|mythos)-(\d+)(?:[-_.](\d+))?(?:-\d{8})?$/,
+	)
+	if (!version) return false
+	const major = Number(version[1])
+	const minor = Number(version[2] ?? 0)
+	return major > 4 || (major === 4 && minor >= 5)
 }
 
 function toAnthropicToolChoice(tc?: ToolChoice, parallelToolCalls?: boolean): unknown {
@@ -445,14 +470,19 @@ export class AnthropicProvider implements LLMProvider {
 		// is tools → system → messages, so each later breakpoint covers all
 		// earlier sections too).
 		const cachingEnabled = params.cacheControl !== undefined
+		const model = this.resolveModel(params)
 		const system = extractSystem(params.messages, cachingEnabled)
 		const messages = toAnthropicMessages(params.messages)
 		if (cachingEnabled) applyMessageCacheBreakpoint(messages)
-		const tools = toAnthropicTools(params, cachingEnabled)
+		const tools = toAnthropicTools(
+			params,
+			cachingEnabled,
+			shouldUseStrictToolInputs(model, this.config.strictToolUse),
+		)
 		const toolChoice = toAnthropicToolChoice(params.toolChoice, params.parallelToolCalls)
 
 		const body: Record<string, unknown> = {
-			model: this.resolveModel(params),
+			model,
 			messages,
 			max_tokens: params.maxTokens ?? this.config.maxTokens ?? DEFAULT_MAX_TOKENS,
 			stream,

--- a/packages/providers/anthropic/src/types.ts
+++ b/packages/providers/anthropic/src/types.ts
@@ -30,6 +30,12 @@ export interface AnthropicConfig {
 	/** Default max_tokens (Anthropic requires this field). Default: 64000. */
 	maxTokens?: number
 	/**
+	 * Constrained tool-input policy. `auto` enables strict tool use for known
+	 * Claude 4.5+ model identifiers, `on` opts a compatible proxy alias in,
+	 * and `off` disables it. Default: `auto`.
+	 */
+	strictToolUse?: 'auto' | 'on' | 'off'
+	/**
 	 * Bearer-style OAuth access token (mutually exclusive with `apiKey`).
 	 * Use when the credential is an Anthropic OAuth or Claude Code OAuth
 	 * token rather than an `sk-ant-api-*` console key. The underlying SDK

--- a/packages/providers/bedrock/src/__tests__/bedrock.test.ts
+++ b/packages/providers/bedrock/src/__tests__/bedrock.test.ts
@@ -53,4 +53,50 @@ describe('@namzu/bedrock', () => {
 			expect(provider.capabilities).toEqual(BEDROCK_CAPABILITIES)
 		})
 	})
+
+	it('keeps the Namzu enforcement hint out of the Bedrock command', async () => {
+		const provider = new BedrockProvider({ region: 'us-east-1' })
+		let commandInput: Record<string, unknown> | undefined
+		;(provider as unknown as { client: unknown }).client = {
+			send: async (command: { input: Record<string, unknown> }) => {
+				commandInput = command.input
+				return {
+					$metadata: { requestId: 'request-test' },
+					stream: (async function* () {})(),
+				}
+			},
+		}
+
+		for await (const _chunk of provider.chatStream({
+			model: 'anthropic.claude-sonnet-5-v1:0',
+			messages: [{ role: 'user', content: 'edit' }],
+			tools: [
+				{
+					type: 'function',
+					function: {
+						name: 'edit',
+						description: 'Edit',
+						parameters: { type: 'object' },
+					},
+				},
+			],
+			enforceToolInputSchema: ['edit'],
+		})) {
+			// Drain the empty test stream.
+		}
+
+		expect(commandInput).not.toHaveProperty('enforceToolInputSchema')
+		expect(commandInput?.toolConfig).toEqual({
+			tools: [
+				{
+					toolSpec: {
+						name: 'edit',
+						description: 'Edit',
+						inputSchema: { json: { type: 'object' } },
+					},
+				},
+			],
+			toolChoice: { auto: {} },
+		})
+	})
 })

--- a/packages/providers/http/README.md
+++ b/packages/providers/http/README.md
@@ -46,6 +46,7 @@ const { provider } = ProviderRegistry.create({
   baseURL: 'https://api.anthropic.com/v1',
   apiKey: process.env.ANTHROPIC_API_KEY!,
   dialect: 'anthropic',
+  strictToolUse: 'auto',
 })
 
 await provider.chat({
@@ -54,6 +55,12 @@ await provider.chat({
   maxTokens: 1024, // REQUIRED for Anthropic
 })
 ```
+
+For Anthropic-dialect tools declared with `modelInputSchema` and
+`enforceModelInput: true`, `strictToolUse: 'auto'` enables constrained inputs
+on recognized Claude 4.5+ models. Use `'on'` for a compatible proxy alias or
+`'off'` to disable the mapping. The option has no effect on the OpenAI dialect,
+and Namzu's non-wire enforcement hint is never forwarded as an HTTP field.
 
 ### Local Ollama (OpenAI-compat endpoint)
 

--- a/packages/providers/http/src/__tests__/http.test.ts
+++ b/packages/providers/http/src/__tests__/http.test.ts
@@ -46,6 +46,21 @@ function mockSseResponse(frames: string[], status = 200): Response {
 	})
 }
 
+function mockAnthropicDoneSse(): Response {
+	return mockSseResponse([
+		'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_done","usage":{"input_tokens":1,"output_tokens":0}}}',
+		'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":1,"output_tokens":0}}',
+		'event: message_stop\ndata: {"type":"message_stop"}',
+	])
+}
+
+function mockOpenAiDoneSse(): Response {
+	return mockSseResponse([
+		'data: {"id":"msg_done","choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":0,"total_tokens":1}}',
+		'data: [DONE]',
+	])
+}
+
 async function collectStream<T>(iter: AsyncIterable<T>): Promise<T[]> {
 	const out: T[] = []
 	for await (const x of iter) out.push(x)
@@ -91,7 +106,10 @@ describe('@namzu/http — registration', () => {
 	})
 
 	it('exposes capabilities on the provider instance for runtime negotiation', () => {
-		const provider = new HttpProvider({ baseURL: 'https://example.com/v1', apiKey: 'test' })
+		const provider = new HttpProvider({
+			baseURL: 'https://example.com/v1',
+			apiKey: 'test',
+		})
 		expect(provider.capabilities).toEqual(HTTP_CAPABILITIES)
 	})
 
@@ -117,7 +135,12 @@ describe('@namzu/http — request construction', () => {
 			mockJsonResponse({
 				id: 'x',
 				model: 'gpt-4o',
-				choices: [{ message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+				choices: [
+					{
+						message: { role: 'assistant', content: 'hi' },
+						finish_reason: 'stop',
+					},
+				],
 				usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
 			}),
 		)
@@ -139,9 +162,15 @@ describe('@namzu/http — request construction', () => {
 		)
 
 		expect(fetchMock).toHaveBeenCalledTimes(1)
-		const call = fetchMock.mock.calls[0]!
+		const call = fetchMock.mock.calls[0]
+		expect(call).toBeDefined()
+		if (!call) throw new Error('expected fetch call')
 		const url = call[0] as string
-		const init = call[1] as { method: string; headers: Record<string, string>; body: string }
+		const init = call[1] as {
+			method: string
+			headers: Record<string, string>
+			body: string
+		}
 		expect(url).toBe('https://api.openai.com/v1/chat/completions')
 		expect(init.method).toBe('POST')
 		expect(init.headers['Content-Type']).toBe('application/json')
@@ -184,9 +213,15 @@ describe('@namzu/http — request construction', () => {
 			}),
 		)
 
-		const call = fetchMock.mock.calls[0]!
+		const call = fetchMock.mock.calls[0]
+		expect(call).toBeDefined()
+		if (!call) throw new Error('expected fetch call')
 		const url = call[0] as string
-		const init = call[1] as { method: string; headers: Record<string, string>; body: string }
+		const init = call[1] as {
+			method: string
+			headers: Record<string, string>
+			body: string
+		}
 		expect(url).toBe('https://api.anthropic.com/v1/messages')
 		expect(init.headers['x-api-key']).toBe('anthropic-key')
 		expect(init.headers['anthropic-version']).toBe('2023-06-01')
@@ -208,7 +243,12 @@ describe('@namzu/http — request construction', () => {
 			mockJsonResponse({
 				id: 'x',
 				model: 'llama3',
-				choices: [{ message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+				choices: [
+					{
+						message: { role: 'assistant', content: 'hi' },
+						finish_reason: 'stop',
+					},
+				],
 			}),
 		)
 		vi.stubGlobal('fetch', fetchMock)
@@ -219,10 +259,15 @@ describe('@namzu/http — request construction', () => {
 		})
 
 		await collect(
-			provider.chatStream({ model: 'llama3', messages: [{ role: 'user', content: 'hi' }] }),
+			provider.chatStream({
+				model: 'llama3',
+				messages: [{ role: 'user', content: 'hi' }],
+			}),
 		)
 
-		const init = fetchMock.mock.calls[0]![1] as { headers: Record<string, string> }
+		const init = fetchMock.mock.calls[0]?.[1] as {
+			headers: Record<string, string>
+		}
 		expect(init.headers.Authorization).toBeUndefined()
 	})
 
@@ -231,7 +276,12 @@ describe('@namzu/http — request construction', () => {
 			mockJsonResponse({
 				id: 'x',
 				model: 'm',
-				choices: [{ message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+				choices: [
+					{
+						message: { role: 'assistant', content: 'hi' },
+						finish_reason: 'stop',
+					},
+				],
 			}),
 		)
 		vi.stubGlobal('fetch', fetchMock)
@@ -242,9 +292,187 @@ describe('@namzu/http — request construction', () => {
 			headers: { 'X-Custom-Tenant': 'team-42' },
 		})
 
-		await collect(provider.chatStream({ model: 'm', messages: [{ role: 'user', content: 'hi' }] }))
-		const init = fetchMock.mock.calls[0]![1] as { headers: Record<string, string> }
+		await collect(
+			provider.chatStream({
+				model: 'm',
+				messages: [{ role: 'user', content: 'hi' }],
+			}),
+		)
+		const init = fetchMock.mock.calls[0]?.[1] as {
+			headers: Record<string, string>
+		}
 		expect(init.headers['X-Custom-Tenant']).toBe('team-42')
+	})
+
+	it('anthropic dialect maps enforced tools to strict without leaking the provider hint', async () => {
+		const fetchMock = vi.fn().mockImplementation(async () => mockAnthropicDoneSse())
+		vi.stubGlobal('fetch', fetchMock)
+		const provider = new HttpProvider({
+			baseURL: 'https://api.anthropic.com/v1',
+			apiKey: 'test',
+			dialect: 'anthropic',
+		})
+		const editSchema = {
+			type: 'object',
+			properties: { new_string: { type: 'string' } },
+			required: ['new_string'],
+			additionalProperties: false,
+		}
+
+		await collectStream(
+			provider.chatStream({
+				model: 'claude-opus-5',
+				messages: [{ role: 'user', content: 'edit' }],
+				tools: [
+					{
+						type: 'function',
+						function: {
+							name: 'edit',
+							description: 'Edit',
+							parameters: editSchema,
+						},
+					},
+					{
+						type: 'function',
+						function: {
+							name: 'read',
+							description: 'Read',
+							parameters: { type: 'object' },
+						},
+					},
+				],
+				enforceToolInputSchema: ['edit'],
+			}),
+		)
+
+		const init = fetchMock.mock.calls[0]?.[1] as { body: string }
+		const body = JSON.parse(init.body)
+		expect(body).not.toHaveProperty('enforceToolInputSchema')
+		expect(body.tools).toEqual([
+			{
+				name: 'edit',
+				description: 'Edit',
+				input_schema: editSchema,
+				strict: true,
+			},
+			{
+				name: 'read',
+				description: 'Read',
+				input_schema: { type: 'object' },
+			},
+		])
+	})
+
+	it('anthropic dialect applies per-call model precedence and auto/on/off overrides', async () => {
+		const fetchMock = vi.fn().mockImplementation(async () => mockAnthropicDoneSse())
+		vi.stubGlobal('fetch', fetchMock)
+		const tools = [
+			{
+				type: 'function' as const,
+				function: {
+					name: 'edit',
+					description: 'Edit',
+					parameters: {
+						type: 'object',
+						properties: { path: { type: 'string' } },
+						required: ['path'],
+						additionalProperties: false,
+					},
+				},
+			},
+		]
+		const call = async (provider: HttpProvider, model: string) => {
+			await collectStream(
+				provider.chatStream({
+					model,
+					messages: [{ role: 'user', content: 'edit' }],
+					tools,
+					enforceToolInputSchema: ['edit'],
+				}),
+			)
+		}
+
+		await call(
+			new HttpProvider({
+				baseURL: 'https://proxy.example/v1',
+				dialect: 'anthropic',
+				model: 'claude-opus-5',
+			}),
+			'proxy-model-alias',
+		)
+		await call(
+			new HttpProvider({
+				baseURL: 'https://proxy.example/v1',
+				dialect: 'anthropic',
+				model: 'proxy-model-alias',
+				strictToolUse: 'on',
+			}),
+			'',
+		)
+		await call(
+			new HttpProvider({
+				baseURL: 'https://proxy.example/v1',
+				dialect: 'anthropic',
+				strictToolUse: 'off',
+			}),
+			'claude-opus-5',
+		)
+		await call(
+			new HttpProvider({
+				baseURL: 'https://proxy.example/v1',
+				dialect: 'anthropic',
+			}),
+			'proxy-production-claude-opus-5-legacy',
+		)
+		await call(
+			new HttpProvider({
+				baseURL: 'https://proxy.example/v1',
+				dialect: 'anthropic',
+			}),
+			'not-claude-sonnet-4-5-compatible',
+		)
+
+		const bodies = fetchMock.mock.calls.map((entry) =>
+			JSON.parse((entry[1] as { body: string }).body),
+		)
+		expect(bodies[0]?.tools[0]).not.toHaveProperty('strict')
+		expect(bodies[1]?.tools[0]).toMatchObject({ strict: true })
+		expect(bodies[2]?.tools[0]).not.toHaveProperty('strict')
+		expect(bodies[3]?.tools[0]).not.toHaveProperty('strict')
+		expect(bodies[4]?.tools[0]).not.toHaveProperty('strict')
+	})
+
+	it('openai dialect strips the non-wire enforcement hint from the request body', async () => {
+		const fetchMock = vi.fn().mockImplementation(async () => mockOpenAiDoneSse())
+		vi.stubGlobal('fetch', fetchMock)
+		const provider = new HttpProvider({
+			baseURL: 'https://api.openai.com/v1',
+			apiKey: 'test',
+			dialect: 'openai',
+		})
+		const tools = [
+			{
+				type: 'function' as const,
+				function: {
+					name: 'edit',
+					description: 'Edit',
+					parameters: { type: 'object' },
+				},
+			},
+		]
+
+		await collectStream(
+			provider.chatStream({
+				model: 'gpt-5',
+				messages: [{ role: 'user', content: 'edit' }],
+				tools,
+				enforceToolInputSchema: ['edit'],
+			}),
+		)
+
+		const body = JSON.parse((fetchMock.mock.calls[0]?.[1] as { body: string }).body)
+		expect(body).not.toHaveProperty('enforceToolInputSchema')
+		expect(body.tools).toEqual(tools)
 	})
 })
 
@@ -318,7 +546,12 @@ describe('@namzu/http — response parsing', () => {
 					model: 'claude-sonnet-4',
 					content: [
 						{ type: 'text', text: 'Let me search.' },
-						{ type: 'tool_use', id: 'tu_1', name: 'search', input: { q: 'cats' } },
+						{
+							type: 'tool_use',
+							id: 'tu_1',
+							name: 'search',
+							input: { q: 'cats' },
+						},
 					],
 					stop_reason: 'tool_use',
 					usage: { input_tokens: 8, output_tokens: 4 },
@@ -395,7 +628,12 @@ describe('@namzu/http — DialectMismatchError', () => {
 				mockJsonResponse({
 					id: 'x',
 					model: 'm',
-					choices: [{ message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+					choices: [
+						{
+							message: { role: 'assistant', content: 'hi' },
+							finish_reason: 'stop',
+						},
+					],
 				}),
 			),
 		)
@@ -407,7 +645,12 @@ describe('@namzu/http — DialectMismatchError', () => {
 		})
 
 		await expect(
-			collect(provider.chatStream({ model: 'm', messages: [{ role: 'user', content: 'hi' }] })),
+			collect(
+				provider.chatStream({
+					model: 'm',
+					messages: [{ role: 'user', content: 'hi' }],
+				}),
+			),
 		).rejects.toThrowError(DialectMismatchError)
 	})
 
@@ -432,7 +675,12 @@ describe('@namzu/http — DialectMismatchError', () => {
 		})
 
 		await expect(
-			collect(provider.chatStream({ model: 'm', messages: [{ role: 'user', content: 'hi' }] })),
+			collect(
+				provider.chatStream({
+					model: 'm',
+					messages: [{ role: 'user', content: 'hi' }],
+				}),
+			),
 		).rejects.toThrowError(DialectMismatchError)
 	})
 
@@ -450,7 +698,10 @@ describe('@namzu/http — DialectMismatchError', () => {
 
 		try {
 			await collect(
-				provider.chatStream({ model: 'm', messages: [{ role: 'user', content: 'hi' }] }),
+				provider.chatStream({
+					model: 'm',
+					messages: [{ role: 'user', content: 'hi' }],
+				}),
 			)
 			expect.fail('expected throw')
 		} catch (err) {
@@ -577,7 +828,10 @@ describe('@namzu/http — streaming', () => {
 
 		await expect(
 			collectStream(
-				provider.chatStream({ model: 'm', messages: [{ role: 'user', content: 'hi' }] }),
+				provider.chatStream({
+					model: 'm',
+					messages: [{ role: 'user', content: 'hi' }],
+				}),
 			),
 		).rejects.toThrowError(DialectMismatchError)
 	})

--- a/packages/providers/http/src/client.ts
+++ b/packages/providers/http/src/client.ts
@@ -81,6 +81,24 @@ function formatToolChoice(tc: ToolChoice | undefined): unknown {
 	return tc
 }
 
+function shouldUseStrictToolInputs(
+	model: string,
+	mode: HttpConfig['strictToolUse'] = 'auto',
+): boolean {
+	if (mode === 'on') return true
+	if (mode === 'off') return false
+
+	const normalized = model.toLowerCase()
+	if (/^(?:anthropic\/)?claude-mythos-preview$/.test(normalized)) return true
+	const version = normalized.match(
+		/^(?:anthropic\/)?claude-(?:haiku|sonnet|opus|fable|mythos)-(\d+)(?:[-_.](\d+))?(?:-\d{8})?$/,
+	)
+	if (!version) return false
+	const major = Number(version[1])
+	const minor = Number(version[2] ?? 0)
+	return major > 4 || (major === 4 && minor >= 5)
+}
+
 function joinUrl(base: string, path: string): string {
 	const trimmedBase = base.endsWith('/') ? base.slice(0, -1) : base
 	const trimmedPath = path.startsWith('/') ? path : `/${path}`
@@ -184,10 +202,12 @@ function formatAnthropicRequest(
 	params: ChatCompletionParams,
 	stream: boolean,
 	defaultModel?: string,
+	strictToolUse: HttpConfig['strictToolUse'] = 'auto',
 ): Record<string, unknown> {
 	const systemParts: string[] = []
 	const messages: AnthropicMessage[] = []
 	let pendingToolResults: AnthropicContentBlock[] = []
+	const model = params.model || defaultModel
 
 	const flushToolResults = () => {
 		if (pendingToolResults.length > 0) {
@@ -248,7 +268,7 @@ function formatAnthropicRequest(
 	flushToolResults()
 
 	const body: Record<string, unknown> = {
-		model: params.model || defaultModel,
+		model,
 		messages,
 		// Anthropic requires max_tokens. Default to 4096 if the caller didn't set one.
 		max_tokens: params.maxTokens ?? 4096,
@@ -262,10 +282,13 @@ function formatAnthropicRequest(
 	if (params.stop) body.stop_sequences = params.stop
 
 	if (params.tools && params.tools.length > 0) {
+		const enforcedNames = new Set(params.enforceToolInputSchema ?? [])
+		const strictEnabled = shouldUseStrictToolInputs(model ?? '', strictToolUse)
 		body.tools = params.tools.map((t) => ({
 			name: t.function.name,
 			description: t.function.description ?? '',
 			input_schema: t.function.parameters ?? { type: 'object' },
+			...(strictEnabled && enforcedNames.has(t.function.name) ? { strict: true } : {}),
 		}))
 	}
 
@@ -350,7 +373,7 @@ export class HttpProvider implements LLMProvider {
 		const url = this.endpoint()
 		const body =
 			this.dialect === 'anthropic'
-				? formatAnthropicRequest(params, true, this.config.model)
+				? formatAnthropicRequest(params, true, this.config.model, this.config.strictToolUse)
 				: buildOpenAIBody(params, true, this.config.model)
 
 		let response: Response

--- a/packages/providers/http/src/types.ts
+++ b/packages/providers/http/src/types.ts
@@ -20,6 +20,12 @@ export interface HttpConfig {
 	headers?: Record<string, string>
 	/** Default model when chat params don't specify one. */
 	model?: string
+	/**
+	 * Anthropic-dialect constrained tool-input policy. `auto` enables strict
+	 * tool use for known Claude 4.5+ model identifiers, `on` opts a compatible
+	 * proxy alias in, and `off` disables it. Default: `auto`.
+	 */
+	strictToolUse?: 'auto' | 'on' | 'off'
 	/** Request timeout in ms. Default: 60000. */
 	timeout?: number
 }

--- a/packages/providers/openai/src/__tests__/openai.test.ts
+++ b/packages/providers/openai/src/__tests__/openai.test.ts
@@ -97,8 +97,14 @@ describe('@namzu/openai', () => {
 				role: 'user',
 				content: [
 					{ type: 'text', text: 'what is in this image?' },
-					{ type: 'image_url', image_url: { url: 'data:image/png;base64,aGVsbG8=' } },
-					{ type: 'image_url', image_url: { url: 'data:image/jpeg;base64,d29ybGQ=' } },
+					{
+						type: 'image_url',
+						image_url: { url: 'data:image/png;base64,aGVsbG8=' },
+					},
+					{
+						type: 'image_url',
+						image_url: { url: 'data:image/jpeg;base64,d29ybGQ=' },
+					},
 				],
 			})
 		})
@@ -115,7 +121,12 @@ describe('@namzu/openai', () => {
 			const [mapped] = toOpenAIMessages(messages)
 			expect(mapped).toEqual({
 				role: 'user',
-				content: [{ type: 'image_url', image_url: { url: 'data:image/webp;base64,aGVsbG8=' } }],
+				content: [
+					{
+						type: 'image_url',
+						image_url: { url: 'data:image/webp;base64,aGVsbG8=' },
+					},
+				],
 			})
 		})
 
@@ -123,5 +134,52 @@ describe('@namzu/openai', () => {
 			const messages: ChatCompletionParams['messages'] = [{ role: 'user', content: 'hello' }]
 			expect(toOpenAIMessages(messages)).toEqual([{ role: 'user', content: 'hello' }])
 		})
+	})
+
+	it('keeps the Namzu enforcement hint out of the OpenAI SDK request', async () => {
+		const provider = new OpenAIProvider({ apiKey: 'test-key' })
+		let requestBody: Record<string, unknown> | undefined
+		;(provider as unknown as { client: unknown }).client = {
+			chat: {
+				completions: {
+					create: async (body: Record<string, unknown>) => {
+						requestBody = body
+						return (async function* () {
+							yield {
+								id: 'msg_done',
+								choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+								usage: {
+									prompt_tokens: 1,
+									completion_tokens: 0,
+									total_tokens: 1,
+								},
+							}
+						})()
+					},
+				},
+			},
+		}
+		const tools = [
+			{
+				type: 'function' as const,
+				function: {
+					name: 'edit',
+					description: 'Edit',
+					parameters: { type: 'object' },
+				},
+			},
+		]
+
+		for await (const _chunk of provider.chatStream({
+			model: 'gpt-5',
+			messages: [{ role: 'user', content: 'edit' }],
+			tools,
+			enforceToolInputSchema: ['edit'],
+		})) {
+			// Drain the test stream.
+		}
+
+		expect(requestBody).not.toHaveProperty('enforceToolInputSchema')
+		expect(requestBody?.tools).toEqual(tools)
 	})
 })

--- a/packages/providers/openrouter/src/__tests__/openrouter.test.ts
+++ b/packages/providers/openrouter/src/__tests__/openrouter.test.ts
@@ -67,4 +67,37 @@ describe('@namzu/openrouter', () => {
 			expect(capabilities).toEqual(OPENROUTER_CAPABILITIES)
 		})
 	})
+
+	it('keeps the Namzu enforcement hint out of the OpenRouter request body', () => {
+		const provider = new OpenRouterProvider({ apiKey: 'test-key' })
+		const tools = [
+			{
+				type: 'function' as const,
+				function: {
+					name: 'edit',
+					description: 'Edit',
+					parameters: { type: 'object' },
+				},
+			},
+		]
+		const body = (
+			provider as unknown as {
+				buildRequestBody(
+					params: import('@namzu/sdk').ChatCompletionParams,
+					stream: boolean,
+				): Record<string, unknown>
+			}
+		).buildRequestBody(
+			{
+				model: 'anthropic/claude-sonnet-5',
+				messages: [{ role: 'user', content: 'edit' }],
+				tools,
+				enforceToolInputSchema: ['edit'],
+			},
+			true,
+		)
+
+		expect(body).not.toHaveProperty('enforceToolInputSchema')
+		expect(body.tools).toEqual(tools)
+	})
 })

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -60,6 +60,7 @@
     "@types/node": "^22.19.17",
     "@vitest/coverage-v8": "^2.1.9",
     "fast-check": "^4.7.0",
+    "jsonschema": "^1.5.0",
     "knip": "^6.4.1",
     "typescript": "^5.5.0",
     "vitest": "^2.0.0",

--- a/packages/sdk/src/registry/tool/execute.test.ts
+++ b/packages/sdk/src/registry/tool/execute.test.ts
@@ -98,6 +98,17 @@ describe('ToolRegistry — register + availability', () => {
 		expect(() => r.register('oops', 'not-a-tool' as never)).toThrow(/requires a ToolDefinition/)
 	})
 
+	it('rejects enforced model input without an explicit model schema', () => {
+		const r = new ToolRegistry()
+		expect(() =>
+			r.register(
+				makeTool('unsafe_strict', {
+					enforceModelInput: true,
+				}),
+			),
+		).toThrow(/enforceModelInput.*modelInputSchema/)
+	})
+
 	it('getAvailability returns active for unknown names (current default)', () => {
 		const r = new ToolRegistry()
 		expect(r.getAvailability('never-registered')).toBe('active')
@@ -228,7 +239,10 @@ describe('ToolRegistry — searchDeferred', () => {
 		r.register(
 			[
 				makeTool('send_invoice', {
-					inputSchema: z.object({ customerEmail: z.string(), amount: z.number() }),
+					inputSchema: z.object({
+						customerEmail: z.string(),
+						amount: z.number(),
+					}),
 				}),
 			],
 			'deferred',
@@ -237,10 +251,50 @@ describe('ToolRegistry — searchDeferred', () => {
 		expect(r.searchDeferred('customerEmail').map((t) => t.name)).toEqual(['send_invoice'])
 	})
 
+	it('indexes canonical model-schema branches without re-advertising runtime aliases', () => {
+		const r = new ToolRegistry()
+		r.register(
+			[
+				makeTool('edit_document', {
+					inputSchema: z.object({ oldStr: z.string(), newStr: z.string() }),
+					modelInputSchema: {
+						type: 'object',
+						properties: {
+							path: { type: 'string' },
+							old_string: { type: 'string' },
+							new_string: { type: 'string' },
+						},
+						required: ['path', 'new_string'],
+						additionalProperties: false,
+						anyOf: [
+							{
+								type: 'object',
+								properties: {
+									path: { type: 'string' },
+									old_string: { type: 'string' },
+									new_string: { type: 'string' },
+								},
+								required: ['path', 'old_string', 'new_string'],
+								additionalProperties: false,
+							},
+						],
+					},
+				}),
+			],
+			'deferred',
+		)
+		expect(r.searchDeferred('old_string').map((t) => t.name)).toEqual(['edit_document'])
+		expect(r.searchDeferred('oldStr')).toEqual([])
+	})
+
 	it('stops generic CRUD verbs so they cannot activate catalog slices', () => {
 		const r = new ToolRegistry()
 		r.register(
-			[makeTool('list_deals', { description: 'List the deals in an account.' })],
+			[
+				makeTool('list_deals', {
+					description: 'List the deals in an account.',
+				}),
+			],
 			'deferred',
 		)
 		r.register([makeTool('list_workflows', { description: 'List workflows.' })], 'deferred')
@@ -370,6 +424,34 @@ describe('ToolRegistry — toPromptSection + toLLMTools', () => {
 		expect(names).toEqual(['a', 'c'])
 	})
 
+	it('toLLMTools: prefers a canonical model schema over runtime compatibility aliases', () => {
+		const r = new ToolRegistry()
+		const modelInputSchema = {
+			type: 'object',
+			properties: { new_string: { type: 'string' } },
+			required: ['new_string'],
+			additionalProperties: false,
+		}
+		r.register(
+			makeTool('edit', {
+				inputSchema: z.object({
+					new_string: z.string().optional(),
+					newStr: z.string().optional(),
+				}),
+				modelInputSchema,
+			}),
+		)
+
+		const firstSchema = r.toLLMTools()[0]?.function.parameters
+		expect(firstSchema).toEqual(modelInputSchema)
+		expect(firstSchema).not.toBe(modelInputSchema)
+		;(firstSchema?.properties as Record<string, unknown>).newStr = { type: 'string' }
+
+		const nextSchema = r.toLLMTools()[0]?.function.parameters
+		expect(nextSchema).toEqual(modelInputSchema)
+		expect(JSON.stringify(nextSchema)).not.toContain('newStr')
+	})
+
 	it('toLLMTools: prefixes description with tier label when labelInDescription is true', () => {
 		const tierConfig: ToolTierConfig = {
 			tiers: [{ id: 'safe', label: 'Safe', priority: 1 }],
@@ -398,7 +480,11 @@ describe('ToolRegistry — execute', () => {
 			'write',
 			{},
 			makeContext({
-				permissionContext: { mode: 'plan', runId: 'run_1', workingDirectory: '/tmp' },
+				permissionContext: {
+					mode: 'plan',
+					runId: 'run_1',
+					workingDirectory: '/tmp',
+				},
 			}),
 		)
 		expect(result.success).toBe(false)
@@ -413,7 +499,11 @@ describe('ToolRegistry — execute', () => {
 			'read',
 			{},
 			makeContext({
-				permissionContext: { mode: 'plan', runId: 'run_1', workingDirectory: '/tmp' },
+				permissionContext: {
+					mode: 'plan',
+					runId: 'run_1',
+					workingDirectory: '/tmp',
+				},
 			}),
 		)
 		expect(result.success).toBe(true)
@@ -451,7 +541,10 @@ describe('ToolRegistry — execute', () => {
 		const r = new ToolRegistry()
 		r.register(
 			makeTool('needs', {
-				inputSchema: z.object({ q: z.string().describe('the query'), n: z.number() }),
+				inputSchema: z.object({
+					q: z.string().describe('the query'),
+					n: z.number(),
+				}),
 			}),
 		)
 		const result = await r.execute('needs', {}, makeContext())
@@ -472,7 +565,10 @@ describe('ToolRegistry — execute', () => {
 	it('validation hint tolerates a schema it cannot introspect', async () => {
 		const r = new ToolRegistry()
 		const bogusSchema = {
-			safeParse: () => ({ success: false, error: { issues: [{ path: [], message: 'nope' }] } }),
+			safeParse: () => ({
+				success: false,
+				error: { issues: [{ path: [], message: 'nope' }] },
+			}),
 		}
 		r.register(makeTool('weird', { inputSchema: bogusSchema as never }))
 		const result = await r.execute('weird', { a: 1 }, makeContext())
@@ -530,7 +626,11 @@ describe('ToolRegistry — execute', () => {
 			'mutate',
 			{},
 			makeContext({
-				permissionContext: { mode: 'plan', runId: 'run_1', workingDirectory: '/tmp' },
+				permissionContext: {
+					mode: 'plan',
+					runId: 'run_1',
+					workingDirectory: '/tmp',
+				},
 			}),
 		)
 		expect(result.success).toBe(false)

--- a/packages/sdk/src/registry/tool/execute.ts
+++ b/packages/sdk/src/registry/tool/execute.ts
@@ -54,7 +54,11 @@ export class ToolRegistry extends ManagedRegistry<ToolDefinition> {
 	private tierConfig?: ToolTierConfig
 
 	constructor(config?: ToolRegistryConfig) {
-		super({ componentName: 'ToolRegistry', idField: 'name', logger: config?.logger })
+		super({
+			componentName: 'ToolRegistry',
+			idField: 'name',
+			logger: config?.logger,
+		})
 		this.tierConfig = config?.tierConfig
 	}
 
@@ -88,6 +92,11 @@ export class ToolRegistry extends ManagedRegistry<ToolDefinition> {
 	}
 
 	private registerOne(id: string, tool: ToolDefinition, state: ToolAvailability): void {
+		if (tool.enforceModelInput && !tool.modelInputSchema) {
+			throw new Error(
+				`Tool "${id}" enables enforceModelInput but does not define modelInputSchema. Constrained input generation requires an explicit provider-safe model schema.`,
+			)
+		}
 		if (tool.tier && this.tierConfig) {
 			const validIds = this.tierConfig.tiers.map((t) => t.id)
 			if (!validIds.includes(tool.tier)) {
@@ -279,10 +288,12 @@ Executable tool names, descriptions, and JSON input schemas are attached through
 				function: {
 					name: tool.name,
 					description,
-					parameters: zodToJsonSchema(tool.inputSchema, {
-						target: 'jsonSchema7',
-						$refStrategy: 'none',
-					}) as Record<string, unknown>,
+					parameters:
+						(tool.modelInputSchema ? structuredClone(tool.modelInputSchema) : undefined) ??
+						(zodToJsonSchema(tool.inputSchema, {
+							target: 'jsonSchema7',
+							$refStrategy: 'none',
+						}) as Record<string, unknown>),
 				},
 			}
 		})
@@ -468,14 +479,38 @@ export function toolDiscoveryHint(description: string, maxLength = 100): string 
  */
 function listArgumentNames(tool: ToolDefinition): string[] {
 	try {
-		const json = zodToJsonSchema(tool.inputSchema, {
-			target: 'jsonSchema7',
-			$refStrategy: 'none',
-		}) as { properties?: Record<string, unknown> }
-		return Object.keys(json.properties ?? {}).map((key) => key.toLowerCase())
+		const json =
+			tool.modelInputSchema ??
+			(zodToJsonSchema(tool.inputSchema, {
+				target: 'jsonSchema7',
+				$refStrategy: 'none',
+			}) as Record<string, unknown>)
+		return [...collectSchemaPropertyNames(json)].map((key) => key.toLowerCase())
 	} catch {
 		return []
 	}
+}
+
+function collectSchemaPropertyNames(
+	schema: unknown,
+	names: Set<string> = new Set(),
+	seen: Set<object> = new Set(),
+): Set<string> {
+	if (!schema || typeof schema !== 'object' || Array.isArray(schema)) return names
+	if (seen.has(schema)) return names
+	seen.add(schema)
+
+	const record = schema as Record<string, unknown>
+	const properties = record.properties
+	if (properties && typeof properties === 'object' && !Array.isArray(properties)) {
+		for (const name of Object.keys(properties)) names.add(name)
+	}
+	for (const keyword of ['anyOf', 'oneOf', 'allOf'] as const) {
+		const branches = record[keyword]
+		if (!Array.isArray(branches)) continue
+		for (const branch of branches) collectSchemaPropertyNames(branch, names, seen)
+	}
+	return names
 }
 
 /**

--- a/packages/sdk/src/registry/toolset/catalog.test.ts
+++ b/packages/sdk/src/registry/toolset/catalog.test.ts
@@ -16,6 +16,18 @@ function makeTool(name: string, description = `${name} tool`): ToolDefinition {
 	}
 }
 
+function makeCatalog(): ToolCatalog {
+	const catalog = new ToolCatalog()
+	catalog.registerSource({ id: 'host', kind: 'host_tool', name: 'Host' })
+	catalog.registerToolset({
+		id: 'tools',
+		sourceId: 'host',
+		name: 'Tools',
+		defaultPolicy: { enabled: true, loading: 'eager' },
+	})
+	return catalog
+}
+
 describe('ToolCatalog', () => {
 	it('keeps sources, toolsets, and tools as separate records', () => {
 		const catalog = new ToolCatalog()
@@ -161,5 +173,111 @@ describe('ToolCatalog', () => {
 		expect(catalog.getTool('web_search')?.policy.loading).toBe('deferred')
 		expect(catalog.getTool('write_file')?.policy.loading).toBe('suspended')
 		expect(catalog.toLLMTools({ loading: ['suspended'] })).toEqual([])
+	})
+
+	it('rejects catalog, definition, and LLM schema name mismatches', () => {
+		const catalog = makeCatalog()
+		expect(() =>
+			catalog.registerTool({
+				name: 'edit',
+				description: 'Edit a file',
+				sourceId: 'host',
+				toolsetId: 'tools',
+				policy: { enabled: true, loading: 'eager' },
+				definition: makeTool('write'),
+			}),
+		).toThrow(/definition name mismatch/)
+
+		expect(() =>
+			catalog.registerTool({
+				name: 'edit',
+				description: 'Edit a file',
+				sourceId: 'host',
+				toolsetId: 'tools',
+				policy: { enabled: true, loading: 'eager' },
+				llmSchema: {
+					type: 'function',
+					function: {
+						name: 'write',
+						description: 'Write',
+						parameters: { type: 'object' },
+					},
+				},
+			}),
+		).toThrow(/LLM schema name mismatch/)
+	})
+
+	it('rejects an explicit LLM schema that could replace an enforced definition schema', () => {
+		const catalog = makeCatalog()
+		const definition: ToolDefinition = {
+			...makeTool('edit'),
+			modelInputSchema: {
+				type: 'object',
+				properties: { path: { type: 'string' } },
+				required: ['path'],
+				additionalProperties: false,
+			},
+			enforceModelInput: true,
+		}
+
+		expect(() =>
+			catalog.registerTool({
+				name: 'edit',
+				description: 'Edit a file',
+				sourceId: 'host',
+				toolsetId: 'tools',
+				policy: { enabled: true, loading: 'eager' },
+				definition,
+				llmSchema: {
+					type: 'function',
+					function: {
+						name: 'edit',
+						description: 'Unsafe override',
+						parameters: { type: 'object' },
+					},
+				},
+			}),
+		).toThrow(/cannot combine an explicit llmSchema with enforceModelInput/)
+	})
+
+	it('rejects an enforced catalog definition without an explicit model schema', () => {
+		const catalog = makeCatalog()
+		expect(() =>
+			catalog.registerTool({
+				name: 'edit',
+				description: 'Edit a file',
+				sourceId: 'host',
+				toolsetId: 'tools',
+				policy: { enabled: true, loading: 'eager' },
+				definition: {
+					...makeTool('edit'),
+					enforceModelInput: true,
+				},
+			}),
+		).toThrow(/enforceModelInput.*modelInputSchema/)
+	})
+
+	it('uses a definition model schema when no explicit catalog schema overrides it', () => {
+		const registry = new ToolRegistry()
+		const modelInputSchema = {
+			type: 'object',
+			properties: { new_string: { type: 'string' } },
+			required: ['new_string'],
+			additionalProperties: false,
+		}
+		registry.register({
+			...makeTool('edit'),
+			modelInputSchema,
+		})
+
+		const catalog = createToolCatalogFromRegistry(registry)
+		const firstSchema = catalog.toLLMTools()[0]?.function.parameters
+		expect(firstSchema).toEqual(modelInputSchema)
+		expect(firstSchema).not.toBe(modelInputSchema)
+		;(firstSchema?.properties as Record<string, unknown>).newStr = { type: 'string' }
+
+		const nextSchema = catalog.toLLMTools()[0]?.function.parameters
+		expect(nextSchema).toEqual(modelInputSchema)
+		expect(JSON.stringify(nextSchema)).not.toContain('newStr')
 	})
 })

--- a/packages/sdk/src/registry/toolset/catalog.ts
+++ b/packages/sdk/src/registry/toolset/catalog.ts
@@ -64,6 +64,26 @@ export class ToolCatalog {
 		if (!this.toolsets.has(tool.toolsetId)) {
 			throw new Error(`Tool "${tool.name}" references unknown toolset "${tool.toolsetId}"`)
 		}
+		if (tool.definition && tool.definition.name !== tool.name) {
+			throw new Error(
+				`Tool "${tool.name}" definition name mismatch: received "${tool.definition.name}"`,
+			)
+		}
+		if (tool.llmSchema && tool.llmSchema.function.name !== tool.name) {
+			throw new Error(
+				`Tool "${tool.name}" LLM schema name mismatch: received "${tool.llmSchema.function.name}"`,
+			)
+		}
+		if (tool.definition?.enforceModelInput && !tool.definition.modelInputSchema) {
+			throw new Error(
+				`Tool "${tool.name}" enables enforceModelInput but does not define modelInputSchema.`,
+			)
+		}
+		if (tool.definition?.enforceModelInput && tool.llmSchema) {
+			throw new Error(
+				`Tool "${tool.name}" cannot combine an explicit llmSchema with enforceModelInput. Put the provider-safe schema on definition.modelInputSchema so enforcement and schema precedence stay paired.`,
+			)
+		}
 		this.tools.set(tool.name, tool)
 	}
 
@@ -226,10 +246,12 @@ function toolDefinitionToLLMTool(definition: ToolDefinition | undefined): LLMToo
 		function: {
 			name: definition.name,
 			description: definition.description,
-			parameters: zodToJsonSchema(definition.inputSchema, {
-				target: 'jsonSchema7',
-				$refStrategy: 'none',
-			}) as Record<string, unknown>,
+			parameters:
+				(definition.modelInputSchema ? structuredClone(definition.modelInputSchema) : undefined) ??
+				(zodToJsonSchema(definition.inputSchema, {
+					target: 'jsonSchema7',
+					$refStrategy: 'none',
+				}) as Record<string, unknown>),
 		},
 	}
 }

--- a/packages/sdk/src/runtime/query/__tests__/capability-negotiation.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/capability-negotiation.test.ts
@@ -46,6 +46,32 @@ class CapturingProvider implements LLMProvider {
 	}
 }
 
+class ClosingSummaryProvider implements LLMProvider {
+	readonly id = 'closing-summary'
+	readonly name = 'Closing Summary Provider'
+	readonly calls: ChatCompletionParams[] = []
+
+	async *chatStream(params: ChatCompletionParams): AsyncIterable<StreamChunk> {
+		this.calls.push(params)
+		if (this.calls.length === 1) {
+			yield {
+				id: 'msg_empty',
+				delta: {},
+				finishReason: 'stop',
+				usage: ZERO_USAGE,
+			}
+			return
+		}
+		yield { id: 'msg_summary', delta: { content: 'closing summary' } }
+		yield {
+			id: 'msg_summary',
+			delta: {},
+			finishReason: 'stop',
+			usage: ZERO_USAGE,
+		}
+	}
+}
+
 const NO_TOOLS_CAPABILITIES: ProviderCapabilities = {
 	supportsTools: false,
 	supportsStreaming: true,
@@ -65,6 +91,25 @@ function registerEchoTool(tools: ToolRegistry): void {
 		name: 'echo',
 		description: 'Echo the text back.',
 		inputSchema: z.object({ text: z.string() }),
+		execute: async () => ({ success: true, output: 'ok' }),
+	})
+}
+
+function registerEnforcedTool(tools: ToolRegistry, name: string): void {
+	tools.register({
+		name,
+		description: `${name} tool`,
+		inputSchema: z.object({
+			new_string: z.string().optional(),
+			newStr: z.string().optional(),
+		}),
+		modelInputSchema: {
+			type: 'object',
+			properties: { new_string: { type: 'string' } },
+			required: ['new_string'],
+			additionalProperties: false,
+		},
+		enforceModelInput: true,
 		execute: async () => ({ success: true, output: 'ok' }),
 	})
 }
@@ -174,6 +219,49 @@ describe('query() capability negotiation', () => {
 
 		expect(run.status).toBe('completed')
 		expect(provider.lastParams?.tools?.map((t) => t.function.name)).toContain('echo')
+	})
+
+	it('propagates enforcement names from the exact allowed and cache-stable tool schemas', async () => {
+		const provider = new CapturingProvider()
+		const tools = new ToolRegistry()
+		registerEnforcedTool(tools, 'edit')
+		registerEnforcedTool(tools, 'cached_edit')
+		registerEnforcedTool(tools, 'excluded_edit')
+		tools.suspendAll()
+		tools.activate(['edit'])
+
+		const run = await drainQuery({
+			...baseParams(provider, tools, await mkWorkdir()),
+			allowedTools: ['edit', 'cached_edit'],
+			messages: [createUserMessage('hello')],
+		})
+
+		expect(run.status).toBe('completed')
+		expect(provider.lastParams?.tools?.map((tool) => tool.function.name)).toEqual([
+			'edit',
+			'cached_edit',
+		])
+		expect(provider.lastParams?.enforceToolInputSchema).toEqual(['edit', 'cached_edit'])
+		expect(JSON.stringify(provider.lastParams?.tools)).not.toContain('newStr')
+	})
+
+	it('keeps the same enforcement hint on the closing-summary provider call', async () => {
+		const provider = new ClosingSummaryProvider()
+		const tools = new ToolRegistry()
+		registerEnforcedTool(tools, 'edit')
+
+		const run = await drainQuery({
+			...baseParams(provider, tools, await mkWorkdir()),
+			messages: [createUserMessage('hello')],
+		})
+
+		expect(run.status).toBe('completed')
+		expect(provider.calls).toHaveLength(2)
+		for (const call of provider.calls) {
+			expect(call.tools?.map((tool) => tool.function.name)).toEqual(['edit'])
+			expect(call.enforceToolInputSchema).toEqual(['edit'])
+		}
+		expect(provider.calls[1]?.toolChoice).toBe('none')
 	})
 
 	it('emits a vision capability_warning when attachments hit a no-vision provider', async () => {

--- a/packages/sdk/src/runtime/query/__tests__/deferred-tools.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/deferred-tools.test.ts
@@ -44,6 +44,58 @@ class CapturingProvider implements LLMProvider {
 	}
 }
 
+class DeferredActivationProvider implements LLMProvider {
+	readonly id = 'deferred-activation'
+	readonly name = 'Deferred Activation Provider'
+	readonly calls: ChatCompletionParams[] = []
+
+	async *chatStream(params: ChatCompletionParams): AsyncIterable<StreamChunk> {
+		this.calls.push(params)
+		if (this.calls.length === 1) {
+			yield {
+				id: 'msg_search',
+				delta: {
+					toolCalls: [
+						{
+							index: 0,
+							id: 'toolu_search',
+							type: 'function',
+							function: { name: SearchToolsTool.name },
+						},
+					],
+				},
+			}
+			yield {
+				id: 'msg_search',
+				delta: {
+					toolCalls: [
+						{
+							index: 0,
+							id: 'toolu_search',
+							function: { arguments: '{"query":"canonical_key"}' },
+						},
+					],
+				},
+			}
+			yield {
+				id: 'msg_search',
+				delta: {},
+				finishReason: 'tool_calls',
+				usage: ZERO_USAGE,
+			}
+			return
+		}
+
+		yield { id: 'msg_done', delta: { content: 'done' } }
+		yield {
+			id: 'msg_done',
+			delta: {},
+			finishReason: 'stop',
+			usage: ZERO_USAGE,
+		}
+	}
+}
+
 function registerDeferredDocumentTool(tools: ToolRegistry, name = 'generate_document'): void {
 	tools.register(
 		{
@@ -154,6 +206,65 @@ describe('query deferred tool discovery', () => {
 			.join('\n')
 		expect(systemPrompt).toContain('Use search_tools to load these before use:')
 		expect(systemPrompt).toContain('- generate_document')
+	})
+
+	it('adds enforcement only after a deferred model-schema tool is activated', async () => {
+		const provider = new DeferredActivationProvider()
+		const tools = new ToolRegistry()
+		tools.register(
+			{
+				name: 'deferred_edit',
+				description: 'Mutate a document using the provided content.',
+				inputSchema: z.object({ legacyKey: z.string() }),
+				modelInputSchema: {
+					type: 'object',
+					properties: { canonical_key: { type: 'string' } },
+					required: ['canonical_key'],
+					additionalProperties: false,
+				},
+				enforceModelInput: true,
+				execute: async () => ({ success: true, output: 'edited' }),
+			},
+			'deferred',
+		)
+
+		const workingDirectory = await mkdtemp(join(tmpdir(), 'namzu-deferred-enforcement-'))
+		workdirs.push(workingDirectory)
+		const run = await drainQuery({
+			provider,
+			tools,
+			allowedTools: ['deferred_edit'],
+			runConfig: {
+				model: 'mock-model',
+				timeoutMs: 5_000,
+				tokenBudget: 100_000,
+				maxIterations: 3,
+				maxResponseTokens: 256,
+			},
+			agentId: 'agent_test',
+			agentName: 'Test Agent',
+			messages: [createUserMessage('find and load the right tool')],
+			workingDirectory,
+			sessionId: 'ses_deferred_enforcement' as SessionId,
+			threadId: 'thd_deferred_enforcement' as ThreadId,
+			projectId: 'prj_deferred_enforcement' as ProjectId,
+			tenantId: 'tnt_deferred_enforcement' as TenantId,
+		})
+
+		expect(run.status).toBe('completed')
+		expect(provider.calls).toHaveLength(2)
+		expect(provider.calls[0]?.tools?.map((tool) => tool.function.name)).toEqual([
+			SearchToolsTool.name,
+		])
+		expect(provider.calls[0]?.enforceToolInputSchema).toBeUndefined()
+		expect(provider.calls[1]?.tools?.map((tool) => tool.function.name)).toEqual([
+			'deferred_edit',
+			SearchToolsTool.name,
+		])
+		expect(provider.calls[1]?.enforceToolInputSchema).toEqual(['deferred_edit'])
+		expect(provider.calls[1]?.tools?.[0]?.function.parameters).toEqual(
+			tools.get('deferred_edit')?.modelInputSchema,
+		)
 	})
 
 	it('does not let search_tools reveal or activate deferred tools outside allowedTools', async () => {

--- a/packages/sdk/src/runtime/query/iteration/index.ts
+++ b/packages/sdk/src/runtime/query/iteration/index.ts
@@ -6,6 +6,7 @@ import { GENAI, NAMZU, agentIterationSpanName } from '../../../telemetry/attribu
 import { getTracer } from '../../../telemetry/runtime-accessors.js'
 import { createAssistantMessage, createUserMessage } from '../../../types/message/index.js'
 import type { RunEvent, StopReason } from '../../../types/run/index.js'
+import type { LLMToolSchema, ToolRegistryContract } from '../../../types/tool/index.js'
 import { toErrorMessage } from '../../../utils/error.js'
 import { generateMessageId } from '../../../utils/id.js'
 import { applyLifecycleHookResults } from '../plugin-hooks.js'
@@ -118,6 +119,7 @@ export class IterationOrchestrator {
 				// risks a 400 because the history still carries
 				// tool_use/tool_result blocks.
 				const openAITools = this.ctx.tools.toLLMTools(this.ctx.allowedTools)
+				const enforceToolInputSchema = enforcedModelInputToolNames(this.ctx.tools, openAITools)
 
 				const messages = forceFinalize
 					? [
@@ -152,6 +154,7 @@ export class IterationOrchestrator {
 						model,
 						messages,
 						tools: openAITools.length > 0 ? openAITools : undefined,
+						enforceToolInputSchema,
 						toolChoice: forceFinalize && openAITools.length > 0 ? 'none' : undefined,
 						temperature: runConfig.temperature,
 						maxTokens: runConfig.maxResponseTokens,
@@ -428,11 +431,13 @@ export class IterationOrchestrator {
 			// tools param identical to prior iterations (cache prefix intact,
 			// no 400 on tool blocks in history) and forbid use via tool_choice.
 			const finalTools = this.ctx.tools.toLLMTools(this.ctx.allowedTools)
+			const enforceToolInputSchema = enforcedModelInputToolNames(this.ctx.tools, finalTools)
 			const response = await collect(
 				this.ctx.provider.chatStream({
 					model,
 					messages: finalMessages,
 					tools: finalTools.length > 0 ? finalTools : undefined,
+					enforceToolInputSchema,
 					toolChoice: finalTools.length > 0 ? 'none' : undefined,
 					temperature: this.ctx.runConfig.temperature,
 					maxTokens: this.ctx.runConfig.maxResponseTokens,
@@ -470,4 +475,14 @@ export class IterationOrchestrator {
 			})
 		}
 	}
+}
+
+function enforcedModelInputToolNames(
+	registry: ToolRegistryContract,
+	tools: readonly LLMToolSchema[],
+): readonly string[] | undefined {
+	const names = tools
+		.map((tool) => tool.function.name)
+		.filter((name) => registry.get(name)?.enforceModelInput === true)
+	return names.length > 0 ? names : undefined
 }

--- a/packages/sdk/src/tools/builtins/__tests__/edit.test.ts
+++ b/packages/sdk/src/tools/builtins/__tests__/edit.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { Validator } from 'jsonschema'
 import { describe, expect, it } from 'vitest'
 import { zodToJsonSchema } from 'zod-to-json-schema'
 import { ToolRegistry } from '../../../registry/tool/execute.js'
@@ -21,8 +22,11 @@ describe('EditTool', () => {
 	it('accepts oldStr/newStr aliases for string replacement', async () => {
 		const dir = mkdtempSync(join(tmpdir(), 'namzu-edit-'))
 		writeFileSync(join(dir, 'doc.md'), 'alpha\nbeta\n')
+		const registry = new ToolRegistry()
+		registry.register(EditTool)
 
-		const result = await EditTool.execute(
+		const result = await registry.execute(
+			'edit',
 			{ path: 'doc.md', oldStr: 'beta', newStr: 'gamma', replace_all: false },
 			makeContext(dir),
 		)
@@ -92,6 +96,56 @@ describe('EditTool', () => {
 		])
 	})
 
+	it('publishes a closed Draft 7 model schema with canonical exclusive operation shapes', () => {
+		const schema = EditTool.modelInputSchema
+		expect(schema).toBeDefined()
+		if (!schema) throw new Error('EditTool.modelInputSchema is required')
+
+		const validator = new Validator()
+		const accepts = (input: unknown) => validator.validate(input, schema as never).valid
+
+		for (const input of [
+			{ path: 'doc.md', old_string: 'old', new_string: 'new' },
+			{
+				path: 'doc.md',
+				old_string: 'old',
+				new_string: 'new',
+				replace_all: true,
+			},
+			{ path: 'doc.md', insertLine: 'end', new_string: 'append' },
+			{ path: 'doc.md', insertLine: 0, new_string: 'prepend' },
+			// Anthropic strict schemas do not support minimum. The model
+			// description says non-negative and runtime Zod remains authoritative.
+			{ path: 'doc.md', insertLine: -1, new_string: 'runtime rejects this' },
+		]) {
+			expect(accepts(input), JSON.stringify(input)).toBe(true)
+		}
+
+		for (const input of [
+			{ path: 'doc.md', new_string: 'missing selector' },
+			{
+				path: 'doc.md',
+				old_string: 'old',
+				insertLine: 'end',
+				new_string: 'ambiguous',
+			},
+			{ path: 'doc.md', insertLine: '"end"', new_string: 'quoted wrong' },
+			{ path: 'doc.md', insertLine: 'end', newStr: 'legacy alias' },
+			{ path: 'doc.md', oldStr: 'old', newStr: 'new' },
+			{
+				path: 'doc.md',
+				insertLine: 'end',
+				new_string: 'append',
+				replace_all: false,
+			},
+		]) {
+			expect(accepts(input), JSON.stringify(input)).toBe(false)
+		}
+
+		expect(JSON.stringify(schema)).not.toMatch(/"(?:minimum|maximum|minLength|maxLength|pattern)":/)
+		assertEveryObjectSchemaIsClosed(schema)
+	})
+
 	it('refuses invalid insertLine values even when a caller bypasses the schema', async () => {
 		for (const insertLine of ['## Progress', null, '', '1']) {
 			const dir = mkdtempSync(join(tmpdir(), 'namzu-edit-'))
@@ -131,3 +185,19 @@ describe('EditTool', () => {
 		expect(result.error).toContain('{"path":"file.md","old_string":"old","new_string":"new"}')
 	})
 })
+
+function assertEveryObjectSchemaIsClosed(value: unknown, path = '$'): void {
+	if (Array.isArray(value)) {
+		value.forEach((item, index) => assertEveryObjectSchemaIsClosed(item, `${path}[${index}]`))
+		return
+	}
+	if (!value || typeof value !== 'object') return
+
+	const record = value as Record<string, unknown>
+	if (record.type === 'object') {
+		expect(record.additionalProperties, `${path} must be closed`).toBe(false)
+	}
+	for (const [key, child] of Object.entries(record)) {
+		assertEveryObjectSchemaIsClosed(child, `${path}.${key}`)
+	}
+}

--- a/packages/sdk/src/tools/builtins/edit.ts
+++ b/packages/sdk/src/tools/builtins/edit.ts
@@ -52,6 +52,60 @@ const inputSchema = z
 
 type EditInput = z.infer<typeof inputSchema>
 
+const modelInputSchema: Record<string, unknown> = {
+	type: 'object',
+	properties: {
+		path: {
+			type: 'string',
+			description: 'Path to the file to edit.',
+		},
+		old_string: {
+			type: 'string',
+			description: 'The exact unique string to find and replace.',
+		},
+		new_string: {
+			type: 'string',
+			description: 'The replacement or inserted text. Keep this payload under 12000 characters.',
+		},
+		insertLine: {
+			anyOf: [{ type: 'integer' }, { type: 'string', const: 'end' }],
+			description:
+				'Line insertion target: a non-negative JSON integer, or the exact JSON string "end" to append.',
+		},
+		replace_all: {
+			type: 'boolean',
+			description: 'Replace every occurrence of old_string instead of one unique match.',
+		},
+	},
+	required: ['path', 'new_string'],
+	additionalProperties: false,
+	anyOf: [
+		{
+			type: 'object',
+			properties: {
+				path: { type: 'string' },
+				old_string: { type: 'string' },
+				new_string: { type: 'string' },
+				replace_all: { type: 'boolean' },
+			},
+			required: ['path', 'old_string', 'new_string'],
+			additionalProperties: false,
+		},
+		{
+			type: 'object',
+			properties: {
+				path: { type: 'string' },
+				insertLine: {
+					anyOf: [{ type: 'integer' }, { type: 'string', const: 'end' }],
+				},
+				new_string: { type: 'string' },
+			},
+			required: ['path', 'insertLine', 'new_string'],
+			additionalProperties: false,
+		},
+	],
+}
+
 type NormalizedEditInput =
 	| {
 			operation: 'replace'
@@ -69,8 +123,10 @@ type NormalizedEditInput =
 export const EditTool = defineTool({
 	name: 'edit',
 	description:
-		'Makes targeted edits to a file using exact string find-and-replace or line insertion. THIS IS THE PREFERRED WAY TO MODIFY AN EXISTING FILE — never reach for `write` to change a file that already exists, because `write` overwrites the whole body and discards earlier work on partial failure. `edit` keeps the rest of the file byte-for-byte intact and is recoverable: if a single edit fails (old_string/oldStr ambiguous, broader restructuring needed), follow up with another `edit` instead of re-emitting the entire file via `write`. The old_string/oldStr must be unique in the file unless replace_all is true. For insertions, pass insertLine plus new_string/newStr; use insertLine: "end" to extend a file at the end. Self-budget new_string/newStr under 12000 characters before emitting the tool call; use repeated bounded edits for long sections. Preserves file formatting and indentation.',
+		'Makes targeted edits to a file using exact string find-and-replace or line insertion. THIS IS THE PREFERRED WAY TO MODIFY AN EXISTING FILE — never reach for `write` to change a file that already exists, because `write` overwrites the whole body and discards earlier work on partial failure. `edit` keeps the rest of the file byte-for-byte intact and is recoverable: if a single exact match fails or broader restructuring is needed, follow up with another `edit` instead of re-emitting the entire file via `write`. For replacement, pass path + old_string + new_string; old_string must be unique unless replace_all is true. For insertion, pass path + insertLine + new_string; use the parsed JSON value insertLine: "end" to append, never a string containing quote characters. Self-budget new_string under 12000 characters before emitting the tool call; use repeated bounded edits for long sections. Preserves file formatting and indentation.',
 	inputSchema,
+	modelInputSchema,
+	enforceModelInput: true,
 	validationErrorHint:
 		'Accepted shapes: {"path":"file.md","insertLine":"end","new_string":"text"} or {"path":"file.md","old_string":"old","new_string":"new"}. Always include path; insertLine accepts only a non-negative JSON integer or the exact string "end".',
 	category: 'filesystem',
@@ -109,7 +165,11 @@ export const EditTool = defineTool({
 			return {
 				success: true,
 				output: `Edited ${input.path}: ${result.replacements} replacement(s) [sandboxed]`,
-				data: { path: input.path, replacements: result.replacements, sandboxed: true },
+				data: {
+					path: input.path,
+					replacements: result.replacements,
+					sandboxed: true,
+				},
 			}
 		}
 
@@ -135,7 +195,10 @@ function normalizeEditInput(
 ): { success: true; operation: NormalizedEditInput } | { success: false; error: string } {
 	const newString = input.new_string ?? input.newStr
 	if (typeof newString !== 'string') {
-		return { success: false, error: 'Either new_string or newStr is required.' }
+		return {
+			success: false,
+			error: 'Either new_string or newStr is required.',
+		}
 	}
 
 	if (input.insertLine !== undefined) {
@@ -154,7 +217,10 @@ function normalizeEditInput(
 
 	const oldString = input.old_string ?? input.oldStr
 	if (typeof oldString !== 'string') {
-		return { success: false, error: 'Either old_string/oldStr or insertLine is required.' }
+		return {
+			success: false,
+			error: 'Either old_string/oldStr or insertLine is required.',
+		}
 	}
 	return {
 		success: true,

--- a/packages/sdk/src/tools/defineTool.ts
+++ b/packages/sdk/src/tools/defineTool.ts
@@ -11,6 +11,8 @@ export interface DefineToolOptions<S extends z.ZodType> {
 	name: string
 	description: string
 	inputSchema: S
+	modelInputSchema?: Record<string, unknown>
+	enforceModelInput?: boolean
 	validationErrorHint?: string
 	category: ToolDefinition['category']
 	permissions: ToolPermission[]
@@ -30,6 +32,8 @@ export function defineTool<S extends z.ZodType>(
 		name: options.name,
 		description: options.description,
 		inputSchema: options.inputSchema,
+		modelInputSchema: options.modelInputSchema,
+		enforceModelInput: options.enforceModelInput,
 		validationErrorHint: options.validationErrorHint,
 		tier: options.tier,
 		category: options.category,

--- a/packages/sdk/src/types/provider/chat.ts
+++ b/packages/sdk/src/types/provider/chat.ts
@@ -12,7 +12,11 @@ export type ResponseFormat =
 	| { type: 'json_object' }
 	| {
 			type: 'json_schema'
-			json_schema: { name: string; schema: Record<string, unknown>; strict?: boolean }
+			json_schema: {
+				name: string
+				schema: Record<string, unknown>
+				strict?: boolean
+			}
 	  }
 
 export interface CacheControl {
@@ -23,6 +27,15 @@ export interface ChatCompletionParams {
 	model: string
 	messages: Message[]
 	tools?: LLMToolSchema[]
+	/**
+	 * Provider hint naming tools whose model-facing JSON Schema should be
+	 * enforced through constrained generation when the selected transport and
+	 * model support it.
+	 *
+	 * This is not a wire field. Provider implementations must consume or omit
+	 * it instead of serializing ChatCompletionParams wholesale.
+	 */
+	enforceToolInputSchema?: readonly string[]
 	temperature?: number
 	maxTokens?: number
 	stream?: boolean

--- a/packages/sdk/src/types/tool/index.ts
+++ b/packages/sdk/src/types/tool/index.ts
@@ -65,6 +65,20 @@ export interface ToolDefinition<TInput = unknown> {
 	description: string
 	inputSchema: z.ZodType<TInput, z.ZodTypeDef, unknown>
 	/**
+	 * Optional canonical JSON Schema shown to models instead of the runtime
+	 * Zod schema. Use this when runtime compatibility accepts aliases or
+	 * constraints that should not be advertised to a model.
+	 *
+	 * This is intentionally independent of TInput: the model-facing contract
+	 * may be narrower than the execution decoder.
+	 */
+	modelInputSchema?: Record<string, unknown>
+	/**
+	 * Ask capable providers to constrain generated input to modelInputSchema.
+	 * ToolRegistry rejects this flag unless modelInputSchema is also present.
+	 */
+	enforceModelInput?: boolean
+	/**
 	 * Concise, model-readable recovery guidance appended when inputSchema
 	 * rejects a call. Use for conditional schemas whose required shapes
 	 * cannot be reconstructed from JSON Schema's top-level `required` list.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,6 +291,9 @@ importers:
       fast-check:
         specifier: ^4.7.0
         version: 4.7.0
+      jsonschema:
+        specifier: ^1.5.0
+        version: 1.5.0
       knip:
         specifier: ^6.4.1
         version: 6.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)


### PR DESCRIPTION
## Summary

- separate canonical model-facing JSON Schema from backward-compatible runtime decoders
- publish a strict canonical edit contract and propagate enforcement through normal, closing, and deferred tool calls
- map reviewed schemas to supported Anthropic transports without leaking Namzu hints to other provider payloads
- document the public SDK/provider surface and retain defensive runtime validation

## Verification

- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
- Vandal integration: lint, architecture, unused advisory, typecheck, 8,235 unit tests, production build