### PR TITLE
fix(sdk): emit one chat span per model call, not two

### DIFF
--- a/.changeset/one-chat-span-per-call.md
+++ b/.changeset/one-chat-span-per-call.md
@@ -1,0 +1,15 @@
+---
+'@namzu/sdk': patch
+---
+
+One `chat` span per model call, not two.
+
+3.2.0 shipped a second `chat {model}` span. `stream-turn.ts` already opened one — with the same justification, that `chatSpanName` had no call sites — and 3.2.0 added another beside it, same name, same parent, both carrying token counts. A consumer summing spans double-counted latency and tokens.
+
+Verified by execution rather than by reading: one scripted model call produced two `chat mock-model` spans, both with `gen_ai.usage.input_tokens`.
+
+The one added in 3.2.0 is removed and the earlier one kept, because it is strictly better — it wraps the call itself and records time to first delta, which the later one did not.
+
+**How it shipped, since that matters more than the fix.** The search that concluded "zero call sites" covered `telemetry/attributes.ts` and `constants/telemetry/` and never the runtime. Then the test asserting `toHaveLength(1)` failed with `2`, and the failure was explained away — attributed to a forced-final turn — and relaxed to `>= 1`. That relaxation is now reverted to an exact count, and a mutation confirms it catches a re-introduced duplicate as well as a removed span. The reasoning is recorded next to the assertion so the next person to see it fail with `2` reads the history instead of re-deriving the same wrong explanation.
+
+Reported by a consuming host reading 3.2.0 against its own telemetry.

--- a/packages/sdk/src/runtime/query/iteration/index.ts
+++ b/packages/sdk/src/runtime/query/iteration/index.ts
@@ -11,7 +11,6 @@ import {
 	GENAI,
 	NAMZU,
 	agentIterationSpanName,
-	chatSpanName,
 	parentContext,
 } from '../../../telemetry/attributes.js'
 import { getTracer } from '../../../telemetry/runtime-accessors.js'
@@ -154,9 +153,6 @@ export class IterationOrchestrator {
 				{},
 				parentContext(this.ctx.rootSpan),
 			)
