### PR TITLE
fix(sdk)!: close the two allow-lists that failed open

### DIFF
--- a/.changeset/shy-donkeys-smoke.md
+++ b/.changeset/shy-donkeys-smoke.md
@@ -1,0 +1,45 @@
+---
+'@namzu/sdk': major
+---
+
+Two allow-lists in the supervisor's delegation surface stop failing open.
+
+**An empty delegate roster now refuses every delegation.** `create_task`
+derived its `agent_id` parameter from `allowedAgentIds`, but widened it from
+the roster enum to a bare string whenever that roster was empty — so the one
+configuration that says "this run may delegate to nobody" was the only one
+that let the model name anybody. The call still failed, one layer down, with
+"no such agent"; the message pointed at a missing registration rather than at
+an empty roster. An allow-list that admits everything when it is empty is the
+fail-safe-defaults violation Saltzer & Schroeder named in 1975 (§3.A.2) and the
+defect catalogued as CWE-183. If you construct a `SupervisorAgent` with
+`agentIds: []` and expected `create_task` to be callable, populate the roster —
+there is no flag that restores the old shape, because the old shape could not
+succeed.
+
+**A host can now decline a coordinator tool, and the kernel will not take a
+name the host already used.** `runtimeToolOverrides` is this SDK's declared way
+to decline a kernel-mounted tool; it is honoured for the task tools and the
+advisory tools, and `SupervisorAgent` forwards it into its own `drainQuery`
+call — but it registered the coordinator tools before that, unconditionally, so
+`{ create_task: 'disabled' }` was obeyed everywhere except the one surface a
+host would most want to decline. A run that must not delegate had prompt text
+and a gateway refusal as its only defences. Coordinator registration now
+consults the same overrides, in the same shape as every other kernel-mounted
+tool in this SDK.
+
+Registration also refuses on a name collision instead of overwriting. Two
+sources contributed the same tool name and nothing here ranks them: the
+coordinator tools are the kernel's, and `config.tools` belongs to the embedding
+host — the most trusted party present, not a plugin whose shadowing can be
+dropped on trust grounds. The registry resolved that by warning and replacing,
+which is a fine registry default and the wrong answer for a contract surface:
+the model kept a `create_task` whose behaviour depended on registration order,
+and a log warning is not something a host can act on before the run starts.
+
+If you register a tool named `create_task`, `continue_task`, `cancel_task`,
+`agent_task_list`, `approve_plan`, or `ask_user_question` on a
+`SupervisorAgent`'s `tools`, that run previously started with your tool
+silently replaced and now throws at startup. Keep your name by declining the
+coordinator one — `runtimeToolOverrides: { create_task: 'disabled' }` — or
+rename your tool. The error names both routes.

--- a/.changeset/shy-donkeys-smoke.md
+++ b/.changeset/shy-donkeys-smoke.md
@@ -2,44 +2,79 @@
 '@namzu/sdk': major
 ---
 
-Two allow-lists in the supervisor's delegation surface stop failing open.
+Two allow-lists in the delegation surface stop failing open, and a host can
+now decline a coordinator tool.
 
-**An empty delegate roster now refuses every delegation.** `create_task`
-derived its `agent_id` parameter from `allowedAgentIds`, but widened it from
-the roster enum to a bare string whenever that roster was empty — so the one
-configuration that says "this run may delegate to nobody" was the only one
-that let the model name anybody. The call still failed, one layer down, with
-"no such agent"; the message pointed at a missing registration rather than at
-an empty roster. An allow-list that admits everything when it is empty is the
-fail-safe-defaults violation Saltzer & Schroeder named in 1975 (§3.A.2) and the
-defect catalogued as CWE-183. If you construct a `SupervisorAgent` with
-`agentIds: []` and expected `create_task` to be callable, populate the roster —
-there is no flag that restores the old shape, because the old shape could not
-succeed.
+## An empty delegate roster means nobody
 
-**A host can now decline a coordinator tool, and the kernel will not take a
-name the host already used.** `runtimeToolOverrides` is this SDK's declared way
-to decline a kernel-mounted tool; it is honoured for the task tools and the
-advisory tools, and `SupervisorAgent` forwards it into its own `drainQuery`
-call — but it registered the coordinator tools before that, unconditionally, so
+`create_task` derived its `agent_id` parameter from `allowedAgentIds` but
+widened it from the roster enum to a bare string whenever that roster was
+empty — so the one configuration meaning "this run may delegate to nobody" was
+the only one that let the model name anybody. An allow-list *is* the
+enumeration of what is permitted; an empty one enumerates nothing and admits
+nothing. Degrading it to an open string to keep functioning is failing open
+(CWE-636), and the rule it breaks is fail-safe defaults (Saltzer & Schroeder
+1975, §I.A.3(b)), restated in NIST SP 800-53 Rev. 5 as SC-7(5) "deny by
+default, allow by exception".
+
+What that reached is why this is worth a break. The id was not merely rejected
+downstream: it went to the gateway, which resolves against an `AgentManager`
+that is typically **shared**, so an agent the host deliberately left out of
+`agentIds` could still launch if it happened to be registered there. When it
+was not registered, the failure text listed every registered agent id back to
+the model, and the plan row was left stranded at `in_progress` because the
+store write precedes the gateway call while the reconciling update follows it.
+
+`create_task` is now **not mounted** when the roster is empty, rather than
+mounted with a schema nothing satisfies — refusing per call reaches the same
+verdict while paying prompt-prefix tokens and an iteration for it (NIST SP
+800-53 CM-7, least functionality). It is the only coordinator tool that reads
+the roster, so `agent_task_list`, `approve_plan` and `ask_user_question` are
+untouched: "no delegates, but still planning and a human channel" remains a
+supported configuration. The schema stays closed underneath as defence in
+depth. If you construct a supervisor with `agentIds: []` and expected
+`create_task` to be callable, populate the roster — there is no flag that
+restores the old shape, because the old shape could not correctly succeed.
+
+`buildAgentTool` carried the identical fallback and now throws at construction
+instead: it returns exactly one tool and that tool *is* the delegation surface,
+so "do not mount it" and "do not build it" are the same statement. It also
+never checked `subagent_type` against the roster inside `execute`, which is
+reachable without going through the registry; it does now.
+
+## A host can decline a coordinator tool
+
+`runtimeToolOverrides` is this SDK's declared way to decline a kernel-mounted
+tool. It is honoured for the task tools and the advisory tools, and
+`SupervisorAgent` forwards it into its own `drainQuery` call — but it
+registered the coordinator tools before that, unconditionally, so
 `{ create_task: 'disabled' }` was obeyed everywhere except the one surface a
 host would most want to decline. A run that must not delegate had prompt text
