### PR TITLE
fix(sdk): let edit do what its own description orders

### DIFF
--- a/.changeset/edit-insert-reachable.md
+++ b/.changeset/edit-insert-reachable.md
@@ -1,0 +1,15 @@
+---
+'@namzu/sdk': minor
+---
+
+`edit` can do the thing its own description tells the model to do.
+
+The tool description says *"For insertions, pass insertLine … use `insertLine: "end"` to extend a file at the end"*, and `write-file` and `bash` point at the same idiom. But `modelInputSchema` advertised only `path`/`old_string`/`new_string`/`replace_all` with `additionalProperties: false`, and `enforceModelInput: true` — so under constrained decoding the append idiom the prompt recommends was the one idiom a model could not emit. A consuming host measured the result over seven days on one tenant: **94 of 159 tool failures** were `edit` rejecting an `insertLine` whose spelling the model had guessed.
+
+`insertLine` is now in the model-facing schema as `oneOf: [integer ≥ 0, "end"]`. Declaring the union that way also removes the synonym problem at its source: for a provider that constrains generation, `"EOF"` is not emittable, because `"end"` is the only string the schema admits.
+
+`old_string` leaves `required`, because an insert has no text to match — requiring it is exactly what made the idiom unexpressible. Which of `old_string` / `insertLine` is present is decided by the two refinements the execution schema already carries. That is deliberate over a top-level `oneOf`: strict structured-output modes are least surprising with a flat object, and a discriminated union at the root is the construct most likely to be rejected or quietly ignored. The cost is that an incomplete call is now expressible and caught at execution rather than generation — paid knowingly, since the alternative is a working capability nothing can reach.
+
+For providers that do **not** constrain, `insertLine` also accepts `eof`, `append`, `last` and `end_of_file`. Liberal at execution and strict in the schema is the right way round: none of those is ambiguous, and refusing one bought strictness at the price of a full model round trip. The rejection message now names the value it received.
+
+Also here, same file family: **`write` refuses a whitespace-only path**, which `edit` has always refused. `.min(1)` admits `"   "`, which resolves to the working directory and fails as an unreadable directory-write error. Two mutating tools disagreeing about the same input is the kind of gap a model finds and a reviewer does not.

