### PR TITLE
feat(sdk): drive five primitives that shipped exported and unreachable

### DIFF
--- a/.changeset/context-reducer-seam.md
+++ b/.changeset/context-reducer-seam.md
@@ -1,0 +1,17 @@
+---
+'@namzu/sdk': minor
+---
+
+Context reduction is a real seam now, and `strategy` has three behaviours instead of two.
+
+`compactionConfig.strategy` accepted `'structured' | 'sliding-window' | 'disabled'`, and the runtime asked one question about it: is it `'disabled'`. So `'sliding-window'` — the value a host picks precisely to avoid paying for summarization — ran the full structured pass, LLM verification call included. The config lied, and it lied in the direction of spending money.
+
+`'sliding-window'` now trims: it keeps the recent turns, drops what precedes them, and summarizes nothing. Every survivor is verbatim. For an agent whose state lives outside the transcript — a task queue, a file it keeps editing, a working-memory block the host renders each turn — the paraphrase was only ever cost.
+
+**A host can also supply their own.** `query({ contextReducer })` takes a function: messages and why it is being asked (`'threshold'` — the estimate says the window is filling; `'overflow'` — the provider already rejected the prompt), returning the shorter history or `undefined` for "I cannot shorten this". It may be async, so a reducer can call a model of its own. A reducer outranks the strategy and fully owns reduction for that run; the structured pass does not also run, because two mechanisms editing one history in the same pass cannot both be reasoned about.
+
+Three ways a reducer's answer is declined, and the third is the interesting one. `undefined` is the reducer itself declining. A throw is treated as the same answer and logged — a broken reduction hook should not kill a healthy run, the same way a broken `prepareStep` does not. And a result that leaves a `tool_result` without its `tool_use` is **refused rather than repaired**: installing it would trade a nameable "your reducer split a tool pair" for an opaque provider rejection a call later, with the reducer never implicated.
+
+The built-in reducer keeps the three invariants the type documents: the leading system floor stays, tool pairs stay together, and messages marked `retain` survive. Where no cut below the requested window is safe it takes one above rather than declining — in a multi-step turn every boundary lands on an assistant or tool message, so declining there would fail exactly when the history is longest.
+
+`ConversationManager`, `createConversationManager`, `SlidingWindowManager`, `StructuredCompactionManager` and `NullManager` are **deprecated** and still exported. That interface cannot be implemented correctly: `reduceContext` is documented as reducing the history but takes `Message[]` and returns `boolean`, so the only way to honour it is in-place mutation — and neither shipped implementation does. Both build a shorter array locally, discard it, and return `true`. Nothing in the runtime ever called any of it, which is how an unfulfillable contract survived this long. Use `ContextReducer`.

--- a/.changeset/deprecate-tool-catalog-surface.md
+++ b/.changeset/deprecate-tool-catalog-surface.md
@@ -1,0 +1,13 @@
+---
+'@namzu/sdk': minor
+---
+
+Deprecate `ToolCatalogSurface` and `ToolsetPolicy.surfaces`.
+
+Neither does anything. No code constructs a member of the union, and nothing reads the field that carries it — setting `surfaces` on a toolset policy has no effect and never had one.
+
+It is also the wrong axis. Which tools a run may use is already expressible four ways, and all of them are per-run and dynamic where this is fixed at definition time: `allowedTools` on the query, `ToolAvailability` (`active` / `deferred` / `suspended`) with mid-run activation through tool search, `runtimeToolOverrides`, and capability negotiation stripping tools a driver cannot carry. `allowedTools` says the same thing, per run.
+
+The member names — `chat`, `managed-agent`, `worker` — encode deployment shapes this kernel does not own, which is the deeper reason not to keep them. A host's surfaces are the host's to name.
+
+Deprecated rather than removed because both are reachable from the published typings, so removing them is a breaking change. They go in the next major. This is the deprecation cycle the release policy asks for: a version where the code still compiles and warns.

--- a/.changeset/per-step-tool-choice.md
+++ b/.changeset/per-step-tool-choice.md
@@ -1,0 +1,13 @@
+---
+'@namzu/sdk': minor
+---
+
+A step can force the model's tool use, and the force cannot outlive that step.
+
+`PrepareStepResult.toolChoice` accepts `'required'`, `'none'`, or a named function. Until now the loop set `tool_choice` only internally, only to `'none'`, and only on the forced-final turn — so a caller could narrow *which* tools a step may reach for, but never make it actually call one. The clearest cost was structured output: the model answers in prose, the loop pays another full billed turn re-prompting, and after the retry limit the run dies — where one forced choice would have produced the object on the first turn.
+
+**Why it lives on the step and not on the run config.** A forced choice that persists makes the model call a tool, read the result, and be forced again — an agent that cannot stop. Studying how a peer SDK handles this was the useful part: it puts `tool_choice` on persistent model settings and then needs three moving parts to undo it — a tool-use tracker, an opt-out flag, and a reset applied at two separate call sites — with the flag defaulting to on precisely because turning it off hangs the agent. Two other peer runtimes ship no forced choice at all.
+
+Putting the knob on `prepareStep` removes that failure instead of managing it. The next step is prepared from scratch, so the force cannot carry forward: there is nothing to reset and no flag to get wrong. The loop still keeps the last word — the forced-final turn's `'none'` wins, so a run that must stop can still stop — and a choice is dropped when no tools are registered, because providers reject `tool_choice` sent without a tool list.
+
+It costs more prompt cache than `activeTools` does: narrowing tools invalidates the tool prefix, moving `tool_choice` invalidates cached message blocks too. That trade is documented on the field so it is paid knowingly, at a phase boundary, rather than by habit.

--- a/.changeset/resume-run-driver.md
+++ b/.changeset/resume-run-driver.md
@@ -1,0 +1,18 @@
+---
+'@namzu/sdk': minor
+---
+
+Ship the driver that picks a run back up in another process.
+
+Every piece of a cross-process resume already existed. `CheckpointManager` wrote the history, budgets, working state, trace context and any human-decision park; `loadRunState` read them back; `query` accepted `runId` + `resumeFromCheckpoint` and restored all of it — budgets included, so a run recalled at $4.80 of a $5 cap does not come back with a fresh $5.
+
+Nothing joined them. `resumeFromCheckpoint` had no caller anywhere outside `packages/sdk/src`, so the whole path shipped untravelled: every host was expected to write the same wiring and none did.
+
+`resumeRun` is that wiring. The division of labour is the one the mechanism already implies — the caller brings what cannot be serialized (the provider client, the tool registry, the sandbox, the working directory), the store brings the state. A snapshot deliberately holds no socket and no open file, so it could never have carried the first half.
+
+It refuses at both failure points rather than guessing:
+
+- **No checkpoint** returns `{ resumed: false, reason: 'no-checkpoint' }`. Starting a fresh run here would be a different run wearing a recycled id, with the original's budget reset.
+- **An outstanding park** returns the `PendingDecision` itself, so the host has what to put in front of a person, instead of resuming past a question the run is waiting on. A park with `resolvedAt` already set is an ordinary resume — blocking on an answered one would strand the run permanently.
+
+`RunStateScope` is exported alongside it. It was internal, so a host calling the already-public `loadRunState` could not name the argument it had to construct.

--- a/.changeset/route-compaction-model.md
+++ b/.changeset/route-compaction-model.md
@@ -1,0 +1,11 @@
+---
+'@namzu/sdk': minor
+---
+
+`taskRouter` now routes something.
+
+The compaction summary is the only model call a run makes that nobody asked for: it reads the older half of a transcript and writes a paraphrase, and it fires on exactly the long runs where the primary model costs the most. It was hardwired to that primary model. Meanwhile `taskRouter` had been accepted, schema-validated and threaded through four types since it was added, with `resolveTaskModel` exported and never called from anywhere — so a host who pointed compaction at a cheap model kept paying the expensive one, with nothing to indicate the setting was decoration.
+
+`taskRouter: { compaction: 'a-small-model' }` now takes effect, falling back to `taskRouter.default` and then to the run's model.
+
+The remaining keys are documented on `TaskRouterConfig` as **not consulted**, which is the point of the change as much as the wiring is. `coding`, `exploration`, `planning`, `verification` and `summarization` describe sub-agent routing; the supervisor already threads the config down to the agent factory, but nothing classifies a spawned task as exploration or coding, and inventing a classifier would put a wrong model behind a right-looking config. `advisory` is deliberately left alone because an advisor already carries its own `model`, and routing would override an explicit choice with a general one. An inert key is worse than an absent one — saying which is which converts a silent lie into a stated limit.

--- a/.github/scripts/public-surface-baseline.json
+++ b/.github/scripts/public-surface-baseline.json
@@ -321,6 +321,7 @@
   "createProbeRegistry",
   "createRAGTool",
   "createRunReporter",
+  "createSlidingWindowReducer",
   "createStructuredOutputTool",
   "createSystemMessage",
   "createToolCatalogFromRegistry",

--- a/.github/scripts/public-surface-baseline.json
+++ b/.github/scripts/public-surface-baseline.json
@@ -461,6 +461,7 @@
   "resolveProviderCapabilities",
   "resolveSkillChain",
   "resolveTaskModel",
+  "resumeRun",
   "runExperiment",
   "runStatusToA2AState",
   "runToA2ATask",

