### PR TITLE
fix(sdk)!: contain read, write and edit to the working directory

### DIFF
--- a/.changeset/clever-parrots-listen.md
+++ b/.changeset/clever-parrots-listen.md
@@ -1,0 +1,45 @@
+---
+'@namzu/sdk': major
+---
+
+`read`, `write` and `edit` are now contained to the working directory.
+
+All three called `resolve(workingDirectory, input.path)` bare, so
+`path: "../../.."` reached whatever sits above the working directory and the
+tool used it. No sandbox had to be misconfigured for this — it holds with no
+sandbox at all, which is the common case, so a model that asks for a parent
+directory got one. `resolveWithin` existed the whole time and these three
+never reached it; the search tools (`glob`, `grep`, `ls`) did.
+
+A lexical check alone would not have been the fix. `atomicWriteFile` resolves
+its destination and writes *through* a symlink deliberately, so that editing a
+linked file updates the target rather than replacing the link with a regular
+file. Paired with a lexical check that is check-then-follow: a link inside the
+working directory pointing outside it climbs nothing on paper, and the write
+lands outside anyway (CWE-59). Containment is therefore decided after
+canonicalization, which is the ordering CWE-22 states as the mitigation for
+the family: canonicalize, then validate the canonical form.
+
+Two details the new resolver has to get right, because getting either wrong
+breaks ordinary use rather than failing safe:
+
+- The root can itself be a symlink — `os.tmpdir()` is one on macOS — so both
+  sides are canonicalized. Canonicalizing only the candidate would refuse
+  every path under a temp directory.
+- The target may not exist yet, and `realpath` throws on a missing path. The
+  deepest existing ancestor is canonicalized and the remainder appended
+  lexically; the remainder cannot hide a link because nothing is there to be
+  one.
+
+This does not claim TOCTOU safety. A component swapped for a symlink between
+the check and the open would still be followed — closing that needs
+per-component `openat`/`O_NOFOLLOW`, which Node does not expose. The threat
+addressed is a link that is already present.
+
+**Migration.** If a host relied on these tools reaching outside
+`workingDirectory` — reading a config beside the repo, writing to a sibling
+output directory — those calls now fail with "Path escapes the working
+directory". Point `workingDirectory` at a root that contains everything the
+run legitimately needs. Sandboxed runs are unaffected: the sandbox has its own
+root and its own resolver, and the host-side canonicalization deliberately
+does not run on that branch.

