### PR TITLE
fix(sdk): constrain question tool inputs

### DIFF
--- a/.changeset/strict-question-input.md
+++ b/.changeset/strict-question-input.md
@@ -1,0 +1,6 @@
+---
+"@namzu/sdk": patch
+---
+
+Constrain `ask_user_question` to its canonical JSON object-array input on
+supported providers and reject malformed compatibility shapes at runtime.

--- a/docs/sdk/agents/README.md
+++ b/docs/sdk/agents/README.md
@@ -1,7 +1,7 @@
 ---
 title: Agents and Orchestration
 description: Choose the right SDK agent class, understand delegation boundaries, and wire orchestration surfaces safely in @namzu/sdk.
-last_updated: 2026-04-18
+last_updated: 2026-07-31
 status: current
 related_packages: ["@namzu/sdk"]
 ---
@@ -211,6 +211,10 @@ Current hard requirements:
 - `SupervisorAgent` requires `sessionId`, `projectId`, and `tenantId`
 - it also requires either `gateway` or `agentManager`
 - if you want managed child spawning, pass `agentManager`
+- `ask_user_question` is registered only when both `resumeHandler` and `runId`
+  are available. Its model contract requires `options` to be a JSON array of
+  2–4 objects with a `label` (and optional `description`); capable providers
+  constrain that shape, while the runtime decoder remains authoritative.
 
 ## 7. What `AgentManager` Actually Owns
 

