### PR TITLE
fix(sdk): make cancellation and the sandbox boundary reach the tools

### DIFF
--- a/.changeset/olive-jars-repeat.md
+++ b/.changeset/olive-jars-repeat.md
@@ -1,0 +1,43 @@
+---
+'@namzu/sdk': minor
+'@namzu/sandbox': patch
+---
+
+Three sandbox and delegation gaps, all of the same kind: something declared,
+threaded through types, and never driven.
+
+**`SandboxExecOptions.signal` now works — on the backend where it can.** The
+option was declared, documented and exported, with a docstring stating that
+without it "a Stop could only ever abandon the *wait* — the sandboxed process
+kept running after the host believed the run had been cancelled". Every
+backend dropped it, so that is exactly what happened. The local sandbox now
+merges the caller's signal with the call's own deadline and hands the result to
+`spawn`, so the child actually dies; a cancelled run is no longer reported as
+`timedOut`, because a run someone stopped did not run too long, and telling the
+model otherwise invites a retry with a bigger budget.
+
+The remote backends still ignore it, now explicitly and with the reason in the
+source. Their wire has no cancel op, so aborting the request would abandon the
+wait while the command kept running — the original failure, wearing the
+appearance of a fix. `SandboxExecOptions.signal` documents which backends
+honour it.
+
+**`ls` respects the sandbox.** It read the host through `node:fs` and named
+`context.sandbox` nowhere, in the one builtin whose whole job is telling the
+model what exists — so under a container or microVM backend the model's picture
+of the filesystem was the host's. Its paths were host-relative too, while
+`read`, `grep` and `glob` all resolve inside the sandbox, so an ls-to-read
+handoff either failed or opened a different file than the one listed. `glob`
+had the identical defect, was fixed, and its fix notes that "every sibling
+builtin already remembers this branch"; this was the sibling that did not.
+
+One behaviour difference worth knowing: inside a sandbox, directories are
+derived from file paths, because `listFiles` reports files. An empty directory
+is invisible there.
+
+**The `Agent` tool's header described a design that no longer exists.** It told
+readers to prefer `Agent` because `create_task` was a non-blocking trio driven
+by notification callbacks. `create_task` blocks and returns the worker's output
+as its own result, and `continue_task` / `cancel_task` are not registered at
+all. The two tools are separated by how much of the coordinator surface they
+bring, not by timing.

