### PR TITLE
fix(files): carry the metadata a signed publish is verified against

### DIFF
--- a/.github/scripts/check-publish-metadata.mjs
+++ b/.github/scripts/check-publish-metadata.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Every publishable package carries the metadata a signed publish needs.
+ *
+ * The release workflow publishes with provenance, and the registry verifies
+ * the attestation against `repository.url` before it accepts the tarball. A
+ * package missing that field is rejected with a 422 — but only at publish
+ * time, at the end of a release, after every sibling has already gone out.
+ * That is exactly what happened to `@namzu/files@0.2.0`: eleven packages
+ * published, one 422'd on a field nothing had ever checked, and the version
+ * was left tagged and released with nothing on the registry behind it.
+ *
+ * Nothing verified this because the field is only load-bearing on the one
+ * code path that costs the most to retry.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+const EXPECTED_REPO = 'https://github.com/cogitave/namzu'
+
+/** Every `packages/**\/package.json`, one level deep and under `providers/`. */
+function packageDirs() {
+	const roots = ['packages']
+	const found = []
+	while (roots.length > 0) {
+		const root = roots.pop()
+		for (const entry of readdirSync(root)) {
+			const dir = join(root, entry)
+			if (entry === 'node_modules' || !statSync(dir).isDirectory()) continue
+			try {
+				statSync(join(dir, 'package.json'))
+				found.push(dir)
+			} catch {
+				roots.push(dir)
+			}
+		}
+	}
+	return found.sort()
+}
+
+const problems = []
+let checked = 0
+
+for (const dir of packageDirs()) {
+	const manifest = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'))
+	if (manifest.private === true) continue
+	checked++
+
+	const repo = manifest.repository
+	const url = typeof repo === 'string' ? repo : (repo?.url ?? '')
+	const normalized = url.replace(/^git\+/, '').replace(/\.git$/, '')
+
+	if (!url) {
+		problems.push(
+			`${manifest.name} (${dir}) has no \`repository\` field. A provenance publish is rejected without it.`,
+		)
+	} else if (normalized !== EXPECTED_REPO) {
+		problems.push(
+			`${manifest.name} (${dir}) points \`repository.url\` at ${normalized}, but provenance is attested against ${EXPECTED_REPO}.`,
+		)
+	}
+
+	// Not required by the registry, but a package page with no link back is
+	// the same omission one step less costly, and the same fix.
+	for (const field of ['license', 'description']) {
+		if (!manifest[field]) problems.push(`${manifest.name} (${dir}) has no \`${field}\`.`)
+	}
+}
+
+if (problems.length > 0) {
+	console.error('\n✗ publish-metadata gate failed:\n')
+	for (const p of problems) console.error(`  - ${p}`)
+	console.error(
+		`\n${problems.length} problem(s) across ${checked} publishable packages. Fix the manifest; a release that reaches the registry and fails there has already published its siblings.\n`,
+	)
+	process.exit(1)
+}
+
+console.log(`✓ publish-metadata gate passed (${checked} publishable packages)`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,14 @@ jobs:
         if: matrix.node-version == 24
         run: node .github/scripts/check-sdk-test-presence.mjs
 
+      # The registry verifies a provenance attestation against
+      # `repository.url` and rejects the tarball without it — at publish
+      # time, after every sibling package has already gone out. Checking it
+      # here costs a second; finding out at the registry costs a release.
+      - name: Publish-metadata gate
+        if: matrix.node-version == 24
+        run: node .github/scripts/check-publish-metadata.mjs
+
       # Pre-publish package validation — runs on every PR + every push to main.
       # Catches cross-package peer-range drift and package.json export shape
       # bugs before they reach a publish tag. Only runs on one node version

--- a/packages/files/package.json
+++ b/packages/files/package.json
@@ -1,62 +1,71 @@
 {
-  "name": "@namzu/files",
-  "version": "0.2.0",
-  "description": "Provider-agnostic file registry contracts for Namzu runtimes.",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    },
-    "./inmem": {
-      "types": "./dist/inmem/index.d.ts",
-      "import": "./dist/inmem/index.js"
-    },
-    "./local": {
-      "types": "./dist/local/index.d.ts",
-      "import": "./dist/local/index.js"
-    },
-    "./postgres": {
-      "types": "./dist/postgres/index.d.ts",
-      "import": "./dist/postgres/index.js"
-    },
-    "./s3": {
-      "types": "./dist/s3/index.d.ts",
-      "import": "./dist/s3/index.js"
-    },
-    "./azure-blob": {
-      "types": "./dist/azure-blob/index.d.ts",
-      "import": "./dist/azure-blob/index.js"
-    },
-    "./gcs": {
-      "types": "./dist/gcs/index.d.ts",
-      "import": "./dist/gcs/index.js"
-    },
-    "./http": {
-      "types": "./dist/http/index.d.ts",
-      "import": "./dist/http/index.js"
-    }
-  },
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "test": "vitest run --passWithNoTests",
-    "typecheck": "tsc --noEmit",
-    "lint": "biome check src/"
-  },
-  "sideEffects": false,
-  "license": "MIT",
-  "dependencies": {
-    "@azure/storage-blob": "^12.27.0"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "^1.9.4",
-    "@types/node": "^22.19.17",
-    "typescript": "^5.5.0",
-    "vitest": "^3.2.6"
-  }
+	"name": "@namzu/files",
+	"version": "0.2.0",
+	"description": "Provider-agnostic file registry contracts for Namzu runtimes.",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
+		"./inmem": {
+			"types": "./dist/inmem/index.d.ts",
+			"import": "./dist/inmem/index.js"
+		},
+		"./local": {
+			"types": "./dist/local/index.d.ts",
+			"import": "./dist/local/index.js"
+		},
+		"./postgres": {
+			"types": "./dist/postgres/index.d.ts",
+			"import": "./dist/postgres/index.js"
+		},
+		"./s3": {
+			"types": "./dist/s3/index.d.ts",
+			"import": "./dist/s3/index.js"
+		},
+		"./azure-blob": {
+			"types": "./dist/azure-blob/index.d.ts",
+			"import": "./dist/azure-blob/index.js"
+		},
+		"./gcs": {
+			"types": "./dist/gcs/index.d.ts",
+			"import": "./dist/gcs/index.js"
+		},
+		"./http": {
+			"types": "./dist/http/index.d.ts",
+			"import": "./dist/http/index.js"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"test": "vitest run --passWithNoTests",
+		"typecheck": "tsc --noEmit",
+		"lint": "biome check src/"
+	},
+	"sideEffects": false,
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/cogitave/namzu.git",
+		"directory": "packages/files"
+	},
+	"homepage": "https://github.com/cogitave/namzu/tree/main/packages/files#readme",
+	"bugs": {
+		"url": "https://github.com/cogitave/namzu/issues"
+	},
+	"dependencies": {
+		"@azure/storage-blob": "^12.27.0"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^1.9.4",
+		"@types/node": "^22.19.17",
+		"typescript": "^5.5.0",
+		"vitest": "^3.2.6"
+	}
 }