--- a/packages/sdk/src/tools/coordinator/__tests__/ask-user-question.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/ask-user-question.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { ToolRegistry } from '../../../registry/tool/execute.js'
 import type { TaskGateway } from '../../../types/agent/gateway.js'
 import type {
 	HITLDecisionRequest,
@@ -141,6 +142,136 @@ describe('coordinator ask_user_question registration', () => {
 
 describe('coordinator ask_user_question input schema', () => {
 	const noopHandler: ResumeHandler = async () => ({ action: 'continue' })
+
+	it('publishes one closed canonical model contract and requests constrained input', () => {
+		const tool = askTool(noopHandler)
+		expect(tool.modelInputSchema).toEqual({
+			type: 'object',
+			properties: {
+				question: {
+					type: 'string',
+					description: 'Full question text — clear, specific, and ending with a question mark.',
+				},
+				header: {
+					type: 'string',
+					description: 'Optional very short topic label, no more than 24 characters.',
+				},
+				options: {
+					type: 'array',
+					description: 'A JSON array of 2-4 genuinely distinct, context-derived option objects.',
+					items: {
+						type: 'object',
+						properties: {
+							label: {
+								type: 'string',
+								description:
+									'Concise option label. Put the recommended option first and append " (Recommended)".',
+							},
+							description: {
+								type: 'string',
+								description: 'Optional one-line explanation of what changes if selected.',
+							},
+						},
+						required: ['label'],
+						additionalProperties: false,
+					},
+				},
+				multiSelect: {
+					type: 'boolean',
+					description: 'True only when several options can apply at once.',
+				},
+				allowFreeText: {
+					type: 'boolean',
+					description: 'Whether the user may answer in their own words.',
+				},
+			},
+			required: ['question', 'options'],
+			additionalProperties: false,
+		})
+		expect(tool.enforceModelInput).toBe(true)
+		expect(tool.validationErrorHint).toBe(
+			'Required shape: {"question":"...?","options":[{"label":"First (Recommended)","description":"What changes"},{"label":"Second","description":"What changes"}]}. "options" must be a JSON array of 2-4 objects, never a string.',
+		)
+	})
+
+	it('returns fresh canonical schemas from the registry boundary', () => {
+		const registry = new ToolRegistry()
+		registry.register(askTool(noopHandler))
+
+		const first = registry.toLLMTools()[0]?.function.parameters
+		expect(first).toEqual(askTool(noopHandler).modelInputSchema)
+		const firstProperties = first?.properties as Record<string, unknown>
+		firstProperties.legacy_options = { type: 'string' }
+
+		const next = registry.toLLMTools()[0]?.function.parameters
+		expect(JSON.stringify(next)).not.toContain('legacy_options')
+		expect(next).toEqual(askTool(noopHandler).modelInputSchema)
+	})
+
+	it('isolates the canonical schema between public coordinator builder results', () => {
+		const first = askTool(noopHandler)
+		const second = askTool(noopHandler)
+		expect(first.modelInputSchema).not.toBe(second.modelInputSchema)
+
+		const firstProperties = first.modelInputSchema?.properties as Record<string, unknown>
+		firstProperties.legacy_options = { type: 'string' }
+
+		expect(JSON.stringify(second.modelInputSchema)).not.toContain('legacy_options')
+	})
+
+	it('rejects the captured XML-like string and other malformed option shapes', () => {
+		const tool = askTool(noopHandler)
+		for (const options of [
+			'<options><option><label>Board</label></option></options>',
+			[42, { label: 'Engineering' }],
+			[{ description: 'Missing label' }, { label: 'Engineering' }],
+			[{ label: 'Board', description: 42 }, { label: 'Engineering' }],
+		]) {
+			expect(
+				tool.inputSchema.safeParse({ question: 'Who is the audience?', options }).success,
+				JSON.stringify(options),
+			).toBe(false)
+		}
+	})
+
+	it('rejects unknown root and option properties instead of stripping them', () => {
+		const tool = askTool(noopHandler)
+		expect(tool.inputSchema.safeParse({ ...baseInput, legacy: true }).success).toBe(false)
+		expect(
+			tool.inputSchema.safeParse({
+				...baseInput,
+				options: [{ label: 'Board', value: 'legacy' }, { label: 'Engineering team' }],
+			}).success,
+		).toBe(false)
+	})
+
+	it('returns the canonical recovery shape through the real registry path', async () => {
+		const requests: HITLDecisionRequest[] = []
+		const registry = new ToolRegistry()
+		registry.register(
+			askTool(async (request) => {
+				requests.push(request)
+				return { action: 'continue' }
+			}),
+		)
+
+		const result = await registry.execute(
+			'ask_user_question',
+			{
+				question: 'Who is the audience?',
+				options: '<options><option><label>Board</label></option></options>',
+			},
+			testToolContext(),
+		)
+
+		expect(result.success).toBe(false)
+		expect(result.error).toContain('Expected array, received string')
+		expect(result.error).toContain(
+			'Required shape: {"question":"...?","options":[{"label":"First (Recommended)","description":"What changes"},{"label":"Second","description":"What changes"}]}.',
+		)
+		expect(result.error).toContain('"options" must be a JSON array of 2-4 objects, never a string.')
+		expect(requests).toHaveLength(0)
+	})
 
 	it('rejects fewer than 2 options and more than 4', () => {
 		const tool = askTool(noopHandler)

--- a/packages/sdk/src/tools/coordinator/index.ts
+++ b/packages/sdk/src/tools/coordinator/index.ts
@@ -56,6 +56,50 @@ const approvePlanStepSchema = z.object({
 	depends_on: z.array(z.string()).optional().describe('Step descriptions this depends on'),
 })
 
+const askUserQuestionModelInputSchema: Record<string, unknown> = {
+	type: 'object',
+	properties: {
+		question: {
+			type: 'string',
+			description: 'Full question text — clear, specific, and ending with a question mark.',
+		},
+		header: {
+			type: 'string',
+			description: 'Optional very short topic label, no more than 24 characters.',
+		},
+		options: {
+			type: 'array',
+			description: 'A JSON array of 2-4 genuinely distinct, context-derived option objects.',
+			items: {
+				type: 'object',
+				properties: {
+					label: {
+						type: 'string',
+						description:
+							'Concise option label. Put the recommended option first and append " (Recommended)".',
+					},
+					description: {
+						type: 'string',
+						description: 'Optional one-line explanation of what changes if selected.',
+					},
+				},
+				required: ['label'],
+				additionalProperties: false,
+			},
+		},
+		multiSelect: {
+			type: 'boolean',
+			description: 'True only when several options can apply at once.',
+		},
+		allowFreeText: {
+			type: 'boolean',
+			description: 'Whether the user may answer in their own words.',
+		},
+	},
+	required: ['question', 'options'],
+	additionalProperties: false,
+}
+
 function normalizeApprovePlanSteps(value: unknown): unknown {
 	if (typeof value !== 'string') return value
 
@@ -382,47 +426,55 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 			name: 'ask_user_question',
 			description:
 				'Ask the user ONE question ONLY when you are blocked on a decision that is genuinely theirs to make — one you cannot resolve from their request, your tools, the files you can read, or sensible defaults. The question must be the genuinely undecidable thing in THIS task. Never ask for information a tool can discover (do not ask what you can read, list, or search), never re-ask what the conversation already answers, and never ask meta-questions like "Shall I proceed?" — plan ratification goes through approve_plan. Provide 2-4 genuinely distinct options derived from the actual context — concrete paths, never generic placeholders (for example, asked to prepare a presentation, ask "Who is the audience?" with options like Board / Engineering team / Customer); keep labels short (1-5 words) and give each option a one-line description of what practically changes if it is chosen. Put your recommended option FIRST and append " (Recommended)" to its label. Set multiSelect: true only when several options can apply at once. A free-text "Something else" escape hatch is always shown automatically — do not add your own "Other" option. Ask ONE question per call and prefer at most one question per assistant turn; if several decisions block you, ask only the ones that materially change your next actions, in sequence — most work needs at most 2-3 questions, so prefer proceeding on stated defaults over interrogating the user. Never invent answers or synthetic content on the user\'s behalf unless they explicitly asked for a random/test scenario. The answer arrives as this tool\'s result; if the result says the user did not answer, do not ask this or any other question again — proceed on your best judgment without assuming consent.',
-			inputSchema: z.object({
-				question: z
-					.string()
-					.min(1)
-					.describe('Full question text — clear, specific, ends with a question mark.'),
-				header: z
-					.string()
-					.max(24)
-					.optional()
-					.describe('Very short topic label for the question (e.g. "Audience", "Auth method").'),
-				options: z
-					.array(
-						z.object({
-							label: z
-								.string()
-								.min(1)
-								.max(80)
-								.describe(
-									'Concise option label (1-5 words). Recommended option goes first with " (Recommended)" appended.',
-								),
-							description: z
-								.string()
-								.max(300)
-								.optional()
-								.describe('One line on what practically changes if this option is chosen.'),
-						}),
-					)
-					.min(2)
-					.max(4)
-					.describe('2-4 genuinely distinct, context-derived options.'),
-				multiSelect: z
-					.boolean()
-					.optional()
-					.default(false)
-					.describe('True only when several options can apply at once.'),
-				allowFreeText: z
-					.boolean()
-					.optional()
-					.default(true)
-					.describe('Whether the user may answer in their own words.'),
-			}),
+			inputSchema: z
+				.object({
+					question: z
+						.string()
+						.min(1)
+						.describe('Full question text — clear, specific, ends with a question mark.'),
+					header: z
+						.string()
+						.max(24)
+						.optional()
+						.describe('Very short topic label for the question (e.g. "Audience", "Auth method").'),
+					options: z
+						.array(
+							z
+								.object({
+									label: z
+										.string()
+										.min(1)
+										.max(80)
+										.describe(
+											'Concise option label (1-5 words). Recommended option goes first with " (Recommended)" appended.',
+										),
+									description: z
+										.string()
+										.max(300)
+										.optional()
+										.describe('One line on what practically changes if this option is chosen.'),
+								})
+								.strict(),
+						)
+						.min(2)
+						.max(4)
+						.describe('2-4 genuinely distinct, context-derived options.'),
+					multiSelect: z
+						.boolean()
+						.optional()
+						.default(false)
+						.describe('True only when several options can apply at once.'),
+					allowFreeText: z
+						.boolean()
+						.optional()
+						.default(true)
+						.describe('Whether the user may answer in their own words.'),
+				})
+				.strict(),
+			modelInputSchema: structuredClone(askUserQuestionModelInputSchema),
+			enforceModelInput: true,
+			validationErrorHint:
+				'Required shape: {"question":"...?","options":[{"label":"First (Recommended)","description":"What changes"},{"label":"Second","description":"What changes"}]}. "options" must be a JSON array of 2-4 objects, never a string.',
 			category: 'custom',
 			permissions: [],
 			readOnly: true,


### PR DESCRIPTION
## Summary

- publish a closed provider-safe model schema for ask_user_question
- request constrained tool input on capable providers while retaining strict Zod validation
- reject string/XML option payloads and unknown compatibility fields without parking the run
- isolate model schemas across public coordinator builder results
- document the canonical 2-4 option object-array contract

## Verification

- pnpm typecheck
- pnpm lint
- pnpm test (SDK: 126 files, 1182 tests passed)