--- a/packages/sandbox/src/backends/docker/index.ts
+++ b/packages/sandbox/src/backends/docker/index.ts
@@ -561,6 +561,12 @@ async function execViaWorker(
 	argv: string[] | undefined,
 	opts: SandboxExecOptions | undefined,
 ): Promise<SandboxExecResult> {
+	// `opts.signal` is deliberately NOT passed to `fetch`. It would abort the
+	// request and leave the worker running the command — abandoning the wait
+	// while the process lives on is the exact failure
+	// `SandboxExecOptions.signal` exists to prevent, and wiring it here would
+	// make the option look honoured while delivering that failure. Honouring
+	// it needs a cancel endpoint on the worker.
 	const start = Date.now()
 	let res: Response
 	try {

--- a/packages/sandbox/src/backends/firecracker/index.ts
+++ b/packages/sandbox/src/backends/firecracker/index.ts
@@ -421,6 +421,16 @@ async function spawnFirecrackerSandbox(
 			argv?: string[],
 			opts?: SandboxExecOptions,
 		): Promise<SandboxExecResult> {
+			// `opts.signal` is deliberately not forwarded, and the reason is
+			// worth writing down because the obvious "fix" is worse than the
+			// gap. There is no cancel op on this wire — the guest agent takes
+			// an execute frame and answers when the command is done. Aborting
+			// the socket here would abandon the WAIT while the process keeps
+			// running inside the microVM, which is verbatim the failure
+			// `SandboxExecOptions.signal` exists to prevent, except it would
+			// then look honoured. Honouring it means a cancel op in the guest
+			// protocol; until then, ignoring it is the truthful behaviour the
+			// option's own contract allows.
 			status = 'busy'
 			try {
 				return await transport.execute({

--- a/packages/sdk/src/sandbox/__tests__/exec-cancellation.test.ts
+++ b/packages/sdk/src/sandbox/__tests__/exec-cancellation.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+
+import { getRootLogger } from '../../utils/logger.js'
+import { LocalSandboxProvider } from '../provider/local.js'
+
+/**
+ * `SandboxExecOptions.signal` was declared, documented, exported — and
+ * dropped by every backend. The local one built a fresh `AbortController`
+ * from the call's own timeout and never linked the caller's signal to it, so
+ * cancelling a run abandoned the *wait* while the sandboxed process kept
+ * running. That is verbatim the failure the option's docstring says it exists
+ * to prevent.
+ *
+ * These drive the real provider rather than a stub, because the defect was
+ * precisely in the wiring between the option and `spawn` — a stub asserting
+ * "the signal was passed along" would have passed against the broken code.
+ */
+describe('a sandboxed command honours the caller cancellation', () => {
+	it('kills a long-running process when the caller aborts', async () => {
+		const provider = new LocalSandboxProvider(getRootLogger())
+		const sandbox = await provider.create()
+		const controller = new AbortController()
+
+		// Long enough that only the abort can end it: the deadline is 60s and
+		// the sleep is 30s, so a pass cannot come from either firing.
+		const running = sandbox.exec('node', ['-e', 'setTimeout(() => {}, 30000)'], {
+			timeout: 60_000,
+			signal: controller.signal,
+		})
+		setTimeout(() => controller.abort(), 50)
+
+		const result = await running
+
+		expect(result.exitCode).not.toBe(0)
+		// Cancelled is not late. Reporting a timeout here would tell the model
+		// to retry with a longer budget for something a human just stopped.
+		expect(result.timedOut).toBe(false)
+		expect(result.durationMs).toBeLessThan(20_000)
+
+		await sandbox.destroy()
+	}, 30_000)
+
+	it('still reports a deadline as a timeout when no caller signal is passed', async () => {
+		const provider = new LocalSandboxProvider(getRootLogger())
+		const sandbox = await provider.create()
+
+		const result = await sandbox.exec('node', ['-e', 'setTimeout(() => {}, 30000)'], {
+			timeout: 300,
+		})
+
+		expect(result.timedOut).toBe(true)
+
+		await sandbox.destroy()
+	}, 30_000)
+
+	it('leaves an uncancelled command alone', async () => {
+		const provider = new LocalSandboxProvider(getRootLogger())
+		const sandbox = await provider.create()
+		const controller = new AbortController()
+
+		const result = await sandbox.exec('node', ['-e', 'console.log("done")'], {
+			timeout: 30_000,
+			signal: controller.signal,
+		})
+
+		expect(result.exitCode).toBe(0)
+		expect(result.stdout).toContain('done')
+		expect(result.timedOut).toBe(false)
+
+		await sandbox.destroy()
+	}, 30_000)
+})

--- a/packages/sdk/src/sandbox/provider/local.ts
+++ b/packages/sdk/src/sandbox/provider/local.ts
@@ -384,11 +384,23 @@ class LocalSandbox implements Sandbox {
 
 		this.log.debug('Executing command', { command, args, timeout, environment: this.environment })
 
+		// The caller's cancellation and this call's own deadline both have to
+		// reach `spawn`, and `spawn` takes exactly one signal.
+		//
+		// Only the deadline used to. `SandboxExecOptions.signal` is declared,
+		// documented, and exported, and every backend dropped it — so a Stop
+		// abandoned the *wait* and left the sandboxed process running, which is
+		// verbatim the failure the option's own docstring says it exists to
+		// prevent. `AbortSignal.any` is what makes both reach the child: it
+		// aborts as soon as either does, and — unlike an `addEventListener`
+		// bridge — it does not retain a listener on the caller's long-lived
+		// signal after this call settles.
 		const ac = new AbortController()
 		const timeoutId = setTimeout(() => ac.abort(), timeout)
+		const spawnSignal = opts?.signal ? AbortSignal.any([ac.signal, opts.signal]) : ac.signal
 
 		try {
-			const result = await this.spawnProcess(spawnCommand, spawnArgs, cwd, env, ac)
+			const result = await this.spawnProcess(spawnCommand, spawnArgs, cwd, env, ac, spawnSignal)
 			return { ...result, durationMs: Date.now() - startTime }
 		} finally {
 			clearTimeout(timeoutId)
@@ -484,12 +496,22 @@ class LocalSandbox implements Sandbox {
 		})
 	}
 
+	/**
+	 * @param ac      this call's own deadline — still the thing that decides
+	 *                whether a termination is reported as `timedOut`.
+	 * @param signal  what actually reaches `spawn`: the deadline, merged with
+	 *                the caller's cancellation when one was passed. Two
+	 *                parameters because they answer different questions —
+	 *                "should this process die" and "did it die because it ran
+	 *                too long" — and a cancelled run did not time out.
+	 */
 	private spawnProcess(
 		command: string,
 		args: string[],
 		cwd: string,
 		env: Record<string, string>,
 		ac: AbortController,
+		signal: AbortSignal = ac.signal,
 	): Promise<Omit<SandboxExecResult, 'durationMs'>> {
 		return new Promise((resolvePromise, rejectPromise) => {
 			let child: ReturnType<typeof spawn>
@@ -498,7 +520,7 @@ class LocalSandbox implements Sandbox {
 					cwd,
 					env,
 					stdio: ['pipe', 'pipe', 'pipe'],
-					signal: ac.signal,
+					signal,
 				})
 			} catch (err) {
 				rejectPromise(err)
@@ -513,8 +535,12 @@ class LocalSandbox implements Sandbox {
 			child.stderr?.on('data', (chunk: Buffer) => stderr.push(chunk))
 
 			child.on('error', (err: NodeJS.ErrnoException) => {
-				if (err.code === 'ABORT_ERR' || ac.signal.aborted) {
-					timedOut = true
+				if (err.code === 'ABORT_ERR' || signal.aborted) {
+					// `timedOut` means the DEADLINE fired. A caller-cancelled
+					// run is aborted but not late, and reporting it as a
+					// timeout would tell the model to retry with a longer
+					// budget for something a human just stopped.
+					timedOut = ac.signal.aborted
 					// Give process a grace period, then SIGKILL
 					if (child.pid) {
 						setTimeout(() => {

--- a/packages/sdk/src/tools/__tests__/sandboxed-search.test.ts
+++ b/packages/sdk/src/tools/__tests__/sandboxed-search.test.ts
@@ -4,6 +4,7 @@ import type { Sandbox } from '../../types/sandbox/index.js'
 import type { ToolContext } from '../../types/tool/index.js'
 import { GlobTool } from '../builtins/glob.js'
 import { GrepTool } from '../builtins/grep.js'
+import { LsTool } from '../builtins/ls.js'
 
 /**
  * Both tools reached `node:fs` directly and referenced `context.sandbox`
@@ -134,6 +135,71 @@ describe('grep inside a sandbox', () => {
 	it('refuses a path that climbs out of the sandbox root', async () => {
 		const sandbox = fakeSandbox({ 'a.ts': 'needle\n' })
 		const result = await GrepTool.execute(args({ path: '../../etc' }), context(sandbox))
+		expect(result.success).toBe(false)
+		expect(result.error).toMatch(/escapes the working directory/)
+	})
+})
+
+/**
+ * `ls` was the sibling `glob`'s fix claimed already remembered this branch.
+ * It did not: it read the host through `node:fs` and named `context.sandbox`
+ * nowhere — in the one builtin whose entire job is telling the model what
+ * exists, so the model's picture of the filesystem was the host's.
+ */
+describe('ls inside a sandbox', () => {
+	const lsArgs = (over: Record<string, unknown> = {}) =>
+		({ path: '.', all: false, recursive: false, max_depth: 3, ...over }) as never
+
+	it('enumerates through the sandbox, not the host', async () => {
+		const sandbox = fakeSandbox({ 'src/a.ts': 'a', 'README.md': 'r' })
+		const result = await LsTool.execute(lsArgs(), context(sandbox))
+
+		expect(sandbox.listFiles).toHaveBeenCalled()
+		expect(result.data).toMatchObject({ sandboxed: true })
+		expect(result.output).not.toContain(HOST_ROOT)
+	})
+
+	it('shows one level: a nested file appears as its directory', async () => {
+		const sandbox = fakeSandbox({ 'src/a.ts': 'a', 'README.md': 'r' })
+		const result = await LsTool.execute(lsArgs(), context(sandbox))
+
+		expect(result.output).toContain('src/')
+		expect(result.output).toContain('README.md')
+		// One level means one level — the nested file is not listed here.
+		expect(result.output).not.toContain('a.ts')
+	})
+
+	it('returns paths the sandbox-side reader can actually open', async () => {
+		const sandbox = fakeSandbox({ 'src/a.ts': 'a' })
+		const result = await LsTool.execute(lsArgs({ recursive: true }), context(sandbox))
+
+		expect(result.output).toContain('./src/a.ts')
+		expect(result.output).not.toContain(HOST_ROOT)
+	})
+
+	it('respects max_depth when recursing', async () => {
+		const sandbox = fakeSandbox({ 'a/b/c/deep.ts': 'd', 'a/shallow.ts': 's' })
+		const result = await LsTool.execute(lsArgs({ recursive: true, max_depth: 2 }), context(sandbox))
+
+		expect(result.output).toContain('./a/shallow.ts')
+		expect(result.output).not.toContain('deep.ts')
+	})
+
+	it('hides dotfiles unless asked, at any depth', async () => {
+		const sandbox = fakeSandbox({ '.env': 'SECRET=1', 'src/.hidden/x.ts': 'x', 'src/a.ts': 'a' })
+
+		const hidden = await LsTool.execute(lsArgs({ recursive: true }), context(sandbox))
+		expect(hidden.output).not.toContain('.env')
+		expect(hidden.output).not.toContain('.hidden')
+
+		const shown = await LsTool.execute(lsArgs({ recursive: true, all: true }), context(sandbox))
+		expect(shown.output).toContain('.env')
+	})
+
+	it('refuses a path that climbs out of the sandbox root', async () => {
+		const sandbox = fakeSandbox({ 'a.ts': 'a' })
+
+		const result = await LsTool.execute(lsArgs({ path: '../../etc' }), context(sandbox))
 		expect(result.success).toBe(false)
 		expect(result.error).toMatch(/escapes the working directory/)
 	})

--- a/packages/sdk/src/tools/builtins/ls.ts
+++ b/packages/sdk/src/tools/builtins/ls.ts
@@ -1,8 +1,11 @@
 import { readdir, stat } from 'node:fs/promises'
 import { join, relative } from 'node:path'
 import { z } from 'zod'
+import type { Sandbox } from '../../types/sandbox/index.js'
+import type { ToolResult } from '../../types/tool/index.js'
 import { defineTool } from '../defineTool.js'
 import { resolveWithin } from '../paths.js'
+import { joinPosix, relativePosix, resolveWithinPosix } from '../posix-path.js'
 
 const inputSchema = z.object({
 	path: z.string().default('.').describe('Directory path to list. Defaults to working directory.'),
@@ -105,6 +108,101 @@ async function listRecursive(
 	}
 }
 
+/**
+ * Enumerate inside the sandbox.
+ *
+ * This tool read the HOST filesystem through `node:fs` and referenced
+ * `context.sandbox` nowhere, so with a container or microVM backend wired in
+ * it enumerated the host — in the one builtin whose entire job is telling the
+ * model what exists. `glob` carried the identical defect, was fixed, and its
+ * fix notes that "every sibling builtin already remembers this branch". This
+ * was the sibling that did not, which is why the claim needed checking rather
+ * than reading.
+ *
+ * Worse than a leak on its own: the paths it returned were host-relative,
+ * while `read`, `grep` and `glob` all resolve INSIDE the sandbox. So every
+ * ls-to-read handoff either failed or opened a different file than the one
+ * listed. This returns the sandbox-relative coordinates the others speak.
+ *
+ * `listFiles` reports files, not directories — every backend implements it as
+ * a recursive file walk — so directories are derived from the paths. A
+ * directory holding nothing is therefore invisible here, which is a real
+ * difference from the host branch and the honest cost of having one
+ * enumeration primitive rather than one per backend.
+ */
+async function listInSandbox(
+	input: { path: string; all: boolean; recursive: boolean; max_depth: number },
+	sandbox: Sandbox,
+): Promise<ToolResult> {
+	const root = resolveWithinPosix(sandbox.rootDir, input.path)
+	const entries = await sandbox.listFiles(root)
+
+	// Relative to the LISTED directory, in the sandbox's own coordinates.
+	const relativePaths: { segments: string[]; size: number }[] = []
+	for (const entry of entries) {
+		const rel = relativePosix(root, joinPosix(root, entry.path))
+		if (!rel || rel.startsWith('..')) continue
+		const segments = rel.split('/').filter(Boolean)
+		if (segments.length === 0) continue
+		if (!input.all && segments.some((s) => s.startsWith('.'))) continue
+		relativePaths.push({ segments, size: entry.size })
+	}
+
+	if (!input.recursive) {
+		// One level: a single segment is a file, more than one means the
+		// first segment is a directory.
+		const files = new Map<string, number>()
+		const dirs = new Set<string>()
+		for (const { segments, size } of relativePaths) {
+			const head = segments[0] as string
+			if (segments.length === 1) files.set(head, size)
+			else dirs.add(head)
+		}
+
+		const lines = [
+			...[...dirs].sort().map((name) => `${name}/`),
+			...[...files.entries()]
+				.sort(([a], [b]) => a.localeCompare(b))
+				.map(([name, size]) => `${name}\t${formatSize(size)}`),
+		]
+
+		return {
+			success: true,
+			output: lines.length > 0 ? lines.join('\n') : '(empty directory)',
+			data: { count: lines.length, sandboxed: true },
+		}
+	}
+
+	const seenDirs = new Set<string>()
+	const lines: string[] = []
+	let count = 0
+	for (const { segments, size } of relativePaths.sort((a, b) =>
+		a.segments.join('/').localeCompare(b.segments.join('/')),
+	)) {
+		if (segments.length > input.max_depth) continue
+		// Emit each parent directory once, before anything inside it.
+		for (let depth = 1; depth < segments.length; depth++) {
+			const dir = segments.slice(0, depth).join('/')
+			if (seenDirs.has(dir)) continue
+			seenDirs.add(dir)
+			if (count >= MAX_ENTRIES) break
+			lines.push(`./${dir}/`)
+			count++
+		}
+		if (count >= MAX_ENTRIES) break
+		lines.push(`./${segments.join('/')} (${formatSize(size)})`)
+		count++
+	}
+
+	const truncated = count >= MAX_ENTRIES ? `\n(truncated at ${MAX_ENTRIES} entries)` : ''
+
+	return {
+		success: true,
+		output: lines.length > 0 ? lines.join('\n') + truncated : '(empty directory)',
+		data: { count, truncated: count >= MAX_ENTRIES, sandboxed: true },
+	}
+}
+
 export const LsTool = defineTool({
 	name: 'ls',
 	description:
@@ -117,6 +215,10 @@ export const LsTool = defineTool({
 	concurrencySafe: true,
 
 	async execute(input, context) {
+		if (context.sandbox) {
+			return await listInSandbox(input, context.sandbox)
+		}
+
 		// Contained, not merely resolved — see `resolveWithin`.
 		const targetPath = resolveWithin(context.workingDirectory, input.path)
 

--- a/packages/sdk/src/tools/coordinator/agent.ts
+++ b/packages/sdk/src/tools/coordinator/agent.ts
@@ -17,14 +17,28 @@ import type { TaskLaunchedCallback } from './index.js'
  * subagent tool calls are isolated — only the summary surfaces to
  * the parent.
  *
- * This is **NOT** the same shape as the legacy `create_task` /
- * `continue_task` / `cancel_task` trio that this package ships
- * alongside it: those are non-blocking and use a `<task-notification>`
- * callback model. The async pattern is useful for hosts that want a
- * work-queue surface, but it asks the model to track work it cannot
- * see finish. Prefer the blocking `Agent` tool; keep the legacy
- * coordinator tools only when you genuinely need fire-and-forget
- * multi-task fan-out.
+ * **How this relates to `create_task`.** This paragraph used to say the two
+ * were different shapes — that `create_task` / `continue_task` /
+ * `cancel_task` were a non-blocking trio driven by a `<task-notification>`
+ * callback, and that the blocking `Agent` tool should be preferred. None of
+ * that is true any more. `create_task` blocks and returns the worker's output
+ * as its own `tool_result`, exactly like this tool; `continue_task` and
+ * `cancel_task` are still defined in `./index.ts` but are deliberately not
+ * registered, because a blocking launch leaves every worker terminal by the
+ * time a later turn learns its id. So a reader following the old advice was
+ * choosing between two tools on a distinction that no longer existed.
+ *
+ * What actually separates them is the surface, not the timing:
+ *
+ * - `create_task` arrives with the rest of the coordinator surface —
+ *   `agent_task_list`, and `approve_plan` / `ask_user_question` when their
+ *   dependencies are wired. That is the supervisor's toolkit.
+ * - This builds one tool and nothing else, for an agent whose only delegation
+ *   need is "hand this to a specialist". `terminal: true` additionally lets a
+ *   pure router settle on the specialist's answer instead of spending a turn
+ *   at full parent context to paraphrase it.
+ *
+ * Neither is legacy. Pick by how much of the coordinator surface you want.
  */
 export interface AgentToolOptions {
 	gateway: TaskGateway

--- a/packages/sdk/src/types/sandbox/index.ts
+++ b/packages/sdk/src/types/sandbox/index.ts
@@ -110,6 +110,16 @@ export interface SandboxExecOptions {
 	 * Without it a Stop (or a per-tool deadline) could only ever abandon
 	 * the *wait* — the sandboxed process kept running after the host
 	 * believed the run had been cancelled.
+	 *
+	 * **Who honours it.** The in-process local sandbox does: the signal is
+	 * merged with the call's own deadline and reaches `spawn`, so the child
+	 * dies. The remote backends do not, and deliberately: their wire has no
+	 * cancel op, so aborting the request would abandon the wait and leave the
+	 * command running — the failure above, wearing the appearance of a fix.
+	 * They will honour it when their protocols carry a cancel.
+	 *
+	 * Passing it is therefore always safe and never harmful; whether it takes
+	 * effect depends on the backend.
 	 */
 	readonly signal?: AbortSignal
 }


### PR DESCRIPTION
fix(sdk): make cancellation and the sandbox boundary reach the tools

Three findings of one kind: declared, threaded through types, driven by
nothing.

`SandboxExecOptions.signal` carried a docstring saying that without it "a
Stop could only ever abandon the *wait* — the sandboxed process kept
running after the host believed the run had been cancelled". No backend
honoured it, so that is what happened on every one. The local sandbox
built a fresh AbortController from the call's timeout and never linked the
caller's; docker's `signal` identifier is the POSIX signal name in the
result; the ACI one is a 2-second deadline on its own HTTP call; the
microVM backend threaded cwd, env and timeout past it.

Local now merges the two with `AbortSignal.any` and hands the result to
`spawn`, so the child dies. Preferred over an `addEventListener` bridge
because it does not retain a listener on a caller's long-lived signal
after this call settles. A cancelled run no longer reports `timedOut`: it
was stopped, not late, and saying otherwise invites a retry with a bigger
budget for something a human just ended.

The remote backends still ignore it, now with the reason in the source.
Their wire has no cancel op, so aborting the request abandons the wait
while the command keeps running — the original failure, wearing the
appearance of a fix. Written at both call sites so the next reader does
not "fix" it by passing the signal to `fetch`, and the interface now says
which backends honour it.

`ls` was the only file builtin naming `context.sandbox` nowhere. It read
the host through `node:fs`, so under a container or microVM backend the
model's picture of the filesystem was the host's — in the one tool whose
whole job is telling it what exists. Its paths were host-relative too,
while `read`, `grep` and `glob` resolve inside the sandbox, so an
ls-to-read handoff either failed or opened a different file than the one
listed. `glob` had the same defect, was fixed, and its fix says "every
sibling builtin already remembers this branch"; this was the one that did
not. Directories are derived from file paths there, because `listFiles`
reports files — so an empty directory is invisible inside a sandbox, and
the code says so.

The `Agent` tool's header told readers to prefer it because `create_task`
was a non-blocking trio on a notification-callback model. `create_task`
blocks and returns the worker's output as its own tool_result, and
`continue_task` / `cancel_task` are built and deliberately not registered.
Rewritten around what actually separates the two — how much of the
coordinator surface each brings — rather than deleted, because the
question it answers is still one a reader has.
