### PR TITLE
fix(sdk): restore the file-mutation safety 3.0.0 reverted

### DIFF
--- a/.changeset/restore-file-mutation-safety.md
+++ b/.changeset/restore-file-mutation-safety.md
@@ -1,0 +1,17 @@
+---
+'@namzu/sdk': patch
+---
+
+Restore the file-mutation safety that 3.0.0 reverted.
+
+Reconciling a long-running branch with `-X ours` resolved conflicts in the branch's favour, and the branch had been cut before four hardening commits landed on `main`. The result shipped: `edit.ts` and `write-file.ts` went out byte-identical to their shape from before that work, and both modules it depended on were left in the tree with zero importers.
+
+What came back, with a test that fails without it:
+
+- **Crash-atomic commits.** Both tools wrote with a bare `writeFile`, so a failure partway through left the destination truncated — the user's own file, in the tool that exists to avoid exactly that. They commit through `atomicWriteFile` again (temp file beside the destination, fsync, rename).
+- **Same-path serialization.** Two concurrent edits to one path interleaved their reads and the second write landed on content the first had already replaced, so one edit vanished and the loser reported `old_string not found` — blaming the model for a race. `withFileMutationLock` wraps both the sandbox and local branches again. For `write`, the lock also closes the gap between the exists-check and the write, which is a check-then-act pair.
+- **Closed input contracts.** `.strict()` was gone, so zod's default silently STRIPPED an unknown key: a misspelled or hallucinated field became a no-op instead of an error. `edit`, `write` and `ask_user_question` reject the unknown again — while still accepting the `oldStr`/`newStr` aliases and `insertLine`, which are declared. Closed is not the same as narrow.
+- **`modelInputSchema` and `enforceModelInput`.** The model-facing schemas are back, and so is the producer: `enforcedModelInputToolNames()` had been deleted, so **nothing** populated `enforceToolInputSchema` and all three drivers that read it were reading a permanently undefined field.
+- **CRLF/LF reconciliation**, so an `old_string` that is right in every visible way still matches a file whose line endings differ.
+
+Also fixes `atomicWriteFile` on Windows, where it had never run: it fsyncs the directory after the rename, which that platform refuses with `EPERM`, and the error was not caught — so every atomic write failed after correctly writing the file. That sync is best-effort now, and only after the commit has already landed.

--- a/docs/sdk/tools/built-in.md
+++ b/docs/sdk/tools/built-in.md
@@ -95,8 +95,13 @@ Purpose:
 
 Notes:
 
-- accepts exactly `path`, `old_string`, `new_string`, and optional `replace_all`
-- compatibility aliases and line-based insertion fields are not accepted
+- the model is constrained to exactly `path`, `old_string`, `new_string`, and
+  optional `replace_all` — one closed shape, so it never has to choose between
+  two spellings of the same field
+- the host schema additionally accepts the `oldStr` / `newStr` aliases and
+  `insertLine`, for hosts that expose replacement under those names
+- either way the contract is closed: a field outside it is rejected, not
+  silently dropped
 - `new_string` may be empty to delete the exact match
 - fails if `old_string` is not unique unless `replace_all` is `true`
 - normalizes only consistent CRLF/LF boundaries; it does not perform fuzzy matching

--- a/packages/sdk/src/runtime/query/iteration/index.ts
+++ b/packages/sdk/src/runtime/query/iteration/index.ts
@@ -30,6 +30,7 @@ import type {
 	StepResult,
 	StopReason,
 } from '../../../types/run/index.js'
+import type { LLMToolSchema, ToolRegistryContract } from '../../../types/tool/index.js'
 import { toErrorMessage } from '../../../utils/error.js'
 import { generateMessageId } from '../../../utils/id.js'
 import type { ToolCallOutcome } from '../executor.js'
