### PR TITLE
fix(sdk): stop an oauth2 connector reaching upstream unauthenticated

### DIFF
--- a/.changeset/oauth2-not-unauthenticated.md
+++ b/.changeset/oauth2-not-unauthenticated.md
@@ -1,0 +1,15 @@
+---
+'@namzu/sdk': minor
+---
+
+An OAuth2 connector no longer reaches the upstream unauthenticated.
+
+`'oauth2'` was grouped with `'none'` and `'custom'` in the HTTP connector's header resolver, returning no headers. Every other auth type throws on a missing credential; this one quietly did not, so a connector configured for OAuth2 sent its request with no credential at all. The upstream's 401 then reads as a bad token rather than as no token, which sends whoever is debugging to look at the token.
+
+An access token supplied in `credentials.accessToken` (or `token`) is now sent as a bearer. Without one the connector **refuses**, naming what is missing.
+
+The token exchange itself is deliberately not implemented here: a client-credentials or authorization-code flow needs a token endpoint, refresh handling and somewhere to keep the result, none of which belong in a request-header helper. What is supported is the case a connector config can express today — a token the host already holds.
+
+`'custom'` keeps returning nothing, and that is not the same omission: it means the host attaches its own headers, so there is nothing to leave out and nothing to refuse.
+
+**Three connector declarations are now documented as not consulted** rather than left to be discovered. `ConnectorTrigger` and `ConnectorDefinition.triggers` are declared and unimplemented — no inbound event starts a run — and the note says what the missing half actually needs: cross-process de-duplication of a retried webhook, which requires a compare-and-set claim that this repo's only durable write primitive (an atomic file replace, last-writer-wins) cannot express, plus a release path so a claim held by a process that dies does not drop the event forever. It also names the two existing pieces to reuse rather than rebuild. `ConnectorMethod.outputSchema` is unread, with a pointer to how the tool layer already solved the same problem. `ConnectorDefinition.supportedAuth` is unchecked, with a note that the right place to check it is instance creation, not request time.

--- a/packages/sdk/src/connector/builtins/__tests__/oauth2-auth.test.ts
+++ b/packages/sdk/src/connector/builtins/__tests__/oauth2-auth.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+
+import type { AuthConfig } from '../../../types/connector/index.js'
+import { HttpConnector } from '../http.js'
+
+/**
+ * `'oauth2'` was grouped with `'none'` and `'custom'`, returning no headers.
+ *
+ * So a connector configured for OAuth2 sent an UNAUTHENTICATED request.
+ * Every other auth type throws on a missing credential; this one quietly
+ * did not, and the upstream's 401 reads as a bad token rather than as no
+ * token at all — which sends whoever is debugging to look at the token.
+ */
+
+function headersFor(auth: AuthConfig): Record<string, string> {
+	const connector = new HttpConnector()
+	// The resolver is private by design; reaching it directly is what keeps
+	// this test about the header decision rather than about fetch.
+	return (
+		connector as unknown as { resolveAuthHeaders(a: AuthConfig): Record<string, string> }
+	).resolveAuthHeaders(auth)
+}
+
+describe('an oauth2 connector does not send an unauthenticated request', () => {
+	it('sends the access token it was given', () => {
+		const headers = headersFor({
+			type: 'oauth2',
+			credentials: { accessToken: 'tok_abc' },
+		} as AuthConfig)
+
+		expect(headers.Authorization).toBe('Bearer tok_abc')
+	})
+
+	it('accepts the token under either name', () => {
+		const headers = headersFor({ type: 'oauth2', credentials: { token: 'tok_xyz' } } as AuthConfig)
+
+		expect(headers.Authorization).toBe('Bearer tok_xyz')
+	})
+
+	it('refuses when there is no token, rather than sending nothing', () => {
+		// The whole defect: an empty header set went out and the request
+		// reached the upstream with no credential at all.
+		expect(() => headersFor({ type: 'oauth2', credentials: {} } as AuthConfig)).toThrow(
+			/accessToken/,
+		)
+	})
+
+	it('refuses when credentials are absent entirely', () => {
+		expect(() => headersFor({ type: 'oauth2' } as AuthConfig)).toThrow(/unauthenticated/)
+	})
+})
+
+describe('the other schemes are unchanged', () => {
+	it("still sends nothing for 'none'", () => {
+		expect(headersFor({ type: 'none' } as AuthConfig)).toEqual({})
+	})
+
+	it("still sends nothing for 'custom', which is the host's job", () => {
+		// Deliberately empty, unlike oauth2: `custom` means the host attaches
+		// its own headers, so there is nothing to omit and nothing to refuse.
+		expect(headersFor({ type: 'custom' } as AuthConfig)).toEqual({})
+	})
+
+	it('still sends a bearer token', () => {
+		expect(
+			headersFor({ type: 'bearer', credentials: { token: 't' } } as AuthConfig).Authorization,
+		).toBe('Bearer t')
+	})
+
+	it('still refuses a bearer with no token', () => {
+		expect(() => headersFor({ type: 'bearer', credentials: {} } as AuthConfig)).toThrow(/token/)
+	})
+})

