### PR TITLE
fix(sdk): make a retrieval namespace actually partition

### DIFF
--- a/.changeset/retrieval-namespace-isolation.md
+++ b/.changeset/retrieval-namespace-isolation.md
@@ -1,0 +1,15 @@
+---
+'@namzu/sdk': minor
+---
+
+A retrieval namespace partitions what a query can see.
+
+`TenantScope.namespace` and `KnowledgeBaseConfig.namespace` were declared from the start and neither reached storage. Ingestion copied `scope.tenantId` onto every chunk and dropped the namespace; the store filtered on tenant alone. So a partition a host asked for did not exist, and every namespace inside a tenant saw every other one's documents.
+
+The namespace is now stamped onto each chunk at ingest and matched at search, across all three retrieval modes.
+
+**An omitted namespace means the default partition, not the absence of a filter.** That distinction is the whole boundary: reading absence as "no filter" is how one leaks, because a caller who never asked for a namespace would then see every namespaced chunk in the tenant — the opposite of what partitioning is for. A caller who genuinely wants everything asks for each namespace it holds.
+
+This is a behaviour change for existing data. Chunks ingested under a namespace before this release carry none, so they now answer only to a query with no namespace. Re-ingest to place them in a partition.
+
+`RetrievalQuery.projectId` is **deprecated and documented as not consulted**. No chunk carries a project — ingestion stamps a tenant and a namespace, and `KnowledgeBaseConfig` has no project field to stamp a third from. Wiring one end of an isolation dimension is worse than wiring neither: a query filtering against a value nothing writes returns zero rows, and "no results" reads as "nothing matched" rather than "this scope was never stored".

--- a/packages/sdk/src/rag/__tests__/namespace-isolation.test.ts
+++ b/packages/sdk/src/rag/__tests__/namespace-isolation.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+
+import type { EmbeddingProvider, TenantScope } from '../../types/rag/index.js'
+import { DefaultIngestionPipeline } from '../ingestion.js'
+import { DefaultRetriever } from '../retriever.js'
+import { InMemoryVectorStore } from '../vector-store.js'
+
+/**
+ * `TenantScope.namespace` and `KnowledgeBaseConfig.namespace` were declared
+ * from the start and neither reached storage. Ingestion copied
+ * `scope.tenantId` onto every chunk and dropped the namespace; the store
+ * filtered on tenant alone. So a partition a host asked for did not exist,
+ * and every namespace in a tenant saw every other one's documents.
+ */
+
+/** Deterministic and content-derived, so similarity is stable across runs. */
+const embedder: EmbeddingProvider = {
+	async embed(texts: string[]) {
+		return texts.map((t) => [t.length % 7, t.charCodeAt(0) % 5, 1])
+	},
+	async embedQuery(text: string) {
+		return [text.length % 7, text.charCodeAt(0) % 5, 1]
+	},
+	dimensions: 3,
+	model: 'test-embedder',
+	id: 'test-embedder',
+}
+
+const tenant = 'tnt_one' as TenantScope['tenantId']
+
+function scope(namespace?: string): TenantScope {
+	return { tenantId: tenant, ...(namespace !== undefined ? { namespace } : {}) }
+}
+
+async function seed() {
+	const store = new InMemoryVectorStore()
+	const ingestion = new DefaultIngestionPipeline(store, embedder)
+	const kb = 'kb_one' as never
+
+	await ingestion.ingest('alpha partition content', {}, scope('alpha'), kb)
+	await ingestion.ingest('beta partition content', {}, scope('beta'), kb)
+	await ingestion.ingest('default partition content', {}, scope(), kb)
+
+	return { store, retriever: new DefaultRetriever(store, embedder), kb }
+}
+
+const texts = (r: { chunks: { chunk: { content: string } }[] }) =>
+	r.chunks.map((c) => c.chunk.content)
+
+describe('a namespace partitions what a query can see', () => {
+	it('returns only its own partition', async () => {
+		const { retriever, kb } = await seed()
+
+		const found = await retriever.retrieve({ text: 'partition content' }, scope('alpha'), kb)
+
+		expect(texts(found)).toEqual(['alpha partition content'])
+	})
+
+	it('does not leak the other partition', async () => {
+		const { retriever, kb } = await seed()
+
+		const found = await retriever.retrieve({ text: 'partition content' }, scope('beta'), kb)
+
+		expect(texts(found).join()).not.toContain('alpha')
+	})
+
+	it('treats an absent namespace as the default partition, not as no filter', async () => {
+		const { retriever, kb } = await seed()
+
+		const found = await retriever.retrieve({ text: 'partition content' }, scope(), kb)
+
+		// The whole point. Reading absence as "no filter" is how the boundary
+		// leaks: a caller who never asked for a namespace would see every
+		// namespaced chunk in the tenant.
+		expect(texts(found)).toEqual(['default partition content'])
+	})
+
+	it('keeps tenants apart as it always did', async () => {
+		const { retriever, kb } = await seed()
+
+		const found = await retriever.retrieve(
+			{ text: 'partition content' },
+			{
+				tenantId: 'tnt_other' as TenantScope['tenantId'],
+				namespace: 'alpha',
+			},
+			kb,
+		)
+
+		expect(found.chunks).toEqual([])
+	})
+
+	it('stamps the namespace onto the chunk at ingest', async () => {
+		const { store } = await seed()
+
+		const results = await store.search({
+			embedding: await embedder.embedQuery('partition content'),
+			topK: 10,
+			tenantId: tenant,
+			namespace: 'alpha',
+		})
+
+		// Ingest is where it has to land — filtering at search against a value
+		// nothing writes returns zero rows, and "no results" reads as "nothing
+		// matched" rather than "this scope was never stored".
+		expect(results.every((r) => r.chunk.content.startsWith('alpha'))).toBe(true)
+		expect(results.length).toBeGreaterThan(0)
+	})
+})