--- a/packages/sdk/src/compaction/__tests__/context-reducer.test.ts
+++ b/packages/sdk/src/compaction/__tests__/context-reducer.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AssistantMessage, Message, ToolMessage } from '../../types/message/index.js'
+import { createSlidingWindowReducer } from '../reducer.js'
+import type { ContextReduction } from '../reducer.js'
+
+/**
+ * `strategy: 'sliding-window'` was accepted by the config schema and then
+ * ignored — the runtime asked only whether the strategy was `'disabled'`, so
+ * a host who chose the cheap non-LLM path silently got the expensive LLM one,
+ * summarization calls and all. These pin the behaviour the name always
+ * claimed, and the three invariants that make a shorter history usable rather
+ * than merely shorter.
+ */
+
+const sys = (content: string): Message => ({ role: 'system', content, timestamp: 1 })
+const user = (content: string): Message => ({ role: 'user', content, timestamp: 1 })
+const asst = (content: string): Message => ({ role: 'assistant', content, timestamp: 1 })
+
+const callsTool = (id: string): AssistantMessage => ({
+	role: 'assistant',
+	content: null,
+	timestamp: 1,
+	toolCalls: [{ id, type: 'function', function: { name: 'echo', arguments: '{}' } }],
+})
+
+const toolResult = (id: string): ToolMessage => ({
+	role: 'tool',
+	content: 'ok',
+	timestamp: 1,
+	toolCallId: id,
+})
+
+function reduction(
+	messages: readonly Message[],
+	over?: Partial<ContextReduction>,
+): ContextReduction {
+	return {
+		messages,
+		reason: 'threshold',
+		estimatedTokens: 1_000,
+		contextWindowTokens: 2_000,
+		model: 'mock-model',
+		keepRecentMessages: 4,
+		...over,
+	}
+}
+
+describe('the sliding window keeps recent turns and drops the rest', () => {
+	it('keeps the configured tail', async () => {
+		const reduce = createSlidingWindowReducer()
+		const messages = [sys('prompt'), ...Array.from({ length: 10 }, (_, i) => user(`m${i}`))]
+
+		const next = await reduce(reduction(messages))
+
+		expect(next).toBeDefined()
+		expect(next?.length).toBe(5) // the system floor plus keepRecentMessages
+		expect(next?.at(-1)).toBe(messages.at(-1))
+	})
+
+	it('cuts harder when the provider already rejected the prompt', async () => {
+		const reduce = createSlidingWindowReducer()
+		const messages = [sys('prompt'), ...Array.from({ length: 10 }, (_, i) => user(`m${i}`))]
+
+		const threshold = await reduce(reduction(messages))
+		const overflow = await reduce(reduction(messages, { reason: 'overflow' }))
+
+		// An overflow means the ordinary window was ALREADY too big. Cutting to
+		// the same size would shed nothing and the caller would retry an
+		// identical prompt.
+		expect(overflow?.length).toBeLessThan(threshold?.length ?? 0)
+	})
+
+	it('summarizes nothing — every survivor is the original object', async () => {
+		const reduce = createSlidingWindowReducer()
+		const messages = [sys('prompt'), ...Array.from({ length: 8 }, (_, i) => user(`m${i}`))]
+
+		const next = await reduce(reduction(messages))
+
+		for (const message of next ?? []) expect(messages).toContain(message)
+	})
+})
+
+describe('the three invariants a shorter history has to keep', () => {
+	it('never drops the leading system floor', async () => {
+		const reduce = createSlidingWindowReducer()
+		const messages = [
+			sys('prompt'),
+			sys('working memory'),
+			...Array.from({ length: 8 }, (_, i) => user(`m${i}`)),
+		]
+
+		const next = await reduce(reduction(messages))
+
+		expect(next?.[0]).toBe(messages[0])
+		expect(next?.[1]).toBe(messages[1])
+	})
+
+	it('does not split a tool_use from its tool_result', async () => {
+		const reduce = createSlidingWindowReducer()
+		// The naive cut at length-3 lands between the assistant call and its
+		// result, which is a provider 400 on the next turn.
+		const messages = [
+			sys('prompt'),
+			user('go'),
+			asst('thinking'),
+			callsTool('c1'),
+			toolResult('c1'),
+			user('again'),
+			asst('done'),
+			user('more'),
+		]
+
+		const next = await reduce(reduction(messages, { keepRecentMessages: 5 }))
+
+		const kept = new Set(next ?? [])
+		// Cutting at 3 would keep the call and its result together; cutting at
+		// 4 would orphan the result. The pair is never split either way.
+		expect(kept.has(messages[4] as Message)).toBe(kept.has(messages[3] as Message))
+	})
+
+	it('takes a cut above the requested window when nothing below is safe', async () => {
+		const reduce = createSlidingWindowReducer()
+		// A multi-step turn: the user is silent while the agent works, so every
+		// boundary inside the recent window opens on an assistant or tool
+		// message. A backwards-only search would decline here — exactly when
+		// the history is longest.
+		const messages = [
+			sys('prompt'),
+			user('go'),
+			callsTool('c1'),
+			toolResult('c1'),
+			asst('working'),
+			callsTool('c2'),
+			toolResult('c2'),
+			// The only user turn after the opening one, and it sits ABOVE the
+			// requested cut — so every candidate below opens on an assistant or
+			// tool message and the backwards search comes back empty.
+			user('next'),
+			callsTool('c3'),
+			toolResult('c3'),
+		]
+
+		const next = await reduce(reduction(messages, { keepRecentMessages: 5 }))
+
+		expect(next).toBeDefined()
+		expect(next?.length).toBeLessThan(messages.length)
+		// It kept LESS than asked rather than declining, and what it kept opens
+		// on a user turn.
+		expect(next?.[1]?.role).toBe('user')
+	})
+
+	it('keeps a pinned turn from the middle of the conversation', async () => {
+		const reduce = createSlidingWindowReducer()
+		const pinned: Message = { ...user('the account id is X'), retain: true }
+		const messages = [
+			sys('prompt'),
+			user('m0'),
+			pinned,
+			...Array.from({ length: 8 }, (_, i) => user(`m${i + 1}`)),
+		]
+
+		const next = await reduce(reduction(messages))
+
+		// Recency is not the only thing that matters, which is what `retain`
+		// exists to say.
+		expect(next).toContain(pinned)
+		expect(next).not.toContain(messages[1])
+	})
+})
+
+describe('refusing beats a reduction that would break the next turn', () => {
+	it('declines when there is nothing but the system floor to cut', async () => {
+		const reduce = createSlidingWindowReducer()
+
+		expect(await reduce(reduction([sys('prompt'), user('go')]))).toBeUndefined()
+	})
+
+	it('declines when every candidate cut splits one assistant fan-out', async () => {
+		const reduce = createSlidingWindowReducer()
+		// Six results answering one call: no cut inside the block is safe, and
+		// the condition clears itself on the next assistant message.
+		const messages = [
+			sys('prompt'),
+			user('go'),
+			{
+				role: 'assistant',
+				content: null,
+				timestamp: 1,
+				toolCalls: Array.from({ length: 6 }, (_, i) => ({
+					id: `c${i}`,
+					type: 'function' as const,
+					function: { name: 'echo', arguments: '{}' },
+				})),
+			} as AssistantMessage,
+			...Array.from({ length: 6 }, (_, i) => toolResult(`c${i}`)),
+		]
+
+		expect(await reduce(reduction(messages, { keepRecentMessages: 2 }))).toBeUndefined()
+	})
+
+	it('declines rather than reporting a reduction that removed nothing', async () => {
+		const reduce = createSlidingWindowReducer()
+		// Every non-system message is pinned, so the survivor set is the input.
+		const messages = [
+			sys('prompt'),
+			...Array.from({ length: 8 }, (_, i) => ({ ...user(`m${i}`), retain: true })),
+		]
+
+		// Saying "reduced" here would have the overflow path retry an identical
+		// prompt and burn a model call to be told the same thing.
+		expect(await reduce(reduction(messages))).toBeUndefined()
+	})
+})
+
+describe('the knob a caller reaches for', () => {
+	it('lets an explicit window override the run config', async () => {
+		const reduce = createSlidingWindowReducer({ keepRecentMessages: 2 })
+		const messages = [sys('prompt'), ...Array.from({ length: 10 }, (_, i) => user(`m${i}`))]
+
+		const next = await reduce(reduction(messages, { keepRecentMessages: 8 }))
+
+		expect(next?.length).toBe(3)
+	})
+
+	it('is a plain function, so a host can wrap one', async () => {
+		const inner = createSlidingWindowReducer()
+		const seen = vi.fn()
+		const reduce = async (input: ContextReduction) => {
+			seen(input.reason)
+			return inner(input)
+		}
+		const messages = [sys('prompt'), ...Array.from({ length: 8 }, (_, i) => user(`m${i}`))]
+
+		await reduce(reduction(messages, { reason: 'overflow' }))
+
+		expect(seen).toHaveBeenCalledWith('overflow')
+	})
+})

