### PR TITLE
test(sdk): restore the contract coverage a squash dropped

### DIFF
--- a/packages/sdk/src/tools/builtins/__tests__/write-file.test.ts
+++ b/packages/sdk/src/tools/builtins/__tests__/write-file.test.ts
@@ -27,6 +27,86 @@ function makeContext(workingDirectory: string, tracker?: FileReadTracker): ToolC
 	}
 }
 
+/**
+ * The published contract, pinned exactly.
+ *
+ * This was dropped when the tool gained `newStr`, and dropping it is what let
+ * the two contracts drift apart silently. They are deliberately NOT the same
+ * contract, and that is the thing worth recording: a host driving `execute`
+ * directly may pass `newStr`, and a model may not — because a model given two
+ * names for the body has to choose, and choosing is what produces the
+ * half-filled calls the closed model schema exists to prevent. Nothing said
+ * that out loud once the test asserting it was rewritten to assert the
+ * opposite.
+ */
+describe('WriteFileTool — the published contract', () => {
+	it('publishes one closed path + content shape to the model', () => {
+		expect(WriteFileTool.modelInputSchema).toEqual({
+			type: 'object',
+			properties: {
+				path: {
+					type: 'string',
+					description: 'Relative path to the file to write. Must not be empty.',
+				},
+				content: {
+					type: 'string',
+					description:
+						'Complete file body. Use "" only for an intentionally empty file. Keep under 12000 characters.',
+				},
+			},
+			required: ['path', 'content'],
+			additionalProperties: false,
+		})
+		expect(WriteFileTool.enforceModelInput).toBe(true)
+	})
+
+	it('keeps newStr off the model surface while accepting it from a host', () => {
+		const modelProperties = WriteFileTool.modelInputSchema?.properties as Record<string, unknown>
+		expect(Object.keys(modelProperties)).not.toContain('newStr')
+
+		// The execution schema is the wider one, on purpose.
+		expect(WriteFileTool.inputSchema.safeParse({ path: 'doc.md', newStr: 'body' }).success).toBe(
+			true,
+		)
+	})
+
+	it('requires a body under one name or the other', () => {
+		expect(WriteFileTool.inputSchema.safeParse({ path: 'doc.md' }).success).toBe(false)
+		// An empty string is a body — an intentionally empty file is legal.
+		expect(WriteFileTool.inputSchema.safeParse({ path: 'doc.md', content: '' }).success).toBe(true)
+	})
+
+	it('refuses a whitespace-only path but not a path with edge whitespace', async () => {
+		expect(WriteFileTool.inputSchema.safeParse({ path: '   ', content: 'body' }).success).toBe(
+			false,
+		)
+
+		// The refusal above must not over-reach: ' fresh.txt ' is a legal name
+		// on every filesystem this runs on, and trimming it would write to a
+		// different file than the caller asked for.
+		const dir = mkdtempSync(join(tmpdir(), 'namzu-write-'))
+		const result = await WriteFileTool.execute(
+			{ path: ' fresh.txt ', content: 'hello' },
+			makeContext(dir),
+		)
+
+		expect(result.success).toBe(true)
+		expect(readFileSync(join(dir, ' fresh.txt '), 'utf-8')).toBe('hello')
+	})
+
+	it('rejects an undeclared field even when execute is called directly', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'namzu-write-'))
+
+		const result = await WriteFileTool.execute(
+			{ path: 'fresh.txt', content: 'hello', append: true } as never,
+			makeContext(dir),
+		)
+
+		expect(result.success).toBe(false)
+		expect(result.error).toContain('Invalid write input')
+	})
+})
+
 describe('WriteFileTool — read-before-overwrite invariant', () => {
 	it('writes a new file without requiring a prior read', async () => {
 		const dir = mkdtempSync(join(tmpdir(), 'namzu-write-'))

--- a/packages/sdk/src/tools/coordinator/__tests__/ask-user-question.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/ask-user-question.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { ToolRegistry } from '../../../registry/tool/execute.js'
 import type { TaskGateway } from '../../../types/agent/gateway.js'
 import type {
 	HITLDecisionRequest,
@@ -172,6 +173,63 @@ describe('coordinator ask_user_question input schema', () => {
 				header: 'Audience',
 			}).success,
 		).toBe(true)
+	})
+})
+
+/**
+ * The model-facing schema is a module-level object shared by every tool this
+ * builder produces, so it is copied on the way out — TWICE, at two independent
+ * boundaries, and each test below pins exactly one of them. The builder clones
+ * when it attaches the schema to the definition; the registry clones again
+ * when it renders a definition for the wire. Removing either clone fails one
+ * of these and not the other, which is how they were confirmed non-vacuous.
+ *
+ * Both clones survived a version in which neither test did: the defences were
+ * still in the source and nothing pinned them, which is precisely the state
+ * where a later edit drops one and no gate objects.
+ *
+ * The failure they prevent is not hypothetical. A caller that mutates a schema
+ * it received — normalizing it for one provider, adding a legacy alias — would
+ * otherwise be editing the object every OTHER tool instance in the process is
+ * also handing out, including definitions already registered in another run.
+ */
+describe('coordinator ask_user_question canonical schema isolation', () => {
+	const noopHandler: ResumeHandler = async () => ({ action: 'continue' })
+
+	it('returns a fresh schema on every render from the registry boundary', () => {
+		const registry = new ToolRegistry()
+		registry.register(askTool(noopHandler))
+
+		const first = registry.toLLMTools()[0]?.function.parameters
+		expect(first).toEqual(askTool(noopHandler).modelInputSchema)
+		const firstProperties = first?.properties as Record<string, unknown>
+		firstProperties.legacy_options = { type: 'string' }
+
+		const next = registry.toLLMTools()[0]?.function.parameters
+		expect(JSON.stringify(next)).not.toContain('legacy_options')
+		expect(next).toEqual(askTool(noopHandler).modelInputSchema)
+	})
+
+	it('isolates the schema between two results of the public builder', () => {
+		const first = askTool(noopHandler)
+		const second = askTool(noopHandler)
+		expect(first.modelInputSchema).not.toBe(second.modelInputSchema)
+
+		const firstProperties = first.modelInputSchema?.properties as Record<string, unknown>
+		firstProperties.legacy_options = { type: 'string' }
+
+		expect(JSON.stringify(second.modelInputSchema)).not.toContain('legacy_options')
+	})
+
+	it('rejects an unknown property inside an option, not only at the root', () => {
+		const tool = askTool(noopHandler)
+
+		expect(
+			tool.inputSchema.safeParse({
+				...baseInput,
+				options: [{ label: 'A', weight: 3 }, { label: 'B' }],
+			}).success,
+		).toBe(false)
 	})
 })
 