--- a/packages/sdk/src/rag/ingestion.ts
+++ b/packages/sdk/src/rag/ingestion.ts
@@ -48,6 +48,7 @@ export class DefaultIngestionPipeline implements IngestionPipeline {
 			documentId,
 			knowledgeBaseId,
 			tenantId: scope.tenantId,
+			...(scope.namespace !== undefined ? { namespace: scope.namespace } : {}),
 			content: cc.content,
 			index: cc.index,
 			tokenCount: estimateTokens(cc.content),

--- a/packages/sdk/src/rag/retriever.ts
+++ b/packages/sdk/src/rag/retriever.ts
@@ -76,6 +76,7 @@ export class DefaultRetriever implements Retriever {
 			embedding,
 			topK: config.topK,
 			tenantId: scope.tenantId,
+			...(scope.namespace !== undefined ? { namespace: scope.namespace } : {}),
 			knowledgeBaseId,
 			minScore: config.minScore,
 		})
@@ -92,6 +93,7 @@ export class DefaultRetriever implements Retriever {
 			embedding,
 			topK: config.topK * 2,
 			tenantId: scope.tenantId,
+			...(scope.namespace !== undefined ? { namespace: scope.namespace } : {}),
 			knowledgeBaseId,
 			minScore: 0,
 		})

--- a/packages/sdk/src/rag/vector-store.ts
+++ b/packages/sdk/src/rag/vector-store.ts
@@ -20,6 +20,11 @@ export class InMemoryVectorStore implements VectorStore {
 
 		for (const chunk of this.chunks.values()) {
 			if (chunk.tenantId !== query.tenantId) continue
+			// Equality INCLUDING absence: an omitted namespace is the default
+			// partition, not the absence of a filter. Treating it as no filter
+			// is how the boundary leaks — a caller who never asked for a
+			// namespace would see every namespaced chunk in the tenant.
+			if (chunk.namespace !== query.namespace) continue
 			if (query.knowledgeBaseId && chunk.knowledgeBaseId !== query.knowledgeBaseId) continue
 			if (!chunk.embedding) continue
 

--- a/packages/sdk/src/types/rag/retrieval.ts
+++ b/packages/sdk/src/types/rag/retrieval.ts
@@ -14,6 +14,22 @@ export interface RetrievalConfig {
 
 export interface RetrievalQuery {
 	text: string
+	/**
+	 * **Not consulted.** No chunk carries a project, so there is nothing to
+	 * match it against: ingestion stamps a tenant and a namespace, and
+	 * `KnowledgeBaseConfig` has no project field to stamp a third from.
+	 *
+	 * Left declared and said out loud rather than quietly filtering on it.
+	 * Wiring one end of an isolation dimension is worse than wiring
+	 * neither — a query that filters against a value nothing writes returns
+	 * zero rows, and "no results" reads as "nothing matched" rather than
+	 * "this scope does not exist". Partition with
+	 * {@link TenantScope.namespace}, which is stamped at ingest and matched
+	 * at search.
+	 *
+	 * @deprecated Use `TenantScope.namespace` until a project reaches
+	 * ingestion.
+	 */
 	projectId?: ProjectId
 	recentMessages?: string[]
 	config?: Partial<RetrievalConfig>

--- a/packages/sdk/src/types/rag/storage.ts
+++ b/packages/sdk/src/types/rag/storage.ts
@@ -16,6 +16,15 @@ export interface Chunk {
 	documentId: DocumentId
 	knowledgeBaseId: KnowledgeBaseId
 	tenantId: TenantId
+	/**
+	 * The partition this chunk was ingested into, from `TenantScope`.
+	 *
+	 * `TenantScope.namespace` and `KnowledgeBaseConfig.namespace` were both
+	 * declared from the start and neither reached storage: ingestion copied
+	 * `scope.tenantId` onto every chunk and dropped the namespace, so a
+	 * partition a host had asked for did not exist at all.
+	 */
+	namespace?: string
 	content: string
 	index: number
 	tokenCount: number

--- a/packages/sdk/src/types/rag/vector.ts
+++ b/packages/sdk/src/types/rag/vector.ts
@@ -11,6 +11,17 @@ export interface VectorStoreQuery {
 	topK: number
 	tenantId: TenantId
 	knowledgeBaseId?: KnowledgeBaseId
+	/**
+	 * The partition to search. Matched by equality, INCLUDING absence.
+	 *
+	 * An omitted namespace means "the default partition", not "no filter".
+	 * Reading it as "no filter" is how an isolation boundary leaks: a caller
+	 * who never asked for a namespace would see every namespaced chunk in
+	 * the tenant, which is the opposite of what partitioning is for. A
+	 * caller who genuinely wants everything asks the store for each
+	 * namespace it holds.
+	 */
+	namespace?: string
 	filter?: Record<string, unknown>
 	minScore?: number
 }


### PR DESCRIPTION
See the changeset. Note the behaviour change for data ingested before this release.