### PR TITLE
fix(sdk): honor what the model and the host were asked to say

### DIFF
--- a/.changeset/honor-what-was-asked.md
+++ b/.changeset/honor-what-was-asked.md
@@ -1,0 +1,15 @@
+---
+'@namzu/sdk': minor
+---
+
+Three things the model or the host was invited to say, and the kernel discarded.
+
+**Plan step dependencies.** `approve_plan` shows the model `depends_on` on every step, described as "Step descriptions this depends on", and then passed `dependsOn: []` for all of them. The declared ordering was dropped at the one place it entered the system. The visible cost is not scheduling — `PlanManager.getNextPendingStep` holds the dependency gate and currently has no callers — it is the **approval**: `dependsOn` is serialized into the `plan_approval` payload a human reads before saying yes, so a reviewer was shown a plan whose steps all looked independent however carefully the model had ordered them.
+
+Descriptions now resolve to step ids, matched case- and whitespace-insensitively because a model does not reproduce its own strings byte-for-byte. Four things are **refused rather than dropped**, each with the offending text named so the model can correct it and call again: a dependency naming no step, one that two steps could answer, a step depending on itself, and a cycle. The cycle check matters most — no step in a loop can ever start, so the plan does not error, it simply stops making progress with nothing to observe. A diamond is not a cycle and is accepted.
+
+**Advisory context.** Two paths reach an advisor. The trigger path always passed the live messages, working state and tool catalogue. The tool path — the one the *model* uses — passed `{ messages: [], iteration: 0 }`, a literal empty context. So an advisor the model consulted about a situation could not see the situation, and the model's own `include_context: true` had nothing to include. The runtime now supplies the live context through a provider function, read at call time rather than captured at construction, because the tool is built once per run and called at an unknown later point.
+
+That is also where `AdvisoryConfig.includeToolCatalog` and `AdvisorDefinition.useCompactedContext` are read for the first time. Both were declared and consulted by nothing, so a host who turned the catalogue off still paid for it in every advisory prompt.
+
+**Advisory urgency.** `urgency` reached exactly one debug log line, so `'high'` and `'low'` produced byte-identical requests. The advisor is now told, because it is the party that can act on it — one sentence rather than a routing policy this kernel has no business inventing. `'normal'` appends nothing at all: a sentence asserting the ordinary case is prompt weight that changes no answer and makes the two that matter harder to notice.