--- a/packages/sdk/src/connector/builtins/http.test.ts
+++ b/packages/sdk/src/connector/builtins/http.test.ts
@@ -140,8 +140,12 @@ describe('HttpConnector', () => {
 			expect(headers.Authorization).toBe(`Basic ${btoa('alice:pw')}`)
 		})
 
-		it('none / oauth2 / custom add no auth headers', async () => {
-			for (const type of ['none', 'oauth2', 'custom'] as const) {
+		it('none / custom add no auth headers', async () => {
+			// `oauth2` was in this list, and that is what the defect was: it
+			// meant a connector configured for OAuth2 reached the upstream with
+			// no credential at all. `none` and `custom` belong here — the first
+			// asks for no auth, the second says the host attaches its own.
+			for (const type of ['none', 'custom'] as const) {
 				const c = new HttpConnector()
 				await c.connect({ baseUrl: 'https://api.example.com' }, { type, credentials: {} })
 				fetchMock.mockResolvedValueOnce(makeResponse({ status: 200, body: {} }))
@@ -150,6 +154,28 @@ describe('HttpConnector', () => {
 				expect(headers.Authorization).toBeUndefined()
 				expect(headers['X-API-Key']).toBeUndefined()
 			}
+		})
+
+		it('oauth2 refuses rather than reaching the upstream unauthenticated', async () => {
+			const c = new HttpConnector()
+
+			await expect(
+				c.connect({ baseUrl: 'https://api.example.com' }, { type: 'oauth2', credentials: {} }),
+			).rejects.toThrow(/accessToken/)
+		})
+
+		it('oauth2 sends the access token it was given', async () => {
+			const c = new HttpConnector()
+			await c.connect(
+				{ baseUrl: 'https://api.example.com' },
+				{ type: 'oauth2', credentials: { accessToken: 'tok_1' } },
+			)
+			fetchMock.mockResolvedValueOnce(makeResponse({ status: 200, body: {} }))
+
+			await c.execute('request', { method: 'GET', path: 'x' })
+
+			const headers = fetchMock.mock.calls.at(-1)?.[1].headers as Record<string, string>
+			expect(headers.Authorization).toBe('Bearer tok_1')
 		})
 
 		it('api_key throws when apiKey is missing', async () => {

--- a/packages/sdk/src/connector/builtins/http.ts
+++ b/packages/sdk/src/connector/builtins/http.ts
@@ -188,9 +188,33 @@ export class HttpConnector extends BaseConnector<HttpConnectorConfig> {
 				const encoded = btoa(`${username}:${password}`)
 				return { Authorization: `Basic ${encoded}` }
 			}
-			case 'none':
-			case 'oauth2':
+			case 'oauth2': {
+				// Grouped with `none` until now, so a connector configured for
+				// OAuth2 sent an UNAUTHENTICATED request — every other auth type
+				// throws on a missing credential, and this one quietly did not.
+				// The upstream answers 401 and the failure reads as a bad token
+				// rather than as no token at all.
+				//
+				// The token exchange itself is not implemented here: a client
+				// credentials or authorization-code flow needs a token endpoint,
+				// refresh handling and a place to keep the result, none of which
+				// belong in a request-header helper. What is supported is an
+				// access token the host already holds, which is the case a
+				// connector config can actually express today.
+				const token = creds.accessToken ?? creds.token
+				if (!token) {
+					throw new Error(
+						'AuthConfig oauth2: missing required credential "accessToken". This connector holds no token endpoint, so an access token obtained elsewhere has to be supplied — sending the request without one would reach the upstream unauthenticated.',
+					)
+				}
+				return { Authorization: `Bearer ${token}` }
+			}
 			case 'custom':
+				// Deliberately empty, unlike `oauth2` above: `custom` means the
+				// host attaches its own headers, so there is nothing here to
+				// omit and nothing to refuse.
+				return {}
+			case 'none':
 				return {}
 			default: {
 				const _exhaustive: never = auth.type

--- a/packages/sdk/src/types/connector/core.ts
+++ b/packages/sdk/src/types/connector/core.ts
@@ -28,9 +28,43 @@ export interface ConnectorMethod<TInput = unknown, TOutput = unknown> {
 	name: string
 	description: string
 	inputSchema: z.ZodType<TInput, z.ZodTypeDef, unknown>
+	/**
+	 * **Not consulted.** Neither in-tree connector declares one, and nothing
+	 * validates a result against it or shows it to a model.
+	 *
+	 * The tool layer solved the same problem already: a remote tool's output
+	 * schema is appended to its description by `describeWithOutput`, because
+	 * no provider's tool wire format has a slot for one. A connector method
+	 * that reaches a model through that bridge should take the same route
+	 * rather than growing a second mechanism.
+	 */
 	outputSchema?: z.ZodType<TOutput, z.ZodTypeDef, unknown>
 }
 
+/**
+ * **Declared, not implemented.** Nothing reads a trigger and nothing emits
+ * a {@link ConnectorEvent}; no inbound event starts a run today.
+ *
+ * Said here rather than left to be discovered, because a connector author
+ * who declares triggers gets no error and no events — the worst combination
+ * to debug. The shape is kept because it is right: a trigger names an
+ * upstream event and the config a subscription needs.
+ *
+ * What is missing is not the type but the delivery half, and it is a larger
+ * piece than it looks. An inbound event has to be de-duplicated across
+ * processes, since the same webhook is retried and the same poll can
+ * overlap; that needs a compare-and-set claim, and the only durable write
+ * primitive here is an atomic file REPLACE, which is last-writer-wins and
+ * cannot express one. It also needs a release path for an event claimed by
+ * a process that then dies, or the first crash silently drops that event
+ * forever.
+ *
+ * Two of those parts already exist and should be reused rather than
+ * rebuilt when this is built: `AbstractAgent.underIdempotencyKey` is the
+ * in-process dedupe seam and names the cross-process half as its known
+ * gap, and `EditOwnershipTracker.claim` is the claim/refuse shape with
+ * same-owner idempotency already worked out.
+ */
 export interface ConnectorTrigger {
 	name: string
 	description: string

--- a/packages/sdk/src/types/connector/definition.ts
+++ b/packages/sdk/src/types/connector/definition.ts
@@ -17,9 +17,19 @@ export interface ConnectorDefinition<TConfig = unknown> {
 	version?: string
 	category?: ConnectorCategory
 	connectionType: ConnectionType
+	/**
+	 * **Not consulted.** A connector declaring this is not checked against
+	 * the auth an instance is actually configured with, so a mismatch
+	 * surfaces as a 401 from the upstream rather than as a refusal here.
+	 *
+	 * Worth wiring where instances are created, not at request time: the
+	 * point of declaring supported schemes is to reject a misconfiguration
+	 * before anything is sent.
+	 */
 	supportedAuth?: AuthType[]
 	configSchema: z.ZodType<TConfig, z.ZodTypeDef, unknown>
 	methods: ConnectorMethod[]
+	/** Declared, not implemented — see {@link ConnectorTrigger}. */
 	triggers?: ConnectorTrigger[]
 }
 


### PR DESCRIPTION
See the changeset. Includes documenting three connector declarations as not consulted, with what the trigger delivery half would actually need.