### PR TITLE
fix(sdk): put the MCP admission boundary on the path servers take, and close spans in finally

### DIFF
--- a/.changeset/mcp-admission-on-the-live-path.md
+++ b/.changeset/mcp-admission-on-the-live-path.md
@@ -1,0 +1,15 @@
+---
+'@namzu/sdk': minor
+---
+
+The MCP admission boundary is on the path a real server takes.
+
+`MCPToolDiscovery` has held two checks since it was written: a per-server allow/deny policy deciding what a server may contribute, and detection for a server whose tool set changed since it was last seen. It was implemented, tested and publicly exported, and **nothing outside its own tests ever constructed one**.
+
+`PluginLifecycleManager.attachMCPServer` — the only code in the tree that connects a real MCP server — called `client.listTools()` and registered whatever came back. So the remote side decided what entered the agent's tool registry, which is least privilege inverted at the one place it matters. Tools land as `deferred` and a run's `allowedTools` filters the model-visible catalogue, so this was never "arbitrary tools reach the model immediately" — but the check written for exactly this was not consulted.
+
+`PluginLifecycleManagerConfig` takes `mcpToolPolicies` and `onMCPToolDrift`, and discovery now runs through the boundary. Passing neither admits everything, exactly as before: adding a boundary must not turn a working plugin into a broken one.
+
+**Drift is keyed by server name rather than client id, and that is what makes it fire at all.** A client id is minted per connection, so on the path a real server takes — a plugin enabling, connecting, being disabled, another enabling — every discovery was the first that id had ever seen and drift could not fire however many times the server changed underneath. The threat it exists for is a server that advertises something benign while a host is deciding and something else afterwards, which is a property of the *server* across connections. For the same reason a disconnect no longer forgets what a server last advertised: forgetting on teardown is precisely the window that swap uses.
+
+Drift compares what was **admitted**, not what was advertised, so a tool the policy refuses either way does not raise a warning. A warning that fires for something already refused trains a host to ignore the one that matters.

--- a/.changeset/spans-close-in-finally.md
+++ b/.changeset/spans-close-in-finally.md
@@ -1,0 +1,15 @@
+---
+'@namzu/sdk': patch
+---
+
+A span closes however its work leaves.
+
+Two sites had the same shape: `end()` called at every exit the author could see. The iteration loop had seventeen of them; the tool executor had three early returns plus a `finally` that opened below them. That makes span closure a rule every future edit has to remember, and it was already broken in both places.
+
+In the iteration loop, the span was created and then four statements ran before the `try` — attaching the tool parent span, stamping attributes, emitting `iteration_started`, draining pending events. A throw from any of those left the span open. The loop body is also an async generator, so a consumer that abandons it reached no exit at all.
+
+In the tool executor, `getOrThrow(toolName)` sat outside the `try` that owned the `finally`. The path where a model invents a tool name — the most likely way that throw happens — opened a span and never closed it.
+
+An iteration span that never ends is a trace that never closes, so the export is incomplete for exactly the run that failed and is hardest to debug from the outside.
+
+Both now end in a single `finally`. No status or exception recording moved; only the moment of closing.