@@ -200,6 +201,7 @@ export class IterationOrchestrator {
 				const step = await this.prepareStep(iterationNum)
 
 				const llmTools = this.ctx.tools.toLLMTools(step.allowedTools ?? this.ctx.allowedTools)
+				const enforceToolInputSchema = enforcedModelInputToolNames(this.ctx.tools, llmTools)
 				const stepModel = step.model ?? model
 
 				const baseMessages = forceFinalize
@@ -266,6 +268,7 @@ export class IterationOrchestrator {
 						model: stepModel,
 						messages,
 						tools: llmTools.length > 0 ? llmTools : undefined,
+						...(enforceToolInputSchema ? { enforceToolInputSchema } : {}),
 						toolChoice: forceFinalize && llmTools.length > 0 ? 'none' : undefined,
 						temperature: step.temperature ?? runConfig.temperature,
 						maxTokens: step.maxResponseTokens ?? runConfig.maxResponseTokens,
@@ -1042,11 +1045,13 @@ export class IterationOrchestrator {
 			// tools param identical to prior iterations (cache prefix intact,
 			// no 400 on tool blocks in history) and forbid use via tool_choice.
 			const finalTools = this.ctx.tools.toLLMTools(this.ctx.allowedTools)
+			const finalEnforced = enforcedModelInputToolNames(this.ctx.tools, finalTools)
 			const response = await collect(
 				this.ctx.provider.chatStream({
 					model,
 					messages: finalMessages,
 					tools: finalTools.length > 0 ? finalTools : undefined,
+					...(finalEnforced ? { enforceToolInputSchema: finalEnforced } : {}),
 					toolChoice: finalTools.length > 0 ? 'none' : undefined,
 					temperature: this.ctx.runConfig.temperature,
 					maxTokens: this.ctx.runConfig.maxResponseTokens,
@@ -1101,4 +1106,26 @@ function subtractUsage(after: TokenUsage, before: TokenUsage): TokenUsage {
 /** Cost deltas are subtractions of floats; keep them presentable. */
 function round6(n: number): number {
 	return Math.round(n * 1e6) / 1e6
+}
+
+/**
+ * Which of the tools going out on this request have a closed model schema.
+ *
+ * A driver reads `enforceToolInputSchema` to decide which tool schemas to
+ * constrain generation against. Nothing populated it, so every driver that
+ * consumed it — three of them — was reading a permanently undefined field
+ * and `enforceModelInput: true` on a tool meant nothing end to end.
+ *
+ * Computed per request rather than once, because the allowed set changes:
+ * a deferred tool activated mid-run has to start being enforced from the
+ * next call, not the next process.
+ */
+function enforcedModelInputToolNames(
+	registry: ToolRegistryContract,
+	tools: readonly LLMToolSchema[],
+): readonly string[] | undefined {
+	const names = tools
+		.map((tool) => tool.function.name)
+		.filter((name) => registry.get(name)?.enforceModelInput === true)
+	return names.length > 0 ? names : undefined
 }

--- a/packages/sdk/src/tools/builtins/__tests__/edit-commits-atomically.test.ts
+++ b/packages/sdk/src/tools/builtins/__tests__/edit-commits-atomically.test.ts
@@ -1,0 +1,103 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ToolContext } from '../../../types/tool/index.js'
+
+/**
+ * That the atomic writer works is tested next door. This tests the thing
+ * that actually regressed: whether the TOOL goes through it.
+ *
+ * `edit` and `write` were reverted to a bare `writeFile`, and the existing
+ * atomicity test kept passing because it called `atomicWriteFile` directly —
+ * proving the module, never the caller. A write that fails partway then
+ * truncates the user's file, which is the one outcome `edit` exists to
+ * avoid.
+ */
+
+const atomicWriteFile = vi.fn(async () => {})
+vi.mock('../atomic-write-file.js', () => ({ atomicWriteFile }))
+
+function makeContext(workingDirectory: string): ToolContext {
+	return {
+		runId: 'run_atomic' as ToolContext['runId'],
+		workingDirectory,
+		abortSignal: new AbortController().signal,
+		env: {},
+		log: () => {},
+	}
+}
+
+describe('the file-mutating tools commit through the atomic writer', () => {
+	it('edit routes its local write through it', async () => {
+		const { EditTool } = await import('../edit.js')
+		atomicWriteFile.mockClear()
+
+		const dir = mkdtempSync(join(tmpdir(), 'namzu-atomic-tool-'))
+		writeFileSync(join(dir, 'doc.md'), 'alpha\nbeta\n')
+
+		const result = await EditTool.execute(
+			{ path: 'doc.md', old_string: 'beta', new_string: 'gamma', replace_all: false },
+			makeContext(dir),
+		)
+
+		expect(result.success).toBe(true)
+		expect(atomicWriteFile).toHaveBeenCalledTimes(1)
+		expect(atomicWriteFile).toHaveBeenCalledWith(resolve(dir, 'doc.md'), 'alpha\ngamma\n')
+		// The mock swallowed the write, so the file is untouched — which is
+		// itself the proof that nothing else wrote it.
+		expect(readFileSync(join(dir, 'doc.md'), 'utf-8')).toBe('alpha\nbeta\n')
+	})
+
+	it('write routes its local write through it', async () => {
+		const { WriteFileTool } = await import('../write-file.js')
+		atomicWriteFile.mockClear()
+
+		const dir = mkdtempSync(join(tmpdir(), 'namzu-atomic-tool-'))
+
+		const result = await WriteFileTool.execute(
+			{ path: 'out.md', content: 'a complete body' },
+			makeContext(dir),
+		)
+
+		expect(result.success).toBe(true)
+		expect(atomicWriteFile).toHaveBeenCalledTimes(1)
+		expect(atomicWriteFile).toHaveBeenCalledWith(resolve(dir, 'out.md'), 'a complete body')
+	})
+
+	it('edit does not use it for a sandboxed write, which the sandbox owns', async () => {
+		const { EditTool } = await import('../edit.js')
+		atomicWriteFile.mockClear()
+
+		let body = 'alpha\nbeta\n'
+		const sandbox = {
+			id: 'sbx',
+			status: 'ready',
+			rootDir: '/workspace',
+			environment: 'basic',
+			async readFile() {
+				return Buffer.from(body)
+			},
+			async writeFile(_path: string, content: string | Buffer) {
+				body = content.toString()
+			},
+			async exec() {
+				throw new Error('not used')
+			},
+			async listFiles() {
+				return []
+			},
+			async destroy() {},
+		}
+
+		const result = await EditTool.execute(
+			{ path: 'doc.md', old_string: 'beta', new_string: 'gamma', replace_all: false },
+			{ ...makeContext('/workspace'), sandbox } as ToolContext,
+		)
+
+		expect(result.success).toBe(true)
+		expect(body).toBe('alpha\ngamma\n')
+		expect(atomicWriteFile).not.toHaveBeenCalled()
+	})
+})

--- a/packages/sdk/src/tools/builtins/__tests__/edit.test.ts
+++ b/packages/sdk/src/tools/builtins/__tests__/edit.test.ts
@@ -1,8 +1,11 @@
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { ToolRegistry } from '../../../registry/tool/execute.js'
+import type { Sandbox } from '../../../types/sandbox/index.js'
 import type { ToolContext } from '../../../types/tool/index.js'
+import { atomicWriteFile } from '../atomic-write-file.js'
 import { EditTool } from '../edit.js'
 
 function makeContext(workingDirectory: string): ToolContext {
@@ -16,6 +19,326 @@ function makeContext(workingDirectory: string): ToolContext {
 }
 
 describe('EditTool', () => {
+	it('publishes one closed canonical replacement contract', () => {
+		const schema = EditTool.modelInputSchema
+		expect(schema).toEqual({
+			type: 'object',
+			properties: {
+				path: {
+					type: 'string',
+					description: 'Path to the file to edit. Must not be empty.',
+				},
+				old_string: {
+					type: 'string',
+					description:
+						'Exact unique text from the file, without read-tool line-number prefixes. Must not be empty.',
+				},
+				new_string: {
+					type: 'string',
+					description:
+						'Exact replacement text. May be empty to delete old_string. Keep under 12000 characters.',
+				},
+				replace_all: {
+					type: 'boolean',
+					description: 'Replace every occurrence instead of requiring one unique match.',
+				},
+			},
+			required: ['path', 'old_string', 'new_string'],
+			additionalProperties: false,
+		})
+
+		expect(
+			EditTool.inputSchema.safeParse({
+				path: 'doc.md',
+				old_string: 'old',
+				new_string: 'new',
+				replace_all: true,
+			}).success,
+		).toBe(true)
+
+		// The MODEL schema above is the closed canonical one. The HOST schema
+		// is wider on purpose — aliases and line insertion are declared — and
+		// the point of `.strict()` is that wider still is not open.
+		for (const supported of [
+			{ path: 'doc.md', oldStr: 'old', newStr: 'new' },
+			{ path: 'doc.md', insertLine: 'end', new_string: 'append' },
+			{ path: 'doc.md', old_string: 'old', new_string: 'new', newStr: 'legacy' },
+		]) {
+			expect(EditTool.inputSchema.safeParse(supported).success, JSON.stringify(supported)).toBe(
+				true,
+			)
+		}
+
+		for (const unknown of [
+			{ path: 'doc.md', old_str: 'old', new_string: 'new' },
+			{ path: 'doc.md', old_string: 'old', new_string: 'new', replaceAll: true },
+		]) {
+			expect(EditTool.inputSchema.safeParse(unknown).success, JSON.stringify(unknown)).toBe(false)
+		}
+		expect(
+			EditTool.inputSchema.safeParse({
+				path: '   ',
+				old_string: 'old',
+				new_string: 'new',
+			}).success,
+		).toBe(false)
+	})
+
+	it('replaces one exact unique string', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'namzu-edit-'))
+		writeFileSync(join(dir, 'doc.md'), 'alpha\nbeta\n')
+
+		const result = await EditTool.execute(
+			{
+				path: 'doc.md',
+				old_string: 'beta',
+				new_string: 'gamma',
+				replace_all: false,
+			},
+			makeContext(dir),
+		)
+
+		expect(result.success).toBe(true)
+		expect(readFileSync(join(dir, 'doc.md'), 'utf-8')).toBe('alpha\ngamma\n')
+	})
+
+	it('validates a path without rewriting edge whitespace', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'namzu-edit-'))
+		writeFileSync(join(dir, ' doc.md '), 'alpha\n')
+
+		const result = await EditTool.execute(
+			{
+				path: ' doc.md ',
+				old_string: 'alpha',
+				new_string: 'beta',
+				replace_all: false,
+			},
+			makeContext(dir),
+		)
+
+		expect(result.success).toBe(true)
+		expect(readFileSync(join(dir, ' doc.md '), 'utf-8')).toBe('beta\n')
+		expect(existsSync(join(dir, 'doc.md'))).toBe(false)
+	})
+
+	it('allows deletion with an empty new_string', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'namzu-edit-'))
+		writeFileSync(join(dir, 'doc.md'), 'alpha\nremove me\nomega\n')
+
+		const result = await EditTool.execute(
+			{
+				path: 'doc.md',
+				old_string: 'remove me\n',
+				new_string: '',
+				replace_all: false,
+			},
+			makeContext(dir),
+		)
+
+		expect(result.success).toBe(true)
+		expect(readFileSync(join(dir, 'doc.md'), 'utf-8')).toBe('alpha\nomega\n')
+	})
+
+	it('replaces every exact occurrence only when replace_all is true', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'namzu-edit-'))
+		writeFileSync(join(dir, 'doc.md'), 'alpha alpha alpha')
+
+		const result = await EditTool.execute(
+			{
+				path: 'doc.md',
+				old_string: 'alpha',
+				new_string: 'beta',
+				replace_all: true,
+			},
+			makeContext(dir),
+		)
+
+		expect(result.success).toBe(true)
+		expect(result.data).toMatchObject({ replacements: 3 })
+		expect(readFileSync(join(dir, 'doc.md'), 'utf-8')).toBe('beta beta beta')
+	})
+
+	it('refuses ambiguous exact matches instead of guessing', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'namzu-edit-'))
+		writeFileSync(join(dir, 'doc.md'), 'alpha\nalpha\n')
+
+		const result = await EditTool.execute(
+			{
+				path: 'doc.md',
+				old_string: 'alpha',
+				new_string: 'beta',
+				replace_all: false,
+			},
+			makeContext(dir),
+		)
+
+		expect(result.success).toBe(false)
+		expect(result.error).toContain('is not unique')
+		expect(readFileSync(join(dir, 'doc.md'), 'utf-8')).toBe('alpha\nalpha\n')
+	})
+
+	it('normalizes consistent CRLF/LF boundaries without fuzzy matching', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'namzu-edit-'))
+		writeFileSync(join(dir, 'doc.md'), 'alpha\r\nbeta\r\nomega\r\n')
+
+		const result = await EditTool.execute(
+			{
+				path: 'doc.md',
+				old_string: 'alpha\nbeta',
+				new_string: 'gamma\ndelta',
+				replace_all: false,
+			},
+			makeContext(dir),
+		)
+
+		expect(result.success).toBe(true)
+		expect(readFileSync(join(dir, 'doc.md'), 'utf-8')).toBe('gamma\r\ndelta\r\nomega\r\n')
+	})
+
+	it('rejects a field it does not accept, even when execute is called directly', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'namzu-edit-'))
+		writeFileSync(join(dir, 'doc.md'), 'alpha\n')
+
+		// Without `.strict()` zod STRIPS an unrecognised key, so each of these
+		// would run as if the caller had never written it — a misspelling
+		// becomes a silent no-op rather than an error anyone can act on.
+		for (const input of [
+			{ path: 'doc.md', old_str: 'alpha', new_string: 'beta' },
+			{ path: 'doc.md', old_string: 'alpha', new_string: 'beta', overwrite: true },
+			{ path: 'doc.md', old_string: 'alpha', new_string: 'beta', replaceAll: true },
+		]) {
+			const result = await EditTool.execute(input as never, makeContext(dir))
+			expect(result.success, JSON.stringify(input)).toBe(false)
+			expect(result.error).toContain('Invalid edit input')
+		}
+
+		expect(readFileSync(join(dir, 'doc.md'), 'utf-8')).toBe('alpha\n')
+	})
+
+	it('accepts the host aliases the schema does declare', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'namzu-edit-'))
+		writeFileSync(join(dir, 'doc.md'), 'alpha\n')
+
+		// The contract is closed, not narrow. `oldStr`/`newStr` and
+		// `insertLine` are in the schema for hosts that speak those names, so
+		// strictness must reject the unknown without rejecting these.
+		const result = await EditTool.execute(
+			{ path: 'doc.md', oldStr: 'alpha', newStr: 'beta' } as never,
+			makeContext(dir),
+		)
+
+		expect(result.success).toBe(true)
+		expect(readFileSync(join(dir, 'doc.md'), 'utf-8')).toBe('beta\n')
+	})
+
+	it('returns one canonical recovery shape after registry validation fails', async () => {
+		const registry = new ToolRegistry()
+		registry.register(EditTool)
+
+		const result = await registry.execute(
+			'edit',
+			{ insertLine: '"end"', newStr: 'content' },
+			makeContext('/tmp'),
+		)
+
+		expect(result.success).toBe(false)
+		expect(result.error).toContain('Validation failed for "edit":')
+		expect(result.error).toContain('Required: path: string')
+		expect(result.error).toContain(
+			'{"path":"file.md","old_string":"exact unique text","new_string":"replacement text"}',
+		)
+		expect(result.error).not.toContain('Accepted shapes')
+	})
+
+	it('serializes independent EditTool read-modify-write cycles for one sandbox path', async () => {
+		let body = Buffer.from('alpha')
+		let reads = 0
+		let writes = 0
+		let releaseFirstWrite = () => {}
+		let markFirstWriteStarted = () => {}
+		const firstWriteStarted = new Promise<void>((resolve) => {
+			markFirstWriteStarted = resolve
+		})
+		const firstWriteGate = new Promise<void>((resolve) => {
+			releaseFirstWrite = resolve
+		})
+		const sandbox = {
+			id: 'sbx_edit_lock',
+			status: 'ready',
+			rootDir: '/workspace',
+			environment: 'basic',
+			async readFile() {
+				reads += 1
+				return Buffer.from(body)
+			},
+			async writeFile(_path: string, content: string | Buffer) {
+				writes += 1
+				if (writes === 1) {
+					markFirstWriteStarted()
+					await firstWriteGate
+				}
+				body = Buffer.isBuffer(content) ? Buffer.from(content) : Buffer.from(content)
+			},
+			async exec() {
+				throw new Error('not used')
+			},
+			async listFiles() {
+				return []
+			},
+			async destroy() {},
+		} as Sandbox
+		const firstContext = { ...makeContext('/workspace'), sandbox }
+		const secondContext = { ...makeContext('/workspace'), sandbox }
+
+		const first = EditTool.execute(
+			{
+				path: 'doc.md',
+				old_string: 'alpha',
+				new_string: 'beta',
+				replace_all: false,
+			},
+			firstContext,
+		)
+		await firstWriteStarted
+		const second = EditTool.execute(
+			{
+				path: 'doc.md',
+				old_string: 'beta',
+				new_string: 'gamma',
+				replace_all: false,
+			},
+			secondContext,
+		)
+		await Promise.resolve()
+		expect(reads).toBe(1)
+
+		releaseFirstWrite()
+		const results = await Promise.all([first, second])
+		expect(results.every((result) => result.success)).toBe(true)
+		expect(reads).toBe(2)
+		expect(writes).toBe(2)
+		expect(body.toString('utf-8')).toBe('gamma')
+	})
+
+	it('leaves the original intact when an atomic local write fails before commit', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'namzu-atomic-write-'))
+		const filePath = join(dir, 'doc.md')
+		writeFileSync(filePath, 'original')
+
+		await expect(
+			atomicWriteFile(filePath, 'replacement', {
+				beforeCommit: async () => {
+					throw new Error('injected pre-commit failure')
+				},
+			}),
+		).rejects.toThrow('injected pre-commit failure')
+
+		expect(readFileSync(filePath, 'utf-8')).toBe('original')
+		expect(readdirSync(dir).filter((entry) => entry.includes('.namzu-'))).toEqual([])
+	})
+
+	// ── the alias + insertion surface this build adds on top ──────────
+
 	it('accepts oldStr/newStr aliases for string replacement', async () => {
 		const dir = mkdtempSync(join(tmpdir(), 'namzu-edit-'))
 		writeFileSync(join(dir, 'doc.md'), 'alpha\nbeta\n')

--- a/packages/sdk/src/tools/builtins/atomic-write-file.ts
+++ b/packages/sdk/src/tools/builtins/atomic-write-file.ts
@@ -47,11 +47,32 @@ export async function atomicWriteFile(
 	}
 }
 
+/**
+ * Best-effort, and only after the rename has already committed.
+ *
+ * Syncing the directory is what makes the RENAME survive a power loss on a
+ * POSIX filesystem. Not every platform permits it — opening a directory and
+ * calling fsync raises `EPERM` on Windows — and there the whole builtin was
+ * unusable: every `edit` and every `write` failed with `EPERM: operation not
+ * permitted, fsync` after correctly writing the file.
+ *
+ * Swallowing is right here and nowhere else in this file. By this point the
+ * destination already holds the complete new body; the only thing still at
+ * stake is durability across an OS-level crash, and on a platform that
+ * refuses the call there is no second way to ask. Failing the write would
+ * trade a durability refinement for a guaranteed error on every write.
+ *
+ * The sibling in `utils/atomic-write.ts` — the one the disk stores use, and
+ * the one that has run on this platform all along — does not sync the
+ * directory at all.
+ */
 async function syncDirectory(directory: string): Promise<void> {
 	let handle: FileHandle | undefined
 	try {
 		handle = await open(directory, 'r')
 		await handle.sync()
+	} catch {
+		// Unsupported on this platform; the rename already landed.
 	} finally {
 		await handle?.close().catch(() => undefined)
 	}

--- a/packages/sdk/src/tools/builtins/edit.ts
+++ b/packages/sdk/src/tools/builtins/edit.ts
@@ -1,17 +1,37 @@
-import { readFile, writeFile } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { z } from 'zod'
 import { defineTool } from '../defineTool.js'
+import { atomicWriteFile } from './atomic-write-file.js'
+import { withFileMutationLock } from './file-mutation-lock.js'
 
+/**
+ * Two schemas, on purpose.
+ *
+ * `inputSchema` is what a HOST may send, and it accepts the `oldStr`/`newStr`
+ * aliases and `insertLine` because hosts that expose replacement under those
+ * names are real. `modelInputSchema` below is what a MODEL is constrained to
+ * — one closed canonical shape — because giving a model four spellings of the
+ * same field is how it learns to guess between them.
+ *
+ * `.strict()` is what makes the accepted set closed. Without it zod's default
+ * is to STRIP an unknown key, so a hallucinated or misspelled field is
+ * silently dropped and the edit proceeds against an input nobody wrote.
+ */
 const inputSchema = z
 	.object({
-		path: z.string().describe('Path to the file to edit'),
+		path: z
+			.string()
+			.refine((value) => value.trim().length > 0, 'Path must not be empty.')
+			.describe('Path to the file to edit. Must not be empty.'),
 		old_string: z
 			.string()
+			.min(1)
 			.optional()
 			.describe('The exact string to find and replace. Must be unique in the file.'),
 		oldStr: z
 			.string()
+			.min(1)
 			.optional()
 			.describe(
 				'Alias for old_string. Used by hosts that expose text replacement as oldStr/newStr.',
@@ -39,6 +59,7 @@ const inputSchema = z
 			.default(false)
 			.describe('Replace all occurrences instead of just the first unique match'),
 	})
+	.strict()
 	.refine((value) => typeof value.new_string === 'string' || typeof value.newStr === 'string', {
 		message: 'Either new_string or newStr is required.',
 	})
@@ -51,6 +72,40 @@ const inputSchema = z
 	)
 
 type EditInput = z.infer<typeof inputSchema>
+
+/**
+ * What a capable provider constrains the model to emit: one shape, closed.
+ *
+ * The aliases above exist for hosts, not for models. A model offered
+ * `old_string` and `oldStr` as separate optional fields has to guess which
+ * one this deployment wants, and `additionalProperties: false` is what turns
+ * an invented field into a generation-time refusal rather than a silent drop.
+ */
+const modelInputSchema: Record<string, unknown> = {
+	type: 'object',
+	properties: {
+		path: {
+			type: 'string',
+			description: 'Path to the file to edit. Must not be empty.',
+		},
+		old_string: {
+			type: 'string',
+			description:
+				'Exact unique text from the file, without read-tool line-number prefixes. Must not be empty.',
+		},
+		new_string: {
+			type: 'string',
+			description:
+				'Exact replacement text. May be empty to delete old_string. Keep under 12000 characters.',
+		},
+		replace_all: {
+			type: 'boolean',
+			description: 'Replace every occurrence instead of requiring one unique match.',
+		},
+	},
+	required: ['path', 'old_string', 'new_string'],
+	additionalProperties: false,
+}
 
 type NormalizedEditInput =
 	| {
@@ -71,6 +126,10 @@ export const EditTool = defineTool({
 	description:
 		'Makes targeted edits to a file using exact string find-and-replace or line insertion. THIS IS THE PREFERRED WAY TO MODIFY AN EXISTING FILE — never reach for `write` to change a file that already exists, because `write` overwrites the whole body and discards earlier work on partial failure. `edit` keeps the rest of the file byte-for-byte intact and is recoverable: if a single edit fails (old_string/oldStr ambiguous, broader restructuring needed), follow up with another `edit` instead of re-emitting the entire file via `write`. The old_string/oldStr must be unique in the file unless replace_all is true. For insertions, pass insertLine plus new_string/newStr; use insertLine: "end" to extend a file at the end. Self-budget new_string/newStr under 12000 characters before emitting the tool call; use repeated bounded edits for long sections. Preserves file formatting and indentation.',
 	inputSchema,
+	modelInputSchema,
+	enforceModelInput: true,
+	validationErrorHint:
+		'Required shape: {"path":"file.md","old_string":"exact unique text","new_string":"replacement text"}. Optional: "replace_all": true.',
 	category: 'filesystem',
 	permissions: ['file_write'],
 	readOnly: false,
@@ -78,7 +137,19 @@ export const EditTool = defineTool({
 	concurrencySafe: false,
 
 	async execute(input: EditInput, context) {
-		const normalized = normalizeEditInput(input)
+		// Re-validated here rather than trusted from the registry: `execute` is
+		// reachable directly, and the closed contract is only closed if the
+		// check runs on the path a caller can actually take.
+		const parsed = inputSchema.safeParse(input)
+		if (!parsed.success) {
+			return {
+				success: false,
+				output: '',
+				error: `Invalid edit input: ${parsed.error.issues.map((issue) => issue.message).join('; ')}`,
+			}
+		}
+
+		const normalized = normalizeEditInput(parsed.data)
 		if (!normalized.success) {
 			return { success: false, output: '', error: normalized.error }
 		}
@@ -93,38 +164,47 @@ export const EditTool = defineTool({
 			}
 		}
 
-		// Sandbox-aware: route through sandbox when available
-		if (context.sandbox) {
-			const buffer = await context.sandbox.readFile(input.path)
-			const content = buffer.toString('utf-8')
+		const filePath = resolve(context.workingDirectory, parsed.data.path)
+		// Read-modify-write is not atomic on its own: two edits to the same
+		// path interleave their reads, and the second write lands on content
+		// the first had already replaced — so one edit vanishes and the loser
+		// reports "old_string not found", blaming the model for a race. The
+		// key spans both branches because sandbox and local are distinct
+		// files even when the path string matches.
+		const lockKey = `${context.sandbox ? 'sandbox' : 'local'}:${filePath}`
 
+		return withFileMutationLock(lockKey, async () => {
+			if (context.sandbox) {
+				const buffer = await context.sandbox.readFile(parsed.data.path)
+				const result = applyEdit(buffer.toString('utf-8'), normalized.operation)
+				if (!result.success) {
+					return { success: false as const, output: '', error: result.error }
+				}
+
+				await context.sandbox.writeFile(parsed.data.path, result.content)
+				return {
+					success: true as const,
+					output: `Edited ${parsed.data.path}: ${result.replacements} replacement(s) [sandboxed]`,
+					data: { path: parsed.data.path, replacements: result.replacements, sandboxed: true },
+				}
+			}
+
+			const content = await readFile(filePath, 'utf-8')
 			const result = applyEdit(content, normalized.operation)
 			if (!result.success) {
-				return { success: false, output: '', error: result.error }
+				return { success: false as const, output: '', error: result.error }
 			}
 
-			await context.sandbox.writeFile(input.path, result.content)
+			// Temp file, fsync, rename — a reader sees the old body or the new
+			// one, never a half-written one. A plain `writeFile` that fails
+			// partway leaves the user's source truncated.
+			await atomicWriteFile(filePath, result.content)
 			return {
-				success: true,
-				output: `Edited ${input.path}: ${result.replacements} replacement(s) [sandboxed]`,
-				data: { path: input.path, replacements: result.replacements, sandboxed: true },
+				success: true as const,
+				output: `Edited ${filePath}: ${result.replacements} replacement(s)`,
+				data: { path: filePath, replacements: result.replacements },
 			}
-		}
-
-		const filePath = resolve(context.workingDirectory, input.path)
-		const content = await readFile(filePath, 'utf-8')
-
-		const result = applyEdit(content, normalized.operation)
-		if (!result.success) {
-			return { success: false, output: '', error: result.error }
-		}
-
-		await writeFile(filePath, result.content, 'utf-8')
-		return {
-			success: true,
-			output: `Edited ${filePath}: ${result.replacements} replacement(s)`,
-			data: { path: filePath, replacements: result.replacements },
-		}
+		})
 	},
 })
 
@@ -188,7 +268,9 @@ function applyEdit(
 		return applyLineInsert(content, input)
 	}
 
-	if (!content.includes(input.oldString)) {
+	const replacement = normalizeLineEndings(content, input)
+
+	if (!content.includes(replacement.oldString)) {
 		return {
 			success: false,
 			error:
@@ -196,19 +278,19 @@ function applyEdit(
 		}
 	}
 
-	if (input.replace_all) {
-		const parts = content.split(input.oldString)
+	if (replacement.replace_all) {
+		const parts = content.split(replacement.oldString)
 		const replacements = parts.length - 1
 		return {
 			success: true,
-			content: parts.join(input.newString),
+			content: parts.join(replacement.newString),
 			replacements,
 		}
 	}
 
 	// Uniqueness check: old_string/oldStr must appear exactly once
-	const firstIndex = content.indexOf(input.oldString)
-	const secondIndex = content.indexOf(input.oldString, firstIndex + 1)
+	const firstIndex = content.indexOf(replacement.oldString)
+	const secondIndex = content.indexOf(replacement.oldString, firstIndex + 1)
 
 	if (secondIndex !== -1) {
 		const lineNumber = content.slice(0, firstIndex).split('\n').length
@@ -223,8 +305,8 @@ function applyEdit(
 		success: true,
 		content:
 			content.slice(0, firstIndex) +
-			input.newString +
-			content.slice(firstIndex + input.oldString.length),
+			replacement.newString +
+			content.slice(firstIndex + replacement.oldString.length),
 		replacements: 1,
 	}
 }
@@ -250,4 +332,45 @@ function applyLineInsert(
 		content: `${lines.join('\n')}${hasTrailingNewline ? '\n' : ''}`,
 		replacements: 1,
 	}
+}
+
+/**
+ * Reconcile the caller's line endings with the file's.
+ *
+ * A model reading a CRLF file and writing back LF (or the reverse) produces
+ * an `old_string` that is correct in every visible way and matches nothing.
+ * The failure reads as "your text is wrong" when the text is right and only
+ * the invisible half of each line break differs.
+ *
+ * Only applied when the file is CONSISTENT. A mixed-ending file has no
+ * single right answer, and rewriting boundaries there would corrupt the
+ * half that was already correct.
+ */
+function normalizeLineEndings(
+	content: string,
+	input: Extract<NormalizedEditInput, { operation: 'replace' }>,
+): Extract<NormalizedEditInput, { operation: 'replace' }> {
+	const withoutCrlf = content.replaceAll('\r\n', '')
+	const usesOnlyCrlf = content.includes('\r\n') && !withoutCrlf.includes('\n')
+	if (usesOnlyCrlf) {
+		return {
+			...input,
+			oldString: content.includes(input.oldString)
+				? input.oldString
+				: input.oldString.replaceAll('\r\n', '\n').replaceAll('\n', '\r\n'),
+			newString: input.newString.replaceAll('\r\n', '\n').replaceAll('\n', '\r\n'),
+		}
+	}
+
+	const usesOnlyLf = content.includes('\n') && !content.includes('\r\n')
+	if (usesOnlyLf) {
+		return {
+			...input,
+			oldString: content.includes(input.oldString)
+				? input.oldString
+				: input.oldString.replaceAll('\r\n', '\n'),
+			newString: input.newString.replaceAll('\r\n', '\n'),
+		}
+	}
+	return input
 }

--- a/packages/sdk/src/tools/builtins/write-file.ts
+++ b/packages/sdk/src/tools/builtins/write-file.ts
@@ -1,8 +1,10 @@
-import { access, mkdir, writeFile } from 'node:fs/promises'
+import { access, mkdir } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { z } from 'zod'
 import type { ToolContext } from '../../types/tool/index.js'
 import { defineTool } from '../defineTool.js'
+import { atomicWriteFile } from './atomic-write-file.js'
+import { withFileMutationLock } from './file-mutation-lock.js'
 
 const inputSchema = z
 	.object({
@@ -25,17 +27,46 @@ const inputSchema = z
 				'Alias for content. Useful for hosts that expose create/write operations as newStr. Self-budget this payload under 12000 characters before calling.',
 			),
 	})
+	.strict()
 	.refine((value) => typeof value.content === 'string' || typeof value.newStr === 'string', {
 		message: 'Either content or newStr is required.',
 	})
 
 type WriteInput = z.infer<typeof inputSchema>
 
+/**
+ * The single shape a model is constrained to emit.
+ *
+ * `newStr` is a host affordance and deliberately absent here: a model given
+ * two names for the body has to pick, and picking is what produces the
+ * half-filled calls this schema exists to prevent.
+ */
+const modelInputSchema: Record<string, unknown> = {
+	type: 'object',
+	properties: {
+		path: {
+			type: 'string',
+			description: 'Relative path to the file to write. Must not be empty.',
+		},
+		content: {
+			type: 'string',
+			description:
+				'Complete file body. Use "" only for an intentionally empty file. Keep under 12000 characters.',
+		},
+	},
+	required: ['path', 'content'],
+	additionalProperties: false,
+}
+
 export const WriteFileTool = defineTool({
 	name: 'write',
 	description:
 		'Writes a file to the local filesystem. Overwrites the existing file at the path if there is one.\n\n- If the file already exists, you must use the `read` tool on it first in this conversation, or this call will fail.\n- Prefer the `edit` tool for modifying existing files — it only sends the diff and preserves the rest of the file byte-for-byte.\n- Use `write` to create a new file or to perform a deliberate full rewrite of a file you have already read.\n- Self-budget content/newStr under 12000 characters before emitting the tool call. For long content, write a smaller opening section, then use `edit` with insertLine: "end" to extend the file section by section. Do not chain multiple `write` calls — each one overwrites the previous.',
 	inputSchema,
+	modelInputSchema,
+	enforceModelInput: true,
+	validationErrorHint:
+		'Required shape: {"path":"file.md","content":"complete file body"}. Pass the whole body, not a diff.',
 	category: 'filesystem',
 	permissions: ['file_write'],
 	readOnly: false,
@@ -43,40 +74,60 @@ export const WriteFileTool = defineTool({
 	concurrencySafe: false,
 
 	async execute(input: WriteInput, context) {
-		const content = input.content ?? input.newStr ?? ''
-		// Sandbox-aware: route through sandbox.writeFile() when available
-		if (context.sandbox) {
-			const sandboxExists = await sandboxFileExists(context, input.path)
-			if (sandboxExists) {
-				const guard = enforceReadBeforeOverwrite(context, input.path)
+		// `execute` is reachable without going through the registry, so the
+		// closed contract has to be enforced on this path too or it is not
+		// closed at all.
+		const parsed = inputSchema.safeParse(input)
+		if (!parsed.success) {
+			return {
+				success: false,
+				output: '',
+				error: `Invalid write input: ${parsed.error.issues.map((issue) => issue.message).join('; ')}`,
+			}
+		}
+		const valid = parsed.data
+		const content = valid.content ?? valid.newStr ?? ''
+		const filePath = resolve(context.workingDirectory, valid.path)
+		// The exists-check and the write are a check-then-act pair. Unlocked,
+		// two writers both see "absent", both skip the read-before-overwrite
+		// guard, and the second silently discards the first.
+		const lockKey = `${context.sandbox ? 'sandbox' : 'local'}:${filePath}`
+
+		return withFileMutationLock(lockKey, async () => {
+			if (context.sandbox) {
+				const sandboxExists = await sandboxFileExists(context, valid.path)
+				if (sandboxExists) {
+					const guard = enforceReadBeforeOverwrite(context, valid.path)
+					if (guard) return guard
+				}
+				await context.sandbox.writeFile(valid.path, content)
+				context.fileReadTracker?.recordRead(valid.path)
+				return {
+					success: true as const,
+					output: `File written successfully: ${valid.path} (${content.length} chars) [sandboxed]`,
+					data: { path: valid.path, size: content.length, sandboxed: true },
+				}
+			}
+
+			const localExists = await pathExists(filePath)
+			if (localExists) {
+				const guard = enforceReadBeforeOverwrite(context, filePath)
 				if (guard) return guard
 			}
-			await context.sandbox.writeFile(input.path, content)
-			context.fileReadTracker?.recordRead(input.path)
+
+			await mkdir(dirname(filePath), { recursive: true })
+			// Temp file, fsync, rename. A plain write that fails partway
+			// leaves the destination truncated — and this tool overwrites a
+			// whole file, so the truncation is the user's previous work.
+			await atomicWriteFile(filePath, content)
+			context.fileReadTracker?.recordRead(filePath)
+
 			return {
-				success: true,
-				output: `File written successfully: ${input.path} (${content.length} chars) [sandboxed]`,
-				data: { path: input.path, size: content.length, sandboxed: true },
+				success: true as const,
+				output: `File written successfully: ${filePath} (${content.length} chars)`,
+				data: { path: filePath, size: content.length },
 			}
-		}
-
-		const filePath = resolve(context.workingDirectory, input.path)
-
-		const localExists = await pathExists(filePath)
-		if (localExists) {
-			const guard = enforceReadBeforeOverwrite(context, filePath)
-			if (guard) return guard
-		}
-
-		await mkdir(dirname(filePath), { recursive: true })
-		await writeFile(filePath, content, 'utf-8')
-		context.fileReadTracker?.recordRead(filePath)
-
-		return {
-			success: true,
-			output: `File written successfully: ${filePath} (${content.length} chars)`,
-			data: { path: filePath, size: content.length },
-		}
+		})
 	},
 })
 


### PR DESCRIPTION
## What happened

The hardening branch was cut before four fixes landed on `main` (#56, #57, #59, #61). Reconciling it used `-X ours`, which resolves a conflicting hunk in the branch's favour — so `edit.ts` and `write-file.ts` shipped in **3.0.0 byte-identical to their shape from before that work**, and `atomic-write-file.ts` and `file-mutation-lock.ts` were left in the tree with **zero importers**.

A 58-agent sweep across the two published trees confirmed 43 regressions, 41 of them in this one cluster. Each was verified by a separate agent trying to refute it.

## The four that matter

| | was | is |
|---|---|---|
| **Crash atomicity** | bare `writeFile` — a failure partway truncates the user's file | commits through `atomicWriteFile` |
| **Same-path races** | two concurrent edits interleave; one is **silently lost** and the loser reports `old_string not found`, blaming the model | `withFileMutationLock` wraps both branches |
| **Closed contract** | `.strict()` gone, so zod **strips** an unknown key — a misspelling becomes a silent no-op | unknown rejected |
| **`enforceModelInput`** | `enforcedModelInputToolNames()` deleted, so **nothing** populated `enforceToolInputSchema` — all three drivers read a permanently undefined field | producer restored at both call sites |

The race was reproduced during verification: reads=2, writes=1, one edit gone.

## Merge, not revert

Main's hardening is grafted onto **this build's** shape. The `oldStr`/`newStr` aliases and `insertLine` survive — they are declared in the host schema, and `.strict()` rejects what is *outside* the schema, not what is in it. Two of main's tests asserted the aliases must be rejected; they now assert what the contract actually claims.

The model still sees one closed canonical shape via `modelInputSchema`, because a model offered two spellings of the same field has to guess.

## Found while restoring it

**`atomicWriteFile` had never worked on Windows.** It fsyncs the directory after the rename; that platform refuses with `EPERM` and nothing caught it, so every atomic write failed *after correctly writing the file*. CI is Linux, so it never surfaced. The sync is best-effort now and runs after the commit has landed — the sibling the disk stores use does not sync the directory at all.

## Verification

7 mutations, 7 caught. The first pass found a **vacuous** test: the existing atomicity test called `atomicWriteFile` directly, proving the module and never the caller, so swapping the tool's call changed nothing. `edit-commits-atomically.test.ts` now mocks the module and asserts the tool routes through it.

Gates: typecheck 0, lint 0, 2144 SDK tests green, brand audit clean.

## Still open from the same sweep

`ask_user_question`'s `.strict()`/`modelInputSchema` and the deleted `deferred-tools` / `capability-negotiation` test cases. Following in a second PR.