--- a/packages/sdk/src/advisory/__tests__/consultation-context.test.ts
+++ b/packages/sdk/src/advisory/__tests__/consultation-context.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AdvisorDefinition } from '../../types/advisory/index.js'
+import type { Message } from '../../types/message/index.js'
+import { AdvisoryContext } from '../context.js'
+import { TriggerEvaluator } from '../evaluator.js'
+import { AdvisoryExecutor } from '../executor.js'
+import { ADVISORY_RESPONSE_CONTRACT } from '../parse.js'
+import { AdvisorRegistry } from '../registry.js'
+
+/**
+ * An advisor consulted BY THE MODEL saw the question and nothing else.
+ *
+ * Two paths reach `AdvisoryExecutor.consult`. The trigger path
+ * (`iteration/phases/advisory.ts`) has always passed the live messages, the
+ * working state and the tool catalogue. The tool path passed
+ * `{ messages: [], iteration: 0 }` — a literal empty context — so the
+ * model's own `include_context: true` had nothing to include, and the
+ * advisor answered a question about a situation it could not see.
+ */
+
+function recordingProvider(): { provider: AdvisorDefinition['provider']; calls: Message[][] } {
+	const calls: Message[][] = []
+	const provider = {
+		chatStream: async function* (params: { messages: Message[] }) {
+			calls.push(params.messages)
+			yield { id: 'a1', delta: { content: 'ADVICE: do the thing' } }
+			yield {
+				id: 'a1',
+				delta: {},
+				finishReason: 'stop',
+				usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+			}
+		},
+	} as unknown as AdvisorDefinition['provider']
+	return { provider, calls }
+}
+
+function advisor(over: Partial<AdvisorDefinition> = {}): AdvisorDefinition {
+	return {
+		id: 'adv_1',
+		name: 'Reviewer',
+		provider: recordingProvider().provider,
+		model: 'mock-model',
+		...over,
+	} as AdvisorDefinition
+}
+
+const log = {
+	debug: vi.fn(),
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	child: () => log,
+} as never
+
+function contextFor(a: AdvisorDefinition): AdvisoryContext {
+	return new AdvisoryContext(
+		new AdvisorRegistry([a]),
+		new AdvisoryExecutor(log),
+		new TriggerEvaluator([]),
+	)
+}
+
+describe('the context a tool-initiated consultation is given', () => {
+	it('is empty until the runtime supplies one', () => {
+		const ctx = contextFor(advisor())
+
+		// The fallback exists for a context built without a runtime, and it is
+		// what every tool-initiated call used to get.
+		expect(ctx.callContext()).toEqual({ messages: [], iteration: 0 })
+	})
+
+	it('is the live run once the runtime wires it', () => {
+		const ctx = contextFor(advisor())
+		const messages: Message[] = [{ role: 'user', content: 'the situation', timestamp: 1 }]
+
+		ctx.setCallContextProvider(() => ({ messages, iteration: 7 }))
+
+		expect(ctx.callContext().messages).toBe(messages)
+		expect(ctx.callContext().iteration).toBe(7)
+	})
+
+	it('is read at call time, not at construction', () => {
+		const ctx = contextFor(advisor())
+		let iteration = 1
+		ctx.setCallContextProvider(() => ({ messages: [], iteration }))
+
+		iteration = 4
+
+		// The tool is built once per run and called at an unknown later point.
+		// A snapshot would hand every advisor the state the run started with.
+		expect(ctx.callContext().iteration).toBe(4)
+	})
+})
+
+describe('what the advisor actually receives', () => {
+	it('sees the conversation when context is included', async () => {
+		const { provider, calls } = recordingProvider()
+		const executor = new AdvisoryExecutor(log)
+
+		await executor.consult(
+			advisor({ provider }),
+			{ advisorId: 'adv_1', question: 'what next?', includeContext: true },
+			{ messages: [{ role: 'user', content: 'deploy is failing', timestamp: 1 }], iteration: 2 },
+		)
+
+		const sent = JSON.stringify(calls[0])
+		expect(sent).toContain('deploy is failing')
+	})
+
+	it('sees none of it when the caller says not to', async () => {
+		const { provider, calls } = recordingProvider()
+		const executor = new AdvisoryExecutor(log)
+
+		await executor.consult(
+			advisor({ provider }),
+			{ advisorId: 'adv_1', question: 'what next?', includeContext: false },
+			{ messages: [{ role: 'user', content: 'deploy is failing', timestamp: 1 }], iteration: 2 },
+		)
+
+		expect(JSON.stringify(calls[0])).not.toContain('deploy is failing')
+	})
+
+	it('is told when the caller marked the request urgent', async () => {
+		const { provider, calls } = recordingProvider()
+		const executor = new AdvisoryExecutor(log)
+
+		await executor.consult(
+			advisor({ provider }),
+			{ advisorId: 'adv_1', question: 'what next?', urgency: 'high' },
+			{ messages: [], iteration: 1 },
+		)
+
+		// The value used to reach exactly one debug log line, so 'high' and
+		// 'low' produced byte-identical requests.
+		expect(String(calls[0]?.[0]?.content)).toContain('URGENT')
+	})
+
+	it('is told when there is room to consider alternatives', async () => {
+		const { provider, calls } = recordingProvider()
+		const executor = new AdvisoryExecutor(log)
+
+		await executor.consult(
+			advisor({ provider }),
+			{ advisorId: 'adv_1', question: 'what next?', urgency: 'low' },
+			{ messages: [], iteration: 1 },
+		)
+
+		expect(String(calls[0]?.[0]?.content)).toContain('low urgency')
+	})
+
+	it("appends nothing at all for 'normal', which is the point of not stating it", async () => {
+		const { provider, calls } = recordingProvider()
+		const executor = new AdvisoryExecutor(log)
+		const a = advisor({ provider })
+
+		await executor.consult(
+			a,
+			{ advisorId: 'adv_1', question: 'what next?', urgency: 'normal' },
+			{ messages: [], iteration: 1 },
+		)
+		await executor.consult(
+			a,
+			{ advisorId: 'adv_1', question: 'what next?', urgency: 'high' },
+			{ messages: [], iteration: 1 },
+		)
+
+		// Asserting "does not contain the other two phrases" is too weak — it
+		// would let ANY new sentence in. The response contract is the last
+		// thing the prompt says when urgency contributes nothing, so ending on
+		// it is what "appended nothing" actually means.
+		expect(String(calls[0]?.[0]?.content).trimEnd().endsWith(ADVISORY_RESPONSE_CONTRACT)).toBe(true)
+		expect(String(calls[1]?.[0]?.content).trimEnd().endsWith(ADVISORY_RESPONSE_CONTRACT)).toBe(
+			false,
+		)
+	})
+
+	it('says nothing about urgency when the caller did not', async () => {
+		const { provider, calls } = recordingProvider()
+		const executor = new AdvisoryExecutor(log)
+
+		await executor.consult(
+			advisor({ provider }),
+			{ advisorId: 'adv_1', question: 'what next?' },
+			{ messages: [], iteration: 1 },
+		)
+
+		expect(String(calls[0]?.[0]?.content).trimEnd().endsWith(ADVISORY_RESPONSE_CONTRACT)).toBe(true)
+	})
+})