-			// Declared out here so the iteration's own finally can close it on
-			// any path that does not reach its success branch.
-			let chatSpan: Span | undefined
 			try {
 				// Tool spans for this turn belong under this iteration. Inside
 				// the try rather than before it: a throw from any of these left
@@ -282,27 +278,6 @@ export class IterationOrchestrator {
 				// aggregated `ChatCompletionResponse` for the legacy
 				// downstream paths (assistantMsg construction, working
 				// state extraction, telemetry attribute stamping).
-				// The model call gets its own span. There was none at all —
-				// `chatSpanName` shipped with zero call sites — so a run's traces
-				// carried no LLM latency whatsoever, and the one thing anybody
-				// opens a trace to find (which turn was slow, and why) was the
-				// one thing not in it.
-				chatSpan = tracer.startSpan(chatSpanName(stepModel), {}, parentContext(iterSpan))
-				chatSpan.setAttributes({
-					[GENAI.OPERATION_NAME]: 'chat',
-					[GENAI.SYSTEM]: this.ctx.provider.id,
-					[GENAI.REQUEST_MODEL]: stepModel,
-					...((step.temperature ?? runConfig.temperature) !== undefined
-						? { [GENAI.REQUEST_TEMPERATURE]: (step.temperature ?? runConfig.temperature) as number }
-						: {}),
-					...((step.maxResponseTokens ?? runConfig.maxResponseTokens) !== undefined
-						? {
-								[GENAI.REQUEST_MAX_TOKENS]: (step.maxResponseTokens ??
-									runConfig.maxResponseTokens) as number,
-							}
-						: {}),
-				})
-
 				const { response, messageId } = yield* streamProviderTurn(
 					this.ctx.provider,
 					{
@@ -338,27 +313,6 @@ export class IterationOrchestrator {
 					this.ctx.log,
 					iterSpan,
 				)
-
-				// Stamped on the call that produced them. The token counts also
-				// stay on the iteration span below, where they have always been:
-				// moving them would silently break whatever reads them today,
-				// and one turn per iteration makes the two agree.
-				chatSpan.setAttributes({
-					[GENAI.RESPONSE_MODEL]: response.model || stepModel,
-					[GENAI.RESPONSE_ID]: response.id,
-					[GENAI.USAGE_INPUT_TOKENS]: response.usage.promptTokens,
-					[GENAI.USAGE_OUTPUT_TOKENS]: response.usage.completionTokens,
-					// An array, per the semantic convention: one call can finish
-					// several ways when a provider returns more than one choice.
-					[GENAI.RESPONSE_FINISH_REASONS]: [response.finishReason ?? 'stop'],
-					[NAMZU.CACHE_READ_TOKENS]: response.usage.cachedTokens ?? 0,
-					[NAMZU.CACHE_WRITE_TOKENS]: response.usage.cacheWriteTokens ?? 0,
-				})
-				chatSpan.setStatus({ code: SpanStatusCode.OK })
-				chatSpan.end()
-				// Closed here for an accurate duration, and cleared so the
-				// iteration finally does not close it a second time.
-				chatSpan = undefined
 
 				// Main-loop turn: also records the prompt size compaction reads.
 				runMgr.recordTurnUsage(response.usage)
@@ -794,8 +748,6 @@ export class IterationOrchestrator {
 				iterSpan.recordException(err instanceof Error ? err : new Error(String(err)))
 				throw err
 			} finally {
-				// A model call that threw never reached its own close above.
-				chatSpan?.end()
 				// The only place the iteration span ends. It used to be ended at each of
 				// seventeen exits, which is a rule every future edit has to
 				// remember; a generator abandoned by its consumer never reached

--- a/packages/sdk/src/telemetry/__tests__/model-call-span.test.ts
+++ b/packages/sdk/src/telemetry/__tests__/model-call-span.test.ts
@@ -109,10 +109,14 @@ describe('the model call has a span of its own', () => {
 	it('opens one named for the model', async () => {
 		await runOnce([{ text: 'done' }])
 
-		// One per model call. A run makes at least one, and a forced-final
-		// turn makes another — both are model calls and both deserve a span.
-		expect(chatSpans().length).toBeGreaterThanOrEqual(1)
-		for (const s of chatSpans()) expect(s.name).toBe('chat mock-model')
+		// EXACTLY one. This was written as `toHaveLength(1)`, failed with 2,
+		// and was relaxed to `>= 1` under a plausible-sounding explanation
+		// about forced-final turns. The 2 was real: a second span with the
+		// same name and the same parent had been added beside the one
+		// `stream-turn.ts` already opened, so a naive sum double-counted both
+		// latency and tokens. Relaxing the assertion is what let that ship.
+		expect(chatSpans()).toHaveLength(1)
+		expect(chatSpans()[0]?.name).toBe('chat mock-model')
 	})
 
 	it('closes it', async () => {
@@ -168,11 +172,13 @@ describe('the model call has a span of its own', () => {
 		expect(attrs).toHaveProperty('namzu.cache.write_tokens')
 	})
 
-	it('opens one per turn, not one per run', async () => {
+	it('opens exactly one per model call, however many turns a run takes', async () => {
 		await runOnce([{ text: 'first' }, { text: 'second' }])
 
-		// A run with several turns is exactly the case a trace is opened for.
-		expect(chatSpans().length).toBeGreaterThanOrEqual(1)
+		// The count has to track model calls, not runs and not iterations —
+		// which is the only way a duplicate is visible at all.
+		const calls = spans.filter((s) => s.name.includes('iteration')).length
+		expect(chatSpans().length).toBeLessThanOrEqual(calls)
 	})
 
 	it('nests under the iteration span rather than emitting as a root', async () => {


### PR DESCRIPTION
3.2.0 shipped a duplicate chat span beside the one `stream-turn.ts` already opened — same name, same parent, both carrying token counts, so a naive sum double-counts latency and tokens.

Reported by a consuming host reading 3.2.0 against its own telemetry. Verified here by execution rather than by reading: one scripted model call produced two `chat mock-model` spans, both with `gen_ai.usage.input_tokens`.

The 3.2.0 span is removed and the earlier one kept — it wraps the call itself and records time to first delta, which the later one did not.

**How it got past a test that had already caught it.** The search behind "chatSpanName has zero call sites" covered `telemetry/attributes.ts` and `constants/telemetry/` and never the runtime. Then the assertion `expect(chatSpans()).toHaveLength(1)` failed with **2** — and that failure was explained away as a forced-final turn and relaxed to `>= 1`. The relaxation is reverted, the history is written beside the assertion, and a mutation confirms it now catches a re-introduced duplicate as well as a removed span.