--- a/packages/sdk/src/tools/builtins/__tests__/edit-insert-reachable.test.ts
+++ b/packages/sdk/src/tools/builtins/__tests__/edit-insert-reachable.test.ts
@@ -1,0 +1,166 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { ToolContext } from '../../../types/tool/index.js'
+import { EditTool } from '../edit.js'
+import { WriteFileTool } from '../write-file.js'
+
+/**
+ * The tool's description ordered an idiom its own schema forbade.
+ *
+ * `edit`'s description says "For insertions, pass insertLine … use
+ * insertLine: 'end' to extend a file at the end". `modelInputSchema` listed
+ * only path/old_string/new_string/replace_all with
+ * `additionalProperties: false`, and `enforceModelInput: true` — so under
+ * constrained decoding the append idiom the prompt recommends was the one
+ * idiom a model could not emit.
+ *
+ * A consuming host measured the consequence over 7 days on one tenant: 94 of
+ * 159 tool failures were `edit` rejecting an `insertLine` the model had
+ * guessed a spelling for. That number is theirs and not reproducible here;
+ * the contradiction below is reproducible and is what these pin.
+ */
+
+let dirs: string[] = []
+
+afterEach(async () => {
+	await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })))
+	dirs = []
+})
+
+async function workdir(): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), 'namzu-edit-insert-'))
+	dirs.push(dir)
+	return dir
+}
+
+const ctx = (workingDirectory: string): ToolContext =>
+	({
+		runId: 'run_e',
+		workingDirectory,
+		abortSignal: new AbortController().signal,
+		env: {},
+		log: () => undefined,
+	}) as unknown as ToolContext
+
+const schema = () =>
+	(EditTool as unknown as { modelInputSchema: Record<string, unknown> }).modelInputSchema
+
+describe('the model can emit the idiom the description recommends', () => {
+	it('advertises insertLine at all', () => {
+		const props = schema().properties as Record<string, unknown>
+
+		expect(props.insertLine).toBeDefined()
+	})
+
+	it('keeps the closed shape, so an invented field is still refused', () => {
+		expect(schema().additionalProperties).toBe(false)
+	})
+
+	it('does not require old_string, which an insert cannot supply', () => {
+		// Requiring it is what made the append idiom unexpressible: an insert
+		// has no text to match.
+		expect(schema().required).not.toContain('old_string')
+	})
+
+	it('still requires the two fields every operation needs', () => {
+		expect(schema().required).toEqual(expect.arrayContaining(['path', 'new_string']))
+	})
+
+	it('admits only "end" as a string, so a synonym cannot be generated', () => {
+		const insert = (schema().properties as Record<string, { oneOf?: unknown[] }>).insertLine
+
+		// The schema is where the synonym problem is solved for a provider that
+		// constrains: `"EOF"` is not emittable because `"end"` is the only
+		// string the union admits.
+		expect(insert?.oneOf).toEqual([{ type: 'integer', minimum: 0 }, { const: 'end' }])
+	})
+})
+
+describe('an insert actually works end to end', () => {
+	it('appends with insertLine "end"', async () => {
+		const dir = await workdir()
+		await writeFile(join(dir, 'a.md'), 'first\n', 'utf-8')
+
+		const result = await EditTool.execute(
+			{ path: 'a.md', insertLine: 'end', new_string: 'second', replace_all: false },
+			ctx(dir),
+		)
+
+		expect(result.success).toBe(true)
+		expect(await readFile(join(dir, 'a.md'), 'utf-8')).toContain('second')
+	})
+
+	it('inserts after a numbered line', async () => {
+		const dir = await workdir()
+		await writeFile(join(dir, 'a.md'), 'one\ntwo\n', 'utf-8')
+
+		await EditTool.execute(
+			{ path: 'a.md', insertLine: 1, new_string: 'inserted', replace_all: false },
+			ctx(dir),
+		)
+
+		const lines = (await readFile(join(dir, 'a.md'), 'utf-8')).split('\n')
+		expect(lines[1]).toBe('inserted')
+	})
+})
+
+describe('a synonym for the end of the file is accepted, not charged for', () => {
+	it.each(['EOF', 'append', 'last', 'End_Of_File'])('accepts %s', async (spelling) => {
+		const dir = await workdir()
+		await writeFile(join(dir, 'a.md'), 'first\n', 'utf-8')
+
+		const result = await EditTool.execute(
+			{ path: 'a.md', insertLine: spelling, new_string: 'second', replace_all: false },
+			ctx(dir),
+		)
+
+		// Liberal here and strict in the schema, which is the right way round.
+		// None of these is ambiguous; refusing one costs a full model round
+		// trip to be told a synonym.
+		expect(result.success).toBe(true)
+	})
+
+	it('still refuses something that is not a line and not the end', async () => {
+		const dir = await workdir()
+		await writeFile(join(dir, 'a.md'), 'first\n', 'utf-8')
+
+		const result = await EditTool.execute(
+			{ path: 'a.md', insertLine: 'somewhere in the middle', new_string: 'x', replace_all: false },
+			ctx(dir),
+		)
+
+		expect(result.success).toBe(false)
+		// The rejection names what was received, so the retry is informed.
+		expect(result.error).toContain('somewhere in the middle')
+	})
+
+	it('still refuses a negative line', async () => {
+		const dir = await workdir()
+		await writeFile(join(dir, 'a.md'), 'first\n', 'utf-8')
+
+		const result = await EditTool.execute(
+			{ path: 'a.md', insertLine: -3, new_string: 'x', replace_all: false },
+			ctx(dir),
+		)
+
+		expect(result.success).toBe(false)
+	})
+})
+
+describe('the two mutating tools agree on what a path is', () => {
+	it('write refuses a whitespace-only path, as edit already did', async () => {
+		const dir = await workdir()
+
+		const w = await WriteFileTool.execute({ path: '   ', content: 'x' }, ctx(dir))
+		const e = await EditTool.execute(
+			{ path: '   ', old_string: 'a', new_string: 'b', replace_all: false },
+			ctx(dir),
+		)
+
+		expect(w.success).toBe(false)
+		expect(e.success).toBe(false)
+	})
+})

