### PR TITLE
feat(sdk): let a host say where plugins may come from

### DIFF
--- a/.changeset/plugin-discovery-scopes.md
+++ b/.changeset/plugin-discovery-scopes.md
@@ -1,0 +1,13 @@
+---
+'@namzu/sdk': minor
+---
+
+`allowedScopes` is a trust boundary now instead of a comment.
+
+`discoverAllPluginDirs` scans two locations — `.namzu/plugins` under the working directory, and the same path under the user's home directory — and they are not equally trusted. A project plugin is reviewable in the repository the agent is working on; a user plugin comes from a home directory the repository's reviewers never see, and a plugin is arbitrary code with hooks into tool execution.
+
+`PluginRuntimeConfig` has carried `enabled`, `autoDiscovery` and `allowedScopes` for as long as it has existed. Nothing anywhere read any of the three, and discovery scanned both locations unconditionally, so a host who set `allowedScopes: ['project']` got user plugins anyway — from a setting that reads exactly like a boundary.
+
+`discoverAllPluginDirs(cwd, { enabled: true, allowedScopes: ['project'] })` now honours it. A disallowed scope is **not scanned** rather than scanned and filtered: reading a directory you have been told not to look in is pointless work, and the returned count would disclose how many plugins live there. `enabled: false` or `autoDiscovery: false` discovers nothing at all, and a parsed `PluginRuntimeConfig` satisfies the options type as-is.
+
+Calling it with no second argument scans both scopes, exactly as before — every existing caller is unaffected, and a caller who opts in gets what the config says.

--- a/docs/sdk/integrations/plugins.md
+++ b/docs/sdk/integrations/plugins.md
@@ -1,7 +1,7 @@
 ---
 title: Plugins and MCP Servers
 description: Load project or user plugins in @namzu/sdk, register namespaced tools, execute hooks, and mount plugin-managed stdio MCP servers.
-last_updated: 2026-08-03
+last_updated: 2026-08-04
 status: current
 related_packages: ["@namzu/sdk"]
 ---
