### PR TITLE
fix(sdk): enforce canonical file mutation inputs

### DIFF
--- a/.changeset/calm-tools-listen.md
+++ b/.changeset/calm-tools-listen.md
@@ -7,5 +7,4 @@
 Separate runtime tool validation from canonical model-facing JSON Schema,
 propagate constrained-input hints through the agent loop, and map reviewed
 schemas to Anthropic strict tool use with capability-aware overrides. The
-built-in edit tool now advertises only canonical arguments while retaining
-legacy aliases for direct runtime callers.
+built-in edit tool advertises only canonical arguments.

--- a/.changeset/clean-edit-contract.md
+++ b/.changeset/clean-edit-contract.md
@@ -1,0 +1,12 @@
+---
+"@namzu/sdk": major
+"@namzu/cli": patch
+---
+
+Replace the built-in filesystem mutation contracts with one strict canonical
+shape per tool: `edit` accepts `path`, `old_string`, `new_string`, and optional
+`replace_all`; `write` accepts `path` and `content`. Remove line insertion and
+legacy aliases, serialize same-process mutations by resolved path, and document
+replay-safe marker advancement for bounded long-document writes. Local writes
+commit through same-directory temp files and atomic rename; sandbox
+implementations are required to provide the same atomic replacement contract.

--- a/docs/sdk/tools/README.md
+++ b/docs/sdk/tools/README.md
@@ -1,7 +1,7 @@
 ---
 title: SDK Tools
 description: Define tools, register them in ToolRegistry, and understand built-in tool behavior in @namzu/sdk.
-last_updated: 2026-07-30
+last_updated: 2026-07-31
 status: current
 related_packages: ["@namzu/sdk", "@namzu/computer-use"]
 ---
@@ -60,31 +60,31 @@ If `execute()` throws, the SDK converts that throw into a structured failed tool
 
 When `inputSchema` rejects a call, `ToolRegistry` appends
 `validationErrorHint` to the structured failure. Keep the hint concise and
-include complete safe payloads when a tool supports conditional input shapes:
+include one complete safe payload:
 
 ```ts
 validationErrorHint:
-  'Accepted shapes: {"path":"file.md","insertLine":"end","new_string":"text"} or {"path":"file.md","old_string":"old","new_string":"new"}.',
+  'Required shape: {"path":"file.md","old_string":"exact text","new_string":"replacement"}.',
 ```
 
-### Separate runtime compatibility from the model contract
+### Publish a provider-safe model contract
 
-Use `modelInputSchema` when direct callers need compatibility aliases or
-runtime-only constraints that should not become choices in the model's tool
-schema. `ToolRegistry` publishes this override through `toLLMTools()` while
-continuing to validate execution with `inputSchema`:
+Use `modelInputSchema` when the generated Zod JSON Schema includes constraints
+outside a provider's constrained-decoding subset. `ToolRegistry` publishes this
+reviewed override through `toLLMTools()` while runtime execution remains
+authoritative:
 
 ```ts
 const editLike = defineTool({
   name: 'edit_like',
   description: 'Replace exact text in a file.',
-  inputSchema: z.object({
-    path: z.string(),
-    old_string: z.string().optional(),
-    oldStr: z.string().optional(), // legacy runtime alias
-    new_string: z.string().optional(),
-    newStr: z.string().optional(), // legacy runtime alias
-  }),
+  inputSchema: z
+    .object({
+      path: z.string().min(1),
+      old_string: z.string().min(1),
+      new_string: z.string(),
+    })
+    .strict(),
   modelInputSchema: {
     type: 'object',
     properties: {
@@ -102,11 +102,20 @@ const editLike = defineTool({
   destructive: false,
   concurrencySafe: false,
   async execute(input) {
-    // Runtime execution may normalize oldStr/newStr for compatibility.
     return { success: true, output: input.path }
   },
 })
 ```
+
+The built-in `edit` and `write` tools deliberately expose the same single
+canonical shape at both boundaries:
+
+- `edit`: `path`, `old_string`, `new_string`, optional `replace_all`
+- `write`: `path`, `content`
+
+They do not accept aliases or combine exact replacement with line-number
+insertion. For append-like work, replace a unique tail or deterministic rolling
+marker with itself plus the new content.
 
 `enforceModelInput: true` without an explicit `modelInputSchema` is rejected at
 registration. Namzu does not assume a Zod-generated schema is compatible with

--- a/docs/sdk/tools/built-in.md
+++ b/docs/sdk/tools/built-in.md
@@ -1,7 +1,7 @@
 ---
 title: Built-In Tools
 description: Reference for the built-in tools exported by @namzu/sdk, including their purpose, safety shape, and common usage patterns.
-last_updated: 2026-07-30
+last_updated: 2026-07-31
 status: current
 related_packages: ["@namzu/sdk", "@namzu/computer-use"]
 ---
@@ -77,24 +77,38 @@ Purpose:
 
 Notes:
 
+- accepts exactly `path` and `content`; compatibility aliases are not accepted
 - destructive by declaration
 - not concurrency-safe
 - sandbox-aware when a sandbox is present
+- serializes same-process mutations by resolved path
+- commits local writes through a same-directory temp file and atomic rename;
+  sandbox `writeFile` implementations carry the same atomic replacement
+  contract
 
 ### 4.3 `Edit`
 
 Purpose:
 
-- apply exact-string replacements or insert text after a numbered line or at the end
+- apply one exact-string replacement
 
 Notes:
 
-- models see only the canonical `old_string` / `new_string` keys; legacy `oldStr` / `newStr` aliases remain runtime-only compatibility inputs
-- replacement requires `path`, `old_string`, and `new_string`
-- insertion requires `path`, `insertLine`, and `new_string`; `insertLine` is a non-negative JSON integer or the parsed JSON string `"end"`
-- rejects a string containing quote characters such as `"\"end\""`
+- accepts exactly `path`, `old_string`, `new_string`, and optional `replace_all`
+- compatibility aliases and line-based insertion fields are not accepted
+- `new_string` may be empty to delete the exact match
 - fails if `old_string` is not unique unless `replace_all` is `true`
+- normalizes only consistent CRLF/LF boundaries; it does not perform fuzzy matching
+- serializes same-process mutations by resolved path
+- commits local writes atomically; sandbox writes rely on the `Sandbox`
+  interface's atomic replacement guarantee
 - useful for targeted edits without rewriting entire files
+
+To append or assemble a long document, write a unique deterministic marker and
+replace it with the bounded chunk plus the next marker. Advance markers
+monotonically (`{{CHUNK_001}}` → `{{CHUNK_002}}`) so retrying a completed edit
+fails safely instead of duplicating content. Distributed hosts must still
+assign one writer per file or provide storage-level compare-and-swap.
 
 ### 4.4 `Bash`
 

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -190,7 +190,7 @@ async function ensureRegistered(id: ProviderId): Promise<void> {
 
 // Builtins we don't expose: `verify_outputs` — not part of the recognizable
 // Claude-Code tool surface, just noise in `/tools`. (`append` was removed
-// from the SDK entirely; `edit` with insertLine:"end" covers it.)
+// from the SDK entirely; exact replacement against a unique tail/marker covers it.)
 const EXCLUDED_BUILTINS = new Set(['verify_outputs'])
 
 // namzu's own identity. Injected as system context so the agent presents as
@@ -739,11 +739,11 @@ export function previewToolInput(toolName: string, input: unknown): readonly str
 		if (content !== undefined) return previewLines(content, 8)
 	}
 	if (name === 'edit') {
-		const oldStr = str('old_string') ?? str('oldStr')
-		const newStr = str('new_string') ?? str('newStr')
+		const oldString = str('old_string')
+		const newString = str('new_string')
 		const lines: string[] = []
-		if (oldStr) for (const l of previewLines(oldStr, 4)) lines.push(`- ${l}`)
-		if (newStr) for (const l of previewLines(newStr, 4)) lines.push(`+ ${l}`)
+		if (oldString) for (const line of previewLines(oldString, 4)) lines.push(`- ${line}`)
+		if (newString) for (const line of previewLines(newString, 4)) lines.push(`+ ${line}`)
 		if (lines.length > 0) return lines
 	}
 	return undefined
@@ -778,11 +778,11 @@ export function toolStartDetail(toolName: string, input: unknown): readonly stri
 		return content !== undefined ? clampLines(content) : undefined
 	}
 	if (name === 'edit') {
-		const oldStr = str('old_string') ?? str('oldStr')
-		const newStr = str('new_string') ?? str('newStr')
+		const oldString = str('old_string')
+		const newString = str('new_string')
 		const lines: string[] = []
-		if (oldStr) for (const l of clampLines(oldStr)) lines.push(`- ${l}`)
-		if (newStr) for (const l of clampLines(newStr)) lines.push(`+ ${l}`)
+		if (oldString) for (const line of clampLines(oldString)) lines.push(`- ${line}`)
+		if (newString) for (const line of clampLines(newString)) lines.push(`+ ${line}`)
 		return lines.length > 0 ? lines : undefined
 	}
 	return undefined