--- a/packages/sdk/src/compaction/factory.ts
+++ b/packages/sdk/src/compaction/factory.ts
@@ -20,6 +20,13 @@ import type { CompactionStrategy } from './types.js'
  * const trimmed = manager.applyManagement(messages)
  * ```
  */
+/**
+ * @deprecated Nothing calls this. Select a strategy with
+ * `compactionConfig.strategy`, or pass a `contextReducer` to `query()`.
+ *
+ * The factory produced managers the runtime had no seam to drive, so its
+ * return value was always dropped on the floor. See {@link ConversationManager}.
+ */
 export function createConversationManager(
 	strategy: CompactionStrategy,
 	config: CompactionConfig,

--- a/packages/sdk/src/compaction/index.ts
+++ b/packages/sdk/src/compaction/index.ts
@@ -11,6 +11,14 @@ export type { DanglingResult } from './dangling.js'
 
 export type { ConversationManager } from './interface.js'
 
+export { createSlidingWindowReducer } from './reducer.js'
+export type {
+	ContextReducer,
+	ContextReduction,
+	ContextReductionReason,
+	SlidingWindowOptions,
+} from './reducer.js'
+
 export { WorkingStateManager } from './manager.js'
 
 export { serializeState } from './serializer.js'

--- a/packages/sdk/src/compaction/interface.ts
+++ b/packages/sdk/src/compaction/interface.ts
@@ -7,6 +7,19 @@ import type { Message } from '../types/message/index.js'
  * A manager applies two strategies:
  * 1. **Routine management** (applyManagement): Called after each iteration to proactively optimize context.
  * 2. **Overflow reduction** (reduceContext): Called when the LLM reports context window exceeded.
+ *
+ * @deprecated Use {@link ContextReducer}, which the runtime actually drives.
+ *
+ * This interface cannot be implemented correctly. `reduceContext` is
+ * documented as reducing the history, but it takes `Message[]` and returns
+ * `boolean` — the only way to honour the contract is to mutate the argument
+ * in place, and neither shipped implementation does. Both build a shorter
+ * array locally, discard it, and return `true`. Nothing in the runtime ever
+ * called any of it, which is why an unfulfillable contract survived.
+ *
+ * `ContextReducer` returns the new history, may be async so a reducer can
+ * call a model, and is told whether it was asked speculatively or after the
+ * provider rejected the prompt. Kept exported until the next major.
  */
 export interface ConversationManager {
 	/** Unique name for this manager (e.g., 'structured', 'sliding-window', 'disabled') */

--- a/packages/sdk/src/compaction/managers/null.ts
+++ b/packages/sdk/src/compaction/managers/null.ts
@@ -5,6 +5,9 @@ import type { ConversationManager } from '../interface.js'
  * No-op conversation manager implementation.
  * Never modifies messages, useful for testing or when context management is disabled.
  */
+/**
+ * @deprecated Use `strategy: 'disabled'`, which the runtime reads.
+ */
 export class NullManager implements ConversationManager {
 	readonly name = 'null'
 

--- a/packages/sdk/src/compaction/managers/slidingWindow.ts
+++ b/packages/sdk/src/compaction/managers/slidingWindow.ts
@@ -20,6 +20,12 @@ export interface SlidingWindowManagerConfig {
  * 2. Use findSafeTrimIndex to ensure tool call/result pairs remain atomic
  * 3. applyManagement runs proactively each iteration; reduceContext on overflow
  */
+/**
+ * @deprecated Use `createSlidingWindowReducer()`, or `strategy: 'sliding-window'`.
+ *
+ * Never reachable through the runtime, and `reduceContext` here computes a
+ * trim index and returns a boolean without trimming anything.
+ */
 export class SlidingWindowManager implements ConversationManager {
 	readonly name = 'sliding-window'
 	private readonly keepRecentMessages: number

--- a/packages/sdk/src/compaction/managers/structured.ts
+++ b/packages/sdk/src/compaction/managers/structured.ts
@@ -22,6 +22,16 @@ import { serializeState } from '../serializer.js'
  *
  * Provides maximum context preservation but more computational overhead.
  */
+/**
+ * @deprecated Not the structured strategy. `strategy: 'structured'` runs the
+ * live path in `runtime/query/iteration/phases/compaction.ts`, which this
+ * class predates and does not share code with.
+ *
+ * What is here is a weaker parallel copy: no LLM-verified summary, no stale
+ * tool-result clearing, no retention pins, no events — and a `reduceContext`
+ * that builds a shorter history into a local array and then returns a
+ * boolean, discarding it.
+ */
 export class StructuredCompactionManager implements ConversationManager {
 	readonly name = 'structured'
 	private readonly config: CompactionConfig

--- a/packages/sdk/src/compaction/reducer.ts
+++ b/packages/sdk/src/compaction/reducer.ts
@@ -1,0 +1,154 @@
+import type { Message } from '../types/message/index.js'
+import { findSafeTrimIndex } from './dangling.js'
+import { findRetainedIndices } from './retention.js'
+
+/**
+ * Why the runtime is asking for a shorter history.
+ *
+ * The two cases want different behaviour and a reducer that cannot tell
+ * them apart has to guess. `'threshold'` is speculative — the estimate says
+ * the window is filling, nothing has failed, and declining costs only some
+ * headroom. `'overflow'` is the provider having already rejected the
+ * prompt: declining there ends the run.
+ */
+export type ContextReductionReason = 'threshold' | 'overflow'
+
+/** Everything a reducer needs to decide, and nothing it cannot act on. */
+export interface ContextReduction {
+	/** The live history, oldest first. Treat as read-only and return a new array. */
+	readonly messages: readonly Message[]
+	readonly reason: ContextReductionReason
+	/** Estimated size of `messages`. Derived from the provider's last prompt count when there is one, else measured. */
+	readonly estimatedTokens: number
+	/** What it has to fit in. Resolved from the model when the host did not say. */
+	readonly contextWindowTokens: number
+	/** The model this run is calling, for a reducer that varies by model. */
+	readonly model: string
+	/** The run's configured recent-window size, as a starting point. */
+	readonly keepRecentMessages: number
+}
+
+/**
+ * Replace the run's history with a shorter one.
+ *
+ * Returning `undefined` means "I could not shorten this" and is a first-class
+ * answer, not a failure — on `'threshold'` the run simply continues, and on
+ * `'overflow'` it fails with an irreducible-prompt error instead of retrying
+ * a prompt nothing changed. That is deliberate: a reducer that returned the
+ * input unchanged while reporting success would send the same rejected
+ * prompt again and burn a call to learn the same thing.
+ *
+ * A reducer OWNS reduction for the run it governs. The built-in structured
+ * pass — LLM-verified summarization, stale tool-result clearing, working
+ * state slots — does not also run, because two mechanisms editing the same
+ * history in one pass cannot both be reasoned about.
+ *
+ * Invariants a reducer is expected to keep, all three enforced by the
+ * built-in one and none of them checkable from here:
+ *
+ * 1. The leading system messages stay. They carry the system prompt and the
+ *    working-memory slot; dropping them changes who the agent is.
+ * 2. `tool_use` and its `tool_result` stay together. A split pair is a 400
+ *    from the provider, so a reducer that splits one turns a context problem
+ *    into a dead run. {@link findSafeTrimIndex} is exported for this.
+ * 3. Messages marked `retain` survive. That marker is how a caller says a
+ *    fact in the middle of the conversation outranks recency.
+ */
+export type ContextReducer = (
+	reduction: ContextReduction,
+) => readonly Message[] | undefined | Promise<readonly Message[] | undefined>
+
+export interface SlidingWindowOptions {
+	/**
+	 * How many trailing messages to keep. Defaults to the run's configured
+	 * `keepRecentMessages`, so the same knob governs both strategies.
+	 */
+	readonly keepRecentMessages?: number
+
+	/**
+	 * Fraction of the window to keep when relieving an overflow, applied to
+	 * the recent count. Defaults to 0.5.
+	 *
+	 * An overflow means the ordinary window was already too big, so cutting
+	 * to the same size again would shed nothing and the caller would retry
+	 * an identical prompt.
+	 */
+	readonly overflowFactor?: number
+}
+
+/**
+ * Keep the last N turns, drop what precedes them, summarize nothing.
+ *
+ * The honest counterpart to the structured strategy rather than a lesser
+ * version of it. Structured compaction pays a summarization call and
+ * paraphrases the agent's own reasoning to buy context; this pays nothing
+ * and admits the older history is gone. For a long-running agent whose
+ * state lives outside the transcript — a task queue, a file it keeps
+ * editing, a working-memory block the host renders each turn — that is the
+ * better trade, and the paraphrase was only ever cost.
+ *
+ * Until now `strategy: 'sliding-window'` was accepted by the config schema
+ * and then ignored: the runtime asked only whether the strategy was
+ * `'disabled'`, so choosing the cheap non-LLM path silently ran the
+ * expensive LLM one. This is the implementation that name always claimed.
+ */
+export function createSlidingWindowReducer(options: SlidingWindowOptions = {}): ContextReducer {
+	const factor = options.overflowFactor ?? 0.5
+
+	return ({ messages, reason, keepRecentMessages }) => {
+		const configured = options.keepRecentMessages ?? keepRecentMessages
+		const keep =
+			reason === 'overflow' ? Math.max(1, Math.floor(configured * factor)) : Math.max(1, configured)
+
+		let leadingSystem = 0
+		while (messages[leadingSystem]?.role === 'system') leadingSystem++
+
+		const naive = messages.length - keep
+		if (naive <= leadingSystem) return undefined
+
+		// `findSafeTrimIndex` moves a cut forward until the kept tail is a
+		// history a provider will accept — no `tool_result` without its
+		// `tool_use`, and never opening on an assistant turn, because the tail
+		// becomes the start of the wire conversation once the older half is
+		// gone. So a candidate is safe exactly when it is already its own
+		// answer.
+		//
+		// Walk BACKWARDS first: that lands on the safe cut nearest the
+		// requested window, keeping a little more than asked rather than a lot
+		// less.
+		const trimmable = [...messages]
+		let cut = -1
+		for (let candidate = naive; candidate > leadingSystem; candidate--) {
+			if (findSafeTrimIndex(trimmable, candidate) === candidate) {
+				cut = candidate
+				break
+			}
+		}
+
+		// Nothing safe below the request. Take the answer ABOVE it instead of
+		// refusing: in a multi-step turn — the agent working through tool calls
+		// with the user silent — every boundary in the recent window lands on
+		// an assistant or tool message, so a backwards-only search declines
+		// exactly when the history is longest and shedding matters most. The
+		// forward cut keeps less than asked, which is a smaller history than
+		// the caller wanted but still a correct one.
+		if (cut < 0) {
+			const forward = findSafeTrimIndex(trimmable, naive)
+			// `messages.length` means "keep nothing", which is not a history.
+			if (forward > leadingSystem && forward < messages.length) cut = forward
+		}
+		if (cut < 0) return undefined
+
+		const retained = findRetainedIndices(messages)
+		const survivors: Message[] = []
+		for (let i = 0; i < messages.length; i++) {
+			const message = messages[i]
+			if (!message) continue
+			if (i < leadingSystem || i >= cut || retained.has(i)) survivors.push(message)
+		}
+
+		// Nothing went. Reporting that as a reduction would have the overflow
+		// path retry an identical prompt.
+		return survivors.length === messages.length ? undefined : survivors
+	}
+}

--- a/packages/sdk/src/public-runtime.ts
+++ b/packages/sdk/src/public-runtime.ts
@@ -502,6 +502,7 @@ export {
 	lookupContextWindow,
 	resolveContextWindow,
 	createConversationManager,
+	createSlidingWindowReducer,
 	extractFromAssistantMessage,
 	extractFromToolCall,
 	extractFromToolResult,

--- a/packages/sdk/src/public-runtime.ts
+++ b/packages/sdk/src/public-runtime.ts
@@ -89,6 +89,12 @@ export type { ToolGrantKeys } from './runtime/query/tool-grants.js'
 export { toWireRunStatus } from './contracts/run-status.js'
 // Durable run state: the snapshot a different process picks a run up from.
 export { captureRunState, loadRunState } from './runtime/query/run-state.js'
+// …and the driver that joins the snapshot back to a running loop. Without
+// it every host wrote the same wiring, and in practice none did.
+export { resumeRun } from './runtime/query/resume-run.js'
+export type { ResumeOutcome, ResumeRunParams } from './runtime/query/resume-run.js'
+// The scope type was internal, so a host calling `loadRunState` could not
+// name the argument it had to construct.
 export type { RunStateScope } from './runtime/query/run-state.js'
 export { prepareReplayState } from './runtime/query/replay/prepare.js'
 export { listCheckpoints } from './runtime/query/replay/list.js'

--- a/packages/sdk/src/public-types.ts
+++ b/packages/sdk/src/public-types.ts
@@ -157,6 +157,10 @@ export type { ToolCallContext } from './verification/index.js'
 export type { DiskSessionStoreConfig, LinkageView } from './store/session/index.js'
 
 export type {
+	ContextReducer,
+	ContextReduction,
+	ContextReductionReason,
+	SlidingWindowOptions,
 	ConversationManager,
 	CompactionStrategy,
 	DanglingResult,

--- a/packages/sdk/src/runtime/query/__tests__/per-step-tool-choice.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/per-step-tool-choice.test.ts
@@ -1,0 +1,180 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { MockLLMProvider } from '../../../provider/mock.js'
+import { ToolRegistry } from '../../../registry/tool/execute.js'
+import type { SessionId, TenantId } from '../../../types/ids/index.js'
+import { createUserMessage } from '../../../types/message/index.js'
+import type { ProjectId, ThreadId } from '../../../types/session/ids.js'
+import { drainQuery } from '../index.js'
+
+/**
+ * Forcing a tool is the one step-shaping knob that can hang an agent.
+ *
+ * A forced choice that PERSISTS makes the model call a tool, read the
+ * result, and be forced again — forever. The peer SDK that puts
+ * `tool_choice` on persistent model settings carries three moving parts to
+ * undo that: a tool-use tracker, an opt-out flag, and a reset applied at
+ * two separate call sites. Its flag defaults to on precisely because
+ * turning it off hangs the agent.
+ *
+ * Putting the knob on `prepareStep` removes the failure instead of
+ * managing it: the next step is prepared from scratch, so a force cannot
+ * outlive the step that asked for it. There is no flag to get wrong.
+ */
+
+let workdirs: string[] = []
+
+afterEach(async () => {
+	await Promise.all(workdirs.map((d) => rm(d, { recursive: true, force: true })))
+	workdirs = []
+})
+
+async function mkWorkdir(): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), 'namzu-tool-choice-'))
+	workdirs.push(dir)
+	return dir
+}
+
+function registerEcho(tools: ToolRegistry): void {
+	tools.register({
+		name: 'echo',
+		description: 'Echo the text back.',
+		inputSchema: z.object({ text: z.string().optional() }),
+		execute: async () => ({ success: true, output: 'ok' }),
+	})
+}
+
+async function baseParams(provider: MockLLMProvider, tools: ToolRegistry) {
+	return {
+		provider,
+		tools,
+		runConfig: {
+			model: 'mock-model',
+			timeoutMs: 30_000,
+			tokenBudget: 100_000,
+			maxIterations: 4,
+			maxResponseTokens: 256,
+		},
+		agentId: 'agent_tc',
+		agentName: 'Tool Choice Agent',
+		workingDirectory: await mkWorkdir(),
+		sessionId: 'ses_tc' as SessionId,
+		threadId: 'thd_tc' as ThreadId,
+		projectId: 'prj_tc' as ProjectId,
+		tenantId: 'tnt_tc' as TenantId,
+		messages: [createUserMessage('go')],
+	}
+}
+
+describe('a step can force the model to call a tool', () => {
+	it('puts the caller choice on that step request', async () => {
+		const provider = new MockLLMProvider({ turns: [{ text: 'done' }] })
+		const tools = new ToolRegistry()
+		registerEcho(tools)
+
+		await drainQuery({
+			...(await baseParams(provider, tools)),
+			prepareStep: () => ({ toolChoice: 'required' as const }),
+		})
+
+		expect(provider.requests.at(0)?.toolChoice).toBe('required')
+	})
+
+	it('carries a named function through unchanged', async () => {
+		const provider = new MockLLMProvider({ turns: [{ text: 'done' }] })
+		const tools = new ToolRegistry()
+		registerEcho(tools)
+
+		await drainQuery({
+			...(await baseParams(provider, tools)),
+			prepareStep: () => ({
+				toolChoice: { type: 'function' as const, function: { name: 'echo' } },
+			}),
+		})
+
+		expect(provider.requests.at(0)?.toolChoice).toEqual({
+			type: 'function',
+			function: { name: 'echo' },
+		})
+	})
+
+	it('leaves the request alone when no step asks', async () => {
+		const provider = new MockLLMProvider({ turns: [{ text: 'done' }] })
+		const tools = new ToolRegistry()
+		registerEcho(tools)
+
+		await drainQuery(await baseParams(provider, tools))
+
+		expect(provider.requests.at(0)?.toolChoice).toBeUndefined()
+	})
+
+	it('says nothing when there are no tools to choose between', async () => {
+		const provider = new MockLLMProvider({ turns: [{ text: 'done' }] })
+
+		await drainQuery({
+			...(await baseParams(provider, new ToolRegistry())),
+			prepareStep: () => ({ toolChoice: 'required' as const }),
+		})
+
+		// `tool_choice` alongside an absent tool list is rejected by the
+		// providers, so a forced choice with nothing registered has to drop.
+		expect(provider.requests.at(0)?.toolChoice).toBeUndefined()
+	})
+})
+
+/**
+ * NOT covered here, and deliberately not faked: the forced-final turn takes
+ * precedence over a step's choice (`forceFinalize` wins in
+ * `iteration/index.ts`), so a budget-exhausted run can still stop asking
+ * for tools and answer. Reaching that branch needs the guard to raise a
+ * budget warning, which needs real usage the mock provider does not report.
+ * The precedence is implemented and read in review; it is not pinned.
+ */
+describe('a forced choice cannot outlive the step that asked for it', () => {
+	it('applies to the named step only, leaving later steps free', async () => {
+		const provider = new MockLLMProvider({
+			turns: [
+				{ toolCalls: [{ id: 'c1', name: 'echo', rawArguments: '{}' }] },
+				{ text: 'finished' },
+			],
+		})
+		const tools = new ToolRegistry()
+		registerEcho(tools)
+
+		await drainQuery({
+			...(await baseParams(provider, tools)),
+			// Only the first step is forced. Without per-step scoping this
+			// would keep forcing and the run would never reach a text answer.
+			prepareStep: ({ stepNumber }) =>
+				stepNumber === 1 ? { toolChoice: 'required' as const } : {},
+		})
+
+		expect(provider.requests.at(0)?.toolChoice).toBe('required')
+		expect(provider.requests.at(1)?.toolChoice).toBeUndefined()
+	})
+
+	it('a run whose every step forces a tool still ends, bounded by the loop', async () => {
+		const provider = new MockLLMProvider({
+			turns: [
+				{ toolCalls: [{ id: 'c1', name: 'echo', rawArguments: '{}' }] },
+				{ toolCalls: [{ id: 'c2', name: 'echo', rawArguments: '{}' }] },
+				{ text: 'finished' },
+			],
+		})
+		const tools = new ToolRegistry()
+		registerEcho(tools)
+
+		const run = await drainQuery({
+			...(await baseParams(provider, tools)),
+			prepareStep: () => ({ toolChoice: 'required' as const }),
+		})
+
+		// The knob cannot hang a run on its own: the iteration cap is still
+		// the backstop, and it settles rather than spinning.
+		expect(['completed', 'failed']).toContain(run.status)
+	})
+})

--- a/packages/sdk/src/runtime/query/__tests__/resume-run.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/resume-run.test.ts
@@ -1,0 +1,262 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { MockLLMProvider } from '../../../provider/mock.js'
+import { ToolRegistry } from '../../../registry/tool/execute.js'
+import type { CheckpointId, IterationCheckpoint } from '../../../types/hitl/index.js'
+import type { RunId, SessionId, TenantId } from '../../../types/ids/index.js'
+import { createUserMessage } from '../../../types/message/index.js'
+import type { CheckpointRunScope, CheckpointStore } from '../../../types/run/checkpoint-store.js'
+import type { ProjectId, ThreadId } from '../../../types/session/ids.js'
+import { resumeRun } from '../resume-run.js'
+import type { RunStateScope } from '../run-state.js'
+
+/**
+ * The pieces of a cross-process resume all existed and nothing joined them.
+ * `CheckpointManager` wrote the history, budgets, working state and any
+ * park; `loadRunState` read them back; `query` accepted `runId` +
+ * `resumeFromCheckpoint` and restored all of it. But `resumeFromCheckpoint`
+ * had no caller anywhere outside `packages/sdk/src`, so the whole path
+ * shipped untravelled — every host was expected to write the same wiring
+ * and none did.
+ *
+ * These cover the join, and especially its two refusals: a resume must not
+ * quietly become a fresh run under a recycled id, and it must not step past
+ * a park without the answer that park is waiting for.
+ */
+
+const SCOPE: RunStateScope = {
+	tenantId: 'tnt_resume' as TenantId,
+	projectId: 'prj_resume' as ProjectId,
+	sessionId: 'ses_resume' as SessionId,
+	runId: 'run_resume' as RunId,
+	threadId: 'thd_resume' as ThreadId,
+}
+
+const ZERO_USAGE = {
+	promptTokens: 0,
+	completionTokens: 0,
+	totalTokens: 0,
+	cachedTokens: 0,
+	cacheWriteTokens: 0,
+}
+
+const ZERO_COST = {
+	inputCostPer1M: 0,
+	outputCostPer1M: 0,
+	totalCost: 0,
+	cacheDiscount: 0,
+}
+
+class InMemoryCheckpointStore implements CheckpointStore {
+	readonly rows = new Map<string, IterationCheckpoint>()
+
+	private key(scope: CheckpointRunScope, id: CheckpointId): string {
+		return [scope.tenantId, scope.projectId, scope.sessionId, scope.runId, id].join('/')
+	}
+
+	async writeCheckpoint(scope: CheckpointRunScope, checkpoint: IterationCheckpoint): Promise<void> {
+		this.rows.set(this.key(scope, checkpoint.id), checkpoint)
+	}
+
+	async readCheckpoint(
+		scope: CheckpointRunScope,
+		id: CheckpointId,
+	): Promise<IterationCheckpoint | null> {
+		return this.rows.get(this.key(scope, id)) ?? null
+	}
+
+	async listCheckpoints(scope: CheckpointRunScope): Promise<IterationCheckpoint[]> {
+		const prefix = `${[scope.tenantId, scope.projectId, scope.sessionId, scope.runId].join('/')}/`
+		return [...this.rows.entries()]
+			.filter(([key]) => key.startsWith(prefix))
+			.map(([, cp]) => cp)
+			.sort((a, b) => a.createdAt - b.createdAt)
+	}
+
+	async deleteCheckpoint(scope: CheckpointRunScope, id: CheckpointId): Promise<void> {
+		this.rows.delete(this.key(scope, id))
+	}
+}
+
+function checkpoint(overrides: Partial<IterationCheckpoint> = {}): IterationCheckpoint {
+	return {
+		id: 'ckpt_1' as CheckpointId,
+		runId: SCOPE.runId,
+		iteration: 2,
+		messages: [createUserMessage('the work so far')],
+		tokenUsage: { ...ZERO_USAGE, promptTokens: 120, totalTokens: 120 },
+		costInfo: { ...ZERO_COST, totalCost: 0.4 },
+		guardState: { iterationCount: 2, elapsedMs: 9_000 },
+		createdAt: Date.now(),
+		...overrides,
+	} as IterationCheckpoint
+}
+
+let workdirs: string[] = []
+
+afterEach(async () => {
+	await Promise.all(workdirs.map((d) => rm(d, { recursive: true, force: true })))
+	workdirs = []
+})
+
+async function mkWorkdir(): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), 'namzu-resume-run-'))
+	workdirs.push(dir)
+	return dir
+}
+
+async function baseParams(store: CheckpointStore) {
+	return {
+		scope: SCOPE,
+		checkpointStore: store,
+		provider: new MockLLMProvider({ turns: [{ text: 'continued' }] }),
+		tools: new ToolRegistry(),
+		runConfig: {
+			model: 'mock-model',
+			timeoutMs: 30_000,
+			tokenBudget: 100_000,
+			maxIterations: 2,
+			maxResponseTokens: 256,
+		},
+		agentId: 'agent_resume',
+		agentName: 'Resume Agent',
+		workingDirectory: await mkWorkdir(),
+		sessionId: SCOPE.sessionId,
+		threadId: SCOPE.threadId,
+		projectId: SCOPE.projectId,
+		tenantId: SCOPE.tenantId,
+		// Required by the contract, and rightly so: a resume that lands on a
+		// park has to have somewhere to ask.
+		resumeHandler: async () => ({ action: 'continue' as const }),
+	}
+}
+
+describe('a run is picked back up from its store', () => {
+	it('continues the same run id rather than starting a new one', async () => {
+		const store = new InMemoryCheckpointStore()
+		await store.writeCheckpoint(SCOPE, checkpoint())
+
+		const outcome = await resumeRun(await baseParams(store))
+
+		expect(outcome.resumed).toBe(true)
+		if (!outcome.resumed) return
+		// The whole point: a resume is the same run in a different process,
+		// so its id, budgets and trace all have to carry across.
+		expect(outcome.run.id).toBe(SCOPE.runId)
+		expect(outcome.state.checkpointId).toBe('ckpt_1')
+	})
+
+	it('carries the spent budget forward instead of granting a fresh one', async () => {
+		const store = new InMemoryCheckpointStore()
+		await store.writeCheckpoint(SCOPE, checkpoint())
+
+		const outcome = await resumeRun(await baseParams(store))
+
+		expect(outcome.resumed).toBe(true)
+		if (!outcome.resumed) return
+		// A run recalled at 120 tokens must not come back at zero — the
+		// budget belongs to the run, not to the process hosting it.
+		expect(outcome.run.tokenUsage.totalTokens).toBeGreaterThanOrEqual(120)
+	})
+
+	it('picks the newest checkpoint when the caller names none', async () => {
+		const store = new InMemoryCheckpointStore()
+		await store.writeCheckpoint(SCOPE, checkpoint({ id: 'ckpt_old' as CheckpointId, createdAt: 1 }))
+		await store.writeCheckpoint(
+			SCOPE,
+			checkpoint({ id: 'ckpt_new' as CheckpointId, createdAt: 2_000 }),
+		)
+
+		const outcome = await resumeRun(await baseParams(store))
+
+		expect(outcome.resumed).toBe(true)
+		if (!outcome.resumed) return
+		expect(outcome.state.checkpointId).toBe('ckpt_new')
+	})
+
+	it('honours an explicitly named checkpoint', async () => {
+		const store = new InMemoryCheckpointStore()
+		await store.writeCheckpoint(SCOPE, checkpoint({ id: 'ckpt_old' as CheckpointId, createdAt: 1 }))
+		await store.writeCheckpoint(
+			SCOPE,
+			checkpoint({ id: 'ckpt_new' as CheckpointId, createdAt: 2_000 }),
+		)
+
+		const outcome = await resumeRun({
+			...(await baseParams(store)),
+			checkpointId: 'ckpt_old' as CheckpointId,
+		})
+
+		expect(outcome.resumed).toBe(true)
+		if (!outcome.resumed) return
+		expect(outcome.state.checkpointId).toBe('ckpt_old')
+	})
+})
+
+describe('it refuses rather than guessing', () => {
+	it('reports no checkpoint instead of silently starting fresh', async () => {
+		const outcome = await resumeRun(await baseParams(new InMemoryCheckpointStore()))
+
+		// Starting a new run here would be the worst outcome: a different
+		// run wearing a recycled id, with the original's budget reset.
+		expect(outcome).toEqual({ resumed: false, reason: 'no-checkpoint' })
+	})
+
+	it('hands back the outstanding question instead of resuming past it', async () => {
+		const store = new InMemoryCheckpointStore()
+		await store.writeCheckpoint(
+			SCOPE,
+			checkpoint({
+				pending: {
+					request: {
+						type: 'tool_review',
+						runId: SCOPE.runId,
+						checkpointId: 'ckpt_1' as CheckpointId,
+						toolCalls: [{ id: 'call_1', name: 'write', input: {} }],
+					},
+					parkedAt: Date.now(),
+					deadlineAt: Date.now() + 60_000,
+				},
+			} as unknown as Partial<IterationCheckpoint>),
+		)
+
+		const outcome = await resumeRun(await baseParams(store))
+
+		expect(outcome.resumed).toBe(false)
+		if (outcome.resumed || outcome.reason !== 'awaiting-decision') {
+			throw new Error(`expected awaiting-decision, got ${JSON.stringify(outcome)}`)
+		}
+		// The host needs the request itself to put in front of a person.
+		expect(outcome.pending.request.type).toBe('tool_review')
+		expect(outcome.state.runId).toBe(SCOPE.runId)
+	})
+
+	it('treats an already-answered park as an ordinary resume', async () => {
+		const store = new InMemoryCheckpointStore()
+		await store.writeCheckpoint(
+			SCOPE,
+			checkpoint({
+				pending: {
+					request: {
+						type: 'tool_review',
+						runId: SCOPE.runId,
+						checkpointId: 'ckpt_1' as CheckpointId,
+						toolCalls: [{ id: 'call_1', name: 'write', input: {} }],
+					},
+					parkedAt: Date.now(),
+					deadlineAt: Date.now() + 60_000,
+					resolvedAt: Date.now(),
+				},
+			} as unknown as Partial<IterationCheckpoint>),
+		)
+
+		const outcome = await resumeRun(await baseParams(store))
+
+		// `resolvedAt` is what makes a park answered. Blocking on one that
+		// already has its answer would strand the run permanently.
+		expect(outcome.resumed).toBe(true)
+	})
+})

--- a/packages/sdk/src/runtime/query/index.ts
+++ b/packages/sdk/src/runtime/query/index.ts
@@ -9,6 +9,7 @@ import {
 import { findDanglingMessages, removeDanglingMessages } from '../../compaction/dangling.js'
 import { extractFromUserMessage } from '../../compaction/extractor.js'
 import { WorkingStateManager } from '../../compaction/manager.js'
+import type { ContextReducer } from '../../compaction/reducer.js'
 import { restoreWorkingState, snapshotWorkingState } from '../../compaction/wire.js'
 import type { CompactionConfig } from '../../config/runtime.js'
 import { TOOL_OUTPUT_DIR_NAME } from '../../constants/tools/index.js'
@@ -421,6 +422,16 @@ export interface QueryParams {
 	 */
 	workingMemoryProvider?: WorkingMemoryProvider
 
+	/**
+	 * Replace context reduction for this run.
+	 *
+	 * Outranks `compactionConfig.strategy`, and the built-in structured pass
+	 * does not also run: two mechanisms editing one history in the same pass
+	 * cannot both be reasoned about. See `ContextReducer` for the invariants a
+	 * reducer is expected to keep.
+	 */
+	contextReducer?: ContextReducer
+
 	agentBus?: import('../../bus/index.js').AgentBus
 
 	verificationGate?: VerificationGateConfig
@@ -800,6 +811,7 @@ export async function* query(params: QueryParams): AsyncGenerator<RunEvent, Run>
 		toolGrants: new ToolGrantSet(),
 		compactionConfig: params.compactionConfig,
 		workingStateManager,
+		contextReducer: params.contextReducer,
 		workingMemoryProvider: params.workingMemoryProvider,
 		advisoryCtx,
 		agentBus: params.agentBus,

--- a/packages/sdk/src/runtime/query/index.ts
+++ b/packages/sdk/src/runtime/query/index.ts
@@ -811,6 +811,7 @@ export async function* query(params: QueryParams): AsyncGenerator<RunEvent, Run>
 		toolGrants: new ToolGrantSet(),
 		compactionConfig: params.compactionConfig,
 		workingStateManager,
+		taskRouter: params.taskRouter,
 		contextReducer: params.contextReducer,
 		workingMemoryProvider: params.workingMemoryProvider,
 		advisoryCtx,

--- a/packages/sdk/src/runtime/query/iteration/index.ts
+++ b/packages/sdk/src/runtime/query/iteration/index.ts
@@ -21,6 +21,7 @@ import {
 	createSystemMessage,
 	createUserMessage,
 } from '../../../types/message/index.js'
+import type { ToolChoice } from '../../../types/provider/chat.js'
 import { classifyProviderError } from '../../../types/provider/errors.js'
 import type { ChatCompletionResponse } from '../../../types/provider/index.js'
 import type { AnswerReview } from '../../../types/run/answer-review.js'
@@ -269,7 +270,17 @@ export class IterationOrchestrator {
 						messages,
 						tools: llmTools.length > 0 ? llmTools : undefined,
 						...(enforceToolInputSchema ? { enforceToolInputSchema } : {}),
-						toolChoice: forceFinalize && llmTools.length > 0 ? 'none' : undefined,
+						// The forced-final turn wins: a step that asked to force a
+						// tool cannot override the loop's own decision to stop
+						// asking for them. Otherwise the step's choice applies —
+						// and only to this step, because the next one is prepared
+						// from scratch.
+						toolChoice:
+							forceFinalize && llmTools.length > 0
+								? 'none'
+								: llmTools.length > 0
+									? step.toolChoice
+									: undefined,
 						temperature: step.temperature ?? runConfig.temperature,
 						maxTokens: step.maxResponseTokens ?? runConfig.maxResponseTokens,
 						cacheControl: { type: 'auto' },
@@ -752,6 +763,7 @@ export class IterationOrchestrator {
 	 */
 	private async prepareStep(stepNumber: number): Promise<{
 		allowedTools?: string[]
+		toolChoice?: ToolChoice
 		model?: string
 		system?: string
 		temperature?: number
@@ -789,6 +801,7 @@ export class IterationOrchestrator {
 
 		const prepared: {
 			allowedTools?: string[]
+			toolChoice?: ToolChoice
 			model?: string
 			system?: string
 			temperature?: number
@@ -809,6 +822,7 @@ export class IterationOrchestrator {
 			}
 			prepared.allowedTools = known
 		}
+		if (result.toolChoice !== undefined) prepared.toolChoice = result.toolChoice
 		if (result.model !== undefined) prepared.model = result.model
 		if (result.system !== undefined) prepared.system = result.system
 		if (result.temperature !== undefined) prepared.temperature = result.temperature

--- a/packages/sdk/src/runtime/query/iteration/phases/compaction-model-routing.test.ts
+++ b/packages/sdk/src/runtime/query/iteration/phases/compaction-model-routing.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { WorkingStateManager } from '../../../../compaction/manager.js'
+import { CompactionConfigSchema } from '../../../../config/runtime.js'
+import type { CompactionConfig } from '../../../../config/runtime.js'
+import type { Message } from '../../../../types/message/index.js'
+import type { TaskRouterConfig } from '../../../../types/router/index.js'
+import { runCompactionCheck } from './compaction.js'
+import type { IterationContext } from './context.js'
+
+/**
+ * The compaction summary is the only model call a run makes that nobody
+ * asked for, and it was hardwired to the primary model. `taskRouter` had been
+ * accepted, schema-validated and threaded through four types since it was
+ * added, with `resolveTaskModel` exported and never called — so a host who
+ * pointed compaction at a cheap model kept paying the expensive one.
+ */
+
+function harness(taskRouter?: TaskRouterConfig): {
+	ctx: IterationContext
+	modelsUsed: string[]
+} {
+	const messages: Message[] = [
+		{ role: 'system', content: 'prompt', timestamp: 1 },
+		...Array.from({ length: 40 }, (_, i) => ({
+			role: 'user' as const,
+			content: `turn ${i} `.repeat(200),
+			timestamp: 1,
+		})),
+	]
+	const config: CompactionConfig = {
+		...CompactionConfigSchema.parse({}),
+		contextWindowTokens: 1_000,
+		keepRecentMessages: 4,
+		llmVerification: true,
+		// Keep the slot count under the rich-state threshold so the verified
+		// summary path — the one that calls a model — is the one taken.
+		richStateThreshold: 1_000,
+	}
+	const modelsUsed: string[] = []
+
+	const ctx = {
+		compactionConfig: config,
+		workingStateManager: new WorkingStateManager(config),
+		runConfig: { model: 'primary-model' },
+		...(taskRouter ? { taskRouter } : {}),
+		runMgr: {
+			id: 'run_routing',
+			messages,
+			accumulateUsage: vi.fn(),
+			clearLastPromptTokens: vi.fn(),
+		},
+		provider: {
+			chatStream: async function* (params: { model: string }) {
+				modelsUsed.push(params.model)
+				yield { id: 'c1', delta: { content: 'a summary' } }
+				yield {
+					id: 'c1',
+					delta: {},
+					finishReason: 'stop',
+					usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+				}
+			},
+		},
+		log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+	} as unknown as IterationContext
+
+	return { ctx, modelsUsed }
+}
+
+describe('the compaction summary goes to the model a host routed it to', () => {
+	it('uses the primary model when nothing is routed', async () => {
+		const h = harness()
+
+		await runCompactionCheck(h.ctx)
+
+		expect(h.modelsUsed).toEqual(['primary-model'])
+	})
+
+	it('uses the compaction model when one is named', async () => {
+		const h = harness({ compaction: 'small-model' })
+
+		await runCompactionCheck(h.ctx)
+
+		expect(h.modelsUsed).toEqual(['small-model'])
+	})
+
+	it('falls back to the router default', async () => {
+		const h = harness({ default: 'fallback-model' })
+
+		await runCompactionCheck(h.ctx)
+
+		expect(h.modelsUsed).toEqual(['fallback-model'])
+	})
+
+	it('prefers the specific key over the default', async () => {
+		const h = harness({ compaction: 'small-model', default: 'fallback-model' })
+
+		await runCompactionCheck(h.ctx)
+
+		expect(h.modelsUsed).toEqual(['small-model'])
+	})
+
+	it('ignores a key that names no model', async () => {
+		// `null` is what the schema produces for an explicitly cleared key, and
+		// it has to mean "unrouted" rather than "route to nothing" — sending an
+		// empty model id is an endpoint error on backends where the id IS the
+		// endpoint.
+		const h = harness({ compaction: null, default: 'fallback-model' })
+
+		await runCompactionCheck(h.ctx)
+
+		expect(h.modelsUsed).toEqual(['fallback-model'])
+	})
+
+	it('does not route a key the runtime does not consult', async () => {
+		// `coding` is documented as inert. Pinning that keeps the docs honest:
+		// if a future change starts consulting it, this test says so.
+		const h = harness({ coding: 'coding-model' })
+
+		await runCompactionCheck(h.ctx)
+
+		expect(h.modelsUsed).toEqual(['primary-model'])
+	})
+})

--- a/packages/sdk/src/runtime/query/iteration/phases/compaction.ts
+++ b/packages/sdk/src/runtime/query/iteration/phases/compaction.ts
@@ -7,6 +7,7 @@ import { serializeState } from '../../../../compaction/serializer.js'
 import { clearStaleToolResults } from '../../../../compaction/tool-result-editing.js'
 import { buildVerifiedSummary } from '../../../../compaction/verifier.js'
 import { CHARS_PER_TOKEN } from '../../../../constants/limits.js'
+import { resolveTaskModel } from '../../../../router/task-router.js'
 import type { Message } from '../../../../types/message/index.js'
 import { createSystemMessage } from '../../../../types/message/index.js'
 import type { IterationContext } from './context.js'
@@ -474,7 +475,13 @@ export async function runCompactionCheck(
 			ctx.provider,
 			config,
 			(usage) => ctx.runMgr.accumulateUsage(usage),
-			ctx.runConfig.model,
+			// The one model call a run makes that the user never asked for. It
+			// reads a transcript and writes a summary, which is the cheapest
+			// thing a small model does well, and it fires on exactly the long
+			// runs where the primary model is most expensive. `taskRouter` had
+			// been accepted, validated and threaded through four types since it
+			// was added, and nothing ever consulted it.
+			resolveTaskModel('compaction', ctx.taskRouter, ctx.runConfig.model),
 		)
 	} else {
 		compactedContent = serializeState(manager.getState())

--- a/packages/sdk/src/runtime/query/iteration/phases/compaction.ts
+++ b/packages/sdk/src/runtime/query/iteration/phases/compaction.ts
@@ -1,5 +1,7 @@
 import { resolveContextWindow } from '../../../../compaction/context-window.js'
-import { findSafeTrimIndex } from '../../../../compaction/dangling.js'
+import { findDanglingMessages, findSafeTrimIndex } from '../../../../compaction/dangling.js'
+import type { ContextReducer, ContextReduction } from '../../../../compaction/reducer.js'
+import { createSlidingWindowReducer } from '../../../../compaction/reducer.js'
 import { findRetainedIndices } from '../../../../compaction/retention.js'
 import { serializeState } from '../../../../compaction/serializer.js'
 import { clearStaleToolResults } from '../../../../compaction/tool-result-editing.js'
@@ -202,6 +204,78 @@ function totalChars(messages: readonly { content: unknown }[]): number {
 	return total
 }
 
+/**
+ * Run a reducer and install what it returns, or leave the history alone.
+ *
+ * Three ways to decline, all of them ending the same way — the run keeps its
+ * full history. `undefined` is the reducer saying so; a throw is treated as
+ * the same answer, because a broken reduction hook should not kill a healthy
+ * run any more than a broken `prepareStep` should; and a result that splits a
+ * tool pair is REFUSED rather than repaired.
+ *
+ * That last one is the least obvious and the most important. `tool_result`
+ * without its `tool_use` is a provider 400 on the next turn, so quietly
+ * repairing it would trade a clear "this reducer split a tool pair" for an
+ * opaque rejection a call later, with the reducer never implicated. The
+ * invariant is written on {@link ContextReducer}; enforcing it where it is
+ * violated is what makes it true rather than aspirational.
+ */
+async function applyReducer(
+	ctx: IterationContext,
+	reducer: ContextReducer,
+	reduction: ContextReduction,
+): Promise<void> {
+	const messages = ctx.runMgr.messages
+	const before = messages.length
+	const beforeChars = totalChars(messages)
+
+	let next: readonly Message[] | undefined
+	try {
+		next = await reducer(reduction)
+	} catch (error) {
+		ctx.log.warn('Context reducer threw — keeping the full history', {
+			runId: ctx.runMgr.id,
+			reason: reduction.reason,
+			error: error instanceof Error ? error.message : String(error),
+		})
+		return
+	}
+
+	if (!next || next.length >= before) {
+		ctx.log.debug('Context reducer shed nothing', {
+			runId: ctx.runMgr.id,
+			reason: reduction.reason,
+			messages: before,
+		})
+		return
+	}
+
+	if (!findDanglingMessages([...next]).isValid) {
+		ctx.log.warn('Context reducer split a tool pair — refusing its result', {
+			runId: ctx.runMgr.id,
+			reason: reduction.reason,
+			hint: 'use findSafeTrimIndex to move a cut off a tool_use/tool_result boundary',
+		})
+		return
+	}
+
+	messages.length = 0
+	for (const message of next) messages.push(message)
+
+	// The provider's count described the pre-reduction prompt. Same reasoning
+	// as the structured path: leaving it would have the next trigger check
+	// compare an old size against the new history and reduce again.
+	ctx.runMgr.clearLastPromptTokens?.()
+
+	ctx.log.info('Context reduced', {
+		runId: ctx.runMgr.id,
+		reason: reduction.reason,
+		oldMessageCount: before,
+		newMessageCount: messages.length,
+		charsShed: beforeChars - totalChars(messages),
+	})
+}
+
 export async function runCompactionCheck(
 	ctx: IterationContext,
 	options?: { force?: boolean },
@@ -209,9 +283,6 @@ export async function runCompactionCheck(
 	const config = ctx.compactionConfig
 	if (!config) return
 	if (config.strategy === 'disabled') return
-
-	const manager = ctx.workingStateManager
-	if (!manager) return
 
 	const measured = measureContext(ctx)
 	const estimatedTokens = measured.tokens
@@ -231,6 +302,29 @@ export async function runCompactionCheck(
 	// A forced pass skips the threshold: it runs because the provider
 	// rejected the prompt, which is stronger evidence than any estimate.
 	if (!options?.force && usage < config.triggerThreshold) return
+
+	// A reducer, when the run has one, OWNS reduction — the structured pass
+	// below does not also run. `strategy: 'sliding-window'` resolves to the
+	// built-in one; a host-supplied reducer outranks the strategy entirely,
+	// because someone who wrote a reducer has said what they want more
+	// specifically than an enum can.
+	const reducer =
+		ctx.contextReducer ??
+		(config.strategy === 'sliding-window' ? createSlidingWindowReducer() : undefined)
+	if (reducer) {
+		await applyReducer(ctx, reducer, {
+			messages: ctx.runMgr.messages,
+			reason: options?.force ? 'overflow' : 'threshold',
+			estimatedTokens,
+			contextWindowTokens: budget,
+			model: ctx.runConfig.model,
+			keepRecentMessages: config.keepRecentMessages,
+		})
+		return
+	}
+
+	const manager = ctx.workingStateManager
+	if (!manager) return
 
 	ctx.log.info('Compaction threshold reached — compacting context', {
 		runId: ctx.runMgr.id,

--- a/packages/sdk/src/runtime/query/iteration/phases/context-reducer-dispatch.test.ts
+++ b/packages/sdk/src/runtime/query/iteration/phases/context-reducer-dispatch.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { WorkingStateManager } from '../../../../compaction/manager.js'
+import type { ContextReducer } from '../../../../compaction/reducer.js'
+import { CompactionConfigSchema } from '../../../../config/runtime.js'
+import type { CompactionConfig } from '../../../../config/runtime.js'
+import type { Message } from '../../../../types/message/index.js'
+import { runCompactionCheck } from './compaction.js'
+import type { IterationContext } from './context.js'
+
+/**
+ * `strategy` had three values and two behaviours.
+ *
+ * The runtime asked only `strategy !== 'disabled'`, so `'sliding-window'` —
+ * the name a host picks precisely to AVOID paying for summarization — ran the
+ * full structured pass, model call included. These tests are about the
+ * dispatch rather than the algorithms: that choosing a strategy selects one,
+ * that a host-supplied reducer outranks the enum, and that the structured
+ * pass does not also run when something else owns reduction.
+ */
+
+const sys = (content: string): Message => ({ role: 'system', content, timestamp: 1 })
+const user = (content: string): Message => ({ role: 'user', content, timestamp: 1 })
+
+function longHistory(): Message[] {
+	// Long enough to be over any threshold once the window is small.
+	return [sys('prompt'), ...Array.from({ length: 40 }, (_, i) => user(`turn ${i} `.repeat(200)))]
+}
+
+interface Harness {
+	readonly ctx: IterationContext
+	readonly messages: Message[]
+	readonly providerCalls: () => number
+	readonly warnings: string[]
+}
+
+function harness(
+	over: Partial<IterationContext> & { compaction?: Partial<CompactionConfig> },
+): Harness {
+	const messages = longHistory()
+	const config: CompactionConfig = {
+		...CompactionConfigSchema.parse({}),
+		// A tiny window puts the run over the trigger immediately.
+		contextWindowTokens: 1_000,
+		keepRecentMessages: 4,
+		...over.compaction,
+	}
+	const warnings: string[] = []
+	let providerCalls = 0
+
+	const ctx = {
+		compactionConfig: config,
+		workingStateManager: new WorkingStateManager(config),
+		runConfig: { model: 'mock-model' },
+		runMgr: {
+			id: 'run_dispatch',
+			messages,
+			accumulateUsage: vi.fn(),
+			clearLastPromptTokens: vi.fn(),
+		},
+		provider: {
+			// The structured path's only observable side effect that a reducer
+			// path must not have: it pays for a summary.
+			chat: async () => {
+				providerCalls++
+				return { content: 'summary', usage: { promptTokens: 1, completionTokens: 1 } }
+			},
+		},
+		log: {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: (message: string) => warnings.push(message),
+			error: vi.fn(),
+		},
+		...over,
+	} as unknown as IterationContext
+
+	return { ctx, messages, providerCalls: () => providerCalls, warnings }
+}
+
+describe('choosing a strategy selects one', () => {
+	it("'sliding-window' trims and summarizes nothing", async () => {
+		const h = harness({ compaction: { strategy: 'sliding-window', llmVerification: true } })
+
+		await runCompactionCheck(h.ctx)
+
+		expect(h.messages.length).toBeLessThan(41)
+		// The whole reason a host names this strategy.
+		expect(h.providerCalls()).toBe(0)
+		// Every survivor is verbatim — no `[COMPACTED CONTEXT]` block appears.
+		expect(h.messages.some((m) => String(m.content).includes('COMPACTED CONTEXT'))).toBe(false)
+	})
+
+	it("'structured' still summarizes", async () => {
+		const h = harness({ compaction: { strategy: 'structured', llmVerification: false } })
+
+		await runCompactionCheck(h.ctx)
+
+		expect(h.messages.some((m) => String(m.content).includes('COMPACTED CONTEXT'))).toBe(true)
+	})
+
+	it("'disabled' leaves the history alone", async () => {
+		const h = harness({ compaction: { strategy: 'disabled' } })
+
+		await runCompactionCheck(h.ctx)
+
+		expect(h.messages.length).toBe(41)
+	})
+})
+
+describe('a host reducer outranks the enum', () => {
+	it('runs instead of the structured pass', async () => {
+		// Deliberately NOT a tiny slice: leave more than the structured pass
+		// needs to act, so "the reducer ran" and "only the reducer ran" are
+		// different observations.
+		const reduce: ContextReducer = ({ messages }) => messages.slice(0, 20)
+		const h = harness({ contextReducer: reduce, compaction: { strategy: 'structured' } })
+
+		await runCompactionCheck(h.ctx)
+
+		expect(h.messages.length).toBe(20)
+		expect(h.messages.some((m) => String(m.content).includes('COMPACTED CONTEXT'))).toBe(false)
+	})
+
+	it('is told whether the provider already rejected the prompt', async () => {
+		const seen: string[] = []
+		const reduce: ContextReducer = ({ messages, reason }) => {
+			seen.push(reason)
+			return messages.slice(0, 5)
+		}
+		const h = harness({ contextReducer: reduce })
+
+		await runCompactionCheck(h.ctx)
+		await runCompactionCheck(h.ctx, { force: true })
+
+		expect(seen).toEqual(['threshold', 'overflow'])
+	})
+
+	it('may be async, so a reducer can call a model of its own', async () => {
+		const reduce: ContextReducer = async ({ messages }) => {
+			await Promise.resolve()
+			return messages.slice(0, 3)
+		}
+		const h = harness({ contextReducer: reduce })
+
+		await runCompactionCheck(h.ctx)
+
+		expect(h.messages.length).toBe(3)
+	})
+
+	it('gets the window it has to fit, not the run token budget', async () => {
+		let saw = 0
+		const reduce: ContextReducer = ({ contextWindowTokens, messages }) => {
+			saw = contextWindowTokens
+			return messages.slice(0, 5)
+		}
+		const h = harness({ contextReducer: reduce, compaction: { contextWindowTokens: 12_345 } })
+
+		await runCompactionCheck(h.ctx)
+
+		expect(saw).toBe(12_345)
+	})
+})
+
+describe('a reducer that cannot be trusted is not obeyed', () => {
+	it('keeps the full history when the reducer throws', async () => {
+		const reduce: ContextReducer = () => {
+			throw new Error('boom')
+		}
+		const h = harness({ contextReducer: reduce })
+
+		await runCompactionCheck(h.ctx)
+
+		// Fail open: a broken reduction hook should not take down a healthy run,
+		// the same way a broken `prepareStep` does not.
+		expect(h.messages.length).toBe(41)
+		expect(h.warnings.some((w) => w.includes('threw'))).toBe(true)
+	})
+
+	it('refuses a result that orphans a tool result', async () => {
+		const h = harness({
+			contextReducer: ({ messages }) => [
+				messages[0] as Message,
+				{ role: 'tool', content: 'ok', timestamp: 1, toolCallId: 'nobody' } as Message,
+			],
+		})
+
+		await runCompactionCheck(h.ctx)
+
+		// Installing this would trade a nameable "your reducer split a tool
+		// pair" for an opaque provider rejection a call later.
+		expect(h.messages.length).toBe(41)
+		expect(h.warnings.some((w) => w.includes('split a tool pair'))).toBe(true)
+	})
+
+	it('ignores a reducer that returns the history unchanged', async () => {
+		const h = harness({ contextReducer: ({ messages }) => messages })
+
+		await runCompactionCheck(h.ctx)
+
+		expect(h.messages.length).toBe(41)
+	})
+
+	it('leaves the history alone when the reducer declines', async () => {
+		const h = harness({ contextReducer: () => undefined })
+
+		await runCompactionCheck(h.ctx)
+
+		expect(h.messages.length).toBe(41)
+	})
+})
+
+describe('the threshold still governs a reducer', () => {
+	it('does not run one below the trigger', async () => {
+		const reduce = vi.fn(() => undefined)
+		const h = harness({
+			contextReducer: reduce,
+			// A window far larger than the history.
+			compaction: { contextWindowTokens: 10_000_000 },
+		})
+
+		await runCompactionCheck(h.ctx)
+
+		expect(reduce).not.toHaveBeenCalled()
+	})
+
+	it('runs one below the trigger when the provider forced the issue', async () => {
+		const reduce = vi.fn(() => undefined)
+		const h = harness({
+			contextReducer: reduce,
+			compaction: { contextWindowTokens: 10_000_000 },
+		})
+
+		await runCompactionCheck(h.ctx, { force: true })
+
+		expect(reduce).toHaveBeenCalledOnce()
+	})
+})

--- a/packages/sdk/src/runtime/query/iteration/phases/context.ts
+++ b/packages/sdk/src/runtime/query/iteration/phases/context.ts
@@ -15,6 +15,7 @@ import type {
 } from '../../../../types/hitl/index.js'
 import type { TaskId } from '../../../../types/ids/index.js'
 import type { LLMProvider } from '../../../../types/provider/index.js'
+import type { TaskRouterConfig } from '../../../../types/router/index.js'
 import type { ReviewAnswer } from '../../../../types/run/answer-review.js'
 import type {
 	AgentRunConfig,
@@ -104,6 +105,9 @@ export interface IterationContext {
 	 * asked about again. Absent on paths that do not review tools.
 	 */
 	readonly toolGrants?: ToolGrantSet
+
+	/** Per-task model overrides. Consulted for the compaction summary call. */
+	readonly taskRouter?: TaskRouterConfig
 
 	readonly compactionConfig?: CompactionConfig
 

--- a/packages/sdk/src/runtime/query/iteration/phases/context.ts
+++ b/packages/sdk/src/runtime/query/iteration/phases/context.ts
@@ -1,6 +1,7 @@
 import type { AdvisoryContext } from '../../../../advisory/context.js'
 import type { AgentBus } from '../../../../bus/index.js'
 import type { WorkingStateManager } from '../../../../compaction/manager.js'
+import type { ContextReducer } from '../../../../compaction/reducer.js'
 import type { CompactionConfig } from '../../../../config/runtime.js'
 import type { PlanManager } from '../../../../manager/plan/lifecycle.js'
 import type { RunPersistence } from '../../../../manager/run/persistence.js'
@@ -107,6 +108,12 @@ export interface IterationContext {
 	readonly compactionConfig?: CompactionConfig
 
 	readonly workingStateManager?: WorkingStateManager
+
+	/**
+	 * Host-supplied context reduction. Outranks `compactionConfig.strategy`
+	 * and replaces the structured pass for this run.
+	 */
+	readonly contextReducer?: ContextReducer
 
 	readonly workingMemoryProvider?: WorkingMemoryProvider
 

--- a/packages/sdk/src/runtime/query/resume-run.ts
+++ b/packages/sdk/src/runtime/query/resume-run.ts
@@ -1,0 +1,93 @@
+import type { PendingDecision } from '../../types/hitl/index.js'
+import type { CheckpointStore } from '../../types/run/checkpoint-store.js'
+import type { Run } from '../../types/run/entity.js'
+import type { RunState } from '../../types/run/state.js'
+import { type QueryParams, drainQuery } from './index.js'
+import { type RunStateScope, loadRunState } from './run-state.js'
+
+/**
+ * What a resume attempt found.
+ *
+ * Three outcomes rather than a nullable `Run`, because the two failures
+ * mean opposite things to a caller. "No checkpoint" is a dead end — there
+ * is nothing to continue and starting fresh would be a different run
+ * wearing the same id. "Awaiting decision" is the run working as designed:
+ * it parked on a question, and continuing means answering it first.
+ */
+export type ResumeOutcome =
+	| { readonly resumed: false; readonly reason: 'no-checkpoint' }
+	| {
+			readonly resumed: false
+			readonly reason: 'awaiting-decision'
+			/** What to put in front of a human. */
+			readonly pending: PendingDecision
+			readonly state: RunState
+	  }
+	| { readonly resumed: true; readonly run: Run; readonly state: RunState }
+
+/**
+ * The half of a run that cannot be serialized, plus where to look.
+ *
+ * `messages` is deliberately absent. On resume the history comes from the
+ * checkpoint and any passed messages would be discarded, so accepting them
+ * would invite a caller to hand over a transcript that is silently ignored.
+ */
+export interface ResumeRunParams
+	extends Omit<QueryParams, 'messages' | 'runId' | 'resumeFromCheckpoint'> {
+	/** Identifies the run inside the checkpoint store. */
+	readonly scope: RunStateScope
+	/** Required to find the checkpoint; also threaded into the resumed run. */
+	readonly checkpointStore: CheckpointStore
+	/**
+	 * Resume a specific checkpoint instead of the one the store would pick.
+	 * Absent means the parked checkpoint if there is one, else the newest.
+	 */
+	readonly checkpointId?: RunState['checkpointId']
+}
+
+/**
+ * Continue a run that a different process started.
+ *
+ * Everything this needs already existed — `CheckpointManager` writes the
+ * history, budgets, working state, trace context and any park;
+ * `loadRunState` reads them back; `query` accepts `runId` +
+ * `resumeFromCheckpoint` and restores all of it. What was missing was the
+ * few lines that join them, so every host wrote their own — and in this
+ * repo nothing outside the SDK ever did, which means the whole path shipped
+ * untravelled.
+ *
+ * The division of labour is the one the mechanism already implies: the
+ * CALLER brings what cannot be serialized — the provider client, the tool
+ * registry, the sandbox, the working directory — and the STORE brings the
+ * state. A snapshot deliberately holds no socket, no client and no open
+ * file, so it could never have carried the first half.
+ *
+ * Refusing beats guessing at both failure points. A missing checkpoint does
+ * not silently become a fresh run under a recycled id, and a park is not
+ * resumed past without the answer it is waiting for.
+ */
+export async function resumeRun(params: ResumeRunParams): Promise<ResumeOutcome> {
+	const { scope, checkpointStore, checkpointId, pendingDecision, ...rest } = params
+
+	const state = await loadRunState(checkpointStore, scope, checkpointId)
+	if (!state?.checkpointId) return { resumed: false, reason: 'no-checkpoint' }
+
+	// A park is outstanding until it is answered. `resolvedAt` is what marks
+	// an answered one, so a checkpoint that carries a resolved decision is an
+	// ordinary resume, not a question waiting on anybody.
+	const outstanding = state.pending && !state.pending.resolvedAt ? state.pending : undefined
+	if (outstanding && !pendingDecision) {
+		return { resumed: false, reason: 'awaiting-decision', pending: outstanding, state }
+	}
+
+	const run = await drainQuery({
+		...rest,
+		messages: [],
+		runId: state.runId,
+		resumeFromCheckpoint: state.checkpointId,
+		checkpointStore,
+		...(pendingDecision ? { pendingDecision } : {}),
+	} as QueryParams)
+
+	return { resumed: true, run, state }
+}

--- a/packages/sdk/src/types/router/task-router.ts
+++ b/packages/sdk/src/types/router/task-router.ts
@@ -8,6 +8,25 @@ export type TaskType =
 	| 'advisory'
 	| 'default'
 
+/**
+ * Send a particular kind of work to a particular model.
+ *
+ * **Which keys the runtime consults today: `compaction`, and `default` as its
+ * fallback.** That is stated because the rest are silently inert, and an
+ * inert key is worse than an absent one — a host who sets `coding` reads it
+ * as taking effect. The compaction summary is the call worth routing first
+ * regardless: it is the only model call a run makes that nobody asked for,
+ * it reads a transcript and writes a summary, and it fires on exactly the
+ * long runs where the primary model costs the most.
+ *
+ * The remaining keys describe sub-agent routing. `SupervisorAgent` already
+ * threads this config down to the agent factory, but nothing classifies a
+ * spawned task as exploration or coding, and guessing a classifier here
+ * would put a wrong model behind a right-looking config.
+ *
+ * `advisory` is deliberately not consulted: an advisor carries its own
+ * `model`, so routing would override an explicit choice with a general one.
+ */
 export interface TaskRouterConfig {
 	readonly compaction?: string | null
 	readonly summarization?: string | null

--- a/packages/sdk/src/types/run/prepare-step.ts
+++ b/packages/sdk/src/types/run/prepare-step.ts
@@ -1,5 +1,6 @@
 import type { RunId } from '../ids/index.js'
 import type { Message } from '../message/index.js'
+import type { ToolChoice } from '../provider/chat.js'
 import type { StepResult } from './step.js'
 
 /**
@@ -51,11 +52,37 @@ export interface PrepareStepResult {
 	 * it is worth doing when a phase boundary genuinely changes what the
 	 * agent should reach for — and not worth doing every step.
 	 *
-	 * Note it does NOT touch `tool_choice`. Not every provider has an `allowed_tools`
-	 * parameter, and moving `tool_choice` invalidates cached MESSAGE blocks
-	 * as well — a strictly worse trade for the same effect.
+	 * Note it does NOT imply a `tool_choice`. Not every provider has an
+	 * `allowed_tools` parameter, and moving `tool_choice` invalidates cached
+	 * MESSAGE blocks as well — a strictly worse trade for the same effect.
+	 * When a step genuinely needs the model FORCED rather than narrowed, ask
+	 * for it explicitly through {@link PrepareStepResult.toolChoice} and pay
+	 * that cost knowingly.
 	 */
 	readonly activeTools?: readonly string[]
+
+	/**
+	 * Force this step's tool use: `'required'` to make the model call
+	 * something, `'none'` to forbid it, or a named function to demand that
+	 * one. Absent leaves the provider's default.
+	 *
+	 * **It applies to this step only, by construction.** That is the whole
+	 * reason it lives here rather than on the run config. A forced choice
+	 * that persists makes the model call a tool, see the result, and be
+	 * forced again — an agent that cannot stop. The one peer SDK that puts
+	 * `tool_choice` on persistent model settings has to undo it with a
+	 * tool-use tracker, an opt-out flag and a reset applied at two call
+	 * sites; the flag defaults to on precisely because turning it off hangs
+	 * the agent. Here there is nothing to reset and no flag to get wrong:
+	 * the next step is prepared fresh, so the force cannot outlive the step
+	 * that asked for it.
+	 *
+	 * **It costs more cache than `activeTools`.** Narrowing tools
+	 * invalidates the tool prefix; moving `tool_choice` invalidates cached
+	 * message blocks too. Worth it at a real phase boundary — "this step
+	 * must produce the structured answer" — and not worth it as a habit.
+	 */
+	readonly toolChoice?: ToolChoice
 
 	/** Use a different model for this step. */
 	readonly model?: string

--- a/packages/sdk/src/types/toolset/index.ts
+++ b/packages/sdk/src/types/toolset/index.ts
@@ -1,5 +1,21 @@
 import type { LLMToolSchema, ToolDefinition, ToolPermission } from '../tool/index.js'
 
+/**
+ * @deprecated Slated for removal in the next major. Nothing produces or
+ * reads it — no code constructs any member, and `ToolsetPolicy.surfaces`,
+ * the only field that carries it, is never consulted.
+ *
+ * It is also the wrong axis. Which tools a run may use is already
+ * expressible four ways, all of them per-run and dynamic where this is
+ * fixed at definition: `allowedTools` on the query, `ToolAvailability`
+ * (`active` / `deferred` / `suspended`) with mid-run activation,
+ * `runtimeToolOverrides`, and capability negotiation stripping tools a
+ * driver cannot carry. Prefer `allowedTools`.
+ *
+ * The member names encode deployment shapes this kernel does not own,
+ * which is the deeper reason not to keep them: a host's surfaces are the
+ * host's to name.
+ */
 export type ToolCatalogSurface = 'chat' | 'supervised' | 'managed-agent' | 'worker' | 'code'
 
 export type ToolSourceKind =
@@ -41,6 +57,12 @@ export interface ToolsetPolicy {
 	readonly enabled?: boolean
 	readonly loading?: ToolLoadingMode
 	readonly preferred?: boolean
+	/**
+	 * @deprecated Slated for removal in the next major. Never read by
+	 * anything — setting it has no effect today. Use `allowedTools` on the
+	 * query to bound which tools a run may use; it says the same thing per
+	 * run instead of per definition. See {@link ToolCatalogSurface}.
+	 */
 	readonly surfaces?: readonly ToolCatalogSurface[]
 	readonly providerConfig?: Record<string, unknown>
 }


### PR DESCRIPTION
Five changes with one thing in common: a primitive existed, was exported, was threaded through the types, and nothing drove it. Each one is either wired up or honestly labelled as inert — never left to read as working.

### `resumeRun` — the driver that continues a run in another process (`bd374cc`)

Everything it needs already existed. `CheckpointManager` writes history, budgets, working state, trace context and any park; `loadRunState` reads them back; `query` accepts `runId` + `resumeFromCheckpoint` and restores all of it. What was missing were the few lines joining them, so every host had to write their own — and nothing in this repo ever did, which means the whole path shipped untravelled.

Three outcomes instead of a nullable `Run`, because the two failures mean opposite things: `no-checkpoint` is a dead end, and `awaiting-decision` is the run working as designed — it parked on a question and continuing means answering it first. Neither is guessed past.

### Per-step `toolChoice` (`07e26f9`)

A step can force the model to call a tool, and the force cannot outlive that step. Structured output paid for the absence most visibly: the model answers in prose, the loop spends another billed turn re-prompting, and after the retry limit the run dies — where one forced choice produces the object on the first turn.

It lives on `PrepareStepResult` rather than the run config, and reading a peer's implementation is what settled that. Putting `tool_choice` on persistent model settings costs three moving parts to undo — a tool-use tracker, an opt-out flag, and a reset applied at two call sites — with the flag defaulting to on because turning it off hangs the agent. A step result is already per-step and not retained, so the reset is structural: nothing carries forward, no flag to get wrong.

### Context reduction is a seam a host can take over (`701b64f`)

`compactionConfig.strategy` took three values and the runtime read it in two places, both asking only whether it was `'disabled'`. So `'sliding-window'` — the value a host picks precisely to avoid paying for summarization — ran the full structured pass, LLM call included. A config that lied, in the direction of spending money. It now trims and summarizes nothing.

`query({ contextReducer })` takes a function: the history plus why it is being asked (the estimate says the window is filling, or the provider already rejected the prompt), returning a shorter history or `undefined`. It may be async so a reducer can call a model of its own, and it fully owns reduction for the run.

A result that orphans a `tool_result` is **refused rather than repaired** — repairing would trade a nameable "your reducer split a tool pair" for an opaque provider rejection a call later, with the reducer never implicated.

### `taskRouter` routes something (`5ebf608`)

The compaction summary is the only model call a run makes that nobody asked for, and it fires on exactly the long runs where the primary model costs most. It was hardwired to that model while `resolveTaskModel` sat exported and uncalled.

The other keys are now documented as **not consulted**, which matters as much as the wiring. Nothing classifies a spawned task as exploration or coding, and inventing a classifier would put a wrong model behind a right-looking config. A test pins the inertness, so a change that starts consulting one fails rather than shipping quietly.

### The tool-surface axis, deprecated not deleted (`de1264a`)

`ToolCatalogSurface` and `ToolsetPolicy.surfaces` are reachable from `dist/index.d.ts` and read by nothing. Same for the `ConversationManager` family — that one cannot even be implemented correctly: `reduceContext` is documented as reducing the history but takes `Message[]` and returns `boolean`, so only in-place mutation could honour it, and neither shipped implementation mutates. Both build a shorter array, discard it, return `true`. Deprecated with the reason written down, per the rule in `AGENTS.md`.

---

**Gates:** typecheck 0, lint 0, 2208 SDK tests green, public surface intact at 492 (baseline regenerated in the commit that widened it, as the gate demands), no third-party names.

**Verification:** every claim above was read at the source before acting, and every new test was mutation-checked — 7/7 on the reducer, 8/8 on the dispatch, 3/3 on the routing. Three of my own mistakes were caught by my own tests during that: a tool-pair refusal that was dead code because I wrote `hasDangling` for a field named `isValid`; a fallback branch a test claimed to cover and never reached; and two mutation anchors ambiguous enough to land on the wrong `return` and report a false pass.

**One gap deliberately not faked.** The forced-final turn takes precedence over a step's `toolChoice`. Reaching that branch from a black-box test needs a budget warning that needs real usage the mock provider does not report. The contrived test was removed and the gap written into the file instead of counting as coverage.