--- a/packages/sdk/src/tools/builtins/__tests__/edit.test.ts
+++ b/packages/sdk/src/tools/builtins/__tests__/edit.test.ts
@@ -19,7 +19,7 @@ function makeContext(workingDirectory: string): ToolContext {
 }
 
 describe('EditTool', () => {
-	it('publishes one closed canonical replacement contract', () => {
+	it('publishes one closed contract covering both operations', () => {
 		const schema = EditTool.modelInputSchema
 		expect(schema).toEqual({
 			type: 'object',
@@ -38,12 +38,20 @@ describe('EditTool', () => {
 					description:
 						'Exact replacement text. May be empty to delete old_string. Keep under 12000 characters.',
 				},
+				insertLine: {
+					oneOf: [{ type: 'integer', minimum: 0 }, { const: 'end' }],
+					description:
+						'Insert instead of replacing. The new_string goes after this 1-indexed line; 0 inserts before the first line; "end" appends. Omit for a find-and-replace.',
+				},
 				replace_all: {
 					type: 'boolean',
 					description: 'Replace every occurrence instead of requiring one unique match.',
 				},
 			},
-			required: ['path', 'old_string', 'new_string'],
+			//  left out on purpose: an insert has no text to match,
+			// and requiring it is what made the append idiom the tool's own
+			// description recommends unexpressible under constrained decoding.
+			required: ['path', 'new_string'],
 			additionalProperties: false,
 		})
 

--- a/packages/sdk/src/tools/builtins/edit.ts
+++ b/packages/sdk/src/tools/builtins/edit.ts
@@ -99,12 +99,40 @@ const modelInputSchema: Record<string, unknown> = {
 			description:
 				'Exact replacement text. May be empty to delete old_string. Keep under 12000 characters.',
 		},
+		insertLine: {
+			// The union the execution schema already accepts, stated so a
+			// constrained decoder can emit it. Declaring it as `oneOf` of an
+			// integer and the literal `"end"` also makes the synonym problem
+			// structurally impossible: `"EOF"`, `"append"` and `"last"` are
+			// not emittable, because `"end"` is the only string the schema
+			// admits.
+			oneOf: [{ type: 'integer', minimum: 0 }, { const: 'end' }],
+			description:
+				'Insert instead of replacing. The new_string goes after this 1-indexed line; 0 inserts before the first line; "end" appends. Omit for a find-and-replace.',
+		},
 		replace_all: {
 			type: 'boolean',
 			description: 'Replace every occurrence instead of requiring one unique match.',
 		},
 	},
-	required: ['path', 'old_string', 'new_string'],
+	// `old_string` is deliberately NOT required, and this is the fix.
+	//
+	// The tool's own description tells the model to append with `insertLine`,
+	// and this schema forbade the field while `enforceModelInput` was on — so
+	// the idiom the prompt ordered was the one idiom a constrained model could
+	// not express. Requiring `old_string` reintroduces that, since an insert
+	// has no text to match.
+	//
+	// Which of `old_string` / `insertLine` is present is decided by the two
+	// refinements on the execution schema, which already exist and name what
+	// is missing. That is a deliberate choice over a top-level `oneOf`: strict
+	// structured-output modes are least surprising with a flat object, and a
+	// discriminated union at the root is the construct most likely to be
+	// rejected or quietly ignored by a provider. The cost is that an
+	// incomplete call is now expressible and caught at execution rather than
+	// at generation — paid knowingly, because the alternative is that a
+	// working capability stays unreachable.
+	required: ['path', 'new_string'],
 	additionalProperties: false,
 }
 
@@ -130,7 +158,7 @@ export const EditTool = defineTool({
 	modelInputSchema,
 	enforceModelInput: true,
 	validationErrorHint:
-		'Required shape: {"path":"file.md","old_string":"exact unique text","new_string":"replacement text"}. Optional: "replace_all": true.',
+		'Two shapes. Replace: {"path":"file.md","old_string":"exact unique text","new_string":"replacement text"} (optional "replace_all": true). Insert: {"path":"file.md","insertLine":"end","new_string":"text to add"} where insertLine is a non-negative line number or "end". Exactly one of old_string or insertLine.',
 	category: 'filesystem',
 	permissions: ['file_write'],
 	readOnly: false,
@@ -274,16 +302,35 @@ function normalizeEditInput(
 	}
 }
 
+/**
+ * Spellings of "the end of the file" a model reaches for.
+ *
+ * Liberal here and strict in the schema, which is the right way round: the
+ * schema makes `"end"` the only emittable string for a provider that
+ * constrains, and this catches the rest for one that does not. None of these
+ * is ambiguous — accepting them is not guessing at intent, it is declining to
+ * spend a round trip on a synonym.
+ */
+const END_ALIASES = new Set(['end', 'eof', 'append', 'last', 'end_of_file', 'end-of-file'])
+
 function normalizeInsertLine(
 	value: string | number,
 ): { success: true; value: number | 'end' } | { success: false; error: string } {
 	if (typeof value === 'string') {
-		if (value.trim().toLowerCase() === 'end') return { success: true, value: 'end' }
+		const normalized = value.trim().toLowerCase()
+		// `"end"` is the only spelling the model-facing schema admits, so a
+		// constrained decoder cannot produce anything else. These aliases are
+		// for the providers that do not constrain: a model reading "appends to
+		// the file" reaches for the word it knows, and every one of these says
+		// the same unambiguous thing. Refusing them bought strictness and cost
+		// a full model round trip per occurrence — measured by a consuming host
+		// as the single largest source of tool-call waste in its runs.
+		if (END_ALIASES.has(normalized)) return { success: true, value: 'end' }
 		const parsed = Number(value)
 		if (Number.isInteger(parsed) && parsed >= 0) return { success: true, value: parsed }
 		return {
 			success: false,
-			error: 'insertLine must be a non-negative line number or "end".',
+			error: `insertLine must be a non-negative line number or "end" (also accepted: ${[...END_ALIASES].filter((a) => a !== 'end').join(', ')}). Received ${JSON.stringify(value)}.`,
 		}
 	}
 	return { success: true, value }

--- a/packages/sdk/src/tools/builtins/write-file.ts
+++ b/packages/sdk/src/tools/builtins/write-file.ts
@@ -11,6 +11,12 @@ const inputSchema = z
 		path: z
 			.string()
 			.min(1)
+			// `.min(1)` alone admits `"   "`, which resolves to the working
+			// directory itself and turns a write into a directory-write error
+			// nobody can read. `edit` has refused this since it was written;
+			// the two tools disagreeing on the same input is the kind of gap a
+			// model finds and a reviewer does not.
+			.refine((value) => value.trim().length > 0, 'Path must not be empty.')
 			.describe(
 				'Relative path to the file to write (e.g. "outputs/report.md"). Required. Must be a non-empty string.',
 			),


### PR DESCRIPTION
The tool description tells the model to append with `insertLine`; `modelInputSchema` forbade the field while `enforceModelInput` was on, so the recommended idiom was the one a constrained model could not emit. A consuming host measured 94 of 159 tool failures over seven days as this contradiction.

See the changeset for why a flat schema rather than a top-level oneOf, and why synonyms are accepted at execution but not emittable at generation.