--- a/packages/sdk/src/connector/mcp/discovery.ts
+++ b/packages/sdk/src/connector/mcp/discovery.ts
@@ -38,7 +38,18 @@ export class MCPToolDiscovery {
 	private clients: MCPClient[]
 	private log: Logger
 	private options: MCPToolDiscoveryOptions
-	/** Last admitted tool set per client, for drift detection. */
+	/**
+	 * Last admitted tool set per SERVER, for drift detection.
+	 *
+	 * Keyed by server name rather than client id, and the difference is the
+	 * whole point. A client id is minted per connection, so on the path a
+	 * real MCP server actually takes — a plugin enabling, connecting, and
+	 * being disabled again — every discovery was the first one that id had
+	 * ever seen, and drift could not fire however many times the server
+	 * changed underneath. The threat is a server that advertises something
+	 * benign when a host approves it and something else afterwards, which is
+	 * a property of the SERVER across connections.
+	 */
 	private lastSeen = new Map<string, MCPToolDefinition[]>()
 
 	constructor(clients: MCPClient[], options: MCPToolDiscoveryOptions = {}) {
@@ -53,7 +64,11 @@ export class MCPToolDiscovery {
 
 	removeClient(clientId: string): void {
 		this.clients = this.clients.filter((c) => c.id !== clientId)
-		this.lastSeen.delete(clientId)
+		// The remembered tool set is deliberately NOT forgotten. Dropping it on
+		// disconnect is what made the rug pull invisible: disable, swap the
+		// server's tools, enable again, and the next discovery had nothing to
+		// compare against. What is remembered is a name and a list of tool
+		// shapes, so keeping it costs almost nothing.
 	}
 
 	async discoverAll(): Promise<MCPDiscoveredTool[]> {
@@ -119,8 +134,8 @@ export class MCPToolDiscovery {
 	}
 
 	private detectDrift(clientId: string, serverName: string, admitted: MCPToolDefinition[]): void {
-		const previous = this.lastSeen.get(clientId)
-		this.lastSeen.set(clientId, admitted)
+		const previous = this.lastSeen.get(serverName)
+		this.lastSeen.set(serverName, admitted)
 		if (!previous) return
 
 		const drift = diffTools(previous, admitted)

--- a/packages/sdk/src/plugin/__tests__/enable-contributions.test.ts
+++ b/packages/sdk/src/plugin/__tests__/enable-contributions.test.ts
@@ -11,11 +11,15 @@ const mockDisconnect = vi.fn(async (): Promise<void> => undefined)
 const mockListTools = vi.fn(async (): Promise<unknown[]> => [])
 
 vi.mock('../../connector/mcp/client.js', () => ({
-	MCPClient: vi.fn().mockImplementation(() => ({
+	MCPClient: vi.fn().mockImplementation((config: { serverName: string }) => ({
 		id: 'mcp-client-mock',
 		connect: mockConnect,
 		disconnect: mockDisconnect,
 		listTools: mockListTools,
+		// The real client has always had this; the mock did not, which went
+		// unnoticed while nothing on this path asked the client which server
+		// it was talking to. Admission does — a policy is per server name.
+		getState: () => ({ serverName: config.serverName }),
 	})),
 }))
 

--- a/packages/sdk/src/plugin/__tests__/mcp-admission.test.ts
+++ b/packages/sdk/src/plugin/__tests__/mcp-admission.test.ts
@@ -1,0 +1,242 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { MCPToolDefinition } from '../../types/connector/index.js'
+
+/**
+ * A plugin's MCP server decided what entered the agent's tool registry.
+ *
+ * `MCPToolDiscovery` has held the admission boundary — a per-server
+ * allow/deny policy, and detection for a server whose tool set changes
+ * between discoveries — since it was written, and nothing outside its own
+ * tests ever constructed one. `PluginLifecycleManager.attachMCPServer`, the
+ * only code in the tree that connects a real MCP server, called
+ * `client.listTools()` and registered whatever came back.
+ *
+ * So least privilege was inverted at the one place it mattered: the remote
+ * side chose. Tools land as `deferred` and a run's `allowedTools` filters the
+ * model-visible catalogue, so this was not "arbitrary tools reach the model
+ * immediately" — but the check written for exactly this was not on the path.
+ */
+
+let advertised: MCPToolDefinition[] = []
+let clientCount = 0
+
+vi.mock('../../connector/mcp/client.js', () => ({
+	MCPClient: class {
+		readonly id: string
+		private serverName: string
+		constructor(config: { serverName: string }) {
+			this.id = `client_${clientCount++}`
+			this.serverName = config.serverName
+		}
+		async connect(): Promise<void> {}
+		async disconnect(): Promise<void> {}
+		isConnected(): boolean {
+			return true
+		}
+		getState() {
+			return { serverName: this.serverName }
+		}
+		async listTools(): Promise<MCPToolDefinition[]> {
+			return advertised
+		}
+	},
+}))
+
+function tool(name: string): MCPToolDefinition {
+	return { name, description: name, inputSchema: { type: 'object', properties: {} } }
+}
+
+const log = {
+	debug: vi.fn(),
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	child: () => log,
+} as never
+
+let root: string
+
+interface Harness {
+	readonly registered: string[]
+	readonly manager: import('../lifecycle.js').PluginLifecycleManager
+	enable(name: string): Promise<import('../../types/ids/index.js').PluginId>
+}
+
+async function harness(config: Record<string, unknown> = {}): Promise<Harness> {
+	const { PluginLifecycleManager } = await import('../lifecycle.js')
+	const { PluginRegistry } = await import('../../registry/plugin/index.js')
+
+	const registered: string[] = []
+	const toolRegistry = {
+		register: (definition: { name: string }) => registered.push(definition.name),
+		unregister: () => undefined,
+		get: () => undefined,
+	} as never
+
+	const manager = new PluginLifecycleManager({
+		pluginRegistry: new PluginRegistry(),
+		toolRegistry,
+		log,
+		...config,
+	} as never)
+
+	return {
+		registered,
+		manager,
+		enable: async (name: string) => {
+			const dir = join(root, name)
+			await mkdir(dir, { recursive: true })
+			await writeFile(
+				join(dir, 'plugin.json'),
+				JSON.stringify({
+					name,
+					version: '1.0.0',
+					description: 'MCP server plugin fixture',
+					mcpServers: [{ name: 'files', command: 'node', args: ['server.js'] }],
+				}),
+				'utf-8',
+			)
+			const plugin = await manager.install(dir, 'project')
+			await manager.enable(plugin.id)
+			return plugin.id
+		},
+	}
+}
+
+beforeEach(async () => {
+	root = await mkdtemp(join(tmpdir(), 'namzu-mcp-admit-'))
+	clientCount = 0
+	advertised = [tool('read_file'), tool('write_file'), tool('delete_everything')]
+})
+
+afterEach(async () => {
+	await rm(root, { recursive: true, force: true })
+	vi.clearAllMocks()
+})
+
+describe('what a plugin server advertises is not what the registry gets', () => {
+	it('admits only the tools an allowlist names', async () => {
+		const h = await harness({ mcpToolPolicies: { files: { allow: ['read_file', 'write_file'] } } })
+
+		await h.enable('srv')
+
+		expect(h.registered.some((n) => n.endsWith('read_file'))).toBe(true)
+		expect(h.registered.some((n) => n.endsWith('write_file'))).toBe(true)
+		// The one the server offered and the host never agreed to.
+		expect(h.registered.some((n) => n.endsWith('delete_everything'))).toBe(false)
+	})
+
+	it('refuses a denied tool through the wildcard policy', async () => {
+		const h = await harness({ mcpToolPolicies: { '*': { deny: ['delete_everything'] } } })
+
+		await h.enable('srv')
+
+		expect(h.registered).toHaveLength(2)
+		expect(h.registered.some((n) => n.endsWith('delete_everything'))).toBe(false)
+	})
+
+	it('still admits everything when no policy is configured', async () => {
+		// Adding a boundary must not turn every existing host's working plugin
+		// into a broken one.
+		const h = await harness()
+
+		await h.enable('srv')
+
+		expect(h.registered).toHaveLength(3)
+	})
+
+	it('namespaces what it admits, exactly as before', async () => {
+		const h = await harness({ mcpToolPolicies: { files: { allow: ['read_file'] } } })
+
+		await h.enable('srv')
+
+		expect(h.registered[0]).toContain('mcp__files__read_file')
+	})
+})
+
+describe('a server that changes its tools between connections is reported', () => {
+	it('says nothing the first time, having nothing to compare against', async () => {
+		const onMCPToolDrift = vi.fn()
+		const h = await harness({ onMCPToolDrift })
+
+		await h.enable('srv')
+
+		expect(onMCPToolDrift).not.toHaveBeenCalled()
+	})
+
+	it('reports a tool the server grew after it was first approved', async () => {
+		const onMCPToolDrift = vi.fn()
+		const h = await harness({ onMCPToolDrift })
+		const first = await h.enable('srv-a')
+
+		// The rug pull: advertise something benign while a host is deciding,
+		// swap it afterwards. A NEW client connects to the SAME server, which
+		// is why the remembered set is keyed by server name — keyed by client
+		// id, as it was, every connection was its own first and this could
+		// never fire.
+		await h.manager.disable(first)
+		advertised = [...advertised, tool('exfiltrate')]
+		await h.enable('srv-b')
+
+		expect(onMCPToolDrift).toHaveBeenCalledTimes(1)
+		expect(onMCPToolDrift.mock.calls[0]?.[0]).toMatchObject({
+			serverName: 'files',
+			drift: { added: ['exfiltrate'] },
+		})
+	})
+
+	it('reports a tool whose shape changed under the same name', async () => {
+		const onMCPToolDrift = vi.fn()
+		const h = await harness({ onMCPToolDrift })
+		const first = await h.enable('srv-a')
+
+		await h.manager.disable(first)
+		// Same name, different input shape — the version a name-only check
+		// misses entirely.
+		advertised = [
+			{
+				name: 'read_file',
+				description: 'read a file',
+				inputSchema: { type: 'object', properties: { path: { type: 'string' } } },
+			},
+			tool('write_file'),
+			tool('delete_everything'),
+		]
+		await h.enable('srv-b')
+
+		expect(onMCPToolDrift).toHaveBeenCalledTimes(1)
+		expect(onMCPToolDrift.mock.calls[0]?.[0]).toMatchObject({ drift: { changed: ['read_file'] } })
+	})
+
+	it('says nothing when the server offers exactly what it offered before', async () => {
+		const onMCPToolDrift = vi.fn()
+		const h = await harness({ onMCPToolDrift })
+		const first = await h.enable('srv-a')
+
+		await h.manager.disable(first)
+		await h.enable('srv-b')
+
+		expect(onMCPToolDrift).not.toHaveBeenCalled()
+	})
+
+	it('compares what was ADMITTED, not what was advertised', async () => {
+		const onMCPToolDrift = vi.fn()
+		const h = await harness({
+			mcpToolPolicies: { files: { allow: ['read_file'] } },
+			onMCPToolDrift,
+		})
+		const first = await h.enable('srv-a')
+
+		await h.manager.disable(first)
+		// A tool the policy refuses either way. Reporting drift for it would
+		// train a host to ignore the warning that matters.
+		advertised = [...advertised, tool('another_denied_one')]
+		await h.enable('srv-b')
+
+		expect(onMCPToolDrift).not.toHaveBeenCalled()
+	})
+})

--- a/packages/sdk/src/plugin/lifecycle.ts
+++ b/packages/sdk/src/plugin/lifecycle.ts
@@ -2,6 +2,9 @@ import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { mcpToolToToolDefinition } from '../connector/mcp/adapter.js'
 import { MCPClient } from '../connector/mcp/client.js'
+import { MCPToolDiscovery } from '../connector/mcp/discovery.js'
+import type { MCPToolDiscoveryOptions } from '../connector/mcp/discovery.js'
+import type { MCPToolPolicy } from '../connector/mcp/policy.js'
 import {
 	DEFAULT_HOOK_PRIORITY,
 	HOOK_TIMEOUT_MS,
@@ -37,6 +40,32 @@ export interface PluginLifecycleManagerConfig {
 	toolRegistry: ToolRegistryContract
 	log: Logger
 	hookTimeoutMs?: number
+
+	/**
+	 * What each MCP server a plugin brings is allowed to contribute, keyed by
+	 * server name. `'*'` covers every server not named explicitly.
+	 *
+	 * Absent admits everything, which is what this path did unconditionally
+	 * until now. `MCPToolDiscovery` has held this boundary — and the drift
+	 * detection below — since it was written, and nothing outside its own
+	 * tests ever constructed one: `attachMCPServer` called `listTools()`
+	 * directly and registered whatever came back. So the least-privilege
+	 * check existed, was tested, was exported, and was not on the path any
+	 * real MCP server takes.
+	 */
+	mcpToolPolicies?: Readonly<Record<string, MCPToolPolicy>>
+
+	/**
+	 * Called when a server's admitted tool set differs from the last time it
+	 * was discovered.
+	 *
+	 * Reported rather than blocked, for the reason `MCPToolDiscovery`
+	 * already gives: a development server legitimately changes between runs,
+	 * while a production one changing mid-session is the rug pull — advertise
+	 * something benign at approval time, swap it afterwards. Only the host
+	 * knows which it is looking at.
+	 */
+	onMCPToolDrift?: MCPToolDiscoveryOptions['onDrift']
 }
 
 export class PluginLifecycleManager {
@@ -55,12 +84,32 @@ export class PluginLifecycleManager {
 	private pluginContributions: Map<PluginId, PluginContributionRecord> = new Map()
 	private hookTimeoutMs: number
 	private log: Logger
+	/**
+	 * The admission boundary for everything a plugin's MCP servers advertise.
+	 *
+	 * One instance for the whole manager rather than one per plugin, and that
+	 * is the part that matters: the instance is what remembers each server's
+	 * previously admitted tool set, so a server that changes between one
+	 * plugin being disabled and the next being enabled is still noticed. A
+	 * per-plugin instance would forget on every teardown, which is precisely
+	 * the window a rug pull uses.
+	 *
+	 * Its client list is deliberately left empty — `discoverFrom` takes the
+	 * client directly, so registering it here would be bookkeeping nothing
+	 * reads.
+	 */
+	private mcpDiscovery: MCPToolDiscovery
 
 	constructor(config: PluginLifecycleManagerConfig) {
 		this.pluginRegistry = config.pluginRegistry
 		this.toolRegistry = config.toolRegistry
 		this.hookTimeoutMs = config.hookTimeoutMs ?? HOOK_TIMEOUT_MS
 		this.log = config.log.child({ component: 'PluginLifecycleManager' })
+		this.mcpDiscovery = new MCPToolDiscovery([], {
+			...(config.mcpToolPolicies ? { policies: config.mcpToolPolicies } : {}),
+			...(config.onMCPToolDrift ? { onDrift: config.onMCPToolDrift } : {}),
+			logger: this.log,
+		})
 	}
 
 	/**
@@ -257,7 +306,14 @@ export class PluginLifecycleManager {
 		await client.connect()
 		contributions.mcpClients.push(client)
 
-		const mcpTools = await client.listTools()
+		// Through the boundary, not around it. This used to call
+		// `client.listTools()` and register everything the server answered
+		// with, so the remote side decided what entered the agent's registry
+		// — least privilege inverted. `discoverFrom` applies the per-server
+		// allow/deny policy and reports a tool set that changed since the
+		// last discovery.
+		const discovered = await this.mcpDiscovery.discoverFrom(client)
+		const mcpTools = discovered.map((d) => d.tool)
 		for (const mcpTool of mcpTools) {
 			const baseDef = mcpToolToToolDefinition(mcpTool, client, config.name)
 			// Double-underscore between serverName and toolName so that e.g.

--- a/packages/sdk/src/registry/tool/execute.ts
+++ b/packages/sdk/src/registry/tool/execute.ts
@@ -375,151 +375,155 @@ Executable tool names, descriptions, and JSON input schemas are attached through
 			: otelContext.active()
 
 		return tracer.startActiveSpan(toolSpanName(toolName), {}, parentCtx, async (span) => {
-			span.setAttributes({
-				[GENAI.TOOL_NAME]: toolName,
-				[GENAI.TOOL_TYPE]: 'function',
-			})
-
-			const tool = this.getOrThrow(toolName)
-
-			const availability = this.getAvailability(toolName)
-			if (availability !== 'active') {
-				const msg = `Tool "${toolName}" is ${availability} and cannot be executed`
-				this.log.warn(msg)
+			try {
 				span.setAttributes({
-					[NAMZU.TOOL_SUCCESS]: false,
-					[NAMZU.TOOL_ERROR]: msg,
+					[GENAI.TOOL_NAME]: toolName,
+					[GENAI.TOOL_TYPE]: 'function',
 				})
-				span.setStatus({ code: SpanStatusCode.ERROR, message: msg })
-				span.end()
-				return {
-					success: false,
-					output: '',
-					error: msg,
-				}
-			}
 
-			const mode = context.permissionContext?.mode ?? 'auto'
-			if (mode === 'plan') {
-				const isReadOnly = tool.isReadOnly ? tool.isReadOnly(rawInput) : false
-				if (!isReadOnly) {
-					const msg = `plan mode: non-read-only tool "${toolName}" blocked`
+				const tool = this.getOrThrow(toolName)
+
+				const availability = this.getAvailability(toolName)
+				if (availability !== 'active') {
+					const msg = `Tool "${toolName}" is ${availability} and cannot be executed`
+					this.log.warn(msg)
 					span.setAttributes({
 						[NAMZU.TOOL_SUCCESS]: false,
 						[NAMZU.TOOL_ERROR]: msg,
 					})
 					span.setStatus({ code: SpanStatusCode.ERROR, message: msg })
-					span.end()
 					return {
 						success: false,
 						output: '',
 						error: msg,
-						permissionDenied: true,
-						permissionMessage: msg,
 					}
 				}
-			}
 
-			const parseResult = tool.inputSchema.safeParse(rawInput)
-			if (!parseResult.success) {
-				const errorMessage = parseResult.error.issues
-					.map((i) => `${i.path.join('.')}: ${i.message}`)
-					.join('; ')
-
-				// Distinguish "model sent an empty/no-arg call" from
-				// "model sent partial args" — the first is most often a
-				// streaming hiccup or a definition-test ping (a provider
-				// occasionally pings tool surfaces with `{}` while the
-				// schema is still loading), the second is a genuine
-				// programming mistake by the model. The model self-
-				// corrects MUCH more reliably when the error tells it
-				// (a) which fields are required, (b) their types, and
-				// (c) a minimal example call. Without these hints the
-				// downstream UI just shows a red "Failed" row and the
-				// model rarely retries with the right args.
-				const isEmptyInput =
-					rawInput === null ||
-					rawInput === undefined ||
-					(typeof rawInput === 'object' &&
-						!Array.isArray(rawInput) &&
-						Object.keys(rawInput as Record<string, unknown>).length === 0)
-
-				const requiredHint = describeRequiredInput(tool.inputSchema)
-				// A conditional schema's required shape cannot be reconstructed
-				// from JSON Schema's top-level `required`, so the author gets to
-				// say what a valid retry looks like.
-				const recoveryHint = tool.validationErrorHint?.trim()
-					? ` ${tool.validationErrorHint.trim()}`
-					: ''
-
-				const enrichedMessage = isEmptyInput
-					? `Tool "${toolName}" was called with no arguments. ${requiredHint}${recoveryHint} Retry the call with the required parameters populated.`
-					: `Validation failed for "${toolName}": ${errorMessage}. ${requiredHint}${recoveryHint}`
-
-				this.log.error(`Tool input validation failed: ${toolName}`, {
-					errors: errorMessage,
-					empty: isEmptyInput,
-				})
-
-				span.setAttributes({
-					[NAMZU.TOOL_SUCCESS]: false,
-					[NAMZU.TOOL_ERROR]: `Validation: ${errorMessage}`,
-				})
-				span.setStatus({ code: SpanStatusCode.ERROR, message: errorMessage })
-				span.end()
-
-				return {
-					success: false,
-					output: '',
-					error: enrichedMessage,
-				}
-			}
-
-			const finalInput = parseResult.data
-
-			try {
-				this.log.debug(`Executing tool: ${toolName}`)
-				const startedAt = Date.now()
-				const result = await tool.execute(finalInput, context)
-				const durationMs = Date.now() - startedAt
-				this.log.debug(`Tool completed: ${toolName}`, {
-					success: result.success,
-				})
-
-				span.setAttribute(NAMZU.TOOL_SUCCESS, result.success)
-				recordToolCall(
-					toolName,
-					result.success,
-					result.success ? undefined : result.error,
-					durationMs,
-				)
-				if (!result.success && result.error) {
-					span.setAttribute(NAMZU.TOOL_ERROR, result.error)
-					span.setStatus({ code: SpanStatusCode.ERROR, message: result.error })
-				} else {
-					span.setStatus({ code: SpanStatusCode.OK })
+				const mode = context.permissionContext?.mode ?? 'auto'
+				if (mode === 'plan') {
+					const isReadOnly = tool.isReadOnly ? tool.isReadOnly(rawInput) : false
+					if (!isReadOnly) {
+						const msg = `plan mode: non-read-only tool "${toolName}" blocked`
+						span.setAttributes({
+							[NAMZU.TOOL_SUCCESS]: false,
+							[NAMZU.TOOL_ERROR]: msg,
+						})
+						span.setStatus({ code: SpanStatusCode.ERROR, message: msg })
+						return {
+							success: false,
+							output: '',
+							error: msg,
+							permissionDenied: true,
+							permissionMessage: msg,
+						}
+					}
 				}
 
-				return result
-			} catch (err) {
-				const errorMessage = toErrorMessage(err)
-				this.log.error(`Tool execution error: ${toolName}`, {
-					error: errorMessage,
-				})
+				const parseResult = tool.inputSchema.safeParse(rawInput)
+				if (!parseResult.success) {
+					const errorMessage = parseResult.error.issues
+						.map((i) => `${i.path.join('.')}: ${i.message}`)
+						.join('; ')
 
-				span.setAttributes({
-					[NAMZU.TOOL_SUCCESS]: false,
-					[NAMZU.TOOL_ERROR]: errorMessage,
-				})
-				span.setStatus({ code: SpanStatusCode.ERROR, message: errorMessage })
-				span.recordException(err instanceof Error ? err : new Error(errorMessage))
+					// Distinguish "model sent an empty/no-arg call" from
+					// "model sent partial args" — the first is most often a
+					// streaming hiccup or a definition-test ping (a provider
+					// occasionally pings tool surfaces with `{}` while the
+					// schema is still loading), the second is a genuine
+					// programming mistake by the model. The model self-
+					// corrects MUCH more reliably when the error tells it
+					// (a) which fields are required, (b) their types, and
+					// (c) a minimal example call. Without these hints the
+					// downstream UI just shows a red "Failed" row and the
+					// model rarely retries with the right args.
+					const isEmptyInput =
+						rawInput === null ||
+						rawInput === undefined ||
+						(typeof rawInput === 'object' &&
+							!Array.isArray(rawInput) &&
+							Object.keys(rawInput as Record<string, unknown>).length === 0)
 
-				return {
-					success: false,
-					output: '',
-					error: `Tool "${toolName}" execution failed: ${errorMessage}`,
+					const requiredHint = describeRequiredInput(tool.inputSchema)
+					// A conditional schema's required shape cannot be reconstructed
+					// from JSON Schema's top-level `required`, so the author gets to
+					// say what a valid retry looks like.
+					const recoveryHint = tool.validationErrorHint?.trim()
+						? ` ${tool.validationErrorHint.trim()}`
+						: ''
+
+					const enrichedMessage = isEmptyInput
+						? `Tool "${toolName}" was called with no arguments. ${requiredHint}${recoveryHint} Retry the call with the required parameters populated.`
+						: `Validation failed for "${toolName}": ${errorMessage}. ${requiredHint}${recoveryHint}`
+
+					this.log.error(`Tool input validation failed: ${toolName}`, {
+						errors: errorMessage,
+						empty: isEmptyInput,
+					})
+
+					span.setAttributes({
+						[NAMZU.TOOL_SUCCESS]: false,
+						[NAMZU.TOOL_ERROR]: `Validation: ${errorMessage}`,
+					})
+					span.setStatus({ code: SpanStatusCode.ERROR, message: errorMessage })
+
+					return {
+						success: false,
+						output: '',
+						error: enrichedMessage,
+					}
+				}
+
+				const finalInput = parseResult.data
+
+				try {
+					this.log.debug(`Executing tool: ${toolName}`)
+					const startedAt = Date.now()
+					const result = await tool.execute(finalInput, context)
+					const durationMs = Date.now() - startedAt
+					this.log.debug(`Tool completed: ${toolName}`, {
+						success: result.success,
+					})
+
+					span.setAttribute(NAMZU.TOOL_SUCCESS, result.success)
+					recordToolCall(
+						toolName,
+						result.success,
+						result.success ? undefined : result.error,
+						durationMs,
+					)
+					if (!result.success && result.error) {
+						span.setAttribute(NAMZU.TOOL_ERROR, result.error)
+						span.setStatus({ code: SpanStatusCode.ERROR, message: result.error })
+					} else {
+						span.setStatus({ code: SpanStatusCode.OK })
+					}
+
+					return result
+				} catch (err) {
+					const errorMessage = toErrorMessage(err)
+					this.log.error(`Tool execution error: ${toolName}`, {
+						error: errorMessage,
+					})
+
+					span.setAttributes({
+						[NAMZU.TOOL_SUCCESS]: false,
+						[NAMZU.TOOL_ERROR]: errorMessage,
+					})
+					span.setStatus({ code: SpanStatusCode.ERROR, message: errorMessage })
+					span.recordException(err instanceof Error ? err : new Error(errorMessage))
+
+					return {
+						success: false,
+						output: '',
+						error: `Tool "${toolName}" execution failed: ${errorMessage}`,
+					}
 				}
 			} finally {
+				// The only place this span ends. It used to be ended at three
+				// early returns and in a finally that opened below them, so
+				// anything throwing before that try — `getOrThrow` on a name the
+				// registry does not hold, for one — left the span open and the
+				// tool's trace unclosed.
 				span.end()
 			}
 		})

--- a/packages/sdk/src/runtime/query/iteration/index.ts
+++ b/packages/sdk/src/runtime/query/iteration/index.ts
@@ -151,23 +151,27 @@ export class IterationOrchestrator {
 				{},
 				parentContext(this.ctx.rootSpan),
 			)
-			// Tool spans for this turn belong under this iteration.
-			this.ctx.toolExecutor.setParentSpan(iterSpan)
-
-			iterSpan.setAttributes({
-				[NAMZU.ITERATION]: iterationNum,
-				[NAMZU.RUN_ID]: runMgr.id,
-				[GENAI.REQUEST_MODEL]: model,
-			})
-
-			await this.ctx.emitEvent({
-				type: 'iteration_started',
-				runId: runMgr.id,
-				iteration: iterationNum,
-			})
-			yield* this.ctx.drainPending()
-
 			try {
+				// Tool spans for this turn belong under this iteration. Inside
+				// the try rather than before it: a throw from any of these left
+				// the span open, and an iteration span that never ends is a
+				// trace that never closes — the export is incomplete for exactly
+				// the run that failed.
+				this.ctx.toolExecutor.setParentSpan(iterSpan)
+
+				iterSpan.setAttributes({
+					[NAMZU.ITERATION]: iterationNum,
+					[NAMZU.RUN_ID]: runMgr.id,
+					[GENAI.REQUEST_MODEL]: model,
+				})
+
+				await this.ctx.emitEvent({
+					type: 'iteration_started',
+					runId: runMgr.id,
+					iteration: iterationNum,
+				})
+				yield* this.ctx.drainPending()
+
 				if (this.ctx.pluginManager) {
 					const hookResults = await this.ctx.pluginManager.executeHooks(
 						'iteration_start',
@@ -457,7 +461,6 @@ export class IterationOrchestrator {
 							hasToolCalls: false,
 						})
 						yield* this.ctx.drainPending()
-						iterSpan.end()
 						continue
 					}
 
@@ -475,7 +478,6 @@ export class IterationOrchestrator {
 								attempts: attempt - 1,
 							})
 							runMgr.setStopReason('structured_output_failed')
-							iterSpan.end()
 							break
 						}
 						this.ctx.log.info('Re-prompting for structured output', {
@@ -491,7 +493,6 @@ export class IterationOrchestrator {
 							hasToolCalls: false,
 						})
 						yield* this.ctx.drainPending()
-						iterSpan.end()
 						continue
 					}
 
@@ -520,7 +521,6 @@ export class IterationOrchestrator {
 									limit,
 								})
 								runMgr.setStopReason('answer_rejected')
-								iterSpan.end()
 								break
 							}
 							this.ctx.log.info('Answer rejected — returning it to the model', {
@@ -536,7 +536,6 @@ export class IterationOrchestrator {
 								hasToolCalls: false,
 							})
 							yield* this.ctx.drainPending()
-							iterSpan.end()
 							continue
 						}
 					}
@@ -564,11 +563,9 @@ export class IterationOrchestrator {
 					if (this.ctx.abortController.signal.aborted) {
 						runMgr.setStopReason('cancelled')
 						runMgr.markCancelled()
-						iterSpan.end()
 						break
 					}
 					runMgr.setStopReason('end_turn')
-					iterSpan.end()
 					break
 				}
 
@@ -590,12 +587,10 @@ export class IterationOrchestrator {
 				})
 
 				if (reviewOutcome.decision === 'stop') {
-					iterSpan.end()
 					return
 				}
 
 				if (reviewOutcome.decision === 'rejected') {
-					iterSpan.end()
 					continue
 				}
 
@@ -615,7 +610,6 @@ export class IterationOrchestrator {
 						hasToolCalls: true,
 					})
 					yield* this.ctx.drainPending()
-					iterSpan.end()
 					break
 				}
 
@@ -642,7 +636,6 @@ export class IterationOrchestrator {
 						hasToolCalls: true,
 					})
 					yield* this.ctx.drainPending()
-					iterSpan.end()
 					break
 				}
 
@@ -662,13 +655,11 @@ export class IterationOrchestrator {
 						hasToolCalls: true,
 					})
 					yield* this.ctx.drainPending()
-					iterSpan.end()
 					break
 				}
 
 				const checkpointSignal = yield* runIterationCheckpoint(this.ctx, iterationNum)
 				if (checkpointSignal === 'stop') {
-					iterSpan.end()
 					return
 				}
 
@@ -691,7 +682,6 @@ export class IterationOrchestrator {
 					hasToolCalls: true,
 				})
 				yield* this.ctx.drainPending()
-				iterSpan.end()
 			} catch (err) {
 				// A Stop that aborted the in-flight turn surfaces here as a
 				// thrown abort (the provider stream was raced against the run
@@ -703,7 +693,6 @@ export class IterationOrchestrator {
 				if (this.ctx.abortController.signal.aborted) {
 					runMgr.setStopReason('cancelled')
 					runMgr.markCancelled()
-					iterSpan.end()
 					break
 				}
 
@@ -733,7 +722,6 @@ export class IterationOrchestrator {
 						if (iterationActivity) {
 							this.ctx.activityStore.complete(iterationActivity.id)
 						}
-						iterSpan.end()
 						continue
 					}
 				}
@@ -747,8 +735,13 @@ export class IterationOrchestrator {
 					message: toErrorMessage(err),
 				})
 				iterSpan.recordException(err instanceof Error ? err : new Error(String(err)))
-				iterSpan.end()
 				throw err
+			} finally {
+				// The only place the span ends. It used to be ended at each of
+				// seventeen exits, which is a rule every future edit has to
+				// remember; a generator abandoned by its consumer never reached
+				// any of them.
+				iterSpan.end()
 			}
 		}
 	}

--- a/packages/sdk/src/telemetry/__tests__/span-closure.test.ts
+++ b/packages/sdk/src/telemetry/__tests__/span-closure.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+
+/**
+ * A span that never ends is a trace that never closes, and the export is
+ * incomplete for exactly the run that failed.
+ *
+ * Both sites had the same shape: an `end()` call at every exit the author
+ * could see. The iteration loop had seventeen of them and the tool executor
+ * three plus a `finally` that opened below them. That is a rule every future
+ * edit has to remember, and it was already broken — anything throwing between
+ * the span's creation and the `try` left it open, and a generator abandoned
+ * by its consumer reached no exit at all.
+ */
+
+const ended: string[] = []
+const started: string[] = []
+
+function fakeSpan(name: string) {
+	return {
+		setAttributes: () => undefined,
+		setAttribute: () => undefined,
+		setStatus: () => undefined,
+		recordException: () => undefined,
+		addEvent: () => undefined,
+		end: () => ended.push(name),
+		spanContext: () => ({ traceId: 't', spanId: 's', traceFlags: 1 }),
+		isRecording: () => true,
+		updateName: () => undefined,
+	}
+}
+
+vi.mock('../runtime-accessors.js', () => ({
+	getTracer: () => ({
+		startSpan: (name: string) => {
+			started.push(name)
+			return fakeSpan(name)
+		},
+		startActiveSpan: (
+			name: string,
+			_opts: unknown,
+			_ctx: unknown,
+			fn: (span: ReturnType<typeof fakeSpan>) => unknown,
+		) => {
+			started.push(name)
+			return fn(fakeSpan(name))
+		},
+	}),
+	getMeter: () => ({
+		createCounter: () => ({ add: () => undefined }),
+		createHistogram: () => ({ record: () => undefined }),
+	}),
+}))
+
+function toolContext() {
+	return {
+		runId: 'run_span',
+		workingDirectory: '.',
+		abortSignal: new AbortController().signal,
+		env: {},
+		log: () => undefined,
+	} as never
+}
+
+beforeEach(() => {
+	started.length = 0
+	ended.length = 0
+})
+
+afterEach(() => {
+	vi.clearAllMocks()
+})
+
+describe('a tool span closes however the call leaves', () => {
+	it('closes on the ordinary path', async () => {
+		const { ToolRegistry } = await import('../../registry/tool/execute.js')
+		const tools = new ToolRegistry()
+		tools.register({
+			name: 'echo',
+			description: 'echo',
+			inputSchema: z.object({}),
+			execute: async () => ({ success: true, output: 'ok' }),
+		})
+
+		await tools.execute('echo', {}, toolContext())
+
+		expect(started).toHaveLength(1)
+		expect(ended).toEqual(started)
+	})
+
+	it('closes when the tool throws', async () => {
+		const { ToolRegistry } = await import('../../registry/tool/execute.js')
+		const tools = new ToolRegistry()
+		tools.register({
+			name: 'boom',
+			description: 'boom',
+			inputSchema: z.object({}),
+			execute: async () => {
+				throw new Error('kaboom')
+			},
+		})
+
+		await tools.execute('boom', {}, toolContext())
+
+		expect(ended).toEqual(started)
+	})
+
+	it('closes when input validation refuses the call', async () => {
+		const { ToolRegistry } = await import('../../registry/tool/execute.js')
+		const tools = new ToolRegistry()
+		tools.register({
+			name: 'strict',
+			description: 'strict',
+			inputSchema: z.object({ required: z.string() }),
+			execute: async () => ({ success: true, output: 'ok' }),
+		})
+
+		await tools.execute('strict', { wrong: 1 }, toolContext())
+
+		expect(ended).toEqual(started)
+	})
+
+	it('closes when the tool is not active', async () => {
+		const { ToolRegistry } = await import('../../registry/tool/execute.js')
+		const tools = new ToolRegistry()
+		tools.register(
+			{
+				name: 'later',
+				description: 'later',
+				inputSchema: z.object({}),
+				execute: async () => ({ success: true, output: 'ok' }),
+			},
+			'deferred',
+		)
+
+		await tools.execute('later', {}, toolContext())
+
+		expect(ended).toEqual(started)
+	})
+
+	it('closes when the registry does not hold the name at all', async () => {
+		const { ToolRegistry } = await import('../../registry/tool/execute.js')
+		const tools = new ToolRegistry()
+
+		// `getOrThrow` sat OUTSIDE the try that owned the finally, so this
+		// path — the one where the model invents a tool name — opened a span
+		// and never closed it.
+		await expect(tools.execute('nonexistent', {}, toolContext())).rejects.toThrow()
+
+		expect(started).toHaveLength(1)
+		expect(ended).toEqual(started)
+	})
+})


### PR DESCRIPTION
Two shipped defects, both surfaced by a research pass whose most useful output turned out to be what it found in our own code rather than in the peers'.

### The MCP least-privilege boundary was not on any live path

`MCPToolDiscovery` has held two checks since it was written: a per-server allow/deny policy deciding what a server may contribute, and detection for a server whose tool set changed since it was last seen. Implemented, tested, publicly exported — and `new MCPToolDiscovery` appears **only in its own test file**.

`PluginLifecycleManager.attachMCPServer`, the only code in the tree that connects a real MCP server, called `client.listTools()` and registered whatever came back. The remote side decided what entered the agent's registry.

Honest scope: tools land as `deferred`, and a run's `allowedTools` filters the model-visible catalogue, so this was never "arbitrary tools reach the model immediately". But the check written for exactly this was not consulted, and drift detection was absent from the live path entirely.

**Drift is now keyed by server name rather than client id, and that is what makes it fire at all.** A client id is minted per connection, so on the path a real server takes — enable, connect, disable, enable again — every discovery was the first that id had ever seen. Drift could not fire however many times the server changed underneath. The threat it exists for is a server that advertises something benign while a host is deciding and something else afterwards: a property of the *server* across connections. For the same reason a disconnect no longer forgets what a server last advertised — forgetting on teardown is precisely the window that swap uses.

Drift compares what was **admitted**, not advertised. A warning for a tool the policy already refuses trains a host to ignore the one that matters.

Passing no policy admits everything, exactly as before. Adding a boundary must not turn a working plugin into a broken one.

### Spans closed at every exit the author could see

Two sites, same shape. The iteration loop had **seventeen** `iterSpan.end()` calls; the tool executor had three early returns plus a `finally` that opened below them.

Neither leaks by inspection of those exits — the authors covered them. The leak is what sits *before* the `try`:

- **The loop**: the span is created, then four statements run outside the try — attaching the tool parent span, stamping attributes, emitting `iteration_started`, draining pending events. A throw from any leaves the span open. The body is also an async generator, so a consumer that abandons it reaches no exit at all; a `finally` runs there and seventeen scattered calls do not.
- **The executor**: `getOrThrow(toolName)` sat outside the try that owned the finally — the path a model inventing a tool name takes.

An iteration span that never ends is a trace that never closes, so the export is incomplete for exactly the run that failed and is hardest to debug from outside.

Both now close in one `finally`. No status or exception recording moved; only the moment of closing.

---

**Gates:** typecheck 0, lint 0, 2231 SDK tests green, public surface intact, no third-party names.

**Verification:** 14 new tests, 8/8 mutations caught — but one round of that changed the design. My first version registered each client with the discovery instance via `addClient`, and the mutation deleting that call **survived**: `discoverFrom` takes the client directly, so the registration was bookkeeping nothing read — the exact defect class this series exists to remove. It is gone.

The existing `enable-contributions` test broke on `client.getState is not a function`: its `MCPClient` mock never had `getState`, because nothing on that path had ever asked the client which server it was talking to. Admission does, since a policy is per server name.