-and a gateway refusal as its only defences. Coordinator registration now
-consults the same overrides, in the same shape as every other kernel-mounted
-tool in this SDK.
+and a gateway refusal as its only defences. This half is pure gap-closure: the
+mechanism, the type and two other call sites already existed, and coordinator
+registration now uses the same idiom.
 
-Registration also refuses on a name collision instead of overwriting. Two
-sources contributed the same tool name and nothing here ranks them: the
-coordinator tools are the kernel's, and `config.tools` belongs to the embedding
-host — the most trusted party present, not a plugin whose shadowing can be
-dropped on trust grounds. The registry resolved that by warning and replacing,
-which is a fine registry default and the wrong answer for a contract surface:
-the model kept a `create_task` whose behaviour depended on registration order,
-and a log warning is not something a host can act on before the run starts.
+## Collisions refuse instead of overwriting
 
-If you register a tool named `create_task`, `continue_task`, `cancel_task`,
-`agent_task_list`, `approve_plan`, or `ask_user_question` on a
-`SupervisorAgent`'s `tools`, that run previously started with your tool
-silently replaced and now throws at startup. Keep your name by declining the
-coordinator one — `runtimeToolOverrides: { create_task: 'disabled' }` — or
-rename your tool. The error names both routes.
+This half is new policy, not a gap-closure. Registration now throws
+`ToolNameCollisionError` (exported, carrying `toolName`) when a coordinator
+tool's name is already registered on the supervisor's `tools`, instead of the
+registry's warn-and-overwrite. The reserved names are `create_task`,
+`agent_task_list`, `approve_plan`, and `ask_user_question` — grep for those
+four.
+
+The old behaviour was not "the host's tool quietly loses and the run works".
+`registerOne` ends by setting availability, and the coordinator call passed
+none, so a tool the host registered `deferred` or `suspended` was silently
+promoted to `active` under someone else's implementation; and because the
+backing store is a `Map`, the replacement inherited the host's insertion
+position in the prompt-cache prefix. That is a different authorization surface,
+not a lost registration — detection of an error condition without action
+(CWE-390), where CWE-694's own mitigation is nearly this fix. Complete
+mediation is the principle (§I.A.3(c)): a registry entry is a remembered
+binding of a name to an authority, and rebinding it leaves every decision made
+about the old binding stale.
+
+To migrate: rename your tool, or keep your name and decline the coordinator one
+with `runtimeToolOverrides: { "create_task": "disabled" }`. The error names
+both routes.

--- a/.github/scripts/public-surface-baseline.json
+++ b/.github/scripts/public-surface-baseline.json
@@ -244,6 +244,7 @@
   "ThreadManager",
   "ToolCatalog",
   "ToolGrantSet",
+  "ToolNameCollisionError",
   "ToolRegistry",
   "TriggerEvaluator",
   "UNKNOWN_TENANT_ID",

--- a/packages/sdk/src/agents/SupervisorAgent.ts
+++ b/packages/sdk/src/agents/SupervisorAgent.ts
@@ -1,6 +1,6 @@
 import { EMPTY_TOKEN_USAGE } from '../constants/limits.js'
 import { LocalTaskGateway } from '../gateway/local.js'
-import { ToolRegistry } from '../registry/tool/execute.js'
+import { ToolNameCollisionError, ToolRegistry } from '../registry/tool/execute.js'
 import { drainQuery } from '../runtime/query/index.js'
 import type { LaunchedTaskMeta } from '../runtime/query/iteration/phases/context.js'
 import { PendingAnswers, QuestionParkBinding } from '../runtime/query/question-park.js'
@@ -211,30 +211,42 @@ export class SupervisorAgent extends AbstractAgent<SupervisorAgentConfig, Superv
 		// A run that must not delegate had prompt text and a gateway refusal as
 		// its only defences.
 		//
