### PR TITLE
feat(sdk): let a step put a skill in front of the model

### DIFF
--- a/.changeset/per-step-skills.md
+++ b/.changeset/per-step-skills.md
@@ -1,0 +1,13 @@
+---
+'@namzu/sdk': minor
+---
+
+A step can put a skill in front of the model.
+
+`PrepareStepResult.skills` renders the named skills into the same ephemeral trailing system message `system` already uses. A run's skills are fixed at `query()` time and rendered into the cached system prefix, so every skill a run might ever need is paid for on every single turn — and a phased agent rarely needs them all at once. Research wants the search skill, writing wants the style guide, and neither benefits from carrying the other.
+
+Appending rather than rewriting is the point: the run's own prompt stays byte-stable, so the cached prefix survives, where folding a phase's skills into it would invalidate the cache every iteration.
+
+It is **additive** to the run's skills, not a replacement. A skill a run always carries should not be removable by a step naming a different one — that would make every step's list a complete restatement, and a phase that forgot one would silently lose it.
+
+**Sub-agents are deliberately not per-step.** A peer runtime resolves instructions, model, tools, skills and subagents from context at run time; this closes the fourth of those and states why the fifth stays out. Which agents `create_task` can reach is baked into that tool's input schema, so varying it per step would rebuild the tool catalogue every turn — a worse prompt-cache trade than moving tools around, for a narrowing a step can already express by withholding `create_task` through `activeTools`.

