### PR TITLE
fix(sdk): carry a human's approval across the spawn boundary

### DIFF
--- a/.changeset/hitl-across-spawn.md
+++ b/.changeset/hitl-across-spawn.md
@@ -1,0 +1,15 @@
+---
+'@namzu/sdk': minor
+---
+
+A human's approval now crosses the spawn boundary.
+
+`BaseAgentConfig` carried no resume handler. `SendMessageOptions.configOverrides` is a `Partial` of it, so a parent could not hand its decision channel to a child **at the type level** — and no runtime path could carry one either. Every delegated child fell through to the SDK's `autoApproveHandler`, however carefully its parent had been wired.
+
+**What that cost, exactly.** A `VerificationGate` *deny* still bit inside a child: denials are threaded into the executor and no later approval releases them. What was lost is the **review** tier — every call the gate left undecided reached the resume handler, and for a child that handler auto-approved. So a host running "ask before acting" had a human review `write` at the top level and never see the same `write` issued one hop down. The shipped CLI encodes the workaround as policy: its sub-agent prompt says *"do not ask the parent questions; make reasonable assumptions"*, because a question had nowhere to go.
+
+`AgentTaskContext.resumeHandler` carries the parent's channel and `AgentManager` stamps it onto the child config — beside the trace parent and the tenant triple, for the same reason: a `configBuilder` is written by whoever registered the agent and cannot be trusted to forward something it was never told about. An explicit `configOverrides.resumeHandler` still wins, so one child can be given a different channel or none. `SupervisorAgent` now puts its own handler on the spawn context; it already gave that handler to its own run and its own coordinator tools, so the two had disagreed — the supervisor paused for a human while the workers it launched approved themselves.
+
+Absent still means auto-approve. A host that never wired a handler is unaffected.
+
+The handler is passed as the function itself, which works because delegation is in-process — `LocalTaskGateway` is the only gateway in the tree. A gateway dispatching across a process boundary could not carry a closure and would have to proxy the request onto the parent's event stream and route the answer back by request id. The upward half of that already exists: `wrapChildListener` stamps lineage on every child event the parent sees, and `user_question_asked` / `tool_review_requested` / `run_paused` are already typed events.

--- a/packages/sdk/src/agents/SupervisorAgent.ts
+++ b/packages/sdk/src/agents/SupervisorAgent.ts
@@ -146,6 +146,12 @@ export class SupervisorAgent extends AbstractAgent<SupervisorAgentConfig, Superv
 					remaining: config.tokenBudget,
 				},
 				factoryOptions: mergedFactoryOptions,
+				// The supervisor already hands this to its OWN run and its own
+				// coordinator tools; handing it to the spawn context is what
+				// makes a worker ask the same person the supervisor asks.
+				// Without it the two disagreed: the supervisor paused for a
+				// human and the workers it launched approved themselves.
+				...(config.resumeHandler ? { resumeHandler: config.resumeHandler } : {}),
 				tenantId,
 				threadId,
 				sessionId,