@@ -101,6 +101,36 @@ for (const pluginDir of pluginDirs.project) {
   await pluginManager.enable(plugin.id)
 }
 ```
+
+### Restricting where plugins may come from
+
+`discoverAllPluginDirs` scans two locations: `.namzu/plugins` under the working
+directory, and the same path under the user's home directory. They are not
+equally trusted. A project plugin is reviewable in the repository the agent is
+working on; a user plugin comes from a home directory the repository's
+reviewers never see, and a plugin is arbitrary code with hooks into tool
+execution.
+
+Pass the discovery half of `PluginRuntimeConfig` to say which locations are
+allowed:
+
+```ts
+const pluginDirs = await discoverAllPluginDirs(process.cwd(), {
+  enabled: true,
+  allowedScopes: ['project'],
+})
+
+// `pluginDirs.user` is empty — the home directory was never read, rather than
+// read and filtered.
+```
+
+`enabled: false` or `autoDiscovery: false` discovers nothing at all. A
+disallowed scope is not scanned rather than scanned and discarded: filtering
+afterwards still reads the directory, and the returned count would tell the
+caller how many plugins live somewhere they said they would not look.
+
+Calling `discoverAllPluginDirs(cwd)` with no second argument scans both scopes,
+which is the behaviour every existing caller already had.
 
 This gives you one important invariant:
 

--- a/packages/sdk/src/plugin/__tests__/discovery-scopes.test.ts
+++ b/packages/sdk/src/plugin/__tests__/discovery-scopes.test.ts
@@ -1,0 +1,133 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { PluginRuntimeConfigSchema } from '../../config/runtime.js'
+import {
+	PLUGIN_MANIFEST_FILENAME,
+	PROJECT_PLUGIN_DIR,
+	USER_PLUGIN_DIR,
+} from '../../constants/plugin/index.js'
+
+/**
+ * `allowedScopes` read exactly like a trust boundary and enforced nothing.
+ *
+ * A plugin is arbitrary code with hooks into tool execution, and the two
+ * scopes are not equally trusted: a project plugin is reviewable in the repo
+ * the agent works on, a user plugin comes from a home directory the repo's
+ * reviewers never see. `PluginRuntimeConfig` carried `enabled`,
+ * `autoDiscovery` and `allowedScopes`; nothing anywhere consulted any of the
+ * three, and discovery scanned both locations unconditionally.
+ */
+
+let home: string
+let workdir: string
+
+vi.mock('node:os', async () => {
+	const actual = await vi.importActual<typeof import('node:os')>('node:os')
+	return { ...actual, homedir: () => home }
+})
+
+async function plantPlugin(dir: string, name: string): Promise<void> {
+	const pluginDir = join(dir, name)
+	await mkdir(pluginDir, { recursive: true })
+	await writeFile(
+		join(pluginDir, PLUGIN_MANIFEST_FILENAME),
+		JSON.stringify({ name, version: '1.0.0' }),
+		'utf-8',
+	)
+}
+
+beforeEach(async () => {
+	home = await mkdtemp(join(tmpdir(), 'namzu-home-'))
+	workdir = await mkdtemp(join(tmpdir(), 'namzu-work-'))
+	await plantPlugin(join(workdir, PROJECT_PLUGIN_DIR), 'project-plugin')
+	await plantPlugin(join(home, USER_PLUGIN_DIR), 'user-plugin')
+})
+
+afterEach(async () => {
+	await Promise.all([
+		rm(home, { recursive: true, force: true }),
+		rm(workdir, { recursive: true, force: true }),
+	])
+})
+
+async function discover(
+	options?: Parameters<typeof import('../loader.js').discoverAllPluginDirs>[1],
+) {
+	const { discoverAllPluginDirs } = await import('../loader.js')
+	return discoverAllPluginDirs(workdir, options)
+}
+
+describe('a scope the host did not allow is not scanned', () => {
+	it('finds both when nothing is said', async () => {
+		const found = await discover()
+
+		expect(found.project).toHaveLength(1)
+		expect(found.user).toHaveLength(1)
+	})
+
+	it('keeps user plugins out when only project is allowed', async () => {
+		const found = await discover({ allowedScopes: ['project'] })
+
+		expect(found.project).toHaveLength(1)
+		// The setting that reads like a boundary now is one.
+		expect(found.user).toEqual([])
+	})
+
+	it('keeps project plugins out when only user is allowed', async () => {
+		const found = await discover({ allowedScopes: ['user'] })
+
+		expect(found.project).toEqual([])
+		expect(found.user).toHaveLength(1)
+	})
+
+	it('finds nothing when neither scope is allowed', async () => {
+		const found = await discover({ allowedScopes: [] })
+
+		expect(found).toEqual({ project: [], user: [] })
+	})
+})
+
+describe('the runtime switches turn discovery off', () => {
+	it('discovers nothing when the plugin runtime is disabled', async () => {
+		const found = await discover({ enabled: false })
+
+		expect(found).toEqual({ project: [], user: [] })
+	})
+
+	it('discovers nothing when auto-discovery is off', async () => {
+		const found = await discover({ autoDiscovery: false })
+
+		expect(found).toEqual({ project: [], user: [] })
+	})
+
+	it('a default-parsed config discovers nothing, because the runtime ships off', async () => {
+		// `enabled` defaults to false in the schema. A host who parses the
+		// config and passes it gets the documented default rather than a
+		// silently-on plugin runtime.
+		const found = await discover(PluginRuntimeConfigSchema.parse({}))
+
+		expect(found).toEqual({ project: [], user: [] })
+	})
+
+	it('an enabled default-parsed config finds both scopes', async () => {
+		const found = await discover(PluginRuntimeConfigSchema.parse({ enabled: true }))
+
+		expect(found.project).toHaveLength(1)
+		expect(found.user).toHaveLength(1)
+	})
+
+	it('a parsed config carries its scope restriction through', async () => {
+		const config = PluginRuntimeConfigSchema.parse({
+			enabled: true,
+			allowedScopes: ['project'],
+		})
+
+		const found = await discover(config)
+
+		expect(found.project).toHaveLength(1)
+		expect(found.user).toEqual([])
+	})
+})

--- a/packages/sdk/src/plugin/loader.ts
+++ b/packages/sdk/src/plugin/loader.ts
@@ -88,23 +88,77 @@ export function assertEnableable(manifest: PluginManifest): void {
 	)
 }
 
+/** Where a plugin came from. Project plugins ship with the repo; user plugins live in the home directory. */
+export type PluginScope = 'project' | 'user'
+
 /**
- * Discovers plugin directories from both project-level and user-level locations.
- * Returns categorized arrays of absolute paths.
+ * The discovery half of {@link PluginRuntimeConfig}.
+ *
+ * Structural rather than an import so this module keeps depending on nothing
+ * — a parsed `PluginRuntimeConfig` satisfies it as-is.
+ */
+export interface PluginDiscoveryOptions {
+	/** Whether the plugin runtime is on at all. `false` discovers nothing. */
+	readonly enabled?: boolean
+	/** Whether to scan for plugins. `false` discovers nothing. */
+	readonly autoDiscovery?: boolean
+	/** Which locations may be scanned. Absent means both. */
+	readonly allowedScopes?: readonly PluginScope[]
+}
+
+/**
+ * Find plugin directories, in the locations the caller permits.
+ *
+ * `allowedScopes` is a trust boundary, not a filter applied afterwards. A
+ * plugin is arbitrary code with hooks into tool execution, and the two scopes
+ * are not equally trusted: project plugins are reviewable in the repo the
+ * agent is working on, while user plugins come from a home directory the
+ * repo's reviewers never see. `['project']` is how a host says the second
+ * kind is not allowed to run here.
+ *
+ * It was previously declared and unread — `PluginRuntimeConfig` carried
+ * `enabled`, `autoDiscovery` and `allowedScopes`, nothing anywhere consulted
+ * any of them, and this function scanned both locations unconditionally. A
+ * host who set `allowedScopes: ['project']` got user plugins anyway, from a
+ * setting that reads exactly like a boundary.
+ *
+ * A disallowed scope is NOT SCANNED rather than scanned and dropped.
+ * Filtering after the fact still reads the directory, which is both pointless
+ * work and a small disclosure — the returned count would tell a caller how
+ * many plugins live somewhere they said they would not look.
+ *
+ * Passing nothing keeps the old behaviour: both scopes, no gate. Existing
+ * callers are unaffected, and a caller who opts in gets what the config says.
  */
 export async function discoverAllPluginDirs(
 	workingDirectory?: string,
+	options?: PluginDiscoveryOptions,
 ): Promise<{ project: string[]; user: string[] }> {
+	if (options?.enabled === false || options?.autoDiscovery === false) {
+		logger.debug('Plugin discovery skipped', {
+			enabled: options.enabled,
+			autoDiscovery: options.autoDiscovery,
+		})
+		return { project: [], user: [] }
+	}
+
+	const scopes = options?.allowedScopes
+	const mayScan = (scope: PluginScope): boolean => !scopes || scopes.includes(scope)
+
 	const projectDir = workingDirectory
 		? join(workingDirectory, PROJECT_PLUGIN_DIR)
 		: join(process.cwd(), PROJECT_PLUGIN_DIR)
 	const userDir = join(homedir(), USER_PLUGIN_DIR)
 
-	const [project, user] = await Promise.all([discoverPlugins(projectDir), discoverPlugins(userDir)])
+	const [project, user] = await Promise.all([
+		mayScan('project') ? discoverPlugins(projectDir) : Promise.resolve([]),
+		mayScan('user') ? discoverPlugins(userDir) : Promise.resolve([]),
+	])
 
 	logger.debug('Plugin discovery complete', {
 		projectCount: project.length,
 		userCount: user.length,
+		...(scopes ? { allowedScopes: scopes } : {}),
 	})
 
 	return { project, user }


### PR DESCRIPTION
`allowedScopes` read exactly like a trust boundary and enforced nothing.

`discoverAllPluginDirs` scans two locations — `.namzu/plugins` under the working directory, and the same path under the user's home directory — and they are not equally trusted. A project plugin is reviewable in the repository the agent is working on; a user plugin comes from a home directory the repository's reviewers never see, and a plugin is arbitrary code with hooks into tool execution.

`PluginRuntimeConfig` has carried `enabled`, `autoDiscovery` and `allowedScopes` for as long as it has existed. Nothing anywhere read any of the three, and discovery scanned both locations unconditionally — so a host who set `allowedScopes: ['project']` got user plugins anyway.

### What changed

```ts
await discoverAllPluginDirs(cwd, { enabled: true, allowedScopes: ['project'] })
// pluginDirs.user is empty, and the home directory was never read.
```

A disallowed scope is **not scanned** rather than scanned and filtered. Reading a directory you have been told not to look in is pointless work, and the returned count would disclose how many plugins live there.

Calling it with no second argument scans both scopes, exactly as before — every existing caller is unaffected, and a parsed `PluginRuntimeConfig` satisfies the options type as-is.

### What was deliberately not done

Auto-discovery is still not switched on inside the SDK. Loading home-directory plugins into every run is a blast-radius change, and it belongs to whoever owns the deployment rather than to this commit.

`hookTimeoutMs` looked equally dead in the same audit and is not: `PluginLifecycleManager` reads its own config field of that name. The runtime-config copy is a duplicate declaration, not a dead one, so it was left alone.

---

**Gates:** typecheck 0, lint 0, 2217 SDK tests green, public surface intact at 492, docs updated (`docs/sdk/integrations/plugins.md` documents this function with a worked example).

**Verification:** 9 tests, all 6 mutations caught — scope filter ignored, each scope forced open individually, `enabled` ignored, `autoDiscovery` ignored, and absent-options inverted.