--- a/packages/sdk/src/runtime/query/__tests__/per-step-skills.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/per-step-skills.test.ts
@@ -1,0 +1,154 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { MockLLMProvider } from '../../../provider/mock.js'
+import { ToolRegistry } from '../../../registry/tool/execute.js'
+import type { SessionId, TenantId } from '../../../types/ids/index.js'
+import { createUserMessage } from '../../../types/message/index.js'
+import type { ProjectId, ThreadId } from '../../../types/session/ids.js'
+import type { Skill } from '../../../types/skills/index.js'
+import { drainQuery } from '../index.js'
+
+/**
+ * A run's skills are fixed at `query()` time and rendered into the cached
+ * system prefix, so every skill a run might ever need is paid for on every
+ * turn. A phased agent rarely needs them all at once.
+ *
+ * A peer runtime resolves instructions, model, tools, skills and subagents
+ * from context at run time. namzu had the first three; this is the fourth.
+ * The fifth is deliberately absent — see the note at the bottom.
+ */
+
+let workdirs: string[] = []
+
+afterEach(async () => {
+	await Promise.all(workdirs.map((d) => rm(d, { recursive: true, force: true })))
+	workdirs = []
+})
+
+function skill(name: string, body?: string): Skill {
+	return {
+		metadata: { name, description: `${name} description` },
+		dirPath: `/skills/${name}`,
+		...(body !== undefined ? { body } : {}),
+	}
+}
+
+async function run(provider: MockLLMProvider, over: Record<string, unknown> = {}): Promise<void> {
+	const dir = await mkdtemp(join(tmpdir(), 'namzu-skills-'))
+	workdirs.push(dir)
+	await drainQuery({
+		provider,
+		tools: new ToolRegistry(),
+		runConfig: {
+			model: 'mock-model',
+			timeoutMs: 30_000,
+			tokenBudget: 100_000,
+			maxIterations: 4,
+			maxResponseTokens: 256,
+		},
+		agentId: 'agent_sk',
+		agentName: 'Skill Agent',
+		workingDirectory: dir,
+		sessionId: 'ses_sk' as SessionId,
+		threadId: 'thd_sk' as ThreadId,
+		projectId: 'prj_sk' as ProjectId,
+		tenantId: 'tnt_sk' as TenantId,
+		messages: [createUserMessage('go')],
+		...over,
+	} as never)
+}
+
+const sent = (provider: MockLLMProvider, index = 0): string =>
+	JSON.stringify(provider.requests.at(index)?.messages ?? [])
+
+describe('a step can put a skill in front of the model', () => {
+	it('renders the skill it named', async () => {
+		const provider = new MockLLMProvider({ turns: [{ text: 'done' }] })
+
+		await run(provider, { prepareStep: () => ({ skills: [skill('search-the-web')] }) })
+
+		expect(sent(provider)).toContain('search-the-web')
+	})
+
+	it('sends nothing extra when the step names none', async () => {
+		const provider = new MockLLMProvider({ turns: [{ text: 'done' }] })
+
+		await run(provider)
+
+		expect(sent(provider)).not.toContain('Available Skills')
+	})
+
+	it('treats an empty list as naming none', async () => {
+		const provider = new MockLLMProvider({ turns: [{ text: 'done' }] })
+
+		await run(provider, { prepareStep: () => ({ skills: [] }) })
+
+		// An empty list is a caller saying "no skills this step", not a
+		// request for an empty section header.
+		expect(sent(provider)).not.toContain('Available Skills')
+	})
+
+	it('carries the step guidance alongside it', async () => {
+		const provider = new MockLLMProvider({ turns: [{ text: 'done' }] })
+
+		await run(provider, {
+			prepareStep: () => ({ system: 'You are researching.', skills: [skill('search-the-web')] }),
+		})
+
+		// Both ride the same ephemeral trailing message; neither should
+		// displace the other.
+		const body = sent(provider)
+		expect(body).toContain('You are researching.')
+		expect(body).toContain('search-the-web')
+	})
+})
+
+describe('a step skill does not outlive its step', () => {
+	it('is absent from the next step that does not ask for it', async () => {
+		const provider = new MockLLMProvider({
+			turns: [{ toolCalls: [] as never, text: 'thinking' }, { text: 'done' }],
+		})
+
+		await run(provider, {
+			prepareStep: ({ stepNumber }: { stepNumber: number }) =>
+				stepNumber === 1 ? { skills: [skill('search-the-web')] } : {},
+		})
+
+		expect(sent(provider, 0)).toContain('search-the-web')
+		if (provider.requests.length > 1) {
+			expect(sent(provider, 1)).not.toContain('search-the-web')
+		}
+	})
+
+	it('does not accumulate across steps', async () => {
+		const provider = new MockLLMProvider({
+			turns: [{ text: 'still working' }, { text: 'done' }],
+		})
+
+		await run(provider, {
+			maxIterations: 2,
+			prepareStep: () => ({ skills: [skill('search-the-web')] }),
+		})
+
+		// Appended for the call, never retained. Were it written into the run's
+		// history the section would stack up turn after turn — the same
+		// message repeated, growing the prompt and invalidating the cached
+		// prefix every iteration.
+		const systemCounts = provider.requests.map(
+			(r) => (r.messages ?? []).filter((m) => m.role === 'system').length,
+		)
+		expect(new Set(systemCounts).size).toBe(1)
+	})
+})
+
+/**
+ * Sub-agents are deliberately NOT per-step, and this is the note rather than
+ * a test that would pretend otherwise. Which agents `create_task` can reach
+ * is baked into that tool's input schema, so varying it per step would
+ * rebuild the tool catalogue every turn — a worse prompt-cache trade than
+ * moving tools around, for a narrowing a step can already express by
+ * withholding `create_task` through `activeTools`.
+ */

--- a/packages/sdk/src/runtime/query/iteration/index.ts
+++ b/packages/sdk/src/runtime/query/iteration/index.ts
@@ -5,6 +5,7 @@ import {
 	DEFAULT_STRUCTURED_OUTPUT_RETRIES,
 	STRUCTURED_OUTPUT_REPROMPT,
 } from '../../../constants/tools/index.js'