--- a/packages/sdk/src/advisory/context.ts
+++ b/packages/sdk/src/advisory/context.ts
@@ -1,7 +1,19 @@
 import type { AdvisoryBudget, AdvisoryCallRecord } from '../types/advisory/index.js'
 import type { TriggerEvaluator } from './evaluator.js'
+import type { AdvisoryCallContext } from './executor.js'
 import type { AdvisoryExecutor } from './executor.js'
 import type { AdvisorRegistry } from './registry.js'
+
+/**
+ * What the run looks like right now, for an advisory call that did not come
+ * from the iteration loop.
+ *
+ * A function rather than a snapshot because the tool is built once per run
+ * and called at an unknown later point: capturing the context at
+ * construction would hand every advisor the state the run had before it
+ * started.
+ */
+export type AdvisoryCallContextProvider = () => AdvisoryCallContext
 
 export class AdvisoryContext {
 	readonly registry: AdvisorRegistry
@@ -10,6 +22,7 @@ export class AdvisoryContext {
 	readonly callHistory: AdvisoryCallRecord[] = []
 
 	private readonly budget: AdvisoryBudget | undefined
+	private callContextProvider: AdvisoryCallContextProvider | undefined
 
 	constructor(
 		registry: AdvisorRegistry,
@@ -21,6 +34,25 @@ export class AdvisoryContext {
 		this.executor = executor
 		this.evaluator = evaluator
 		this.budget = budget
+	}
+
+	/** Wired by the runtime once the run exists. */
+	setCallContextProvider(provider: AdvisoryCallContextProvider): void {
+		this.callContextProvider = provider
+	}
+
+	/**
+	 * The call context for a tool-initiated consultation.
+	 *
+	 * The trigger path (`iteration/phases/advisory.ts`) has always passed the
+	 * live messages, working state and tool catalogue. The TOOL path passed
+	 * `{ messages: [], iteration: 0 }` — a literal empty context — so an
+	 * advisor consulted by the model saw the question and nothing else, and
+	 * the model's `include_context` had nothing to include either way. The
+	 * empty fallback survives only for a context built without a runtime.
+	 */
+	callContext(): AdvisoryCallContext {
+		return this.callContextProvider?.() ?? { messages: [], iteration: 0 }
 	}
 
 	recordCall(record: AdvisoryCallRecord): void {

--- a/packages/sdk/src/advisory/executor.ts
+++ b/packages/sdk/src/advisory/executor.ts
@@ -11,6 +11,19 @@ import { calculateCost } from '../utils/cost.js'
 import { type Logger, getRootLogger } from '../utils/logger.js'
 import { ADVISORY_RESPONSE_CONTRACT, parseAdvisoryResponse } from './parse.js'
 
+/**
+ * What the advisor is told about how urgent the caller said this is.
+ *
+ * `'normal'` says nothing on purpose. A sentence asserting the ordinary case
+ * is prompt weight that changes no answer, and stating it on every call
+ * would make the two that matter harder to notice.
+ */
+const URGENCY_DIRECTION: Record<'low' | 'normal' | 'high', string | undefined> = {
+	high: 'This request is marked URGENT. Lead with the single most important action and keep the reasoning to what is needed to justify it.',
+	normal: undefined,
+	low: 'This request is marked low urgency. There is room to note secondary considerations and alternatives worth weighing.',
+}
+
 export interface AdvisoryCallContext {
 	readonly messages: Message[]
 	readonly workingStateSummary?: string
@@ -53,7 +66,7 @@ export class AdvisoryExecutor {
 	): Promise<AdvisoryExecutionResult> {
 		const startMs = Date.now()
 
-		const systemPrompt = this.buildSystemPrompt(advisor)
+		const systemPrompt = this.buildSystemPrompt(advisor, request.urgency)
 		const contextMessages = this.buildContext(advisor, request, callCtx)
 
 		const messages: Message[] = [
@@ -100,11 +113,25 @@ export class AdvisoryExecutor {
 		}
 	}
 
-	private buildSystemPrompt(advisor: AdvisorDefinition): string {
+	private buildSystemPrompt(
+		advisor: AdvisorDefinition,
+		urgency?: AdvisoryRequest['urgency'],
+	): string {
 		// The contract is appended to every branch, not folded into the
 		// default: an advisor with its own prompt or a persona is still read
 		// back by the same parser, and used to be the one never told so.
-		return `${this.describeAdvisor(advisor)}\n\n${ADVISORY_RESPONSE_CONTRACT}`
+		const parts = [this.describeAdvisor(advisor), ADVISORY_RESPONSE_CONTRACT]
+
+		// The caller is invited to say how urgent this is, and the value used
+		// to reach exactly one debug log line — `urgency: 'high'` and
+		// `urgency: 'low'` produced byte-identical requests. Telling the
+		// ADVISOR is the honest minimum: it is the party that can act on the
+		// answer, and it costs one sentence rather than a routing policy this
+		// kernel has no business inventing.
+		const direction = URGENCY_DIRECTION[urgency ?? 'normal']
+		if (direction) parts.push(direction)
+
+		return parts.join('\n\n')
 	}
 
 	private describeAdvisor(advisor: AdvisorDefinition): string {

--- a/packages/sdk/src/runtime/query/index.ts
+++ b/packages/sdk/src/runtime/query/index.ts
@@ -10,6 +10,7 @@ import { findDanglingMessages, removeDanglingMessages } from '../../compaction/d
 import { extractFromUserMessage } from '../../compaction/extractor.js'
 import { WorkingStateManager } from '../../compaction/manager.js'
 import type { ContextReducer } from '../../compaction/reducer.js'
+import { serializeState as serializeWorkingState } from '../../compaction/serializer.js'
 import { restoreWorkingState, snapshotWorkingState } from '../../compaction/wire.js'
 import type { CompactionConfig } from '../../config/runtime.js'
 import { TOOL_OUTPUT_DIR_NAME } from '../../constants/tools/index.js'
@@ -762,6 +763,31 @@ export async function* query(params: QueryParams): AsyncGenerator<RunEvent, Run>
 			triggerEvaluator,
 			params.advisory.budget,
 		)
+
+		// What the run looks like when the MODEL consults an advisor, as
+		// opposed to when a trigger does. The trigger path has always passed
+		// this; the tool path passed an empty context, so an advisor the model
+		// asked for help saw the question and nothing else.
+		//
+		// `includeToolCatalog` and `useCompactedContext` are read here and
+		// nowhere else. Both were declared on `AdvisoryConfig` /
+		// `AdvisorDefinition` and consulted by nothing, so a host who turned
+		// the catalogue off still paid for it in every advisory prompt.
+		const advisoryConfig = params.advisory
+		advisoryCtx.setCallContextProvider(() => {
+			const summary =
+				workingStateManager && advisoryConfig.advisors.some((a) => a.useCompactedContext)
+					? serializeWorkingState(workingStateManager.getState())
+					: undefined
+			return {
+				messages: ctx.runMgr.messages,
+				...(summary !== undefined ? { workingStateSummary: summary } : {}),
+				...(advisoryConfig.includeToolCatalog
+					? { toolCatalog: params.tools.toLLMTools(effectiveAllowedTools) }
+					: {}),
+				iteration: ctx.runMgr.currentIteration,
+			}
+		})
 
 		if (params.advisory.enableAgentTool) {
 			const advisoryTools = buildAdvisoryTools({ advisoryCtx })

--- a/packages/sdk/src/tools/advisory/index.ts
+++ b/packages/sdk/src/tools/advisory/index.ts
@@ -104,7 +104,7 @@ export function buildAdvisoryTools(opts: AdvisoryToolsOptions): ToolDefinition[]
 			const executionResult = await advisoryCtx.executor.consult(
 				advisor,
 				{ advisorId: advisor.id, question, domain, urgency, includeContext: include_context },
-				{ messages: [], iteration: 0 },
+				advisoryCtx.callContext(),
 			)
 
 			advisoryCtx.recordCall({

--- a/packages/sdk/src/tools/coordinator/__tests__/plan-dependencies.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/plan-dependencies.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolvePlanDependencies } from '../plan-dependencies.js'
+
+/**
+ * The model is shown `depends_on` on every plan step and told it means
+ * "Step descriptions this depends on". `approve_plan` then passed
+ * `dependsOn: []` for every step, so the ordering it declared was discarded
+ * at the only place it entered the system.
+ *
+ * The cost is not scheduling — the dependency gate in `PlanManager` has no
+ * callers — it is the approval. `dependsOn` is serialized into the
+ * `plan_approval` payload a human reads before saying yes, so the reviewer
+ * saw a plan whose steps all looked independent however carefully the model
+ * had ordered them.
+ */
+
+const id = (index: number) => `step_${index + 1}`
+
+describe('what the model described becomes what the plan holds', () => {
+	it('resolves a description to the step that carries it', () => {
+		const result = resolvePlanDependencies(
+			[
+				{ description: 'Read the config' },
+				{ description: 'Write the report', depends_on: ['Read the config'] },
+			],
+			id,
+		)
+
+		expect(result).toEqual({ ok: true, dependsOn: [[], ['step_1']] })
+	})
+
+	it('resolves several dependencies on one step', () => {
+		const result = resolvePlanDependencies(
+			[
+				{ description: 'Read the config' },
+				{ description: 'Read the code' },
+				{ description: 'Write the report', depends_on: ['Read the config', 'Read the code'] },
+			],
+			id,
+		)
+
+		expect(result.ok && result.dependsOn[2]).toEqual(['step_1', 'step_2'])
+	})
+
+	it('resolves a forward dependency, since order of declaration is not order of execution', () => {
+		const result = resolvePlanDependencies(
+			[
+				{ description: 'Write the report', depends_on: ['Read the config'] },
+				{ description: 'Read the config' },
+			],
+			id,
+		)
+
+		expect(result.ok && result.dependsOn[0]).toEqual(['step_2'])
+	})
+
+	it('leaves a step with no dependencies empty', () => {
+		const result = resolvePlanDependencies([{ description: 'Read the config' }], id)
+
+		expect(result).toEqual({ ok: true, dependsOn: [[]] })
+	})
+
+	it('forgives whitespace and casing a model did not keep identical', () => {
+		const result = resolvePlanDependencies(
+			[
+				{ description: 'Read  the config' },
+				{ description: 'Write', depends_on: ['read the   CONFIG '] },
+			],
+			id,
+		)
+
+		// Rejecting this would teach the model nothing, for a plan that was
+		// right.
+		expect(result.ok && result.dependsOn[1]).toEqual(['step_1'])
+	})
+
+	it('collapses the same dependency named twice', () => {
+		const result = resolvePlanDependencies(
+			[{ description: 'Read' }, { description: 'Write', depends_on: ['Read', 'Read'] }],
+			id,
+		)
+
+		expect(result.ok && result.dependsOn[1]).toEqual(['step_1'])
+	})
+})
+
+describe('a dependency that cannot mean anything is refused, not dropped', () => {
+	it('refuses a dependency naming no step', () => {
+		const result = resolvePlanDependencies(
+			[{ description: 'Write', depends_on: ['Read the config'] }],
+			id,
+		)
+
+		expect(result.ok).toBe(false)
+		// The model has to be able to act on it, so the offending text is named.
+		expect(!result.ok && result.error).toContain('Read the config')
+	})
+
+	it('refuses a dependency two steps could answer', () => {
+		const result = resolvePlanDependencies(
+			[
+				{ description: 'Review' },
+				{ description: 'Review' },
+				{ description: 'Report', depends_on: ['Review'] },
+			],
+			id,
+		)
+
+		// Picking either is a coin flip whose result a human then approves as
+		// if it were the model's intent.
+		expect(result.ok).toBe(false)
+		expect(!result.ok && result.error).toContain('2 steps share that description')
+	})
+
+	it('refuses a step that depends on itself', () => {
+		const result = resolvePlanDependencies([{ description: 'Loop', depends_on: ['Loop'] }], id)
+
+		expect(result.ok).toBe(false)
+		expect(!result.ok && result.error).toContain('depends on itself')
+	})
+
+	it('refuses a two-step cycle', () => {
+		const result = resolvePlanDependencies(
+			[
+				{ description: 'A', depends_on: ['B'] },
+				{ description: 'B', depends_on: ['A'] },
+			],
+			id,
+		)
+
+		expect(result.ok).toBe(false)
+		expect(!result.ok && result.error).toContain('loop')
+	})
+
+	it('refuses a cycle several steps long', () => {
+		const result = resolvePlanDependencies(
+			[
+				{ description: 'A', depends_on: ['C'] },
+				{ description: 'B', depends_on: ['A'] },
+				{ description: 'C', depends_on: ['B'] },
+			],
+			id,
+		)
+
+		// This is the failure worth catching hardest: no step in a loop can
+		// start, so the plan does not error — it simply stops.
+		expect(result.ok).toBe(false)
+		expect(!result.ok && result.error).toContain('loop')
+	})
+
+	it('names every step in the loop so it can be broken', () => {
+		const result = resolvePlanDependencies(
+			[
+				{ description: 'Alpha', depends_on: ['Gamma'] },
+				{ description: 'Beta' },
+				{ description: 'Gamma', depends_on: ['Alpha'] },
+			],
+			id,
+		)
+
+		expect(result.ok).toBe(false)
+		if (result.ok) return
+		expect(result.error).toContain('Alpha')
+		expect(result.error).toContain('Gamma')
+		// Beta is not in the loop and must not be blamed for it.
+		expect(result.error).not.toContain('Beta')
+	})
+
+	it('accepts a diamond, which is not a cycle', () => {
+		const result = resolvePlanDependencies(
+			[
+				{ description: 'Start' },
+				{ description: 'Left', depends_on: ['Start'] },
+				{ description: 'Right', depends_on: ['Start'] },
+				{ description: 'Join', depends_on: ['Left', 'Right'] },
+			],
+			id,
+		)
+
+		// Two paths reaching one step is an ordinary plan shape, and a naive
+		// visited-set cycle check calls it a loop.
+		expect(result.ok).toBe(true)
+		expect(result.ok && result.dependsOn[3]).toEqual(['step_2', 'step_3'])
+	})
+})

--- a/packages/sdk/src/tools/coordinator/index.ts
+++ b/packages/sdk/src/tools/coordinator/index.ts
@@ -8,6 +8,7 @@ import type { RunId, TaskId } from '../../types/ids/index.js'
 import type { TaskStore } from '../../types/task/index.js'
 import type { ToolDefinition } from '../../types/tool/index.js'
 import { defineTool } from '../defineTool.js'
+import { resolvePlanDependencies } from './plan-dependencies.js'
 
 export type TaskLaunchedCallback = (
 	agentTaskId: TaskId,
@@ -437,6 +438,15 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 					}
 				}
 
+				// Resolve BEFORE touching the plan manager. A refusal here has to
+				// leave no half-built plan behind: `startGenerating` replaces the
+				// current plan, so failing after it would discard a plan that was
+				// fine in favour of one that never completes.
+				const dependencies = resolvePlanDependencies(steps, (index) => `step_${index + 1}`)
+				if (!dependencies.ok) {
+					return { success: false, output: '', error: dependencies.error }
+				}
+
 				pm.startGenerating(title)
 				for (let i = 0; i < steps.length; i++) {
 					const step = steps[i]
@@ -445,7 +455,10 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 						id: `step_${i + 1}`,
 						description: step.description,
 						toolName: step.agent_id ? 'create_task' : undefined,
-						dependsOn: [],
+						// Was `[]` unconditionally, which dropped every ordering
+						// constraint the model was invited to express — and put an
+						// empty dependency list in front of the human approving it.
+						dependsOn: [...(dependencies.dependsOn[i] ?? [])],
 						order: i + 1,
 					})
 				}

--- a/packages/sdk/src/tools/coordinator/plan-dependencies.ts
+++ b/packages/sdk/src/tools/coordinator/plan-dependencies.ts
@@ -1,0 +1,175 @@
+/**
+ * Turn the dependencies a model described into the step ids a plan uses.
+ *
+ * The model is shown `depends_on: string[]` on every plan step, described to
+ * it as "Step descriptions this depends on" — descriptions, because that is
+ * the only handle it has. Step ids are minted at execute time (`step_1`,
+ * `step_2`, ...), so the model cannot name one and should not be asked to.
+ *
+ * The translation between the two was never written. `approve_plan` passed
+ * `dependsOn: []` for every step, so whatever ordering the model declared
+ * was dropped at the one place it entered the system. The visible cost is
+ * not scheduling — `PlanManager.getNextPendingStep` holds the dependency
+ * gate and currently has no callers — it is the APPROVAL: `dependsOn` is
+ * serialized into the `plan_approval` payload a human reads before saying
+ * yes, so a reviewer was shown a plan whose steps all looked independent
+ * however carefully the model had ordered them.
+ */
+
+/** What the model said, before ids exist. */
+export interface DescribedStep {
+	readonly description: string
+	readonly depends_on?: readonly string[]
+}
+
+export type ResolvedDependencies =
+	| { readonly ok: true; readonly dependsOn: readonly (readonly string[])[] }
+	| { readonly ok: false; readonly error: string }
+
+/**
+ * Resolve every step's declared dependencies to step ids, or refuse.
+ *
+ * Returns one id array per input step, positionally.
+ *
+ * **Refusing beats dropping.** Every failure here means the model expressed
+ * an ordering it cannot have and the plan does not mean what it says; the
+ * old behaviour — discard silently — is what put an empty dependency list in
+ * front of a human approver. The error text names the offending description
+ * so the model can correct it and call again, which is the same shape every
+ * other recoverable tool failure in this kernel uses.
+ */
+export function resolvePlanDependencies(
+	steps: readonly DescribedStep[],
+	idOf: (index: number) => string,
+): ResolvedDependencies {
+	const byDescription = new Map<string, number[]>()
+	for (let i = 0; i < steps.length; i++) {
+		const description = steps[i]?.description
+		if (description === undefined) continue
+		const key = normalize(description)
+		const at = byDescription.get(key)
+		if (at) at.push(i)
+		else byDescription.set(key, [i])
+	}
+
+	const resolved: string[][] = []
+
+	for (let i = 0; i < steps.length; i++) {
+		const step = steps[i]
+		const declared = step?.depends_on
+		if (!step || !declared || declared.length === 0) {
+			resolved.push([])
+			continue
+		}
+
+		const ids: string[] = []
+		const seen = new Set<number>()
+
+		for (const wanted of declared) {
+			const matches = byDescription.get(normalize(wanted))
+
+			if (!matches) {
+				return {
+					ok: false,
+					error: `Step ${i + 1} depends on "${wanted}", which is not the description of any step in this plan. A dependency has to name another step exactly. Fix the description or drop the dependency, then call approve_plan again.`,
+				}
+			}
+
+			// Two steps sharing a description make "depends on that one"
+			// unanswerable. Picking either is a coin flip whose result a human
+			// then approves as if it were the model's intent.
+			if (matches.length > 1) {
+				return {
+					ok: false,
+					error: `Step ${i + 1} depends on "${wanted}", but ${matches.length} steps share that description, so it does not identify one. Make the descriptions distinct, then call approve_plan again.`,
+				}
+			}
+
+			const target = matches[0] as number
+
+			if (target === i) {
+				return {
+					ok: false,
+					error: `Step ${i + 1} depends on itself. A step cannot wait for its own completion; remove the dependency and call approve_plan again.`,
+				}
+			}
+
+			// Duplicates in one step's list are harmless — same edge twice.
+			if (seen.has(target)) continue
+			seen.add(target)
+			ids.push(idOf(target))
+		}
+
+		resolved.push(ids)
+	}
+
+	// A cycle is the failure worth catching hardest. Every step in one waits
+	// for another that is waiting for it, so the dependency gate never
+	// releases any of them and a plan that reads as fine simply stops. There
+	// is no error to observe at that point — the run just makes no progress.
+	const cycle = findCycle(resolved, (index) => idOf(index))
+	if (cycle) {
+		return {
+			ok: false,
+			error: `These steps depend on each other in a loop: ${cycle.map((i) => `step ${i + 1} ("${steps[i]?.description ?? ''}")`).join(' -> ')}. No step in a loop can ever start, because each waits for another that is waiting for it. Break the loop and call approve_plan again.`,
+		}
+	}
+
+	return { ok: true, dependsOn: resolved }
+}
+
+/**
+ * Descriptions come from a model, so they carry incidental whitespace and
+ * casing differences between the step and the reference to it. Matching on
+ * the exact string would reject "Run the tests" against "run the tests " —
+ * a refusal the model cannot learn anything from, for a plan that was right.
+ */
+function normalize(description: string): string {
+	return description.trim().replace(/\s+/g, ' ').toLowerCase()
+}
+
+/** Indices forming a dependency cycle, in order, or undefined. */
+function findCycle(
+	dependsOn: readonly (readonly string[])[],
+	idOf: (index: number) => string,
+): number[] | undefined {
+	const indexOfId = new Map<string, number>()
+	for (let i = 0; i < dependsOn.length; i++) indexOfId.set(idOf(i), i)
+
+	const UNVISITED = 0
+	const ON_STACK = 1
+	const DONE = 2
+	const state = new Array<number>(dependsOn.length).fill(UNVISITED)
+	const stack: number[] = []
+
+	const walk = (node: number): number[] | undefined => {
+		state[node] = ON_STACK
+		stack.push(node)
+
+		for (const depId of dependsOn[node] ?? []) {
+			const next = indexOfId.get(depId)
+			if (next === undefined) continue
+			if (state[next] === ON_STACK) {
+				// Report the loop itself, not the path that reached it.
+				const from = stack.indexOf(next)
+				return [...stack.slice(from), next]
+			}
+			if (state[next] === UNVISITED) {
+				const found = walk(next)
+				if (found) return found
+			}
+		}
+
+		stack.pop()
+		state[node] = DONE
+		return undefined
+	}
+
+	for (let i = 0; i < dependsOn.length; i++) {
+		if (state[i] !== UNVISITED) continue
+		const found = walk(i)
+		if (found) return found
+	}
+
+	return undefined
+}


### PR DESCRIPTION
Three declarations invited an answer and threw it away. Found by a systematic sweep for the defect class that has produced every fix in this series: a primitive is declared, threaded through the types, exported — and read by nothing.

### The model was shown a field it was asked to fill

`approve_plan` renders `depends_on: string[]` into the tool schema the model sees, described as *"Step descriptions this depends on"*. `execute` then wrote `dependsOn: []` for every step.

The interesting part is where it hurts. It is **not** scheduling — `PlanManager.getNextPendingStep` holds the dependency gate and has no callers today. It is the **approval**: `dependsOn` is serialized into the `plan_approval` payload at `runtime/query/index.ts:513` and `iteration/phases/plan.ts:32`, which is what a human reads before saying yes. A reviewer was shown a plan whose steps all looked independent however carefully the model had ordered them.

Descriptions now resolve to the step ids the plan uses — the model cannot name an id, they are minted at execute time as `step_N` — matched case- and whitespace-insensitively, because a model does not reproduce its own strings byte-for-byte and refusing over a trailing space teaches it nothing.

Four cases are **refused rather than dropped**, each naming the offending text so the model can fix it and call again:

| Case | Why refusing beats dropping |
|---|---|
| Names no step | The ordering the model expressed does not exist |
| Two steps could answer it | Picking one is a coin flip a human then approves as intent |
| Depends on itself | A step cannot wait for its own completion |
| Cycle | **No step in a loop can start, so the plan does not error — it stops** |

The cycle check earns its code. A diamond is not a cycle and is accepted; a naive visited-set check calls it one.

Resolution runs **before** `startGenerating`, because that call replaces the current plan — refusing after it would discard a good plan in favour of one that never completes.

### An advisor the model consulted could not see the situation

Two paths reach `AdvisoryExecutor.consult`. The trigger path (`iteration/phases/advisory.ts:104-109`) has always passed the live messages, working state and tool catalogue. The tool path — the one the *model* uses — passed `{ messages: [], iteration: 0 }`, a literal empty context. So `include_context: true` had nothing to include, and the advisor answered a question about a situation it was never shown.

The runtime now supplies it through a provider function read **at call time**, not captured at construction: the tool is built once per run and called at an unknown later point, so a snapshot would hand every advisor the state the run started with.

That wiring is also the first reader `AdvisoryConfig.includeToolCatalog` and `AdvisorDefinition.useCompactedContext` have ever had. Both were declared and consulted by nothing, so a host who turned the catalogue off still paid for it in every advisory prompt.

### Urgency reached one log line

`urgency` appeared exactly once outside its declaration — inside a `logger.debug` payload — so the two ends of the scale produced byte-identical provider requests. The advisor is now told, because it is the party that can act on the answer. That is one sentence rather than a model-routing policy this kernel has no business inventing.

The ordinary case appends nothing at all. Stating it is prompt weight that changes no answer and makes the two that matter harder to notice.

---

**Gates:** typecheck 0, lint 0, 2239 SDK tests green, public surface intact at 492, no third-party names.

**Verification:** 22 tests, 10/10 mutations caught — but only after two vacuous attempts, which is worth recording. The test for "the ordinary urgency appends nothing" first asserted the absence of two phrases and **survived** a mutation that added a third sentence. The second attempt asserted byte-equality between explicit-normal and absent-urgency, and was *also* vacuous: `urgency ?? 'normal'` makes those the same branch by construction. Only the third — the prompt must end on the response contract — actually pins it.