### PR DESCRIPTION
test(sdk): restore the contract coverage a squash dropped

935b8f3 took write-file.test.ts from 136 lines to 97 and
ask-user-question.test.ts from 501 to 370. Comparing test names rather
than line counts shows the losses were not uniform, and one of them was
not a loss at all.

`rejects legacy content aliases even when execute is called directly` was
INVERTED, not deleted: it is now `accepts newStr`. The 2.x source had no
`newStr` — `write` published exactly `{path, content}`, closed — so the
input contract was deliberately widened and the test recording the older
decision was rewritten to assert the opposite.

The widening stands. The split it created is defensible and arguably
better than what it replaced: `newStr` is absent from `modelInputSchema`
under `enforceModelInput`, so a model cannot express it, while a host
calling `execute` directly can. What was missing is anyone stating that,
which is why the drift went unremarked. `keeps newStr off the model
surface while accepting it from a host` pins both halves and says why they
differ.

Restored alongside it: the exact model schema, the whitespace-only path
refusal paired with a proof it does not over-reach — ' fresh.txt ' still
writes to that exact name, and trimming would write to a different file
than the caller asked for — the body-required refinement, and
undeclared-field rejection on the direct execute path.

The two ask_user_question tests guard a defence that is still in the
source. The shared module-level model schema is handed out through
`structuredClone`; the clone survived the squash and the tests pinning it
did not, which is the state where a later edit removes it and no gate
objects. Mutating each clone showed there are two, at independent
boundaries — the builder attaching the schema, and the registry rendering
it for the wire — and each test pins exactly one. Option-level unknown
properties are pinned again too; the surviving test covers only a root
field.

Tests only, no source change. That is the shape a coverage restoration
should have, and it is the evidence that every restored assertion holds
against today's behaviour.

## Verification

Every restored assertion was mutation-checked against the source it guards:

| mutation | caught by |
|---|---|
| drop the whitespace-only path refine | `refuses a whitespace-only path but not a path with edge whitespace` |
| drop `.strict()` | `rejects an undeclared field even when execute is called directly` |
| drop the content-or-newStr refine | `requires a body under one name or the other` |
| reword a model schema description | `publishes one closed path + content shape to the model` |
| leak `newStr` onto the model surface | that one **and** `keeps newStr off the model surface…` |
| drop the builder's `structuredClone` | `isolates the schema between two results of the public builder` |
| drop the registry render's `structuredClone` | `returns a fresh schema on every render from the registry boundary` |

The first run of that battery reported all five write-file mutations as *not caught*. They were all caught — the harness's failure-name regex did not survive the em-dash in the describe title plus ANSI colour codes, and `execSync` was not merging stderr. It surfaced only because one result contradicted a failure I had just watched by hand. A mutation harness that reports false negatives certifies vacuous tests as sound, so the harness now strips ANSI, merges streams, and prints the summary line whenever it finds no failures.

No source files are touched, which is the evidence that every restored assertion holds against today's behaviour rather than against 2.x's.