-		// Collision REFUSES rather than overwrites. Two sources contributed the
-		// same tool name and nothing in this SDK ranks them: the coordinator
-		// tools are the kernel's, and `config.tools` is the embedding host's —
-		// the most trusted party present, not a plugin whose shadowing can be
-		// dropped on trust grounds. `ManagedRegistry` resolves it by warning and
-		// replacing, which is a sane registry default and the wrong answer for a
-		// contract surface: the model keeps a `create_task` whose behaviour
-		// silently depends on registration order, and a log warning is not
-		// something a host can act on before the run starts. Refusing an
-		// ambiguous authorization rather than guessing at it is fail-safe
-		// defaults (Saltzer & Schroeder 1975, §3.A.2), and it is what peer
-		// runtimes do for the same shape: an agent SDK raises on duplicate tool
-		// names contributed by two connector servers rather than picking one,
-		// and a second raises when its namespacing cannot disambiguate two
-		// dynamic providers, naming the manual fix in the message. This does the
-		// same — and the fix it names is a mechanism this SDK already has.
+		// Collision REFUSES rather than overwrites, and the principle is
+		// complete mediation rather than fail-safe defaults: "proposals to gain
+		// performance by remembering the result of an authority check [must] be
+		// examined skeptically. If a change in authority occurs, such remembered
+		// results must be systematically updated" (Saltzer & Schroeder 1975,
+		// §I.A.3(c)). A registry entry is a remembered binding of a name to an
+		// authority, and a later write that rebinds the name leaves every
+		// decision made about the old binding stale.
+		//
+		// The counter-argument is that today the host's tool merely loses
+		// quietly and the run still works, so six reserved names is a real cost
+		// on a name a consumer may have chosen long ago. It does not hold,
+		// because "loses quietly" is not what happens. `registerOne` ends with
+		// `availability.set(id, state)` and this call passes no state, so a tool
+		// the host registered `deferred` or `suspended` is silently PROMOTED to
+		// active under someone else's implementation; and because the store is a
+		// Map, the replacement inherits the host's insertion position in the
+		// prompt-cache prefix. That is a different authorization surface, not a
+		// lost registration. CWE-390 is the shape `ManagedRegistry` has here —
+		// detection of an error condition without action — and CWE-694's own
+		// mitigation is nearly this fix: do not operate any resource with a
+		// non-unique identifier, and report the error.
+		//
+		// Refusing is also what the peer set does. One runtime's registry
+		// primitive throws on both duplicate and reserved names; another refuses
+		// its injected delegation name in a pre-flight that tells the author to
+		// rename. Closer to home, `ProviderRegistry.register` already throws
+		// unless the caller passes `{ replace: true }` — declared intent is what
+		// separates a legitimate replacement from an accidental one, and no such
+		// intent is expressible here.
 		const overrides = input.runtimeToolOverrides
 		for (const tool of coordinatorToolDefs) {
 			const override = overrides?.[tool.name]
 			if (override === 'disabled') continue
 			if (config.tools?.has(tool.name)) {
-				throw new Error(
-					`Coordinator tool "${tool.name}" collides with a tool this host already registered. The kernel will not replace it. Rename the host tool, or decline the coordinator one with runtimeToolOverrides: { "${tool.name}": "disabled" }.`,
-				)
+				throw new ToolNameCollisionError(tool.name, 'the supervisor coordinator surface')
 			}
 			tools.register(tool, override ?? 'active')
 		}

--- a/packages/sdk/src/agents/SupervisorAgent.ts
+++ b/packages/sdk/src/agents/SupervisorAgent.ts
@@ -198,8 +198,45 @@ export class SupervisorAgent extends AbstractAgent<SupervisorAgentConfig, Superv
 				tools.register(tool, config.tools.getAvailability(tool.name))
 			}
 		}