--- a/packages/sdk/src/agents/__tests__/supervisor-hands-down-hitl.test.ts
+++ b/packages/sdk/src/agents/__tests__/supervisor-hands-down-hitl.test.ts
@@ -1,0 +1,131 @@
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+
+import { MockLLMProvider } from '../../provider/mock.js'
+import { ToolRegistry } from '../../registry/tool/execute.js'
+import type { AgentTaskContext } from '../../types/agent/task.js'
+import type { ResumeHandler } from '../../types/hitl/index.js'
+import { SupervisorAgent } from '../SupervisorAgent.js'
+
+/**
+ * The supervisor already handed its resume handler to its OWN run and its
+ * own coordinator tools. It did not hand it to the spawn context, so the
+ * two disagreed: the supervisor paused for a human, and every worker it
+ * launched approved itself.
+ *
+ * This is the link a mutation run found untested — the previous version of
+ * these tests drove `AgentManager` with a context built by hand, which is
+ * not the path a host takes.
+ */
+
+/** Captures the context the supervisor builds for its spawns. */
+function spyManager(): {
+	contexts: AgentTaskContext[]
+	manager: unknown
+} {
+	const contexts: AgentTaskContext[] = []
+	const manager = {
+		sendMessage: vi.fn(async (_options: unknown, context: AgentTaskContext) => {
+			contexts.push(context)
+			return {
+				taskId: 'task_1',
+				status: 'completed',
+				result: {
+					runId: 'run_child',
+					status: 'completed',
+					usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+					cost: { totalCost: 0 },
+					iterations: 1,
+					durationMs: 1,
+					messages: [],
+					result: 'worker done',
+				},
+			}
+		}),
+		await: vi.fn(async () => undefined),
+		cancel: vi.fn(),
+		dispose: vi.fn(),
+		on: vi.fn(),
+		off: vi.fn(),
+	}
+	return { contexts, manager }
+}
+
+async function runSupervisor(resumeHandler?: ResumeHandler) {
+	const { contexts, manager } = spyManager()
+	const agent = new SupervisorAgent({
+		id: 'supervisor',
+		name: 'Supervisor',
+		version: '1',
+		category: 'test',
+		description: 'coordinates workers',
+	})
+
+	const provider = new MockLLMProvider({
+		turns: [
+			{
+				toolCalls: [
+					{
+						id: 'c1',
+						name: 'create_task',
+						rawArguments: JSON.stringify({
+							agent_id: 'worker',
+							prompt: 'do the thing',
+							description: 'a task',
+						}),
+					},
+				],
+			},
+			{ text: 'all done' },
+		],
+	})
+
+	await agent
+		.run(
+			{
+				messages: [{ role: 'user', content: 'go', timestamp: 1 }],
+				workingDirectory: await mkdtemp(join(tmpdir(), 'namzu-sup-')),
+			},
+			{
+				provider,
+				agentIds: ['worker'],
+				agentManager: manager,
+				tools: new ToolRegistry(),
+				systemPrompt: 'You coordinate.',
+				model: 'mock-model',
+				tokenBudget: 100_000,
+				timeoutMs: 30_000,
+				maxIterations: 4,
+				sessionId: 'ses_sup',
+				threadId: 'thd_sup',
+				projectId: 'prj_sup',
+				tenantId: 'tnt_sup',
+				...(resumeHandler ? { resumeHandler } : {}),
+			} as never,
+		)
+		.catch(() => undefined)
+
+	return contexts
+}
+
+describe('a supervisor hands its decision channel to the workers it launches', () => {
+	it('puts its own handler on the spawn context', async () => {
+		const handler = vi.fn(async () => ({ action: 'approve_tools' })) as unknown as ResumeHandler
+
+		const contexts = await runSupervisor(handler)
+
+		expect(contexts.length).toBeGreaterThan(0)
+		expect(contexts[0]?.resumeHandler).toBe(handler)
+	})
+
+	it('leaves the context without one when it has none itself', async () => {
+		const contexts = await runSupervisor()
+
+		expect(contexts.length).toBeGreaterThan(0)
+		// Absent still means the worker auto-approves, which is what every
+		// worker did before any of this.
+		expect(contexts[0]?.resumeHandler).toBeUndefined()
+	})
+})