### PR DESCRIPTION
## What broke

The release published eleven packages and then failed on the twelfth:

```
error an error occurred while publishing @namzu/files:
E422 Unprocessable Entity - PUT https://registry.npmjs.org/@namzu%2ffiles
Error verifying sigstore provenance bundle: Failed to validate repository
information: package.json: "repository.url" is "", expected to match
"https://github.com/cogitave/namzu" from provenance
```

`@namzu/files` was the only publishable package with no `repository` field. The release workflow publishes with `NPM_CONFIG_PROVENANCE: true`, and the registry verifies the attestation against that field before it accepts the tarball.

So the registry still serves `@namzu/files@0.1.0` — the package is published and healthy, it is the `0.2.0` bump that never landed. No tag and no GitHub release were created for it either, because `changesets/action` only tags what it successfully published, so nothing is left dangling.

## Why nothing caught it

The field is load-bearing on exactly one code path — the publish — which runs last, in a workflow, after every sibling package is already public. There is no local command that exercises it. `publint` runs in the release workflow and does not check this.

## The fix

- **`packages/files/package.json`** gains `repository`, `homepage` and `bugs`, matching the sibling packages' shape.
- **`.github/scripts/check-publish-metadata.mjs`** reads every non-private manifest and fails the build if `repository.url` is missing or does not match the repository the attestation names, or if `license` / `description` is absent. Wired into `ci.yml` on the node-24 leg beside the other pre-publish gates. Verified by deleting the field and watching the gate fail.

## Version

Left at `0.2.0` on purpose. The bump commit is on `main` and nothing else about `0.2.0` exists yet, so on merge the "publish any unpublished packages" path pushes it as-is and creates the tag and release behind it. Bumping instead would strand `0.2.0` for no reason.

No changeset for the same reason: the published API does not change, and a bump would strand `0.2.0` permanently.

## Separately

`@namzu/sdk@3.0.0`'s GitHub Release was also missing — `changesets/action` inlines the changelog entry as the release body, and this one is 151,322 characters against GitHub's 125,000 limit. Created by hand from a summarized body with the full changelog linked. Any release this large will hit it again; not addressed here.