--- a/packages/sdk/src/tools/__tests__/file-tool-containment.test.ts
+++ b/packages/sdk/src/tools/__tests__/file-tool-containment.test.ts
@@ -1,0 +1,190 @@
+import { mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import type { ToolContext } from '../../types/tool/index.js'
+import { EditTool } from '../builtins/edit.js'
+import { ReadFileTool } from '../builtins/read-file.js'
+import { WriteFileTool } from '../builtins/write-file.js'
+
+/**
+ * `read`, `write` and `edit` all called `resolve(workingDirectory, input.path)`
+ * bare. The search tools — `glob`, `grep`, `ls` — were contained; the three
+ * that actually read and mutate user files were not, so `path: "../../.."`
+ * reached whatever sits above the working directory with no sandbox involved.
+ * `resolveWithin` existed the whole time, and its own docstring says the
+ * filesystem tools never reached it.
+ *
+ * The second half is subtler and is why a lexical check alone was not the
+ * answer. `atomicWriteFile` resolves its destination and writes THROUGH a
+ * symlink on purpose, so that editing a linked file updates the target rather
+ * than replacing the link with a regular file. Paired with a lexical check
+ * that is check-then-follow: `./escape -> /elsewhere` climbs nothing on paper
+ * and the write lands outside anyway. CWE-59; the ordering fix is CWE-22's
+ * stated mitigation — canonicalize, then validate the canonical form.
+ *
+ * The over-rejection cases matter as much as the escapes. A containment check
+ * that refuses legitimate paths is not a safer version of one that works, and
+ * the trap is real: `os.tmpdir()` is itself a symlink on macOS, so
+ * canonicalizing the candidate while comparing against a raw root would refuse
+ * every path in a temp directory — including every path in this file.
+ */
+
+function workspace() {
+	const root = mkdtempSync(join(tmpdir(), 'namzu-contain-'))
+	const outside = mkdtempSync(join(tmpdir(), 'namzu-outside-'))
+	writeFileSync(join(outside, 'secret.txt'), 'SECRET')
+	writeFileSync(join(root, 'inside.txt'), 'inside content')
+	return { root, outside }
+}
+
+const ctx = (root: string): ToolContext =>
+	({
+		runId: 'run_test' as ToolContext['runId'],
+		workingDirectory: root,
+		abortSignal: new AbortController().signal,
+		env: {},
+		log: () => {},
+	}) as unknown as ToolContext
+
+/**
+ * Whether this host can create a symlink at all.
+ *
+ * Windows refuses without elevation or Developer Mode (`EPERM`), and the
+ * first version of this file swallowed that per-test and returned early — so
+ * three symlink tests reported PASSED on a machine where they had exercised
+ * nothing. A test that cannot run must say so; a green tick for work that
+ * did not happen is the failure this whole file exists to catch, one level
+ * up. `skipIf` makes the reporter print it as skipped, and CI runs on Linux
+ * where the probe succeeds and the cases actually execute.
+ */
+const CAN_SYMLINK = (() => {
+	try {
+		const probeRoot = mkdtempSync(join(tmpdir(), 'namzu-symprobe-'))
+		symlinkSync(probeRoot, join(probeRoot, 'self'), 'dir')
+		return true
+	} catch {
+		return false
+	}
+})()
+
+describe('the file tools stay inside the working directory', () => {
+	it('read refuses a traversal', async () => {
+		const { root, outside } = workspace()
+		const climb = join('..', join(outside).split(/[\\/]/).pop() as string, 'secret.txt')
+
+		const result = await ReadFileTool.execute({ path: climb } as never, ctx(root))
+
+		expect(result.success).toBe(false)
+		expect(result.error).toMatch(/escapes the working directory/)
+	})
+
+	it('write refuses a traversal', async () => {
+		const { root } = workspace()
+
+		const result = await WriteFileTool.execute(
+			{ path: '../escaped.txt', content: 'nope' } as never,
+			ctx(root),
+		)
+
+		expect(result.success).toBe(false)
+		expect(result.error).toMatch(/escapes the working directory/)
+	})
+
+	it('edit refuses a traversal', async () => {
+		const { root } = workspace()
+
+		const result = await EditTool.execute(
+			{ path: '../escaped.txt', old_string: 'a', new_string: 'b' } as never,
+			ctx(root),
+		)
+
+		expect(result.success).toBe(false)
+		expect(result.error).toMatch(/escapes the working directory/)
+	})
+
+	it.skipIf(!CAN_SYMLINK)('write refuses a path that climbs out THROUGH a symlink', async () => {
+		const { root, outside } = workspace()
+		symlinkSync(outside, join(root, 'escape'), 'dir')
+
+		const result = await WriteFileTool.execute(
+			{ path: 'escape/planted.txt', content: 'nope' } as never,
+			ctx(root),
+		)
+
+		expect(result.success).toBe(false)
+		expect(result.error).toMatch(/escapes the working directory/)
+		// The whole point: nothing was written outside.
+		expect(() => readFileSync(join(outside, 'planted.txt'))).toThrow()
+	})
+
+	it.skipIf(!CAN_SYMLINK)(
+		'read refuses a file reached through a symlink out of the root',
+		async () => {
+			const { root, outside } = workspace()
+			symlinkSync(outside, join(root, 'escape'), 'dir')
+
+			const result = await ReadFileTool.execute({ path: 'escape/secret.txt' } as never, ctx(root))
+
+			expect(result.success).toBe(false)
+			expect(result.error).toMatch(/escapes the working directory/)
+		},
+	)
+
+	it.skipIf(!CAN_SYMLINK)(
+		'edit refuses a file reached through a symlink out of the root',
+		async () => {
+			const { root, outside } = workspace()
+			symlinkSync(join(outside, 'secret.txt'), join(root, 'linked.txt'), 'file')
+
+			const result = await EditTool.execute(
+				{ path: 'linked.txt', old_string: 'SECRET', new_string: 'REPLACED' } as never,
+				ctx(root),
+			)
+
+			expect(result.success).toBe(false)
+			expect(readFileSync(join(outside, 'secret.txt'), 'utf-8')).toBe('SECRET')
+		},
+	)
+})
+
+describe('the containment check does not over-reject', () => {
+	it('reads a file inside the root, whose temp root is itself a symlink on some platforms', async () => {
+		const { root } = workspace()
+
+		const result = await ReadFileTool.execute({ path: 'inside.txt' } as never, ctx(root))
+
+		expect(result.success).toBe(true)
+		expect(result.output).toContain('inside content')
+	})
+
+	it('creates a file that does not exist yet, in a directory that does not either', async () => {
+		const { root } = workspace()
+
+		const result = await WriteFileTool.execute(
+			{ path: 'nested/deeper/fresh.txt', content: 'hello' } as never,
+			ctx(root),
+		)
+
+		expect(result.success).toBe(true)
+		expect(readFileSync(join(root, 'nested', 'deeper', 'fresh.txt'), 'utf-8')).toBe('hello')
+	})
+
+	it.skipIf(!CAN_SYMLINK)('still follows a symlink that stays inside the root', async () => {
+		const { root } = workspace()
+		mkdirSync(join(root, 'real'))
+		writeFileSync(join(root, 'real', 'target.txt'), 'original')
+		symlinkSync(join(root, 'real', 'target.txt'), join(root, 'alias.txt'), 'file')
+
+		const result = await EditTool.execute(
+			{ path: 'alias.txt', old_string: 'original', new_string: 'updated' } as never,
+			ctx(root),
+		)
+
+		expect(result.success).toBe(true)
+		// Written THROUGH the link, so the link survives and the target moved —
+		// the behaviour `atomicWriteFile` exists to preserve.
+		expect(readFileSync(join(root, 'real', 'target.txt'), 'utf-8')).toBe('updated')
+	})
+})

--- a/packages/sdk/src/tools/builtins/edit.ts
+++ b/packages/sdk/src/tools/builtins/edit.ts
@@ -1,7 +1,8 @@
 import { readFile } from 'node:fs/promises'
-import { resolve } from 'node:path'
+
 import { z } from 'zod'
 import { defineTool } from '../defineTool.js'
+import { resolveWithinReal } from '../paths.js'
 import { atomicWriteFile } from './atomic-write-file.js'
 import { fingerprintContent, staleFileError } from './content-fingerprint.js'
 import { withFileMutationLock } from './file-mutation-lock.js'
@@ -193,14 +194,20 @@ export const EditTool = defineTool({
 			}
 		}
 
-		const filePath = resolve(context.workingDirectory, parsed.data.path)
+		// Host-side containment, on the host branch only. The sandbox has its
+		// own root and its own resolver; canonicalizing a sandbox-relative
+		// path against the HOST filesystem asks a question about the wrong
+		// machine, and answers it with whatever happens to exist there.
+		const filePath = context.sandbox
+			? undefined
+			: await resolveWithinReal(context.workingDirectory, parsed.data.path)
 		// Read-modify-write is not atomic on its own: two edits to the same
 		// path interleave their reads, and the second write lands on content
 		// the first had already replaced — so one edit vanishes and the loser
 		// reports "old_string not found", blaming the model for a race. The
 		// key spans both branches because sandbox and local are distinct
 		// files even when the path string matches.
-		const lockKey = `${context.sandbox ? 'sandbox' : 'local'}:${filePath}`
+		const lockKey = context.sandbox ? `sandbox:${parsed.data.path}` : `local:${filePath as string}`
 
 		return withFileMutationLock(lockKey, async () => {
 			if (context.sandbox) {
@@ -218,7 +225,8 @@ export const EditTool = defineTool({
 				}
 			}
 
-			const content = await readFile(filePath, 'utf-8')
+			const hostPath = filePath as string
+			const content = await readFile(hostPath, 'utf-8')
 
 			const result = applyEdit(content, normalized.operation)
 			if (!result.success) {
@@ -241,9 +249,9 @@ export const EditTool = defineTool({
 				// changed elsewhere in the file, and refusing there would
 				// reject safe edits every time anyone touched an unrelated
 				// line.
-				const seen = context.fileReadTracker?.fingerprint?.(filePath)
+				const seen = context.fileReadTracker?.fingerprint?.(hostPath)
 				if (seen !== undefined && seen !== fingerprintContent(content)) {
-					return { success: false as const, output: '', error: staleFileError(filePath) }
+					return { success: false as const, output: '', error: staleFileError(hostPath) }
 				}
 				return { success: false as const, output: '', error: result.error }
 			}
@@ -251,15 +259,15 @@ export const EditTool = defineTool({
 			// Temp file, fsync, rename — a reader sees the old body or the new
 			// one, never a half-written one. A plain `writeFile` that fails
 			// partway leaves the user's source truncated.
-			await atomicWriteFile(filePath, result.content)
+			await atomicWriteFile(hostPath, result.content)
 			// This runtime is now the last writer, so the next edit in the same
 			// turn compares against what we just wrote rather than the read
 			// before it.
-			context.fileReadTracker?.recordRead(filePath, result.content)
+			context.fileReadTracker?.recordRead(hostPath, result.content)
 			return {
 				success: true as const,
-				output: `Edited ${filePath}: ${result.replacements} replacement(s)`,
-				data: { path: filePath, replacements: result.replacements },
+				output: `Edited ${hostPath}: ${result.replacements} replacement(s)`,
+				data: { path: hostPath, replacements: result.replacements },
 			}
 		})
 	},

--- a/packages/sdk/src/tools/builtins/read-file.ts
+++ b/packages/sdk/src/tools/builtins/read-file.ts
@@ -1,7 +1,8 @@
 import { readFile } from 'node:fs/promises'
-import { extname, resolve } from 'node:path'
+import { extname } from 'node:path'
 import { z } from 'zod'
 import { defineTool } from '../defineTool.js'
+import { resolveWithinReal } from '../paths.js'
 
 const inputSchema = z.object({
 	path: z.string().describe('Path to the file to read (absolute or relative)'),
@@ -74,7 +75,7 @@ export const ReadFileTool = defineTool({
 			}
 		}
 
-		const filePath = resolve(context.workingDirectory, input.path)
+		const filePath = await resolveWithinReal(context.workingDirectory, input.path)
 		const buffer = await readFile(filePath)
 		const binaryGuidance = describeStructuredBinaryRead(filePath, buffer)
 		if (binaryGuidance) {

--- a/packages/sdk/src/tools/builtins/write-file.ts
+++ b/packages/sdk/src/tools/builtins/write-file.ts
@@ -1,8 +1,9 @@
 import { access, mkdir } from 'node:fs/promises'
-import { dirname, resolve } from 'node:path'
+import { dirname } from 'node:path'
 import { z } from 'zod'
 import type { ToolContext } from '../../types/tool/index.js'
 import { defineTool } from '../defineTool.js'
+import { resolveWithinReal } from '../paths.js'
 import { atomicWriteFile } from './atomic-write-file.js'
 import { withFileMutationLock } from './file-mutation-lock.js'
 
@@ -93,11 +94,17 @@ export const WriteFileTool = defineTool({
 		}
 		const valid = parsed.data
 		const content = valid.content ?? valid.newStr ?? ''
-		const filePath = resolve(context.workingDirectory, valid.path)
+		// Host-side containment, on the host branch only. The sandbox has its
+		// own root and its own resolver; canonicalizing a sandbox-relative
+		// path against the HOST filesystem asks a question about the wrong
+		// machine and answers it with whatever happens to exist there.
+		const filePath = context.sandbox
+			? undefined
+			: await resolveWithinReal(context.workingDirectory, valid.path)
 		// The exists-check and the write are a check-then-act pair. Unlocked,
 		// two writers both see "absent", both skip the read-before-overwrite
 		// guard, and the second silently discards the first.
-		const lockKey = `${context.sandbox ? 'sandbox' : 'local'}:${filePath}`
+		const lockKey = context.sandbox ? `sandbox:${valid.path}` : `local:${filePath as string}`
 
 		return withFileMutationLock(lockKey, async () => {
 			if (context.sandbox) {
@@ -115,23 +122,24 @@ export const WriteFileTool = defineTool({
 				}
 			}
 
-			const localExists = await pathExists(filePath)
+			const hostPath = filePath as string
+			const localExists = await pathExists(hostPath)
 			if (localExists) {
-				const guard = enforceReadBeforeOverwrite(context, filePath)
+				const guard = enforceReadBeforeOverwrite(context, hostPath)
 				if (guard) return guard
 			}
 
-			await mkdir(dirname(filePath), { recursive: true })
+			await mkdir(dirname(hostPath), { recursive: true })
 			// Temp file, fsync, rename. A plain write that fails partway
 			// leaves the destination truncated — and this tool overwrites a
 			// whole file, so the truncation is the user's previous work.
-			await atomicWriteFile(filePath, content)
-			context.fileReadTracker?.recordRead(filePath)
+			await atomicWriteFile(hostPath, content)
+			context.fileReadTracker?.recordRead(hostPath)
 
 			return {
 				success: true as const,
-				output: `File written successfully: ${filePath} (${content.length} chars)`,
-				data: { path: filePath, size: content.length },
+				output: `File written successfully: ${hostPath} (${content.length} chars)`,
+				data: { path: hostPath, size: content.length },
 			}
 		})
 	},
@@ -150,9 +158,9 @@ function enforceReadBeforeOverwrite(
 	}
 }
 
-async function pathExists(filePath: string): Promise<boolean> {
+async function pathExists(hostPath: string): Promise<boolean> {
 	try {
-		await access(filePath)
+		await access(hostPath)
 		return true
 	} catch {
 		return false

--- a/packages/sdk/src/tools/paths.ts
+++ b/packages/sdk/src/tools/paths.ts
@@ -1,4 +1,5 @@
-import { isAbsolute, relative, resolve } from 'node:path'
+import { realpath } from 'node:fs/promises'
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path'
 
 /**
  * Resolve a caller-supplied path against a root, refusing anything that
@@ -41,4 +42,85 @@ export function isWithin(root: string, candidate: string): boolean {
 	} catch {
 		return false
 	}
+}
+
+/**
+ * The same containment rule, decided after symlinks are resolved.
+ *
+ * {@link resolveWithin} is lexical, and a lexical check is not a boundary for
+ * a tool that then follows links. `./notes -> /etc` passes it, because
+ * `./notes/passwd` climbs nothing on paper; the write lands in `/etc`. That is
+ * CWE-59, *Improper Link Resolution Before File Access*, and the mitigation
+ * CWE-22 states for the family is the ordering this function exists to get
+ * right: canonicalize first, validate the canonical form, never the input.
+ *
+ * `atomicWriteFile` makes the ordering load-bearing rather than theoretical.
+ * It resolves the destination and writes THROUGH a link on purpose — so that
+ * editing a linked file updates the target instead of replacing the link with
+ * a regular file — which is correct behaviour and, paired with a lexical
+ * check, is check-then-follow.
+ *
+ * Three things this has to get right that a single `realpath` does not:
+ *
+ * 1. **The root can itself be a symlink.** `os.tmpdir()` is one on macOS
+ *    (`/var/folders/…` under `/private`). Canonicalizing only the candidate
+ *    and comparing against a raw root rejects every path in a temp directory —
+ *    a containment check that refuses everything is not safer, it is broken,
+ *    and it fails in exactly the environment tests run in.
+ * 2. **The target may not exist.** `write` creates files, and `realpath` on a
+ *    missing path throws. So this canonicalizes the deepest ancestor that DOES
+ *    exist and appends the rest lexically. The remainder cannot hide a link,
+ *    because nothing is there to be one.
+ * 3. **The lexical check still runs first.** It costs nothing, refuses the
+ *    common `../../..` before touching the filesystem, and its message names
+ *    the offending input — which the canonical comparison, working on two
+ *    absolute paths, cannot.
+ *
+ * What this does NOT give you is TOCTOU safety. A component swapped for a
+ * symlink between this check and the open would still be followed; closing
+ * that needs per-component `openat`/`O_NOFOLLOW`, which Node does not expose.
+ * The threat here is a link that is already there — a repository that contains
+ * one, or one an earlier tool call created — not an attacker racing the
+ * process on the user's own machine.
+ */
+export async function resolveWithinReal(
+	root: string,
+	candidate: string | undefined,
+): Promise<string> {
+	// Cheap, and the only step that can name the caller's input in its error.
+	const lexical = resolveWithin(root, candidate)
+
+	const realRoot = await realpath(root).catch(() => resolve(root))
+
+	// Walk up to the deepest existing ancestor. Terminates at the filesystem
+	// root, where `dirname` becomes a fixed point.
+	let existing = lexical
+	let remainder = ''
+	for (;;) {
+		const found = await realpath(existing).then(
+			(value) => value,
+			() => undefined,
+		)
+		if (found !== undefined) {
+			existing = found
+			break
+		}
+		const parent = dirname(existing)
+		if (parent === existing) {
+			// Nothing on this branch exists at all, so there is no link to
+			// follow and the lexical answer is already the canonical one.
+			return lexical
+		}
+		remainder = remainder ? join(basename(existing), remainder) : basename(existing)
+		existing = parent
+	}
+
+	const rel = relative(realRoot, existing)
+	if (rel.startsWith('..') || isAbsolute(rel)) {
+		throw new Error(
+			`Path escapes the working directory: ${candidate}. It resolves through a link to ${existing}, outside ${realRoot}.`,
+		)
+	}
+
+	return remainder ? join(existing, remainder) : existing
 }


### PR DESCRIPTION
fix(sdk)!: contain read, write and edit to the working directory

All three called `resolve(workingDirectory, input.path)` bare, so
`path: "../../.."` reached whatever sits above the working directory and
the tool used it. This needed no sandbox and no misconfiguration — it
holds with no sandbox at all, which is the common case. `resolveWithin`
existed the whole time and its own docstring says the filesystem tools
never reached it; the fix had gone to the tools that enumerate and not to
the three that read and mutate.

A lexical check alone would not have closed it. `atomicWriteFile` resolves
its destination and writes THROUGH a symlink deliberately, so that editing
a linked file updates the target rather than swapping the link for a
regular file. That behaviour is correct and it is what makes the ordering
load-bearing: a link inside the working directory pointing outside it
climbs nothing on paper, so a lexical check passes and the write lands
outside anyway. CWE-59, and the ordering here is the mitigation CWE-22
states for the family — canonicalize, then validate the canonical form,
never the input.

Two details decide whether the resolver is usable rather than merely
strict:

The root can itself be a symlink. `os.tmpdir()` is one on macOS.
Canonicalizing the candidate and comparing against a raw root refuses
every path under a temp directory — a containment check that refuses
everything is not a stricter one, it is broken, and it breaks in exactly
the environment the tests run in.

The target may not exist. `write` creates files and `realpath` throws on a
missing path, so the deepest existing ancestor is canonicalized and the
remainder appended lexically. The remainder cannot hide a link because
nothing is there to be one.

This does not claim TOCTOU safety, and says so where the function is
defined. A component swapped between the check and the open is still
followed; closing that needs per-component `openat`/`O_NOFOLLOW`, which
Node does not expose. The threat addressed is a link already present.

Host resolution runs on the host branch only. The first wiring computed it
above the sandbox branch, which canonicalized a sandbox-relative path
against the host filesystem — a question about the wrong machine. The
existing sandbox tests caught it.

The four symlink cases are skipped where the platform refuses symlink
creation, via a capability probe rather than a swallowed error per test:
the first version returned early on failure, so on Windows three tests
reported passed having exercised nothing.

BREAKING CHANGE: `read`, `write` and `edit` refuse paths outside
`workingDirectory`. A host that relied on reaching a config beside the
repository or writing to a sibling output directory should point
`workingDirectory` at a root containing everything the run legitimately
needs. Sandboxed runs are unaffected.