--- a/packages/sdk/src/manager/agent/__tests__/hitl-across-spawn.test.ts
+++ b/packages/sdk/src/manager/agent/__tests__/hitl-across-spawn.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { AgentRegistry } from '../../../registry/agent/definitions.js'
+import { DefaultCapacityValidator } from '../../../session/handoff/capacity.js'
+import { SessionSummaryMaterializer } from '../../../session/summary/materialize.js'
+import { WorkspaceBackendRegistry } from '../../../session/workspace/registry.js'
+import { InMemorySessionStore } from '../../../store/session/memory.js'
+import { InMemoryThreadStore } from '../../../store/thread/memory.js'
+import type { BaseAgentConfig, BaseAgentResult } from '../../../types/agent/base.js'
+import type { Agent } from '../../../types/agent/core.js'
+import type { AgentTaskContext, SendMessageOptions } from '../../../types/agent/task.js'
+import type { ResumeHandler } from '../../../types/hitl/index.js'
+import type { TenantId } from '../../../types/ids/index.js'
+import type { ActorRef } from '../../../types/session/actor.js'
+import { ThreadManager } from '../../thread/lifecycle.js'
+import { AgentManager } from '../lifecycle.js'
+
+/**
+ * A human's approval did not cross the spawn boundary.
+ *
+ * `BaseAgentConfig` carried no resume handler, and
+ * `SendMessageOptions.configOverrides` is a `Partial` of it — so a parent
+ * could not hand its channel to a child AT THE TYPE LEVEL. Every delegated
+ * child fell through to `autoApproveHandler` however carefully its parent
+ * had been wired.
+ *
+ * The cost is narrower than "no gate in children", and worth stating
+ * exactly. A `VerificationGate` DENY still bites inside a child, because
+ * denials are threaded into the executor and no later approval releases
+ * them. What was lost is the REVIEW tier — every call the gate left
+ * undecided reached the resume handler, and for a child that handler
+ * auto-approved. A host running "ask before acting" had a human review
+ * `write` at the top level and never see the same `write` one hop down.
+ */
+
+const tenant = 'tnt_hitl' as TenantId
+const actor = (tenantId: TenantId): ActorRef =>
+	({ kind: 'user', userId: 'usr_root', tenantId }) as unknown as ActorRef
+
+/** Records the config the child was actually handed. */
+function recordingAgent(seen: BaseAgentConfig[]): Agent<BaseAgentConfig, BaseAgentResult> {
+	return {
+		metadata: {
+			type: 'reactive',
+			id: 'worker',
+			name: 'Worker',
+			version: '1',
+			category: 'test',
+			description: 'records its config',
+			capabilities: {
+				supportsTools: true,
+				supportsStreaming: true,
+				supportsConcurrency: true,
+				supportsSubAgents: false,
+			},
+		},
+		async run(_input: unknown, config: BaseAgentConfig) {
+			seen.push(config)
+			return {
+				runId: 'run_child' as never,
+				status: 'completed',
+				usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+				cost: { totalCost: 0 },
+				iterations: 1,
+				durationMs: 1,
+				messages: [],
+				result: 'done',
+			} as unknown as BaseAgentResult
+		},
+	} as unknown as Agent<BaseAgentConfig, BaseAgentResult>
+}
+
+async function harness() {
+	const seen: BaseAgentConfig[] = []
+	const store = new InMemorySessionStore()
+	const threadStore = new InMemoryThreadStore()
+	const threadManager = new ThreadManager({ threadStore, sessionStore: store })
+	const project = await store.createProject({ tenantId: tenant, name: 'p' }, tenant)
+	const thread = await threadStore.createThread({ projectId: project.id, title: 'hitl' }, tenant)
+	const parent = await store.createSession(
+		{ threadId: thread.id, projectId: project.id, currentActor: actor(tenant) },
+		tenant,
+	)
+	await store.updateSession({ ...parent, status: 'active' }, tenant)
+
+	const registry = new AgentRegistry()
+	const agent = recordingAgent(seen)
+	registry.register({
+		info: {
+			id: agent.metadata.id,
+			name: agent.metadata.name,
+			version: agent.metadata.version,
+			category: agent.metadata.category,
+			description: agent.metadata.description,
+			tools: [],
+			defaults: { model: 'test', tokenBudget: 1_000 },
+		},
+		typedAgent: agent,
+	} as never)
+
+	// A second registration WITH a configBuilder. That is the branch a real
+	// registered agent takes, and the first version of these tests covered
+	// only the bare one — so three mutations of the branch that matters
+	// survived untouched.
+	registry.register({
+		info: {
+			id: 'built-worker',
+			name: 'Built Worker',
+			version: '1',
+			category: 'test',
+			description: 'has a configBuilder',
+			tools: [],
+			defaults: { model: 'test', tokenBudget: 1_000 },
+		},
+		typedAgent: agent,
+		configBuilder: (opts: Record<string, unknown>) => ({
+			model: 'test',
+			tokenBudget: (opts.tokenBudget as number) ?? 1_000,
+			timeoutMs: (opts.timeoutMs as number) ?? 30_000,
+		}),
+	} as never)
+
+	const manager = new AgentManager(registry, undefined, {
+		sessionStore: store,
+		summaryMaterializer: new SessionSummaryMaterializer({
+			store,
+			generateSummaryId: () => 'sum_1' as never,
+		}),
+		workspaceRegistry: new WorkspaceBackendRegistry(),
+		capacity: new DefaultCapacityValidator(store),
+		threadManager,
+	})
+
+	const context = (over: Partial<AgentTaskContext> = {}): AgentTaskContext =>
+		({
+			parentRunId: 'run_parent',
+			parentAgentId: 'supervisor',
+			parentAbortController: new AbortController(),
+			depth: 0,
+			budgetTracker: { total: 100_000, remaining: 100_000 },
+			tenantId: tenant,
+			threadId: thread.id,
+			sessionId: parent.id,
+			projectId: project.id,
+			parentActor: actor(tenant),
+			...over,
+		}) as AgentTaskContext
+
+	const options = (over: Partial<SendMessageOptions> = {}): SendMessageOptions =>
+		({
+			agentId: 'worker',
+			input: { messages: [], workingDirectory: '/tmp' },
+			parentSessionId: parent.id,
+			tenantId: tenant,
+			projectId: project.id,
+			parentActor: actor(tenant),
+			...over,
+		}) as SendMessageOptions
+
+	const spawn = async (ctx: AgentTaskContext, opts?: Partial<SendMessageOptions>) => {
+		await manager.sendMessage(options(opts), ctx)
+		// The child runs detached; give it a tick to reach `agent.run`.
+		await new Promise((r) => setTimeout(r, 20))
+	}
+
+	return { seen, context, spawn }
+}
+
+describe('a child asks the same person its parent asks', () => {
+	it('inherits the parent channel', async () => {
+		const h = await harness()
+		const handler = vi.fn(async () => ({ action: 'approve_tools' })) as unknown as ResumeHandler
+
+		await h.spawn(h.context({ resumeHandler: handler }))
+
+		expect(h.seen[0]?.resumeHandler).toBe(handler)
+	})
+
+	it('leaves a child without one when the parent has none', async () => {
+		const h = await harness()
+
+		await h.spawn(h.context())
+
+		// Absent still means auto-approve, so a host that never wired a
+		// handler is unaffected by any of this.
+		expect(h.seen[0]?.resumeHandler).toBeUndefined()
+	})
+
+	it('lets an explicit override win, so one child can be given a different channel', async () => {
+		const h = await harness()
+		const parentHandler = vi.fn() as unknown as ResumeHandler
+		const childHandler = vi.fn() as unknown as ResumeHandler
+
+		await h.spawn(h.context({ resumeHandler: parentHandler }), {
+			configOverrides: { resumeHandler: childHandler },
+		})
+
+		expect(h.seen[0]?.resumeHandler).toBe(childHandler)
+	})
+
+	it('does not disturb the scoping the manager already stamps', async () => {
+		const h = await harness()
+		const handler = vi.fn() as unknown as ResumeHandler
+
+		await h.spawn(h.context({ resumeHandler: handler }))
+
+		// The handler is stamped beside the trace parent and the tenant
+		// triple, for the same reason: a configBuilder cannot be trusted to
+		// forward something it was never told about.
+		const config = h.seen[0]
+		expect(config?.tenantId).toBe(tenant)
+		expect(config?.depth).toBe(1)
+	})
+})
+
+describe('the type allows what the spawn path needs', () => {
+	it('accepts a handler through configOverrides', () => {
+		const handler = vi.fn() as unknown as ResumeHandler
+
+		// The assertion the whole change exists for. The field lived on
+		// `ReactiveAgentConfig`, not on `BaseAgentConfig`, and
+		// `configOverrides` is `Partial<BaseAgentConfig>` — so this line did
+		// not compile, which is why no runtime path could ever have carried
+		// one.
+		const overrides: Partial<BaseAgentConfig> = { resumeHandler: handler }
+
+		expect(overrides.resumeHandler).toBe(handler)
+	})
+})
+
+/**
+ * The same three questions against the branch a REAL registered agent
+ * takes. `configBuilder` is written by whoever registered the agent and
+ * cannot be trusted to forward something it was never told about, so the
+ * manager stamps the handler afterwards — exactly as it does the trace
+ * parent and the tenant triple.
+ *
+ * These exist because the first version of this file covered only the
+ * bare-config branch, and three mutations of this one survived unnoticed.
+ */
+describe('a child built by a configBuilder inherits it too', () => {
+	it('inherits the parent channel', async () => {
+		const h = await harness()
+		const handler = vi.fn() as unknown as ResumeHandler
+
+		await h.spawn(h.context({ resumeHandler: handler }), { agentId: 'built-worker' })
+
+		expect(h.seen[0]?.resumeHandler).toBe(handler)
+	})
+
+	it('is left without one when the parent has none', async () => {
+		const h = await harness()
+
+		await h.spawn(h.context(), { agentId: 'built-worker' })
+
+		// Nothing is invented. A host that never wired a handler still gets
+		// the auto-approving default, which is what every child got before.
+		expect(h.seen[0]?.resumeHandler).toBeUndefined()
+	})
+
+	it('lets an explicit override win over the parent', async () => {
+		const h = await harness()
+		const parentHandler = vi.fn() as unknown as ResumeHandler
+		const childHandler = vi.fn() as unknown as ResumeHandler
+
+		await h.spawn(h.context({ resumeHandler: parentHandler }), {
+			agentId: 'built-worker',
+			configOverrides: { resumeHandler: childHandler },
+		})
+
+		expect(h.seen[0]?.resumeHandler).toBe(childHandler)
+	})
+})