+		// Registered the way every other kernel-mounted tool in this SDK is
+		// registered: honouring `runtimeToolOverrides`, and refusing to take a
+		// name the host already used.
+		//
+		// Both halves were missing here and nowhere else. `runtimeToolOverrides`
+		// is declared on `AgentInput`, is forwarded into this very `drainQuery`
+		// call below, and is consulted for the task tools and for the advisory
+		// tools — but the coordinator tools were registered before that and
+		// unconditionally, so `{ create_task: 'disabled' }` was honoured
+		// everywhere except the one surface a host would most want to decline.
+		// A run that must not delegate had prompt text and a gateway refusal as
+		// its only defences.
+		//
+		// Collision REFUSES rather than overwrites. Two sources contributed the
+		// same tool name and nothing in this SDK ranks them: the coordinator
+		// tools are the kernel's, and `config.tools` is the embedding host's —
+		// the most trusted party present, not a plugin whose shadowing can be
+		// dropped on trust grounds. `ManagedRegistry` resolves it by warning and
+		// replacing, which is a sane registry default and the wrong answer for a
+		// contract surface: the model keeps a `create_task` whose behaviour
+		// silently depends on registration order, and a log warning is not
+		// something a host can act on before the run starts. Refusing an
+		// ambiguous authorization rather than guessing at it is fail-safe
+		// defaults (Saltzer & Schroeder 1975, §3.A.2), and it is what peer
+		// runtimes do for the same shape: an agent SDK raises on duplicate tool
+		// names contributed by two connector servers rather than picking one,
+		// and a second raises when its namespacing cannot disambiguate two
+		// dynamic providers, naming the manual fix in the message. This does the
+		// same — and the fix it names is a mechanism this SDK already has.
+		const overrides = input.runtimeToolOverrides
 		for (const tool of coordinatorToolDefs) {
-			tools.register(tool)
+			const override = overrides?.[tool.name]
+			if (override === 'disabled') continue
+			if (config.tools?.has(tool.name)) {
+				throw new Error(
+					`Coordinator tool "${tool.name}" collides with a tool this host already registered. The kernel will not replace it. Rename the host tool, or decline the coordinator one with runtimeToolOverrides: { "${tool.name}": "disabled" }.`,
+				)
+			}
+			tools.register(tool, override ?? 'active')
 		}
 
 		const childInvocationState = deriveChildState(

--- a/packages/sdk/src/agents/__tests__/supervisor-coordinator-registration.test.ts
+++ b/packages/sdk/src/agents/__tests__/supervisor-coordinator-registration.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 
 import { MockLLMProvider } from '../../provider/mock.js'
-import { ToolRegistry } from '../../registry/tool/execute.js'
+import { ToolNameCollisionError, ToolRegistry } from '../../registry/tool/execute.js'
 import { defineTool } from '../../tools/defineTool.js'
 import { SupervisorAgent } from '../SupervisorAgent.js'
 
@@ -123,8 +123,12 @@ describe('supervisor coordinator-tool registration', () => {
 	})
 
 	it('refuses to take a name the host already registered', async () => {
+		// Named and carrying the name, so a host can catch it narrowly rather
+		// than match on message text — the shape `DuplicateProviderError`
+		// already set in this repo.
+		await expect(runWith({ hostTools: ['create_task'] })).rejects.toThrow(ToolNameCollisionError)
 		await expect(runWith({ hostTools: ['create_task'] })).rejects.toThrow(
-			/collides with a tool this host already registered/,
+			/runtimeToolOverrides: \{ "create_task": "disabled" \}/,
 		)
 	})
 

--- a/packages/sdk/src/agents/__tests__/supervisor-coordinator-registration.test.ts
+++ b/packages/sdk/src/agents/__tests__/supervisor-coordinator-registration.test.ts
@@ -1,0 +1,144 @@
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+
+import { MockLLMProvider } from '../../provider/mock.js'
+import { ToolRegistry } from '../../registry/tool/execute.js'
+import { defineTool } from '../../tools/defineTool.js'
+import { SupervisorAgent } from '../SupervisorAgent.js'
+
+/**
+ * How the supervisor mounts its own coordinator tools.
+ *
+ * `runtimeToolOverrides` is this SDK's declared way for a host to decline a
+ * kernel-mounted tool. It is honoured for the task tools and the advisory
+ * tools inside `drainQuery`, and the supervisor forwards it there — but the
+ * supervisor registered the coordinator tools BEFORE that call and
+ * unconditionally, so `{ create_task: 'disabled' }` was obeyed everywhere
+ * except the one surface a host would most want to decline.
+ *
+ * The second case is the collision: `ManagedRegistry` warns and overwrites, so
+ * a host tool sharing a coordinator name vanished into a log line and the
+ * model kept a `create_task` whose behaviour depended on registration order.
+ */
+
+const HOST_TOOL_DESCRIPTION = 'a tool this host registered deliberately'
+
+function stubManager() {
+	return {
+		sendMessage: vi.fn(async () => ({ taskId: 'task_1', status: 'completed' })),
+		await: vi.fn(async () => undefined),
+		cancel: vi.fn(),
+		dispose: vi.fn(),
+		on: vi.fn(),
+		off: vi.fn(),
+	}
+}
+
+const hostTool = (name: string) =>
+	defineTool({
+		name,
+		description: HOST_TOOL_DESCRIPTION,
+		inputSchema: z.object({}),
+		category: 'custom',
+		permissions: [],
+		readOnly: true,
+		destructive: false,
+		concurrencySafe: true,
+		async execute() {
+			return { success: true as const, output: 'host tool ran' }
+		},
+	})
+
+async function runWith(options: {
+	hostTools?: string[]
+	runtimeToolOverrides?: Record<string, 'active' | 'deferred' | 'disabled'>
+}) {
+	const agent = new SupervisorAgent({
+		id: 'supervisor',
+		name: 'Supervisor',
+		version: '1',
+		category: 'test',
+		description: 'coordinates workers',
+	})
+
+	const provider = new MockLLMProvider({ turns: [{ text: 'nothing to delegate' }] })
+
+	const tools = new ToolRegistry()
+	for (const name of options.hostTools ?? []) tools.register(hostTool(name))
+
+	await agent.run(
+		{
+			messages: [{ role: 'user', content: 'go', timestamp: 1 }],
+			workingDirectory: await mkdtemp(join(tmpdir(), 'namzu-sup-reg-')),
+			...(options.runtimeToolOverrides
+				? { runtimeToolOverrides: options.runtimeToolOverrides }
+				: {}),
+		} as never,
+		{
+			provider,
+			agentIds: ['worker'],
+			agentManager: stubManager(),
+			tools,
+			systemPrompt: 'You coordinate.',
+			model: 'mock-model',
+			tokenBudget: 100_000,
+			timeoutMs: 30_000,
+			maxIterations: 2,
+			sessionId: 'ses_sup',
+			threadId: 'thd_sup',
+			projectId: 'prj_sup',
+			tenantId: 'tnt_sup',
+		} as never,
+	)
+
+	const advertised = provider.requests[0]?.tools ?? []
+	return {
+		names: new Set(advertised.map((t) => t.function.name)),
+		describedAs: (name: string) =>
+			advertised.find((t) => t.function.name === name)?.function.description ?? '',
+	}
+}
+
+describe('supervisor coordinator-tool registration', () => {
+	it('advertises create_task by default', async () => {
+		expect((await runWith({})).names).toContain('create_task')
+	})
+
+	it('does not advertise a coordinator tool the host disabled', async () => {
+		const { names } = await runWith({ runtimeToolOverrides: { create_task: 'disabled' } })
+
+		expect(names).not.toContain('create_task')
+		// Declining one coordinator tool must not decline the rest.
+		expect(names).toContain('agent_task_list')
+	})
+
+	it('leaves a host tool that shares no coordinator name alone', async () => {
+		const { names } = await runWith({ hostTools: ['host_only'] })
+
+		expect(names).toContain('host_only')
+		expect(names).toContain('create_task')
+	})
+
+	it('refuses to take a name the host already registered', async () => {
+		await expect(runWith({ hostTools: ['create_task'] })).rejects.toThrow(
+			/collides with a tool this host already registered/,
+		)
+	})
+
+	it('lets the host keep its own tool under that name by declining the coordinator one', async () => {
+		const { names, describedAs } = await runWith({
+			hostTools: ['create_task'],
+			runtimeToolOverrides: { create_task: 'disabled' },
+		})
+
+		expect(names).toContain('create_task')
+		expect(names).toContain('agent_task_list')
+		// The name surviving is not the assertion — WHOSE tool holds it is.
+		// Overwriting also leaves the name present, so a membership check
+		// alone passes against the very behaviour this replaces.
+		expect(describedAs('create_task')).toBe(HOST_TOOL_DESCRIPTION)
+	})
+})

--- a/packages/sdk/src/public-runtime.ts
+++ b/packages/sdk/src/public-runtime.ts
@@ -158,6 +158,7 @@ export {
 	PluginRegistry,
 	Registry,
 	ToolCatalog,
+	ToolNameCollisionError,
 	ToolRegistry,
 	createToolCatalogFromRegistry,
 	loadingFromAvailability,

--- a/packages/sdk/src/registry/index.ts
+++ b/packages/sdk/src/registry/index.ts
@@ -2,7 +2,7 @@ export { Registry } from './Registry.js'
 export { ManagedRegistry } from './ManagedRegistry.js'
 export type { ManagedRegistryConfig } from './ManagedRegistry.js'
 
-export { ToolRegistry } from './tool/execute.js'
+export { ToolNameCollisionError, ToolRegistry } from './tool/execute.js'
 export type { ToolExecutionResult } from './tool/execute.js'
 export {
 	ToolCatalog,

--- a/packages/sdk/src/registry/tool/execute.ts
+++ b/packages/sdk/src/registry/tool/execute.ts
@@ -84,6 +84,29 @@ export function assertToolName(name: string): void {
 }
 
 /**
+ * Two sources contributed the same tool name and neither may take it.
+ *
+ * Named, and carrying the name, for the reason `DuplicateProviderError` is:
+ * a host that wants to handle this — fall back to its own tool, log and
+ * continue, surface it in a config error — has to be able to catch it
+ * narrowly rather than match on message text. It also names both remedies,
+ * because a hard collision policy without a way to decline would make
+ * shadowing-by-name the only way to say "I do not want this tool", which is
+ * precisely what now throws.
+ */
+export class ToolNameCollisionError extends Error {
+	readonly toolName: string
+
+	constructor(toolName: string, context: string) {
+		super(
+			`Tool name "${toolName}" is already registered by this host, and ${context} will not replace it. Rename the host tool, or decline the one being mounted with runtimeToolOverrides: { "${toolName}": "disabled" }.`,
+		)
+		this.name = 'ToolNameCollisionError'
+		this.toolName = toolName
+	}
+}
+
+/**
  * Append a tool's declared return shape to its description.
  *
  * No provider's tool wire format has a slot for an output schema, so the

--- a/packages/sdk/src/tools/coordinator/__tests__/empty-roster.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/empty-roster.test.ts
@@ -1,18 +1,26 @@
 import { describe, expect, it } from 'vitest'
 import type { TaskGateway } from '../../../types/agent/gateway.js'
+import { buildAgentTool } from '../agent.js'
 import { buildCoordinatorTools } from '../index.js'
 
 /**
  * `create_task` used to widen its `agent_id` parameter from the roster enum to
  * a bare string whenever the roster was empty — so the one configuration that
  * says "this run may delegate to nobody" was the one that let the model name
- * anybody. An allow-list that admits everything when it is empty is the
- * fail-safe-defaults violation Saltzer & Schroeder named in 1975 (§3.A.2) and
- * the defect catalogued as CWE-183.
+ * anybody. Degrading a closed list to an open one because the list is empty is
+ * failing open (CWE-636), and Saltzer & Schroeder named the rule it breaks in
+ * 1975: fail-safe defaults, §I.A.3(b).
  *
- * The refusal has to land here rather than downstream: an unknown id reaching
- * the agent registry fails with "no such agent", which sends whoever reads it
- * looking for a missing registration instead of an empty roster.
+ * The control is that the tool is not mounted at all — refusing per call would
+ * reach the same verdict while paying prompt tokens and an iteration for it.
+ * The schema stays closed underneath as defence-in-depth for a definition
+ * built directly.
+ *
+ * What was reachable before is worth stating, because it is why this is a
+ * break worth taking: the id went to the gateway, which resolves against an
+ * `AgentManager` that is typically SHARED — so a name the host deliberately
+ * left out of `agentIds` could still launch if it happened to be registered
+ * there.
  */
 
 const gateway = {
@@ -23,27 +31,40 @@ const gateway = {
 	cancel: () => undefined,
 } as unknown as TaskGateway
 
-function createTaskFor(allowedAgentIds: string[]) {
-	const tool = buildCoordinatorTools({
+function toolsFor(allowedAgentIds: string[], resumeHandler?: unknown) {
+	return buildCoordinatorTools({
 		gateway,
 		workingDirectory: '/tmp/test',
 		allowedAgentIds,
-	}).find((t) => t.name === 'create_task')
+		...(resumeHandler ? { resumeHandler: resumeHandler as never, runId: 'run_1' as never } : {}),
+	})
+}
+
+function createTaskFor(allowedAgentIds: string[]) {
+	const tool = toolsFor(allowedAgentIds).find((t) => t.name === 'create_task')
 	if (!tool) throw new Error('create_task missing from coordinator builder')
 	return tool
 }
 
 describe('create_task delegate roster', () => {
-	it('refuses every agent id when the roster is empty', () => {
-		const parsed = createTaskFor([]).inputSchema.safeParse({
-			agent_id: 'anything-at-all',
-			prompt: 'do the thing',
-			description: 'a task',
-		})
+	it('does not mount create_task at all when the roster is empty', () => {
+		const names = toolsFor([]).map((t) => t.name)
 
-		expect(parsed.success).toBe(false)
-		if (parsed.success) return
-		expect(JSON.stringify(parsed.error.issues)).toContain('no delegates configured')
+		expect(names).not.toContain('create_task')
+	})
+
+	it('still mounts the coordinator tools that do not read the roster', () => {
+		// "No delegates, but still planning and a human channel" is a
+		// supported configuration, so this omits one tool rather than
+		// refusing to build.
+		const names = toolsFor([], async () => ({ action: 'approve_tools' })).map((t) => t.name)
+
+		expect(names).toContain('agent_task_list')
+		expect(names).toContain('ask_user_question')
+	})
+
+	it('mounts create_task once the roster has an entry', () => {
+		expect(toolsFor(['worker']).map((t) => t.name)).toContain('create_task')
 	})
 
 	it('still admits an id that is on a non-empty roster', () => {
@@ -64,5 +85,34 @@ describe('create_task delegate roster', () => {
 		})
 
 		expect(parsed.success).toBe(false)
+	})
+})
+
+describe('the Agent tool carries the same closed roster', () => {
+	it('refuses to build at all with no delegates', () => {
+		// Unlike the coordinator builder, this one returns exactly one tool
+		// and that tool IS the delegation surface, so "do not mount" and "do
+		// not build" are the same statement.
+		expect(() =>
+			buildAgentTool({ gateway, workingDirectory: '/tmp/test', allowedAgentIds: [] }),
+		).toThrow(/at least one entry in allowedAgentIds/)
+	})
+
+	it('refuses an off-roster subagent at execution, not only in the schema', async () => {
+		// `execute` is reachable without the registry, so a schema-only check
+		// leaves the roster unenforced on that path.
+		const tool = buildAgentTool({
+			gateway,
+			workingDirectory: '/tmp/test',
+			allowedAgentIds: ['worker'],
+		})
+
+		const result = await tool.execute(
+			{ description: 'x', prompt: 'y', subagent_type: 'not-on-the-roster' },
+			{ workingDirectory: '/tmp/test' } as never,
+		)
+
+		expect(result.success).toBe(false)
+		expect(result.error).toMatch(/Unknown subagent_type/)
 	})
 })

--- a/packages/sdk/src/tools/coordinator/__tests__/empty-roster.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/empty-roster.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import type { TaskGateway } from '../../../types/agent/gateway.js'
+import { buildCoordinatorTools } from '../index.js'
+
+/**
+ * `create_task` used to widen its `agent_id` parameter from the roster enum to
+ * a bare string whenever the roster was empty — so the one configuration that
+ * says "this run may delegate to nobody" was the one that let the model name
+ * anybody. An allow-list that admits everything when it is empty is the
+ * fail-safe-defaults violation Saltzer & Schroeder named in 1975 (§3.A.2) and
+ * the defect catalogued as CWE-183.
+ *
+ * The refusal has to land here rather than downstream: an unknown id reaching
+ * the agent registry fails with "no such agent", which sends whoever reads it
+ * looking for a missing registration instead of an empty roster.
+ */
+
+const gateway = {
+	dispatch: async () => {
+		throw new Error('gateway must not be reached — the schema refuses first')
+	},
+	listTasks: () => [],
+	cancel: () => undefined,
+} as unknown as TaskGateway
+
+function createTaskFor(allowedAgentIds: string[]) {
+	const tool = buildCoordinatorTools({
+		gateway,
+		workingDirectory: '/tmp/test',
+		allowedAgentIds,
+	}).find((t) => t.name === 'create_task')
+	if (!tool) throw new Error('create_task missing from coordinator builder')
+	return tool
+}
+
+describe('create_task delegate roster', () => {
+	it('refuses every agent id when the roster is empty', () => {
+		const parsed = createTaskFor([]).inputSchema.safeParse({
+			agent_id: 'anything-at-all',
+			prompt: 'do the thing',
+			description: 'a task',
+		})
+
+		expect(parsed.success).toBe(false)
+		if (parsed.success) return
+		expect(JSON.stringify(parsed.error.issues)).toContain('no delegates configured')
+	})
+
+	it('still admits an id that is on a non-empty roster', () => {
+		const parsed = createTaskFor(['worker']).inputSchema.safeParse({
+			agent_id: 'worker',
+			prompt: 'do the thing',
+			description: 'a task',
+		})
+
+		expect(parsed.success).toBe(true)
+	})
+
+	it('still refuses an id that is off a non-empty roster', () => {
+		const parsed = createTaskFor(['worker']).inputSchema.safeParse({
+			agent_id: 'some-other-agent',
+			prompt: 'do the thing',
+			description: 'a task',
+		})
+
+		expect(parsed.success).toBe(false)
+	})
+})

--- a/packages/sdk/src/tools/coordinator/agent.ts
+++ b/packages/sdk/src/tools/coordinator/agent.ts
@@ -51,8 +51,25 @@ export function buildAgentTool(opts: AgentToolOptions): ToolDefinition {
 	const { gateway, allowedAgentIds: agentIds, onTaskLaunched } = opts
 	const cwd = opts.workingDirectory
 
-	const subagentTypeEnum =
-		agentIds.length > 0 ? z.enum(agentIds as [string, ...string[]]) : z.string()
+	// This tool IS the delegation surface — it is the only thing this builder
+	// returns — so "do not mount it on an empty roster" collapses to "do not
+	// build it". Refusing at construction is therefore coherent here in a way
+	// it is not for `buildCoordinatorTools`, whose other tools remain useful
+	// with no delegates.
+	//
+	// It carried the same widen-to-string fallback `create_task` did: an empty
+	// roster, which is the one input meaning "delegate to nobody", produced the
+	// one schema accepting anybody. Saltzer & Schroeder's own reason for
+	// checking the twin applies — "in a large system some objects will be
+	// inadequately considered, so a default of lack of permission is safer"
+	// (§I.A.3(b)) — and shipping the closed reading in one delegation surface
+	// while leaving it open in the exported one is exactly that oversight.
+	if (agentIds.length === 0) {
+		throw new Error(
+			'buildAgentTool requires at least one entry in allowedAgentIds. An empty roster means this run may delegate to nobody, so there is no subagent the tool could name — do not build the tool.',
+		)
+	}
+	const subagentTypeEnum = z.enum(agentIds as [string, ...string[]])
 
 	return defineTool({
 		name: 'Agent',
@@ -84,6 +101,21 @@ export function buildAgentTool(opts: AgentToolOptions): ToolDefinition {
 					success: false,
 					output: '',
 					error: `subagent_type is required — choose one of: ${agentIds.join(', ')}`,
+				}
+			}
+			// The roster is enforced here as well as in the schema. `execute` is
+			// reachable without going through the registry — this repo's own
+			// callers do it — so a schema-only check leaves the roster
+			// unenforced on that path, and the id would reach the gateway to be
+			// resolved against an AgentManager that is typically shared and may
+			// well hold an agent this run's roster deliberately omits. Every
+			// access checked for authority, not only the mediated one
+			// (Saltzer & Schroeder §I.A.3(c), complete mediation).
+			if (!agentIds.includes(agentId)) {
+				return {
+					success: false,
+					output: '',
+					error: `Unknown subagent_type "${agentId}" — choose one of: ${agentIds.join(', ')}`,
 				}
 			}
 			const handle = await gateway.createTask({

--- a/packages/sdk/src/tools/coordinator/index.ts
+++ b/packages/sdk/src/tools/coordinator/index.ts
@@ -161,6 +161,36 @@ function normalizeApprovePlanSteps(value: unknown): unknown {
 	}))
 }
 
+/**
+ * The delegate roster, as a closed set — including when it is empty.
+ *
+ * This used to be `agentIds.length > 0 ? z.enum(agentIds) : z.string()`, so
+ * the one input that means "this run may delegate to nobody" became "this run
+ * may name anything". An allow-list that admits everything when it is empty is
+ * the failure Saltzer & Schroeder named in 1975 as the violation of
+ * **fail-safe defaults** — "the default situation is lack of access, and the
+ * protection scheme identifies conditions under which access is permitted"
+ * (§3.A.2, *The Protection of Information in Computer Systems*). CWE-183,
+ * *Permissive List of Allowed Inputs*, is the same defect catalogued.
+ *
+ * `z.never()` is the closed reading: every value fails, so an empty roster
+ * refuses every delegation, and the refusal lands at the tool's own boundary
+ * with a message naming the cause — rather than travelling on to
+ * `AgentManager`'s registry, which fails later and reports a missing agent
+ * instead of an empty roster.
+ */
+function delegateSchema(agentIds: readonly string[]): z.ZodType<string> {
+	if (agentIds.length === 0) {
+		return z.never({
+			errorMap: () => ({
+				message:
+					'This run has no delegates configured, so it cannot launch a task. That is the configured state, not a missing argument.',
+			}),
+		}) as unknown as z.ZodType<string>
+	}
+	return z.enum(agentIds as [string, ...string[]])
+}
+
 export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefinition[] {
 	const {
 		gateway,
@@ -181,7 +211,7 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 	const cwd = opts.workingDirectory
 	void opts.onTaskLaunched
 
-	const agentIdEnum = agentIds.length > 0 ? z.enum(agentIds as [string, ...string[]]) : z.string()
+	const agentIdEnum = delegateSchema(agentIds)
 
 	const createTask = defineTool({
 		name: 'create_task',

--- a/packages/sdk/src/tools/coordinator/index.ts
+++ b/packages/sdk/src/tools/coordinator/index.ts
@@ -166,18 +166,29 @@ function normalizeApprovePlanSteps(value: unknown): unknown {
  *
  * This used to be `agentIds.length > 0 ? z.enum(agentIds) : z.string()`, so
  * the one input that means "this run may delegate to nobody" became "this run
- * may name anything". An allow-list that admits everything when it is empty is
- * the failure Saltzer & Schroeder named in 1975 as the violation of
- * **fail-safe defaults** — "the default situation is lack of access, and the
- * protection scheme identifies conditions under which access is permitted"
- * (§3.A.2, *The Protection of Information in Computer Systems*). CWE-183,
- * *Permissive List of Allowed Inputs*, is the same defect catalogued.
+ * may name anything". An allow-list *is* the enumeration of the conditions
+ * under which access is permitted; an empty one enumerates nothing and so
+ * admits nothing. Degrading it to an open string instead is **failing open**
+ * (CWE-636: falling back to a state less secure than the alternatives
+ * available, in order to keep functioning) — and CWE-183, *Permissive List of
+ * Allowed Inputs*, catalogues the limit case where the list admits something
+ * unsafe. Saltzer & Schroeder named the underlying rule in 1975 as **fail-safe
+ * defaults**: "the default situation is lack of access, and the protection
+ * scheme identifies conditions under which access is permitted"
+ * (*The Protection of Information in Computer Systems*, §I.A.3(b)). The same
+ * paragraph states the asymmetry that decides it — a mechanism granting
+ * explicit permission tends to fail by refusing, which is detected quickly,
+ * while one enumerating refusals tends to fail by allowing, "a failure which
+ * may go unnoticed in normal use".
  *
- * `z.never()` is the closed reading: every value fails, so an empty roster
- * refuses every delegation, and the refusal lands at the tool's own boundary
- * with a message naming the cause — rather than travelling on to
- * `AgentManager`'s registry, which fails later and reports a missing agent
- * instead of an empty roster.
+ * The primary control is that `create_task` is not mounted at all on an empty
+ * roster (see the assembly at the end of this builder). This branch is
+ * defence-in-depth for a definition constructed directly, and should normally
+ * never render: `z.never()` renders as `{"not":{}}`, which is valid draft-07
+ * but sits outside the keyword subset some strict tool-schema validators
+ * accept, and a rejected tool schema fails the whole request rather than the
+ * one tool. `z.enum([])` is no better — it renders an empty `enum` array,
+ * equally outside some validators' subsets.
  */
 function delegateSchema(agentIds: readonly string[]): z.ZodType<string> {
 	if (agentIds.length === 0) {
@@ -433,7 +444,25 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 	// could only ever manufacture a "cancelled" for something already done.
 	// Host-owned interruption still uses the gateway contract directly.
 	void cancelTask
-	const tools: ToolDefinition[] = [createTask, agentTaskList]
+	// An empty roster withholds `create_task` rather than mounting an
+	// unsatisfiable one. Mounting it and refusing at parse time reaches the
+	// same verdict, but it reaches it the expensive way: the model is shown a
+	// tool every turn whose description reads "Available agents: ." and whose
+	// one required parameter no value can satisfy, and it pays a turn to find
+	// that out. That is the shape this codebase already criticises for
+	// per-call denial — the denial is correct and the cost is prompt-prefix
+	// tokens plus an iteration per attempt. Not offering the capability is
+	// least functionality (NIST SP 800-53 Rev. 5 CM-7: provide only
+	// mission-essential capabilities; SC-7(5) states the same rule under the
+	// name "deny by default, allow by exception").
+	//
+	// `create_task` is the only coordinator tool that reads the roster, so the
+	// withholding is exactly one tool wide. "No delegates, but still planning
+	// and a human channel" stays a supported configuration, which is why this
+	// omits rather than refusing to build: a caller asking this builder for
+	// `ask_user_question` with no roster is doing something legitimate.
+	const tools: ToolDefinition[] =
+		agentIds.length > 0 ? [createTask, agentTaskList] : [agentTaskList]
 
 	if (getPlanManager) {
 		const approvePlan = defineTool({


### PR DESCRIPTION
Closes phase 4 of the host findings: the two allow-lists in the delegation surface that failed open, plus the decline mechanism that one site was ignoring.

## What was wrong

**An empty roster meant "anybody".** `create_task` derived `agent_id` from `allowedAgentIds` but widened it from the roster enum to a bare string whenever that roster was empty — so the one configuration meaning "this run may delegate to nobody" was the only one that let the model name anybody. The id was not merely rejected downstream: it reached the gateway, which resolves against an `AgentManager` that is typically **shared**, so an agent the host deliberately left out of `agentIds` could still launch if it happened to be registered there. When it was not, the failure text listed every registered agent id back to the model, and the plan row was stranded at `in_progress` because the store write precedes the gateway call while the reconciling update follows it.

**A host could not decline a coordinator tool.** `runtimeToolOverrides` is this SDK's declared way to decline a kernel-mounted tool. It is honoured for the task tools (`runtime/query/index.ts:550`) and the advisory tools (`:794`), and `SupervisorAgent` forwards it into its own `drainQuery` call — but it registered the coordinator tools before that, unconditionally, so `{ create_task: 'disabled' }` was obeyed everywhere except the one surface a host would most want to decline. A run that must not delegate had prompt text and a gateway refusal as its only defences.

**Collisions overwrote silently.** Not "the host's tool quietly loses and the run works": `registerOne` ends by setting availability and the coordinator call passed none, so a tool the host registered `deferred` or `suspended` was silently promoted to `active` under someone else's implementation, and because the store is a `Map` the replacement inherited the host's insertion position in the prompt-cache prefix. A different authorization surface, not a lost registration.

## What changed

- `create_task` is **not mounted** on an empty roster, rather than mounted with a schema nothing satisfies. It is the only coordinator tool that reads the roster, so `agent_task_list`, `approve_plan` and `ask_user_question` are untouched — "no delegates, but still planning and a human channel" stays supported, which is why this omits rather than refusing to build.
- `buildAgentTool` carried the identical fallback and now throws at construction: it returns exactly one tool and that tool *is* the delegation surface. It also never checked `subagent_type` against the roster inside `execute`, which is reachable without the registry; it does now.
- Coordinator registration consults `runtimeToolOverrides` in the same shape as the two existing call sites.
- Collisions throw `ToolNameCollisionError` (exported, carrying `toolName`), matching `DuplicateProviderError` one directory over so a host can catch it narrowly. Reserved names: `create_task`, `agent_task_list`, `approve_plan`, `ask_user_question`.

## Two commits, deliberately

`4810f87` closed the empty-roster hole with `z.never()`. A grounding pass against this repo's own render path overturned that mechanism and `9851812` replaces it. Kept as two commits because the reasoning is the useful part: `z.never()` renders as `{"not":{}}` with `agent_id` still `required`, `normalizeToolSchema` strips only `$schema`, and both first-party provider clients pass the object through verbatim — so an unusual keyword reaches the provider, and a rejected tool schema fails the whole request rather than one tool. It also left the tool mounted, showing the model `Available agents: .` every turn and a validation hint that described the parameter as fillable.

## Grounding

Fail-safe defaults, Saltzer & Schroeder 1975 §I.A.3(b) — an allow-list *is* the enumeration of what is permitted, so an empty one admits nothing; degrading it to keep functioning is failing open (CWE-636), with CWE-183 the limit case. Not mounting rather than denying per call is least functionality (NIST SP 800-53 Rev. 5 CM-7; SC-7(5) states the same rule as "deny by default, allow by exception"). The collision half rests on complete mediation (§I.A.3(c)) — a registry entry is a remembered authority check — with CWE-390 naming warn-without-action and CWE-694's own mitigation nearly matching the fix.

Peer precedent was read from source, not summarised: one runtime's registry primitive throws on duplicate and reserved names; another refuses its injected delegation name in a pre-flight that tells the author to rename; a third makes delegation one tool per delegate so an empty roster structurally yields zero tools and there is no fallback branch to degrade into.

## Not in this PR

A misspelled override key (`{ create_taks: 'disabled' }`) silently disables nothing — the same fail-open class. It is not fixed here because the override map is shared across surfaces, so validating it against one site's names would throw on a legitimate override for a tool mounted elsewhere. Recorded as an open question with the three candidate designs rather than implemented wrong.

## Gates

typecheck 0, lint 0, full suite green, public surface 496 (baseline regenerated for the one added export). Both behaviour changes verified by mutation: reverting to the pre-fix registration fails exactly the three new assertions and passes the two that assert preserved behaviour.