+import { renderSkillsSection } from '../../../persona/assembler.js'
 import { collect } from '../../../provider/collect.js'
 import {
 	GENAI,
@@ -31,6 +32,7 @@ import type {
 	StepResult,
 	StopReason,
 } from '../../../types/run/index.js'
+import type { Skill } from '../../../types/skills/index.js'
 import type { LLMToolSchema, ToolRegistryContract } from '../../../types/tool/index.js'
 import { toErrorMessage } from '../../../utils/error.js'
 import { generateMessageId } from '../../../utils/id.js'
@@ -230,8 +232,17 @@ export class IterationOrchestrator {
 				// exactly this reason. Shallow is enough: the defect is array
 				// mutation, and per-iteration this is trivial next to the model
 				// call it precedes.
-				const messages = step.system
-					? [...baseMessages, createSystemMessage(step.system)]
+				// A step's skills and its guidance ride the same ephemeral
+				// trailing system message. Appending leaves the cached prefix
+				// intact; rewriting the run's own prompt to carry a phase's
+				// skills would invalidate it on every iteration.
+				// `renderSkillsSection` already answers null for an empty list, so
+				// there is no length check here — a second guard for the same
+				// case is one more thing to keep in agreement with the first.
+				const stepSkills = step.skills ? renderSkillsSection([...step.skills]) : null
+				const stepPreamble = [step.system, stepSkills].filter(Boolean).join('\n\n')
+				const messages = stepPreamble
+					? [...baseMessages, createSystemMessage(stepPreamble)]
 					: [...baseMessages]
 
 				if (this.ctx.pluginManager) {
@@ -759,6 +770,7 @@ export class IterationOrchestrator {
 		toolChoice?: ToolChoice
 		model?: string
 		system?: string
+		skills?: readonly Skill[]
 		temperature?: number
 		maxResponseTokens?: number
 	}> {
@@ -797,6 +809,7 @@ export class IterationOrchestrator {
 			toolChoice?: ToolChoice
 			model?: string
 			system?: string
+			skills?: readonly Skill[]
 			temperature?: number
 			maxResponseTokens?: number
 		} = {}
@@ -818,6 +831,7 @@ export class IterationOrchestrator {
 		if (result.toolChoice !== undefined) prepared.toolChoice = result.toolChoice
 		if (result.model !== undefined) prepared.model = result.model
 		if (result.system !== undefined) prepared.system = result.system
+		if (result.skills !== undefined) prepared.skills = result.skills
 		if (result.temperature !== undefined) prepared.temperature = result.temperature
 		if (result.maxResponseTokens !== undefined) {
 			prepared.maxResponseTokens = result.maxResponseTokens

--- a/packages/sdk/src/types/run/prepare-step.ts
+++ b/packages/sdk/src/types/run/prepare-step.ts
@@ -1,6 +1,7 @@
 import type { RunId } from '../ids/index.js'
 import type { Message } from '../message/index.js'
 import type { ToolChoice } from '../provider/chat.js'
+import type { Skill } from '../skills/index.js'
 import type { StepResult } from './step.js'
 
 /**
@@ -83,6 +84,33 @@ export interface PrepareStepResult {
 	 * must produce the structured answer" — and not worth it as a habit.
 	 */
 	readonly toolChoice?: ToolChoice
+
+	/**
+	 * Put these skills in front of the model for this step only.
+	 *
+	 * A run's skills are fixed at `query()` time and rendered into the cached
+	 * system prefix, so every skill a run might ever need is paid for on
+	 * every single turn. A phased agent rarely needs them all at once —
+	 * research wants the search skill, writing wants the style guide, and
+	 * neither benefits from carrying the other.
+	 *
+	 * Rendered into the same ephemeral trailing system message `system`
+	 * uses, and for the same reason: appending leaves the cached prefix
+	 * intact, where rewriting the run's prompt would invalidate it every
+	 * iteration for what is usually one phase's worth of guidance.
+	 *
+	 * ADDITIVE to the run's skills, not a replacement. A skill the run
+	 * always carries is not something a step should be able to take away by
+	 * naming a different one — that would make every step's list a complete
+	 * restatement, and a phase that forgot one would silently lose it.
+	 *
+	 * Sub-agents are deliberately NOT per-step. Which agents `create_task`
+	 * can reach is baked into that tool's input schema, so varying it would
+	 * rebuild the tool catalogue every step — a worse prompt-cache trade
+	 * than moving tools, for a narrowing a step can already express by
+	 * withholding `create_task` through {@link PrepareStepResult.activeTools}.
+	 */
+	readonly skills?: readonly Skill[]
 
 	/** Use a different model for this step. */
 	readonly model?: string


### PR DESCRIPTION
See the changeset for the reasoning, including why sub-agents deliberately stay out.