--- a/packages/sdk/src/manager/agent/lifecycle.ts
+++ b/packages/sdk/src/manager/agent/lifecycle.ts
@@ -273,6 +273,17 @@ export class AgentManager {
 			if (options.configOverrides?.parentSpan) {
 				childConfig.parentSpan = options.configOverrides.parentSpan
 			}
+			// Stamped for the same reason as the trace parent above: a
+			// `configBuilder` is written by whoever registered the agent and
+			// cannot be trusted to forward something it was never told about.
+			// An explicit override still wins, so a host can hand one child a
+			// different channel — or none.
+			//
+			// Without this every delegated child fell through to
+			// `autoApproveHandler`, so a host's "ask before acting" gate
+			// covered the top-level run and nothing it delegated.
+			const inheritedHandler = options.configOverrides?.resumeHandler ?? context.resumeHandler
+			if (inheritedHandler) childConfig.resumeHandler = inheritedHandler
 		} else {
 			this.log.warn('No configBuilder, using bare config', {
 				agentId: options.agentId,
@@ -292,6 +303,7 @@ export class AgentManager {
 				tenantId: context.tenantId,
 				parentRunId: context.parentRunId,
 				depth: context.depth + 1,
+				resumeHandler: options.configOverrides?.resumeHandler ?? context.resumeHandler,
 			}
 		}
 

--- a/packages/sdk/src/types/agent/base.ts
+++ b/packages/sdk/src/types/agent/base.ts
@@ -1,4 +1,5 @@
 import type { AgentStatus, CostInfo, TokenUsage } from '../common/index.js'
+import type { ResumeHandler } from '../hitl/index.js'
 import type { RunId, SessionId, TenantId } from '../ids/index.js'
 import type { InvocationState } from '../invocation/index.js'
 import type { Message } from '../message/index.js'
@@ -78,6 +79,32 @@ export interface BaseAgentConfig {
 
 	/** Span a delegated run hangs off. Absent for a top-level run. */
 	parentSpan?: import('@opentelemetry/api').Span
+
+	/**
+	 * Where this agent takes a decision it cannot make alone — a tool that
+	 * needs approval, a question for a human, a plan to sign off.
+	 *
+	 * Declared HERE, on the base config, rather than only on the agent
+	 * shapes that happened to want it. `AgentManager` builds a child as a
+	 * `BaseAgentConfig` and `SendMessageOptions.configOverrides` is a
+	 * `Partial` of it, so a field further down the hierarchy is one a
+	 * spawn cannot express AT THE TYPE LEVEL — and that is what happened:
+	 * every delegated child fell through to the SDK's `autoApproveHandler`
+	 * however carefully its parent had been wired.
+	 *
+	 * What that cost is narrower than "no gate in children" and worth
+	 * stating exactly. A `VerificationGate` DENY still bites inside a
+	 * child, because denials are threaded into the executor and no later
+	 * approval releases them. What was lost is the REVIEW tier: every call
+	 * the gate left undecided went to the resume handler, and for a child
+	 * that handler auto-approved. So a host running "ask before acting"
+	 * had a human review `write` at the top level and never see the same
+	 * `write` issued one hop down.
+	 *
+	 * Absent still means auto-approve, so a host that never wired one is
+	 * unaffected.
+	 */
+	resumeHandler?: ResumeHandler
 }
 
 export type RuntimeToolOverrides = Record<string, ToolAvailability | 'disabled'>

--- a/packages/sdk/src/types/agent/task.ts
+++ b/packages/sdk/src/types/agent/task.ts
@@ -1,6 +1,7 @@
 import type { ActorRef } from '../../types/session/actor.js'
 import type { WorkspaceBackendKind } from '../../types/workspace/ref.js'
 import type { TokenUsage } from '../common/index.js'
+import type { ResumeHandler } from '../hitl/index.js'
 import type { RunId, SessionId, TaskId, TenantId } from '../ids/index.js'
 import type { Message } from '../message/index.js'
 import type { RunEventListener } from '../run/events.js'
@@ -40,6 +41,23 @@ export interface AgentTaskContext {
 	budgetTracker: AgentTaskBudget
 
 	factoryOptions?: AgentFactoryOptions
+
+	/**
+	 * The parent's channel to whoever can answer a decision it cannot make
+	 * alone, handed down so a child asks the same person.
+	 *
+	 * Passed as the function itself, which works because delegation is
+	 * in-process: `LocalTaskGateway` is the only `TaskGateway` in the tree.
+	 * A gateway that dispatched across a process boundary could not carry a
+	 * closure and would have to proxy the request onto the parent's event
+	 * stream and route the answer back by request id — the upward half of
+	 * which already exists, since `wrapChildListener` stamps lineage on
+	 * every child event the parent sees.
+	 *
+	 * Absent means the child auto-approves, exactly as every child did
+	 * before this existed.
+	 */
+	resumeHandler?: ResumeHandler
 
 	/** Isolation boundary. Required per session-hierarchy.md §12.1. */
 	tenantId: TenantId


### PR DESCRIPTION
The highest-severity finding of a sub-agent coverage audit against three peer runtimes: a parent's HITL channel could not reach a child at the type level, so every delegate auto-approved. See the changeset for exactly what degraded and what did not.