--- a/packages/providers/anthropic/src/__tests__/anthropic.test.ts
+++ b/packages/providers/anthropic/src/__tests__/anthropic.test.ts
@@ -312,27 +312,12 @@ describe('AnthropicProvider — buildCreateParams', () => {
 				type: 'object',
 				properties: {
 					path: { type: 'string' },
+					old_string: { type: 'string' },
 					new_string: { type: 'string' },
-					insertLine: {
-						anyOf: [{ type: 'integer' }, { type: 'string', const: 'end' }],
-					},
+					replace_all: { type: 'boolean' },
 				},
-				required: ['path', 'new_string'],
+				required: ['path', 'old_string', 'new_string'],
 				additionalProperties: false,
-				anyOf: [
-					{
-						type: 'object',
-						properties: {
-							path: { type: 'string' },
-							insertLine: {
-								anyOf: [{ type: 'integer' }, { type: 'string', const: 'end' }],
-							},
-							new_string: { type: 'string' },
-						},
-						required: ['path', 'insertLine', 'new_string'],
-						additionalProperties: false,
-					},
-				],
 			}
 			const body = buildParams(makeProvider(), {
 				model: 'claude-opus-5',

--- a/packages/providers/http/src/__tests__/http.test.ts
+++ b/packages/providers/http/src/__tests__/http.test.ts
@@ -314,8 +314,13 @@ describe('@namzu/http — request construction', () => {
 		})
 		const editSchema = {
 			type: 'object',
-			properties: { new_string: { type: 'string' } },
-			required: ['new_string'],
+			properties: {
+				path: { type: 'string' },
+				old_string: { type: 'string' },
+				new_string: { type: 'string' },
+				replace_all: { type: 'boolean' },
+			},
+			required: ['path', 'old_string', 'new_string'],
 			additionalProperties: false,
 		}
 

--- a/packages/sdk/src/runtime/query/__tests__/long-document-flow.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/long-document-flow.test.ts
@@ -107,27 +107,27 @@ describe('query long-document tool flow', () => {
 				name: 'write',
 				input: {
 					path: 'outputs/long-document-flow.md',
-					content: '# Long document flow\n\n{{BODY}}\n',
+					content: '# Long document flow\n\n{{CHUNK_001}}\n',
 				},
 			},
+			...chunks.map((chunk, index) => ({
+				name: 'edit',
+				input: {
+					path: 'outputs/long-document-flow.md',
+					old_string: `{{CHUNK_${String(index + 1).padStart(3, '0')}}}`,
+					new_string: `${chunk}\n{{CHUNK_${String(index + 2).padStart(3, '0')}}}`,
+					replace_all: false,
+				},
+			})),
 			{
 				name: 'edit',
 				input: {
 					path: 'outputs/long-document-flow.md',
-					oldStr: '{{BODY}}',
-					newStr: chunks[0],
+					old_string: `{{CHUNK_${String(chunks.length + 1).padStart(3, '0')}}}`,
+					new_string: '',
 					replace_all: false,
 				},
 			},
-			...chunks.slice(1).map((chunk) => ({
-				name: 'edit',
-				input: {
-					path: 'outputs/long-document-flow.md',
-					insertLine: 'end',
-					newStr: chunk,
-					replace_all: false,
-				},
-			})),
 		])
 		const tools = new ToolRegistry()
 		tools.register(WriteFileTool)
@@ -169,9 +169,9 @@ describe('query long-document tool flow', () => {
 
 		expect(run.status).toBe('completed')
 		expect(run.result).toBe('Long document created and verified.')
-		expect(provider.calls).toBe(6)
-		expect(executingTools).toEqual(['write', 'edit', 'edit', 'edit', 'edit'])
-		expect(final).not.toContain('{{BODY}}')
+		expect(provider.calls).toBe(7)
+		expect(executingTools).toEqual(['write', 'edit', 'edit', 'edit', 'edit', 'edit'])
+		expect(final).not.toContain('{{CHUNK_')
 		expect(final.split('\n').length).toBeGreaterThan(160)
 		expect(final).toContain('## Section 1')
 		expect(final).toContain('## Section 4')

--- a/packages/sdk/src/runtime/query/__tests__/stream-recovery.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/stream-recovery.test.ts
@@ -170,7 +170,7 @@ describe('query stream recovery', () => {
 			'call was cut off',
 		)
 		expect(completedTool?.type === 'tool_completed' ? completedTool.result : '').toContain(
-			'extend it with edit using insertLine',
+			'advance that marker with bounded exact edit calls',
 		)
 	})
 

--- a/packages/sdk/src/runtime/query/executor.ts
+++ b/packages/sdk/src/runtime/query/executor.ts
@@ -103,7 +103,7 @@ export class ToolExecutor {
 
 		// Respect each tool's `concurrencySafe` flag. Read-only tools
 		// (ls/grep/glob/…) run in parallel; tools that mutate shared state
-		// (edit/write/append/bash — `concurrencySafe: false`) are serialized in
+		// (edit/write/bash — `concurrencySafe: false`) are serialized in
 		// a single chain, so e.g. several `edit` calls to the SAME file in one
 		// turn apply one-after-another instead of racing read→modify→write
 		// (which let the last writer clobber the rest). Results are written by
@@ -497,5 +497,5 @@ function formatFailedToolOutput(output: string | undefined, error: string | unde
 }
 
 function truncatedToolInputMessage(toolName: string): string {
-	return `Error: Tool "${toolName}" call was cut off while the model was streaming JSON arguments. The tool was NOT executed. Retry with a much shorter input. Self-budget any content/newStr payload under 12000 characters before calling file tools. For long files, create a short opening with write, then extend it with edit using insertLine: "end" in bounded section chunks; for delegated work, pass a shared workspace filename/reference instead of embedding the content in the tool call.`
+	return `Error: Tool "${toolName}" call was cut off while the model was streaming JSON arguments. The tool was NOT executed. Retry with a much shorter input. Self-budget content/new_string under 12000 characters before calling file tools. For long files, create a short opening with write and a deterministic marker, then advance that marker with bounded exact edit calls; for delegated work, pass a shared workspace filename/reference instead of embedding the content in the tool call.`
 }

--- a/packages/sdk/src/tools/builtins/__tests__/edit.test.ts
+++ b/packages/sdk/src/tools/builtins/__tests__/edit.test.ts
@@ -1,11 +1,11 @@
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { Validator } from 'jsonschema'
 import { describe, expect, it } from 'vitest'
-import { zodToJsonSchema } from 'zod-to-json-schema'
 import { ToolRegistry } from '../../../registry/tool/execute.js'
+import type { Sandbox } from '../../../types/sandbox/index.js'
 import type { ToolContext } from '../../../types/tool/index.js'
+import { atomicWriteFile } from '../atomic-write-file.js'
 import { EditTool } from '../edit.js'
 
 function makeContext(workingDirectory: string): ToolContext {
@@ -19,15 +19,75 @@ function makeContext(workingDirectory: string): ToolContext {
 }
 
 describe('EditTool', () => {
-	it('accepts oldStr/newStr aliases for string replacement', async () => {
+	it('publishes one closed canonical replacement contract', () => {
+		const schema = EditTool.modelInputSchema
+		expect(schema).toEqual({
+			type: 'object',
+			properties: {
+				path: {
+					type: 'string',
+					description: 'Path to the file to edit. Must not be empty.',
+				},
+				old_string: {
+					type: 'string',
+					description:
+						'Exact unique text from the file, without read-tool line-number prefixes. Must not be empty.',
+				},
+				new_string: {
+					type: 'string',
+					description:
+						'Exact replacement text. May be empty to delete old_string. Keep under 12000 characters.',
+				},
+				replace_all: {
+					type: 'boolean',
+					description: 'Replace every occurrence instead of requiring one unique match.',
+				},
+			},
+			required: ['path', 'old_string', 'new_string'],
+			additionalProperties: false,
+		})
+
+		expect(
+			EditTool.inputSchema.safeParse({
+				path: 'doc.md',
+				old_string: 'old',
+				new_string: 'new',
+				replace_all: true,
+			}).success,
+		).toBe(true)
+
+		for (const legacy of [
+			{ path: 'doc.md', oldStr: 'old', newStr: 'new' },
+			{ path: 'doc.md', insertLine: 'end', new_string: 'append' },
+			{
+				path: 'doc.md',
+				old_string: 'old',
+				new_string: 'new',
+				newStr: 'legacy',
+			},
+		]) {
+			expect(EditTool.inputSchema.safeParse(legacy).success, JSON.stringify(legacy)).toBe(false)
+		}
+		expect(
+			EditTool.inputSchema.safeParse({
+				path: '   ',
+				old_string: 'old',
+				new_string: 'new',
+			}).success,
+		).toBe(false)
+	})
+
+	it('replaces one exact unique string', async () => {
 		const dir = mkdtempSync(join(tmpdir(), 'namzu-edit-'))
 		writeFileSync(join(dir, 'doc.md'), 'alpha\nbeta\n')
-		const registry = new ToolRegistry()
-		registry.register(EditTool)
 
-		const result = await registry.execute(
-			'edit',
-			{ path: 'doc.md', oldStr: 'beta', newStr: 'gamma', replace_all: false },
+		const result = await EditTool.execute(
+			{
+				path: 'doc.md',
+				old_string: 'beta',
+				new_string: 'gamma',
+				replace_all: false,
+			},
 			makeContext(dir),
 		)
 
@@ -35,25 +95,36 @@ describe('EditTool', () => {
 		expect(readFileSync(join(dir, 'doc.md'), 'utf-8')).toBe('alpha\ngamma\n')
 	})
 
-	it('inserts content after a 1-indexed line number', async () => {
+	it('validates a path without rewriting edge whitespace', async () => {
 		const dir = mkdtempSync(join(tmpdir(), 'namzu-edit-'))
-		writeFileSync(join(dir, 'doc.md'), 'alpha\nbeta\n')
+		writeFileSync(join(dir, ' doc.md '), 'alpha\n')
 
 		const result = await EditTool.execute(
-			{ path: 'doc.md', insertLine: 1, newStr: 'inserted', replace_all: false },
+			{
+				path: ' doc.md ',
+				old_string: 'alpha',
+				new_string: 'beta',
+				replace_all: false,
+			},
 			makeContext(dir),
 		)
 
 		expect(result.success).toBe(true)
-		expect(readFileSync(join(dir, 'doc.md'), 'utf-8')).toBe('alpha\ninserted\nbeta\n')
+		expect(readFileSync(join(dir, ' doc.md '), 'utf-8')).toBe('beta\n')
+		expect(existsSync(join(dir, 'doc.md'))).toBe(false)
 	})
 
-	it('inserts content at the end with insertLine=end', async () => {
+	it('allows deletion with an empty new_string', async () => {
 		const dir = mkdtempSync(join(tmpdir(), 'namzu-edit-'))
-		writeFileSync(join(dir, 'doc.md'), 'alpha\n')
+		writeFileSync(join(dir, 'doc.md'), 'alpha\nremove me\nomega\n')
 
 		const result = await EditTool.execute(
-			{ path: 'doc.md', insertLine: 'end', newStr: 'omega', replace_all: false },
+			{
+				path: 'doc.md',
+				old_string: 'remove me\n',
+				new_string: '',
+				replace_all: false,
+			},
 			makeContext(dir),
 		)
 
@@ -61,143 +132,186 @@ describe('EditTool', () => {
 		expect(readFileSync(join(dir, 'doc.md'), 'utf-8')).toBe('alpha\nomega\n')
 	})
 
-	it('publishes only the insertLine values the executor can apply', () => {
-		for (const insertLine of ['## Progress', null, '', '1', -1]) {
-			const parsed = EditTool.inputSchema.safeParse({
-				path: 'doc.md',
-				insertLine,
-				newStr: 'inserted',
-			})
-			expect(parsed.success, JSON.stringify(insertLine)).toBe(false)
-		}
+	it('replaces every exact occurrence only when replace_all is true', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'namzu-edit-'))
+		writeFileSync(join(dir, 'doc.md'), 'alpha alpha alpha')
 
-		for (const insertLine of [0, 1, 'end']) {
-			const parsed = EditTool.inputSchema.safeParse({
-				path: 'doc.md',
-				insertLine,
-				newStr: 'inserted',
-			})
-			expect(parsed.success, JSON.stringify(insertLine)).toBe(true)
-		}
-
-		const json = zodToJsonSchema(EditTool.inputSchema, {
-			target: 'jsonSchema7',
-			$refStrategy: 'none',
-		}) as {
-			properties?: {
-				insertLine?: {
-					anyOf?: Record<string, unknown>[]
-				}
-			}
-		}
-		expect(json.properties?.insertLine?.anyOf).toEqual([
-			{ type: 'integer', minimum: 0 },
-			{ type: 'string', const: 'end' },
-		])
-	})
-
-	it('publishes a closed Draft 7 model schema with canonical exclusive operation shapes', () => {
-		const schema = EditTool.modelInputSchema
-		expect(schema).toBeDefined()
-		if (!schema) throw new Error('EditTool.modelInputSchema is required')
-
-		const validator = new Validator()
-		const accepts = (input: unknown) => validator.validate(input, schema as never).valid
-
-		for (const input of [
-			{ path: 'doc.md', old_string: 'old', new_string: 'new' },
+		const result = await EditTool.execute(
 			{
 				path: 'doc.md',
-				old_string: 'old',
-				new_string: 'new',
+				old_string: 'alpha',
+				new_string: 'beta',
 				replace_all: true,
 			},
-			{ path: 'doc.md', insertLine: 'end', new_string: 'append' },
-			{ path: 'doc.md', insertLine: 0, new_string: 'prepend' },
-			// Anthropic strict schemas do not support minimum. The model
-			// description says non-negative and runtime Zod remains authoritative.
-			{ path: 'doc.md', insertLine: -1, new_string: 'runtime rejects this' },
-		]) {
-			expect(accepts(input), JSON.stringify(input)).toBe(true)
-		}
+			makeContext(dir),
+		)
 
-		for (const input of [
-			{ path: 'doc.md', new_string: 'missing selector' },
+		expect(result.success).toBe(true)
+		expect(result.data).toMatchObject({ replacements: 3 })
+		expect(readFileSync(join(dir, 'doc.md'), 'utf-8')).toBe('beta beta beta')
+	})
+
+	it('refuses ambiguous exact matches instead of guessing', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'namzu-edit-'))
+		writeFileSync(join(dir, 'doc.md'), 'alpha\nalpha\n')
+
+		const result = await EditTool.execute(
 			{
 				path: 'doc.md',
-				old_string: 'old',
-				insertLine: 'end',
-				new_string: 'ambiguous',
-			},
-			{ path: 'doc.md', insertLine: '"end"', new_string: 'quoted wrong' },
-			{ path: 'doc.md', insertLine: 'end', newStr: 'legacy alias' },
-			{ path: 'doc.md', oldStr: 'old', newStr: 'new' },
-			{
-				path: 'doc.md',
-				insertLine: 'end',
-				new_string: 'append',
+				old_string: 'alpha',
+				new_string: 'beta',
 				replace_all: false,
 			},
+			makeContext(dir),
+		)
+
+		expect(result.success).toBe(false)
+		expect(result.error).toContain('old_string is not unique')
+		expect(readFileSync(join(dir, 'doc.md'), 'utf-8')).toBe('alpha\nalpha\n')
+	})
+
+	it('normalizes consistent CRLF/LF boundaries without fuzzy matching', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'namzu-edit-'))
+		writeFileSync(join(dir, 'doc.md'), 'alpha\r\nbeta\r\nomega\r\n')
+
+		const result = await EditTool.execute(
+			{
+				path: 'doc.md',
+				old_string: 'alpha\nbeta',
+				new_string: 'gamma\ndelta',
+				replace_all: false,
+			},
+			makeContext(dir),
+		)
+
+		expect(result.success).toBe(true)
+		expect(readFileSync(join(dir, 'doc.md'), 'utf-8')).toBe('gamma\r\ndelta\r\nomega\r\n')
+	})
+
+	it('rejects legacy and extra fields even when execute is called directly', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'namzu-edit-'))
+		writeFileSync(join(dir, 'doc.md'), 'alpha\n')
+
+		for (const input of [
+			{ path: 'doc.md', oldStr: 'alpha', newStr: 'beta' },
+			{
+				path: 'doc.md',
+				old_string: 'alpha',
+				new_string: 'beta',
+				insertLine: 'end',
+			},
 		]) {
-			expect(accepts(input), JSON.stringify(input)).toBe(false)
+			const result = await EditTool.execute(input as never, makeContext(dir))
+			expect(result.success, JSON.stringify(input)).toBe(false)
+			expect(result.error).toContain('Invalid edit input')
 		}
 
-		expect(JSON.stringify(schema)).not.toMatch(/"(?:minimum|maximum|minLength|maxLength|pattern)":/)
-		assertEveryObjectSchemaIsClosed(schema)
+		expect(readFileSync(join(dir, 'doc.md'), 'utf-8')).toBe('alpha\n')
 	})
 
-	it('refuses invalid insertLine values even when a caller bypasses the schema', async () => {
-		for (const insertLine of ['## Progress', null, '', '1']) {
-			const dir = mkdtempSync(join(tmpdir(), 'namzu-edit-'))
-			writeFileSync(join(dir, 'doc.md'), 'alpha\nbeta\n')
-
-			const result = await EditTool.execute(
-				{
-					path: 'doc.md',
-					insertLine,
-					newStr: 'inserted',
-					replace_all: false,
-				} as never,
-				makeContext(dir),
-			)
-
-			expect(result.success, JSON.stringify(insertLine)).toBe(false)
-			expect(result.error).toBe('insertLine must be a non-negative line number or "end".')
-			expect(readFileSync(join(dir, 'doc.md'), 'utf-8')).toBe('alpha\nbeta\n')
-		}
-	})
-
-	it('returns complete recovery shapes when path is missing and insertLine is invalid', async () => {
+	it('returns one canonical recovery shape after registry validation fails', async () => {
 		const registry = new ToolRegistry()
 		registry.register(EditTool)
 
 		const result = await registry.execute(
 			'edit',
-			{ insertLine: '## Progress' },
+			{ insertLine: '"end"', newStr: 'content' },
 			makeContext('/tmp'),
 		)
 
 		expect(result.success).toBe(false)
 		expect(result.error).toContain('Validation failed for "edit":')
-		expect(result.error).toContain('insertLine: Invalid input')
-		expect(result.error).toContain('Required: path: string — Path to the file to edit.')
-		expect(result.error).toContain('{"path":"file.md","insertLine":"end","new_string":"text"}')
-		expect(result.error).toContain('{"path":"file.md","old_string":"old","new_string":"new"}')
+		expect(result.error).toContain('Required: path: string')
+		expect(result.error).toContain(
+			'{"path":"file.md","old_string":"exact unique text","new_string":"replacement text"}',
+		)
+		expect(result.error).not.toContain('Accepted shapes')
+	})
+
+	it('serializes independent EditTool read-modify-write cycles for one sandbox path', async () => {
+		let body = Buffer.from('alpha')
+		let reads = 0
+		let writes = 0
+		let releaseFirstWrite = () => {}
+		let markFirstWriteStarted = () => {}
+		const firstWriteStarted = new Promise<void>((resolve) => {
+			markFirstWriteStarted = resolve
+		})
+		const firstWriteGate = new Promise<void>((resolve) => {
+			releaseFirstWrite = resolve
+		})
+		const sandbox = {
+			id: 'sbx_edit_lock',
+			status: 'ready',
+			rootDir: '/workspace',
+			environment: 'basic',
+			async readFile() {
+				reads += 1
+				return Buffer.from(body)
+			},
+			async writeFile(_path: string, content: string | Buffer) {
+				writes += 1
+				if (writes === 1) {
+					markFirstWriteStarted()
+					await firstWriteGate
+				}
+				body = Buffer.isBuffer(content) ? Buffer.from(content) : Buffer.from(content)
+			},
+			async exec() {
+				throw new Error('not used')
+			},
+			async listFiles() {
+				return []
+			},
+			async destroy() {},
+		} as Sandbox
+		const firstContext = { ...makeContext('/workspace'), sandbox }
+		const secondContext = { ...makeContext('/workspace'), sandbox }
+
+		const first = EditTool.execute(
+			{
+				path: 'doc.md',
+				old_string: 'alpha',
+				new_string: 'beta',
+				replace_all: false,
+			},
+			firstContext,
+		)
+		await firstWriteStarted
+		const second = EditTool.execute(
+			{
+				path: 'doc.md',
+				old_string: 'beta',
+				new_string: 'gamma',
+				replace_all: false,
+			},
+			secondContext,
+		)
+		await Promise.resolve()
+		expect(reads).toBe(1)
+
+		releaseFirstWrite()
+		const results = await Promise.all([first, second])
+		expect(results.every((result) => result.success)).toBe(true)
+		expect(reads).toBe(2)
+		expect(writes).toBe(2)
+		expect(body.toString('utf-8')).toBe('gamma')
+	})
+
+	it('leaves the original intact when an atomic local write fails before commit', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'namzu-atomic-write-'))
+		const filePath = join(dir, 'doc.md')
+		writeFileSync(filePath, 'original')
+
+		await expect(
+			atomicWriteFile(filePath, 'replacement', {
+				beforeCommit: async () => {
+					throw new Error('injected pre-commit failure')
+				},
+			}),
+		).rejects.toThrow('injected pre-commit failure')
+
+		expect(readFileSync(filePath, 'utf-8')).toBe('original')
+		expect(readdirSync(dir).filter((entry) => entry.includes('.namzu-'))).toEqual([])
 	})
 })
-
-function assertEveryObjectSchemaIsClosed(value: unknown, path = '$'): void {
-	if (Array.isArray(value)) {
-		value.forEach((item, index) => assertEveryObjectSchemaIsClosed(item, `${path}[${index}]`))
-		return
-	}
-	if (!value || typeof value !== 'object') return
-
-	const record = value as Record<string, unknown>
-	if (record.type === 'object') {
-		expect(record.additionalProperties, `${path} must be closed`).toBe(false)
-	}
-	for (const [key, child] of Object.entries(record)) {
-		assertEveryObjectSchemaIsClosed(child, `${path}.${key}`)
-	}
-}

--- a/packages/sdk/src/tools/builtins/__tests__/payload-budget.test.ts
+++ b/packages/sdk/src/tools/builtins/__tests__/payload-budget.test.ts
@@ -17,8 +17,8 @@ describe('filesystem tool payload budgeting', () => {
 		expect(() =>
 			EditTool.inputSchema.parse({
 				path: 'outputs/long.md',
-				oldStr: '{{SECTION}}',
-				newStr: oversized,
+				old_string: '{{SECTION}}',
+				new_string: oversized,
 				replace_all: false,
 			}),
 		).not.toThrow()
@@ -31,7 +31,7 @@ describe('filesystem tool payload budgeting', () => {
 		expect(names).not.toContain('append')
 	})
 
-	it('assembles long documents with bounded write plus edit insert chunks', async () => {
+	it('assembles replay-safe long documents by advancing an exact marker', async () => {
 		const dir = mkdtempSync(join(tmpdir(), 'namzu-long-doc-'))
 		const ctx: ToolContext = {
 			runId: 'run_test' as ToolContext['runId'],
@@ -40,12 +40,12 @@ describe('filesystem tool payload budgeting', () => {
 			env: {},
 			log: () => {},
 		}
-		const opening = '# Long document regression\n\n{{BODY}}\n'
+		const opening = '# Long document regression\n\n{{CHUNK_001}}\n'
 		const chunks = Array.from({ length: 6 }, (_, sectionIndex) => {
 			const lines = Array.from({ length: 45 }, (_, lineIndex) => {
 				const section = sectionIndex + 1
 				const line = lineIndex + 1
-				return `Section ${section}.${line}: this bounded paragraph proves long-form output grows through edit insertions rather than one oversized JSON tool argument.`
+				return `Section ${section}.${line}: this bounded paragraph proves long-form output grows through exact marker edits rather than one oversized JSON tool argument.`
 			})
 			const chunk = [`## Section ${sectionIndex + 1}`, ...lines, ''].join('\n')
 			expect(chunk.length).toBeLessThan(12_000)
@@ -58,32 +58,52 @@ describe('filesystem tool payload budgeting', () => {
 		)
 		expect(writeResult.success).toBe(true)
 
-		const firstEdit = await EditTool.execute(
-			{
-				path: 'outputs/regression-long-document.md',
-				oldStr: '{{BODY}}',
-				newStr: chunks[0],
-				replace_all: false,
-			},
-			ctx,
-		)
-		expect(firstEdit.success).toBe(true)
-
-		for (const chunk of chunks.slice(1)) {
+		for (const [index, chunk] of chunks.entries()) {
+			const currentMarker = `{{CHUNK_${String(index + 1).padStart(3, '0')}}}`
+			const nextMarker = `{{CHUNK_${String(index + 2).padStart(3, '0')}}}`
 			const result = await EditTool.execute(
 				{
 					path: 'outputs/regression-long-document.md',
-					insertLine: 'end',
-					newStr: chunk,
+					old_string: currentMarker,
+					new_string: `${chunk}\n${nextMarker}`,
 					replace_all: false,
 				},
 				ctx,
 			)
 			expect(result.success).toBe(true)
+
+			if (index === 0) {
+				const beforeReplay = readFileSync(join(dir, 'outputs/regression-long-document.md'), 'utf-8')
+				const replay = await EditTool.execute(
+					{
+						path: 'outputs/regression-long-document.md',
+						old_string: currentMarker,
+						new_string: `${chunk}\n${nextMarker}`,
+						replace_all: false,
+					},
+					ctx,
+				)
+				expect(replay.success).toBe(false)
+				expect(readFileSync(join(dir, 'outputs/regression-long-document.md'), 'utf-8')).toBe(
+					beforeReplay,
+				)
+			}
 		}
 
+		const finalMarker = `{{CHUNK_${String(chunks.length + 1).padStart(3, '0')}}}`
+		const finalize = await EditTool.execute(
+			{
+				path: 'outputs/regression-long-document.md',
+				old_string: finalMarker,
+				new_string: '',
+				replace_all: false,
+			},
+			ctx,
+		)
+		expect(finalize.success).toBe(true)
+
 		const final = readFileSync(join(dir, 'outputs/regression-long-document.md'), 'utf-8')
-		expect(final).not.toContain('{{BODY}}')
+		expect(final).not.toContain('{{CHUNK_')
 		expect(final.split('\n').length).toBeGreaterThan(250)
 		expect(final).toContain('## Section 1')
 		expect(final).toContain('## Section 6')

--- a/packages/sdk/src/tools/builtins/__tests__/write-file.test.ts
+++ b/packages/sdk/src/tools/builtins/__tests__/write-file.test.ts
@@ -8,10 +8,10 @@ import { WriteFileTool } from '../write-file.js'
 function makeTracker(): FileReadTracker & { keys(): string[] } {
 	const set = new Set<string>()
 	return {
-		recordRead: (k) => {
-			set.add(k)
+		recordRead: (key) => {
+			set.add(key)
 		},
-		hasRead: (k) => set.has(k),
+		hasRead: (key) => set.has(key),
 		keys: () => Array.from(set),
 	}
 }
@@ -27,7 +27,33 @@ function makeContext(workingDirectory: string, tracker?: FileReadTracker): ToolC
 	}
 }
 
-describe('WriteFileTool — read-before-overwrite invariant', () => {
+describe('WriteFileTool — canonical contract and read-before-overwrite invariant', () => {
+	it('publishes one closed path + content contract', () => {
+		expect(WriteFileTool.modelInputSchema).toEqual({
+			type: 'object',
+			properties: {
+				path: {
+					type: 'string',
+					description: 'Non-empty path to the file to write.',
+				},
+				content: {
+					type: 'string',
+					description:
+						'Complete bounded file body. May be empty only for an intentionally empty file.',
+				},
+			},
+			required: ['path', 'content'],
+			additionalProperties: false,
+		})
+		expect(WriteFileTool.inputSchema.safeParse({ path: 'doc.md', content: '' }).success).toBe(true)
+		expect(WriteFileTool.inputSchema.safeParse({ path: 'doc.md', newStr: 'legacy' }).success).toBe(
+			false,
+		)
+		expect(WriteFileTool.inputSchema.safeParse({ path: '   ', content: 'body' }).success).toBe(
+			false,
+		)
+	})
+
 	it('writes a new file without requiring a prior read', async () => {
 		const dir = mkdtempSync(join(tmpdir(), 'namzu-write-'))
 		const tracker = makeTracker()
@@ -40,15 +66,28 @@ describe('WriteFileTool — read-before-overwrite invariant', () => {
 		expect(tracker.hasRead(join(dir, 'fresh.txt'))).toBe(true)
 	})
 
-	it('accepts newStr as the canonical create/write content alias', async () => {
+	it('preserves edge whitespace in a valid path', async () => {
 		const dir = mkdtempSync(join(tmpdir(), 'namzu-write-'))
-		const tracker = makeTracker()
-		const ctx = makeContext(dir, tracker)
 
-		const result = await WriteFileTool.execute({ path: 'fresh.txt', newStr: 'hello' }, ctx)
+		const result = await WriteFileTool.execute(
+			{ path: ' fresh.txt ', content: 'hello' },
+			makeContext(dir),
+		)
 
 		expect(result.success).toBe(true)
-		expect(readFileSync(join(dir, 'fresh.txt'), 'utf-8')).toBe('hello')
+		expect(readFileSync(join(dir, ' fresh.txt '), 'utf-8')).toBe('hello')
+	})
+
+	it('rejects legacy content aliases even when execute is called directly', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'namzu-write-'))
+
+		const result = await WriteFileTool.execute(
+			{ path: 'fresh.txt', newStr: 'legacy' } as never,
+			makeContext(dir),
+		)
+
+		expect(result.success).toBe(false)
+		expect(result.error).toContain('Invalid write input')
 	})
 
 	it('refuses to overwrite an existing file the agent has not read', async () => {
@@ -84,14 +123,14 @@ describe('WriteFileTool — read-before-overwrite invariant', () => {
 		expect(readFileSync(filePath, 'utf-8')).toBe('replaced')
 	})
 
-	it('falls back to legacy behaviour when no fileReadTracker is provided (back-compat)', async () => {
+	it('preserves existing hosts without a file read tracker', async () => {
 		const dir = mkdtempSync(join(tmpdir(), 'namzu-write-'))
-		writeFileSync(join(dir, 'legacy.txt'), 'before')
+		writeFileSync(join(dir, 'existing.txt'), 'before')
 		const ctx = makeContext(dir)
 
-		const result = await WriteFileTool.execute({ path: 'legacy.txt', content: 'after' }, ctx)
+		const result = await WriteFileTool.execute({ path: 'existing.txt', content: 'after' }, ctx)
 
 		expect(result.success).toBe(true)
-		expect(readFileSync(join(dir, 'legacy.txt'), 'utf-8')).toBe('after')
+		expect(readFileSync(join(dir, 'existing.txt'), 'utf-8')).toBe('after')
 	})
 })

--- a/packages/sdk/src/tools/builtins/atomic-write-file.ts
+++ b/packages/sdk/src/tools/builtins/atomic-write-file.ts
@@ -1,0 +1,58 @@
+import { randomUUID } from 'node:crypto'
+import { type FileHandle, mkdir, open, rename, stat, unlink } from 'node:fs/promises'
+import { basename, dirname, join } from 'node:path'
+
+interface AtomicWriteHooks {
+	/** Internal fault-injection seam; production callers never pass this. */
+	beforeCommit?: () => Promise<void>
+}
+
+/**
+ * Commit a complete file body without exposing a truncated destination.
+ *
+ * The temp file lives beside the destination so rename stays on one
+ * filesystem. A failed pre-commit write leaves the original untouched.
+ */
+export async function atomicWriteFile(
+	filePath: string,
+	content: string,
+	hooks: AtomicWriteHooks = {},
+): Promise<void> {
+	const directory = dirname(filePath)
+	await mkdir(directory, { recursive: true })
+
+	const existingMode = await stat(filePath)
+		.then((value) => value.mode)
+		.catch(() => undefined)
+	const tempPath = join(
+		directory,
+		`.${basename(filePath)}.namzu-${process.pid}-${randomUUID()}.tmp`,
+	)
+	let handle: FileHandle | undefined
+	let committed = false
+
+	try {
+		handle = await open(tempPath, 'wx', existingMode ?? 0o666)
+		await handle.writeFile(content, 'utf-8')
+		await handle.sync()
+		await handle.close()
+		handle = undefined
+		await hooks.beforeCommit?.()
+		await rename(tempPath, filePath)
+		committed = true
+		await syncDirectory(directory)
+	} finally {
+		await handle?.close().catch(() => undefined)
+		if (!committed) await unlink(tempPath).catch(() => undefined)
+	}
+}
+
+async function syncDirectory(directory: string): Promise<void> {
+	let handle: FileHandle | undefined
+	try {
+		handle = await open(directory, 'r')
+		await handle.sync()
+	} finally {
+		await handle?.close().catch(() => undefined)
+	}
+}

--- a/packages/sdk/src/tools/builtins/bash.ts
+++ b/packages/sdk/src/tools/builtins/bash.ts
@@ -22,7 +22,7 @@ const inputSchema = z.object({
 		.string()
 		.min(1)
 		.describe(
-			'The bash command to execute. Required, non-empty. Single command per call (use `&&` / `;` chaining for compound commands). Avoid heredocs that span more than a few hundred bytes — large content should be created with `write`, then extended with `edit` insertLine: "end", not piped into bash.',
+			'The bash command to execute. Required, non-empty. Single command per call (use `&&` / `;` chaining for compound commands). Avoid heredocs that span more than a few hundred bytes — create large content with bounded write plus exact marker-advancing edit calls instead.',
 		),
 	timeout: z
 		.preprocess(
@@ -41,7 +41,7 @@ function isDangerousCommand(command: string): boolean {
 export const BashTool = defineTool({
 	name: 'bash',
 	description:
-		'Executes a bash command and returns stdout/stderr output. Command timeout is configurable. The `command` parameter is required — never call this tool with empty arguments. For very long content (e.g. building a large file), prefer `write` for the opening and `edit` with insertLine: "end" for follow-up chunks over a heredoc to avoid hitting the output token limit mid-stream.',
+		'Executes a bash command and returns stdout/stderr output. Command timeout is configurable. The `command` parameter is required — never call this tool with empty arguments. For very long content, prefer a bounded write with a deterministic marker followed by exact marker-advancing edit calls over a heredoc.',
 	inputSchema,
 	category: 'shell',
 	permissions: ['shell_execute'],

--- a/packages/sdk/src/tools/builtins/edit.ts
+++ b/packages/sdk/src/tools/builtins/edit.ts
@@ -1,54 +1,33 @@
-import { readFile, writeFile } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { z } from 'zod'
 import { defineTool } from '../defineTool.js'
+import { atomicWriteFile } from './atomic-write-file.js'
+import { withFileMutationLock } from './file-mutation-lock.js'
 
 const inputSchema = z
 	.object({
-		path: z.string().describe('Path to the file to edit'),
+		path: z
+			.string()
+			.refine((value) => value.trim().length > 0, 'Path must not be empty.')
+			.describe('Path to the file to edit. Must not be empty.'),
 		old_string: z
 			.string()
-			.optional()
-			.describe('The exact string to find and replace. Must be unique in the file.'),
-		oldStr: z
-			.string()
-			.optional()
+			.min(1)
 			.describe(
-				'Alias for old_string. Used by hosts that expose text replacement as oldStr/newStr.',
+				'The exact unique text to replace, without read-tool line-number prefixes. Must not be empty.',
 			),
 		new_string: z
 			.string()
-			.optional()
 			.describe(
-				'The replacement string. Self-budget this payload under 12000 characters before calling.',
-			),
-		newStr: z
-			.string()
-			.optional()
-			.describe(
-				'Alias for new_string. Also used as inserted content when insertLine is provided. Self-budget this payload under 12000 characters before calling.',
-			),
-		insertLine: z
-			.union([z.number().int().min(0), z.literal('end')])
-			.optional()
-			.describe(
-				'Optional line insertion target. Pass a JSON integer to insert after that 1-indexed line, 0 to insert before the first line, or the exact string "end" to append. Headings, anchors, numeric strings, null, and empty strings are invalid.',
+				'The exact replacement text. May be empty to delete old_string. Keep this payload under 12000 characters.',
 			),
 		replace_all: z
 			.boolean()
 			.default(false)
-			.describe('Replace all occurrences instead of just the first unique match'),
+			.describe('Replace every occurrence instead of requiring one unique match.'),
 	})
-	.refine((value) => typeof value.new_string === 'string' || typeof value.newStr === 'string', {
-		message: 'Either new_string or newStr is required.',
-	})
-	.refine(
-		(value) =>
-			value.insertLine !== undefined ||
-			typeof value.old_string === 'string' ||
-			typeof value.oldStr === 'string',
-		{ message: 'Either old_string/oldStr or insertLine is required.' },
-	)
+	.strict()
 
 type EditInput = z.infer<typeof inputSchema>
 
@@ -57,78 +36,42 @@ const modelInputSchema: Record<string, unknown> = {
 	properties: {
 		path: {
 			type: 'string',
-			description: 'Path to the file to edit.',
+			description: 'Path to the file to edit. Must not be empty.',
 		},
 		old_string: {
 			type: 'string',
-			description: 'The exact unique string to find and replace.',
+			description:
+				'Exact unique text from the file, without read-tool line-number prefixes. Must not be empty.',
 		},
 		new_string: {
 			type: 'string',
-			description: 'The replacement or inserted text. Keep this payload under 12000 characters.',
-		},
-		insertLine: {
-			anyOf: [{ type: 'integer' }, { type: 'string', const: 'end' }],
 			description:
-				'Line insertion target: a non-negative JSON integer, or the exact JSON string "end" to append.',
+				'Exact replacement text. May be empty to delete old_string. Keep under 12000 characters.',
 		},
 		replace_all: {
 			type: 'boolean',
-			description: 'Replace every occurrence of old_string instead of one unique match.',
+			description: 'Replace every occurrence instead of requiring one unique match.',
 		},
 	},
-	required: ['path', 'new_string'],
+	required: ['path', 'old_string', 'new_string'],
 	additionalProperties: false,
-	anyOf: [
-		{
-			type: 'object',
-			properties: {
-				path: { type: 'string' },
-				old_string: { type: 'string' },
-				new_string: { type: 'string' },
-				replace_all: { type: 'boolean' },
-			},
-			required: ['path', 'old_string', 'new_string'],
-			additionalProperties: false,
-		},
-		{
-			type: 'object',
-			properties: {
-				path: { type: 'string' },
-				insertLine: {
-					anyOf: [{ type: 'integer' }, { type: 'string', const: 'end' }],
-				},
-				new_string: { type: 'string' },
-			},
-			required: ['path', 'insertLine', 'new_string'],
-			additionalProperties: false,
-		},
-	],
 }
 
-type NormalizedEditInput =
-	| {
-			operation: 'replace'
-			oldString: string
-			newString: string
-			replace_all: boolean
-	  }
-	| {
-			operation: 'insert'
-			insertLine: number | 'end'
-			newString: string
-			replace_all: boolean
-	  }
+type ExactReplacement = Readonly<{
+	oldString: string
+	newString: string
+	replaceAll: boolean
+}>
 
 export const EditTool = defineTool({
 	name: 'edit',
 	description:
-		'Makes targeted edits to a file using exact string find-and-replace or line insertion. THIS IS THE PREFERRED WAY TO MODIFY AN EXISTING FILE — never reach for `write` to change a file that already exists, because `write` overwrites the whole body and discards earlier work on partial failure. `edit` keeps the rest of the file byte-for-byte intact and is recoverable: if a single exact match fails or broader restructuring is needed, follow up with another `edit` instead of re-emitting the entire file via `write`. For replacement, pass path + old_string + new_string; old_string must be unique unless replace_all is true. For insertion, pass path + insertLine + new_string; use the parsed JSON value insertLine: "end" to append, never a string containing quote characters. Self-budget new_string under 12000 characters before emitting the tool call; use repeated bounded edits for long sections. Preserves file formatting and indentation.',
+		"Performs one targeted exact-string replacement in an existing file. Pass path + old_string + new_string; old_string must match exactly and be unique unless replace_all is true. Read the file immediately before editing, preserve whitespace and indentation, and never include the read tool's line-number prefix in old_string. To append or insert, replace a unique existing tail/marker with itself plus the new text; advance a deterministic marker such as {{CHUNK_001}} to {{CHUNK_002}} so replaying a completed edit cannot duplicate content. Prefer this tool over rewriting an existing file. Self-budget new_string under 12000 characters.",
 	inputSchema,
 	modelInputSchema,
 	enforceModelInput: true,
 	validationErrorHint:
-		'Accepted shapes: {"path":"file.md","insertLine":"end","new_string":"text"} or {"path":"file.md","old_string":"old","new_string":"new"}. Always include path; insertLine accepts only a non-negative JSON integer or the exact string "end".',
+		'Required shape: {"path":"file.md","old_string":"exact unique text","new_string":"replacement text"}. Optional: "replace_all": true.',
 	category: 'filesystem',
 	permissions: ['file_write'],
 	readOnly: false,
@@ -136,152 +79,120 @@ export const EditTool = defineTool({
 	concurrencySafe: false,
 
 	async execute(input: EditInput, context) {
-		const normalized = normalizeEditInput(input)
-		if (!normalized.success) {
-			return { success: false, output: '', error: normalized.error }
-		}
-		if (
-			normalized.operation.operation === 'replace' &&
-			normalized.operation.oldString === normalized.operation.newString
-		) {
+		const parsed = inputSchema.safeParse(input)
+		if (!parsed.success) {
 			return {
 				success: false,
 				output: '',
-				error: 'old_string/oldStr and new_string/newStr are identical — no change needed',
+				error: `Invalid edit input: ${parsed.error.issues.map((issue) => issue.message).join('; ')}`,
 			}
 		}
+		const canonicalInput = parsed.data
 
-		// Sandbox-aware: route through sandbox when available
-		if (context.sandbox) {
-			const buffer = await context.sandbox.readFile(input.path)
-			const content = buffer.toString('utf-8')
-
-			const result = applyEdit(content, normalized.operation)
-			if (!result.success) {
-				return { success: false, output: '', error: result.error }
-			}
-
-			await context.sandbox.writeFile(input.path, result.content)
+		const replacement: ExactReplacement = {
+			oldString: canonicalInput.old_string,
+			newString: canonicalInput.new_string,
+			replaceAll: canonicalInput.replace_all,
+		}
+		if (replacement.oldString === replacement.newString) {
 			return {
-				success: true,
-				output: `Edited ${input.path}: ${result.replacements} replacement(s) [sandboxed]`,
-				data: {
-					path: input.path,
-					replacements: result.replacements,
-					sandboxed: true,
-				},
+				success: false,
+				output: '',
+				error: 'old_string and new_string are identical — no change needed.',
 			}
 		}
 
-		const filePath = resolve(context.workingDirectory, input.path)
-		const content = await readFile(filePath, 'utf-8')
+		const filePath = resolve(context.workingDirectory, canonicalInput.path)
+		const lockKey = `${context.sandbox ? 'sandbox' : 'local'}:${filePath}`
 
-		const result = applyEdit(content, normalized.operation)
-		if (!result.success) {
-			return { success: false, output: '', error: result.error }
-		}
+		return withFileMutationLock(lockKey, async () => {
+			if (context.sandbox) {
+				const buffer = await context.sandbox.readFile(canonicalInput.path)
+				const result = applyEdit(buffer.toString('utf-8'), replacement)
+				if (!result.success) return { success: false as const, output: '', error: result.error }
 
-		await writeFile(filePath, result.content, 'utf-8')
-		return {
-			success: true,
-			output: `Edited ${filePath}: ${result.replacements} replacement(s)`,
-			data: { path: filePath, replacements: result.replacements },
-		}
+				await context.sandbox.writeFile(canonicalInput.path, result.content)
+				return {
+					success: true as const,
+					output: `Edited ${canonicalInput.path}: ${result.replacements} replacement(s) [sandboxed]`,
+					data: {
+						path: canonicalInput.path,
+						replacements: result.replacements,
+						sandboxed: true,
+					},
+				}
+			}
+
+			const content = await readFile(filePath, 'utf-8')
+			const result = applyEdit(content, replacement)
+			if (!result.success) return { success: false as const, output: '', error: result.error }
+
+			await atomicWriteFile(filePath, result.content)
+			return {
+				success: true as const,
+				output: `Edited ${filePath}: ${result.replacements} replacement(s)`,
+				data: { path: filePath, replacements: result.replacements },
+			}
+		})
 	},
 })
 
-function normalizeEditInput(
-	input: EditInput,
-): { success: true; operation: NormalizedEditInput } | { success: false; error: string } {
-	const newString = input.new_string ?? input.newStr
-	if (typeof newString !== 'string') {
+function normalizeLineEndings(content: string, input: ExactReplacement): ExactReplacement {
+	const withoutCrlf = content.replaceAll('\r\n', '')
+	const usesOnlyCrlf = content.includes('\r\n') && !withoutCrlf.includes('\n')
+	if (usesOnlyCrlf) {
 		return {
-			success: false,
-			error: 'Either new_string or newStr is required.',
+			...input,
+			oldString: content.includes(input.oldString)
+				? input.oldString
+				: input.oldString.replaceAll('\r\n', '\n').replaceAll('\n', '\r\n'),
+			newString: input.newString.replaceAll('\r\n', '\n').replaceAll('\n', '\r\n'),
 		}
 	}
 
-	if (input.insertLine !== undefined) {
-		const insertLine = normalizeInsertLine(input.insertLine)
-		if (!insertLine.success) return insertLine
+	const usesOnlyLf = content.includes('\n') && !content.includes('\r\n')
+	if (usesOnlyLf) {
 		return {
-			success: true,
-			operation: {
-				operation: 'insert',
-				insertLine: insertLine.value,
-				newString,
-				replace_all: input.replace_all,
-			},
+			...input,
+			oldString: content.includes(input.oldString)
+				? input.oldString
+				: input.oldString.replaceAll('\r\n', '\n'),
+			newString: input.newString.replaceAll('\r\n', '\n'),
 		}
 	}
-
-	const oldString = input.old_string ?? input.oldStr
-	if (typeof oldString !== 'string') {
-		return {
-			success: false,
-			error: 'Either old_string/oldStr or insertLine is required.',
-		}
-	}
-	return {
-		success: true,
-		operation: {
-			operation: 'replace',
-			oldString,
-			newString,
-			replace_all: input.replace_all,
-		},
-	}
-}
-
-function normalizeInsertLine(
-	value: unknown,
-): { success: true; value: number | 'end' } | { success: false; error: string } {
-	if (value === 'end') return { success: true, value: 'end' }
-	if (typeof value === 'number' && Number.isInteger(value) && value >= 0) {
-		return { success: true, value }
-	}
-	return {
-		success: false,
-		error: 'insertLine must be a non-negative line number or "end".',
-	}
+	return input
 }
 
 function applyEdit(
 	content: string,
-	input: NormalizedEditInput,
+	rawInput: ExactReplacement,
 ): { success: true; content: string; replacements: number } | { success: false; error: string } {
-	if (input.operation === 'insert') {
-		return applyLineInsert(content, input)
-	}
-
+	const input = normalizeLineEndings(content, rawInput)
 	if (!content.includes(input.oldString)) {
 		return {
 			success: false,
 			error:
-				'old_string/oldStr not found in file. Make sure the string matches exactly, including whitespace and indentation.',
+				'old_string was not found. Read the file again and copy exact text without line-number prefixes.',
 		}
 	}
 
-	if (input.replace_all) {
+	if (input.replaceAll) {
 		const parts = content.split(input.oldString)
-		const replacements = parts.length - 1
 		return {
 			success: true,
 			content: parts.join(input.newString),
-			replacements,
+			replacements: parts.length - 1,
 		}
 	}
 
-	// Uniqueness check: old_string/oldStr must appear exactly once
 	const firstIndex = content.indexOf(input.oldString)
-	const secondIndex = content.indexOf(input.oldString, firstIndex + 1)
-
+	const secondIndex = content.indexOf(input.oldString, firstIndex + input.oldString.length)
 	if (secondIndex !== -1) {
-		const lineNumber = content.slice(0, firstIndex).split('\n').length
+		const firstLine = content.slice(0, firstIndex).split('\n').length
 		const secondLine = content.slice(0, secondIndex).split('\n').length
 		return {
 			success: false,
-			error: `old_string/oldStr is not unique — found at lines ${lineNumber} and ${secondLine}. Provide more surrounding context to make it unique, or use replace_all: true.`,
+			error: `old_string is not unique — found at lines ${firstLine} and ${secondLine}. Include more surrounding context, or use replace_all: true.`,
 		}
 	}
 
@@ -291,29 +202,6 @@ function applyEdit(
 			content.slice(0, firstIndex) +
 			input.newString +
 			content.slice(firstIndex + input.oldString.length),
-		replacements: 1,
-	}
-}
-
-function applyLineInsert(
-	content: string,
-	input: Extract<NormalizedEditInput, { operation: 'insert' }>,
-): { success: true; content: string; replacements: number } {
-	const hasTrailingNewline = content.endsWith('\n')
-	const lines = content.split('\n')
-	if (hasTrailingNewline) lines.pop()
-
-	const line =
-		input.insertLine === 'end'
-			? lines.length
-			: Math.min(Math.max(input.insertLine, 0), lines.length)
-	const inserted = input.newString.endsWith('\n')
-		? input.newString.slice(0, -1).split('\n')
-		: input.newString.split('\n')
-	lines.splice(line, 0, ...inserted)
-	return {
-		success: true,
-		content: `${lines.join('\n')}${hasTrailingNewline ? '\n' : ''}`,
 		replacements: 1,
 	}
 }

--- a/packages/sdk/src/tools/builtins/file-mutation-lock.ts
+++ b/packages/sdk/src/tools/builtins/file-mutation-lock.ts
@@ -1,0 +1,27 @@
+const mutationTails = new Map<string, Promise<void>>()
+
+/**
+ * Serialize read-modify-write filesystem operations by resolved path within
+ * one SDK process. Distributed hosts must still assign one writer per file or
+ * provide a storage-level compare-and-swap primitive.
+ */
+export async function withFileMutationLock<T>(
+	key: string,
+	operation: () => Promise<T>,
+): Promise<T> {
+	const previous = mutationTails.get(key) ?? Promise.resolve()
+	let release = () => {}
+	const current = new Promise<void>((resolve) => {
+		release = resolve
+	})
+	const tail = previous.then(() => current)
+	mutationTails.set(key, tail)
+
+	await previous
+	try {
+		return await operation()
+	} finally {
+		release()
+		if (mutationTails.get(key) === tail) mutationTails.delete(key)
+	}
+}

--- a/packages/sdk/src/tools/builtins/index.ts
+++ b/packages/sdk/src/tools/builtins/index.ts
@@ -26,8 +26,8 @@ import { WriteFileTool } from './write-file.js'
 // `code.claude.com/docs/en/tools-reference`) does NOT include `LS` —
 // directory listing is canonical `Bash` + `Glob`. `search_tools` has no
 // Claude analogue at all. Including these in the defaults gives the model
-// tools that look right but degrade alignment. File extension is canonical
-// `edit` with `insertLine: "end"` — the legacy `Append` tool is gone.
+// tools that look right but degrade alignment. File extension uses canonical
+// exact replacement against a unique tail or deterministic marker.
 // Hosts that genuinely want LS/search can still register them explicitly.
 
 export function getBuiltinTools(): ToolDefinition[] {

--- a/packages/sdk/src/tools/builtins/write-file.ts
+++ b/packages/sdk/src/tools/builtins/write-file.ts
@@ -1,41 +1,53 @@
-import { access, mkdir, writeFile } from 'node:fs/promises'
-import { dirname, resolve } from 'node:path'
+import { access } from 'node:fs/promises'
+import { resolve } from 'node:path'
 import { z } from 'zod'
 import type { ToolContext } from '../../types/tool/index.js'
 import { defineTool } from '../defineTool.js'
+import { atomicWriteFile } from './atomic-write-file.js'
+import { withFileMutationLock } from './file-mutation-lock.js'
 
 const inputSchema = z
 	.object({
 		path: z
 			.string()
-			.min(1)
+			.refine((value) => value.trim().length > 0, 'Path must not be empty.')
 			.describe(
-				'Relative path to the file to write (e.g. "outputs/report.md"). Required. Must be a non-empty string.',
+				'Relative path to the file to write (e.g. "outputs/report.md"). Must not be empty.',
 			),
 		content: z
 			.string()
-			.optional()
 			.describe(
-				'Full file body to write. Required (use "" only for an intentionally empty file). The file is fully overwritten — pass the COMPLETE intended content for this bounded chunk, not a diff. Self-budget content under 12000 characters before calling; if the intended body is longer, write a smaller opening section here, then use `edit` with insertLine: "end" to extend the file section by section. Do NOT try to chain multiple `write` calls, since each one overwrites the previous.',
-			),
-		newStr: z
-			.string()
-			.optional()
-			.describe(
-				'Alias for content. Useful for hosts that expose create/write operations as newStr. Self-budget this payload under 12000 characters before calling.',
+				'Complete bounded file body. Use "" only for an intentionally empty file. Keep under 12000 characters. For longer documents, include a deterministic marker such as {{CHUNK_001}} and advance it with exact edit calls.',
 			),
 	})
-	.refine((value) => typeof value.content === 'string' || typeof value.newStr === 'string', {
-		message: 'Either content or newStr is required.',
-	})
+	.strict()
 
 type WriteInput = z.infer<typeof inputSchema>
+
+const modelInputSchema: Record<string, unknown> = {
+	type: 'object',
+	properties: {
+		path: {
+			type: 'string',
+			description: 'Non-empty path to the file to write.',
+		},
+		content: {
+			type: 'string',
+			description: 'Complete bounded file body. May be empty only for an intentionally empty file.',
+		},
+	},
+	required: ['path', 'content'],
+	additionalProperties: false,
+}
 
 export const WriteFileTool = defineTool({
 	name: 'write',
 	description:
-		'Writes a file to the local filesystem. Overwrites the existing file at the path if there is one.\n\n- If the file already exists, you must use the `read` tool on it first in this conversation, or this call will fail.\n- Prefer the `edit` tool for modifying existing files — it only sends the diff and preserves the rest of the file byte-for-byte.\n- Use `write` to create a new file or to perform a deliberate full rewrite of a file you have already read.\n- Self-budget content/newStr under 12000 characters before emitting the tool call. For long content, write a smaller opening section, then use `edit` with insertLine: "end" to extend the file section by section. Do not chain multiple `write` calls — each one overwrites the previous.',
+		'Writes a complete bounded file body. Pass exactly path + content. If the file exists, read it first; prefer edit for targeted changes. Self-budget content under 12000 characters. For longer documents, write an opening with a deterministic marker such as {{CHUNK_001}}, then use exact edit calls that advance the marker one chunk at a time. Do not chain write calls because each overwrites the file.',
 	inputSchema,
+	modelInputSchema,
+	enforceModelInput: true,
+	validationErrorHint: 'Required shape: {"path":"file.md","content":"complete bounded file body"}.',
 	category: 'filesystem',
 	permissions: ['file_write'],
 	readOnly: false,
@@ -43,40 +55,52 @@ export const WriteFileTool = defineTool({
 	concurrencySafe: false,
 
 	async execute(input: WriteInput, context) {
-		const content = input.content ?? input.newStr ?? ''
-		// Sandbox-aware: route through sandbox.writeFile() when available
-		if (context.sandbox) {
-			const sandboxExists = await sandboxFileExists(context, input.path)
-			if (sandboxExists) {
-				const guard = enforceReadBeforeOverwrite(context, input.path)
+		const parsed = inputSchema.safeParse(input)
+		if (!parsed.success) {
+			return {
+				success: false,
+				output: '',
+				error: `Invalid write input: ${parsed.error.issues.map((issue) => issue.message).join('; ')}`,
+			}
+		}
+		const canonicalInput = parsed.data
+
+		const filePath = resolve(context.workingDirectory, canonicalInput.path)
+		const lockKey = `${context.sandbox ? 'sandbox' : 'local'}:${filePath}`
+		return withFileMutationLock(lockKey, async () => {
+			if (context.sandbox) {
+				const sandboxExists = await sandboxFileExists(context, canonicalInput.path)
+				if (sandboxExists) {
+					const guard = enforceReadBeforeOverwrite(context, canonicalInput.path)
+					if (guard) return guard
+				}
+				await context.sandbox.writeFile(canonicalInput.path, canonicalInput.content)
+				context.fileReadTracker?.recordRead(canonicalInput.path)
+				return {
+					success: true as const,
+					output: `File written successfully: ${canonicalInput.path} (${canonicalInput.content.length} chars) [sandboxed]`,
+					data: {
+						path: canonicalInput.path,
+						size: canonicalInput.content.length,
+						sandboxed: true,
+					},
+				}
+			}
+
+			const localExists = await pathExists(filePath)
+			if (localExists) {
+				const guard = enforceReadBeforeOverwrite(context, filePath)
 				if (guard) return guard
 			}
-			await context.sandbox.writeFile(input.path, content)
-			context.fileReadTracker?.recordRead(input.path)
+
+			await atomicWriteFile(filePath, canonicalInput.content)
+			context.fileReadTracker?.recordRead(filePath)
 			return {
-				success: true,
-				output: `File written successfully: ${input.path} (${content.length} chars) [sandboxed]`,
-				data: { path: input.path, size: content.length, sandboxed: true },
+				success: true as const,
+				output: `File written successfully: ${filePath} (${canonicalInput.content.length} chars)`,
+				data: { path: filePath, size: canonicalInput.content.length },
 			}
-		}
-
-		const filePath = resolve(context.workingDirectory, input.path)
-
-		const localExists = await pathExists(filePath)
-		if (localExists) {
-			const guard = enforceReadBeforeOverwrite(context, filePath)
-			if (guard) return guard
-		}
-
-		await mkdir(dirname(filePath), { recursive: true })
-		await writeFile(filePath, content, 'utf-8')
-		context.fileReadTracker?.recordRead(filePath)
-
-		return {
-			success: true,
-			output: `File written successfully: ${filePath} (${content.length} chars)`,
-			data: { path: filePath, size: content.length },
-		}
+		})
 	},
 })
 

--- a/packages/sdk/src/types/sandbox/index.ts
+++ b/packages/sdk/src/types/sandbox/index.ts
@@ -93,6 +93,10 @@ export interface Sandbox {
 	readonly rootDir: string
 	readonly environment: SandboxEnvironment
 	exec(command: string, args?: string[], opts?: SandboxExecOptions): Promise<SandboxExecResult>
+	/**
+	 * Atomically replace the destination body: readers must observe either the
+	 * previous complete body or the new complete body, never a truncated file.
+	 */
 	writeFile(path: string, content: string | Buffer): Promise<void>
 	readFile(path: string): Promise<Buffer>
 	/**


### PR DESCRIPTION
## Summary
- replace `edit` with one strict `{ path, old_string, new_string, replace_all? }` contract
- replace `write` with one strict `{ path, content }` contract and remove runtime aliases
- serialize same-process mutations, commit local bodies atomically, and require atomic sandbox replacement
- migrate long-document guidance/tests to replay-safe rolling markers
- update CLI rendering, provider wire-schema coverage, public docs, and Changesets

## Breaking change
`insertLine`, `oldStr`, and `newStr` are no longer accepted. Callers must use exact replacement for edits and `content` for writes.

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- focused SDK edit/write/long-document/provider suites
