### PR TITLE
feat(anthropic)!: resolve thinking per model, send effort, report thinking tokens

### DIFF
--- a/.changeset/brave-melons-think.md
+++ b/.changeset/brave-melons-think.md
@@ -1,0 +1,56 @@
+---
+'@namzu/sdk': major
+'@namzu/anthropic': major
+---
+
+Thinking is now resolved per model, `effort` is sendable, and thinking tokens
+are reported.
+
+**Thinking on a current model was a failed request, not a degraded one.** The
+driver mapped `type: 'enabled'` straight to the wire and everything else to
+`disabled`. The vendor rejects a mismatched mode with a 400 rather than
+falling back: `thinking.type.enabled` is refused from Claude 4.7 onward,
+`adaptive` is refused on 4.5 and earlier, and the always-on models refuse
+`disabled`. One body for every model does not compromise quality, it fails.
+
+`ThinkingConfig.type` gains `'adaptive'`, and the Anthropic driver resolves the
+declared intent against the model it is about to call — sending the mode that
+model accepts, dropping a budget where budgets have no meaning, and omitting
+the field entirely rather than asking an always-on model to stop thinking. An
+unrecognised model is treated as manual-only, which is the previous behaviour
+and keeps a gateway serving an older model working.
+
+**`ThinkingConfig.display` is narrowed to `'summarized' | 'omitted'`**, and now
+actually reaches the wire. It was `'full' | 'summarized'`: `'full'` is not a
+value any vendor accepts — a declared option that could only ever have been
+rejected — and `'omitted'` was missing. It also was not serialized at all,
+which matters more than it sounds: `display` defaults to `'omitted'` on newer
+models, so a caller wanting to show reasoning received thinking blocks with
+empty text and nothing to explain why.
+
+**`effort` is new on `ChatCompletionParams`** — `'low' | 'medium' | 'high' |
+'xhigh' | 'max'`. It goes out as `output_config.effort`, a *sibling* of
+`thinking` rather than a field inside it, because it shapes the whole response
+and one manual-mode model accepts it alongside a token budget; nesting it would
+have made that combination unsayable. It is dropped on models that do not
+accept it, and refused in the one combination the vendor rejects — thinking
+disabled at `xhigh`/`max`.
+
+**`TokenUsage.reasoningTokens`** carries `output_tokens_details.thinking_tokens`
+when the vendor reports it. It is a *subset* of `completionTokens`, not an
+addition — reasoning is billed as output, so summing it into a total would
+double-count. Absent means not reported, never zero: coercing would claim every
+turn on every silent driver did no thinking, and streamed events carry the
+breakdown only on the final delta.
+
+**Migration.** `display: 'full'` no longer compiles — use `'summarized'`, which
+is what it meant. Code passing `thinking: { type: 'enabled', budgetTokens }`
+keeps working and is now translated per model instead of rejected by newer
+ones. `assertThinkingSupported` in `@namzu/openai` refuses `'adaptive'` as it
+already refused `'enabled'`, since that driver implements neither.
+
+Not changed: a report accompanying this work claimed `temperature`, `top_p` and
+`top_k` are rejected on 5-series models and should be dropped by the driver.
+The Messages reference, the extended-thinking page and the thinking
+troubleshooting page document no such restriction, so nothing was implemented —
+silently dropping sampling parameters that would have worked is its own defect.

--- a/.github/scripts/public-surface-baseline.json
+++ b/.github/scripts/public-surface-baseline.json
@@ -1132,6 +1132,7 @@
     "ReactiveAgentResult",
     "ReadFileTool",
     "ReasoningBlock",
+    "ReasoningEffort",
     "RegisterLazyOptions",
     "RegisterOptions",
     "RegisterSharedRunPlanInput",

--- a/packages/providers/anthropic/src/__tests__/thinking-capability.test.ts
+++ b/packages/providers/anthropic/src/__tests__/thinking-capability.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	resolveEffort,
+	resolveThinkingBody,
+	resolveThinkingCapability,
+} from '../thinking-capability.js'
+
+/**
+ * The driver mapped `enabled` straight through and everything else to
+ * `disabled`. On a current model that is not a degraded request, it is a
+ * failed one: `thinking.type.enabled` is rejected with a 400 from 4.7 onward,
+ * `adaptive` is rejected on 4.5 and earlier, and the always-on models reject
+ * `disabled`.
+ *
+ * The table below is transcribed from the vendor's per-model reference, one
+ * case per row, because that table IS the specification — a summary of it in
+ * prose would be the thing that drifts.
+ */
+
+/** [model, adaptive, manual, canDisable, effort] */
+const TABLE: readonly [string, boolean, boolean, boolean, boolean][] = [
+	['claude-fable-5', true, false, false, true],
+	['claude-mythos-5', true, false, false, true],
+	['claude-mythos-preview', true, true, false, true],
+	['claude-opus-5', true, false, true, true],
+	['claude-opus-4-8', true, false, true, true],
+	['claude-opus-4-7', true, false, true, true],
+	['claude-sonnet-5', true, false, true, true],
+	['claude-opus-4-6', true, true, true, true],
+	['claude-sonnet-4-6', true, true, true, true],
+	['claude-opus-4-5', false, true, true, true],
+	['claude-haiku-4-5', false, true, true, false],
+	['claude-sonnet-4-5', false, true, true, false],
+	['claude-opus-4-1', false, true, true, false],
+]
+
+describe('what each model accepts', () => {
+	for (const [model, adaptive, manual, canDisable, effort] of TABLE) {
+		it(`resolves ${model}`, () => {
+			expect(resolveThinkingCapability(model)).toEqual({ adaptive, manual, canDisable, effort })
+		})
+	}
+
+	it('tolerates a vendor prefix and a date suffix', () => {
+		expect(resolveThinkingCapability('anthropic/claude-sonnet-5')).toMatchObject({
+			adaptive: true,
+			manual: false,
+		})
+		expect(resolveThinkingCapability('claude-sonnet-4-5-20250929')).toMatchObject({
+			adaptive: false,
+			manual: true,
+		})
+	})
+
+	it('treats an unrecognised model as manual-only', () => {
+		// The pre-existing behaviour, and the safe answer for a name this
+		// table has not seen: an older model behind a gateway keeps working,
+		// and a newer one fails with the vendor's own clear 400 rather than
+		// with a request this driver quietly rewrote.
+		expect(resolveThinkingCapability('some-gateway/mystery-model')).toEqual({
+			adaptive: false,
+			manual: true,
+			canDisable: true,
+			effort: false,
+		})
+	})
+})
+
+describe('turning an intent into a body this model accepts', () => {
+	const adaptiveOnly = resolveThinkingCapability('claude-sonnet-5')
+	const manualOnly = resolveThinkingCapability('claude-sonnet-4-5')
+	const alwaysOn = resolveThinkingCapability('claude-fable-5')
+
+	it('sends adaptive to an adaptive model', () => {
+		expect(resolveThinkingBody({ type: 'adaptive' }, adaptiveOnly)).toEqual({ type: 'adaptive' })
+	})
+
+	it('rewrites a manual intent to adaptive where manual is rejected', () => {
+		// The caller asked to think. This model's way of thinking is adaptive,
+		// and the budget has no meaning there, so it goes.
+		expect(resolveThinkingBody({ type: 'enabled', budgetTokens: 10_000 }, adaptiveOnly)).toEqual({
+			type: 'adaptive',
+		})
+	})
+
+	it('rewrites an adaptive intent to manual where adaptive is rejected', () => {
+		expect(resolveThinkingBody({ type: 'adaptive' }, manualOnly)).toEqual({ type: 'enabled' })
+	})
+
+	it('keeps the budget on a model that has budgets', () => {
+		expect(resolveThinkingBody({ type: 'enabled', budgetTokens: 10_000 }, manualOnly)).toEqual({
+			type: 'enabled',
+			budget_tokens: 10_000,
+		})
+	})
+
+	it('carries display through, which is the whole reason thinking text arrives', () => {
+		// It defaults to `omitted` on newer models, so a caller who wants to
+		// show reasoning and never serializes this gets empty blocks.
+		expect(resolveThinkingBody({ type: 'adaptive', display: 'summarized' }, adaptiveOnly)).toEqual({
+			type: 'adaptive',
+			display: 'summarized',
+		})
+	})
+
+	it('omits the field entirely when a model cannot be told to stop thinking', () => {
+		// Not an error: failing here teaches nothing the vendor 400 would not,
+		// and it breaks a caller whose config spans models. No field means the
+		// model's documented default, which is the closest honest reading.
+		expect(resolveThinkingBody({ type: 'disabled' }, alwaysOn)).toBeUndefined()
+	})
+
+	it('honours disable where it is accepted', () => {
+		expect(resolveThinkingBody({ type: 'disabled' }, adaptiveOnly)).toEqual({ type: 'disabled' })
+	})
+
+	it('sends nothing when the caller asked for nothing', () => {
+		expect(resolveThinkingBody(undefined, adaptiveOnly)).toBeUndefined()
+	})
+})
+
+describe('when effort rides along', () => {
+	const adaptiveOnly = resolveThinkingCapability('claude-sonnet-5')
+	const noEffort = resolveThinkingCapability('claude-sonnet-4-5')
+
+	it('passes effort to a model that takes it', () => {
+		expect(resolveEffort('high', { type: 'adaptive' }, adaptiveOnly)).toBe('high')
+	})
+
+	it('drops effort on a model that does not', () => {
+		expect(resolveEffort('high', { type: 'enabled' }, noEffort)).toBeUndefined()
+	})
+
+	it('keeps effort on the one manual model that accepts it', () => {
+		// Opus 4.5: effort shapes the answer, the budget sets thinking depth,
+		// and both are meant to be set. So effort is not adaptive-only and
+		// must not be gated on the mode.
+		const opus45 = resolveThinkingCapability('claude-opus-4-5')
+		expect(resolveEffort('high', { type: 'enabled', budget_tokens: 8000 }, opus45)).toBe('high')
+	})
+
+	it('refuses the combination the vendor rejects', () => {
+		// Thinking off at effort xhigh/max is a 400 on Opus 5 and later, and
+		// is incoherent anyway: do not think, and think as hard as possible.
+		expect(resolveEffort('xhigh', { type: 'disabled' }, adaptiveOnly)).toBeUndefined()
+		expect(resolveEffort('max', { type: 'disabled' }, adaptiveOnly)).toBeUndefined()
+		expect(resolveEffort('high', { type: 'disabled' }, adaptiveOnly)).toBe('high')
+	})
+})

--- a/packages/providers/anthropic/src/__tests__/thinking-request-body.test.ts
+++ b/packages/providers/anthropic/src/__tests__/thinking-request-body.test.ts
@@ -1,0 +1,111 @@
+import type { ChatCompletionParams } from '@namzu/sdk'
+import { describe, expect, it, vi } from 'vitest'
+
+import { AnthropicProvider } from '../client.js'
+
+/**
+ * The resolver's own tests pass whether or not the client calls it. These
+ * drive the real `chatStream` and read the body that would have gone on the
+ * wire, because "declared, typed, exported, and never sent" is precisely the
+ * defect being fixed here — `display` had been on `ThinkingConfig` all along
+ * and the request builder dropped it.
+ */
+
+async function bodyFor(params: Partial<ChatCompletionParams>): Promise<Record<string, unknown>> {
+	const seen: { body?: Record<string, unknown> } = {}
+	const provider = new AnthropicProvider({ apiKey: 'test-key' })
+	;(provider as unknown as { client: { messages: { create: unknown } } }).client = {
+		messages: {
+			create: vi.fn(async (body: Record<string, unknown>) => {
+				seen.body = body
+				return (async function* () {
+					yield { type: 'message_start', message: { id: 'msg_1' } }
+				})()
+			}),
+		},
+	}
+	for await (const _chunk of provider.chatStream({
+		model: 'claude-sonnet-5',
+		messages: [{ role: 'user', content: 'hi' }],
+		...params,
+	} as ChatCompletionParams)) {
+		// drain
+	}
+	return seen.body ?? {}
+}
+
+describe('the thinking configuration that reaches the wire', () => {
+	it('sends adaptive to a model that only accepts adaptive', async () => {
+		const body = await bodyFor({ model: 'claude-sonnet-5', thinking: { type: 'adaptive' } })
+
+		expect(body.thinking).toEqual({ type: 'adaptive' })
+	})
+
+	it('does not send a manual budget to a model that rejects manual mode', async () => {
+		// This is the failure being fixed: the old builder passed `enabled`
+		// straight through, and the vendor answers that with a 400.
+		const body = await bodyFor({
+			model: 'claude-sonnet-5',
+			thinking: { type: 'enabled', budgetTokens: 10_000 },
+		})
+
+		expect(body.thinking).toEqual({ type: 'adaptive' })
+		expect(JSON.stringify(body)).not.toContain('budget_tokens')
+	})
+
+	it('still sends a manual budget to a manual model', async () => {
+		const body = await bodyFor({
+			model: 'claude-sonnet-4-5',
+			thinking: { type: 'enabled', budgetTokens: 10_000 },
+		})
+
+		expect(body.thinking).toEqual({ type: 'enabled', budget_tokens: 10_000 })
+	})
+
+	it('serializes display, without which the thinking text comes back empty', async () => {
+		const body = await bodyFor({
+			model: 'claude-sonnet-5',
+			thinking: { type: 'adaptive', display: 'summarized' },
+		})
+
+		expect(body.thinking).toEqual({ type: 'adaptive', display: 'summarized' })
+	})
+
+	it('sends effort beside thinking, not inside it', async () => {
+		const body = await bodyFor({
+			model: 'claude-sonnet-5',
+			thinking: { type: 'adaptive' },
+			effort: 'xhigh',
+		})
+
+		expect(body.output_config).toEqual({ effort: 'xhigh' })
+		expect(body.thinking).toEqual({ type: 'adaptive' })
+	})
+
+	it('sends effort even with no thinking configuration at all', async () => {
+		// Effort shapes the whole response, so it is not conditional on a
+		// thinking block being present.
+		const body = await bodyFor({ model: 'claude-sonnet-5', effort: 'low' })
+
+		expect(body.output_config).toEqual({ effort: 'low' })
+	})
+
+	it('drops effort on a model that does not accept it', async () => {
+		const body = await bodyFor({ model: 'claude-sonnet-4-5', effort: 'high' })
+
+		expect(body.output_config).toBeUndefined()
+	})
+
+	it('omits thinking entirely on a model that cannot be told to stop', async () => {
+		const body = await bodyFor({ model: 'claude-fable-5', thinking: { type: 'disabled' } })
+
+		expect(body.thinking).toBeUndefined()
+	})
+
+	it('sends no thinking field when the caller configured none', async () => {
+		const body = await bodyFor({ model: 'claude-sonnet-5' })
+
+		expect(body.thinking).toBeUndefined()
+		expect(body.output_config).toBeUndefined()
+	})
+})

--- a/packages/providers/anthropic/src/client.ts
+++ b/packages/providers/anthropic/src/client.ts
@@ -20,6 +20,11 @@ import {
 	providerVendorError,
 	toolResultToText,
 } from '@namzu/sdk'
+import {
+	resolveEffort,
+	resolveThinkingBody,
+	resolveThinkingCapability,
+} from './thinking-capability.js'
 import type { AnthropicConfig } from './types.js'
 
 // Floor for `max_tokens` when neither the request nor the provider
@@ -451,6 +456,15 @@ interface RawAnthropicUsage {
 	output_tokens?: number
 	cache_read_input_tokens?: number | null
 	cache_creation_input_tokens?: number | null
+	/**
+	 * Reasoning share of the output, when the vendor reports it.
+	 *
+	 * Counted INSIDE `output_tokens`, so it is carried as a breakdown rather
+	 * than added to the total. When streaming, this arrives only on the final
+	 * `message_delta` — earlier events carry no breakdown at all, which is why
+	 * an absent value has to mean "not reported" and not "zero".
+	 */
+	output_tokens_details?: { thinking_tokens?: number } | null
 }
 
 function emptyUsage(): TokenUsage {
@@ -467,12 +481,17 @@ function parseUsage(raw?: RawAnthropicUsage): TokenUsage {
 	if (!raw) return emptyUsage()
 	const input = raw.input_tokens ?? 0
 	const output = raw.output_tokens ?? 0
+	const thinking = raw.output_tokens_details?.thinking_tokens
 	return {
 		promptTokens: input,
 		completionTokens: output,
 		totalTokens: input + output,
 		cachedTokens: raw.cache_read_input_tokens ?? 0,
 		cacheWriteTokens: raw.cache_creation_input_tokens ?? 0,
+		// Only when reported. Defaulting to 0 would say "this turn did no
+		// thinking" about every turn on every driver that stays silent, and
+		// about every streamed event before the last one.
+		...(thinking !== undefined ? { reasoningTokens: thinking } : {}),
 	}
 }
 
@@ -686,20 +705,25 @@ export class AnthropicProvider implements LLMProvider {
 		// otherwise) — this also drops a parallelToolCalls-derived choice on
 		// tool-less requests.
 		if (tools && toolChoice) body.tool_choice = toolChoice
-		if (params.thinking) {
-			// Thinking could not be REQUESTED at all before this: on a model
-			// where it is off by default the feature was unreachable, and on
-			// one where it is on by default its budget could not be tuned.
-			body.thinking =
-				params.thinking.type === 'enabled'
-					? {
-							type: 'enabled',
-							...(params.thinking.budgetTokens !== undefined
-								? { budget_tokens: params.thinking.budgetTokens }
-								: {}),
-						}
-					: { type: 'disabled' }
-		}
+		// Resolved against the model rather than sent verbatim. This used to
+		// map `enabled` straight through and everything else to `disabled`,
+		// which fails outright on current models: `thinking.type.enabled` is
+		// rejected with a 400 from 4.7 onward, `adaptive` is rejected on 4.5
+		// and earlier, and the always-on models reject `disabled`. One body
+		// for every model is not a compromise here, it is a failed request.
+		//
+		// `display` is carried through now too. It defaults to `omitted` on
+		// newer models, so a caller who wanted to show reasoning and never
+		// serialized the field received thinking blocks with empty text and
+		// nothing to explain why.
+		const capability = resolveThinkingCapability(params.model)
+		const thinkingBody = resolveThinkingBody(params.thinking, capability)
+		if (thinkingBody) body.thinking = thinkingBody
+
+		// A sibling of `thinking`, not a field inside it — and gated on the
+		// model, since only some accept it at all.
+		const effort = resolveEffort(params.effort, thinkingBody, capability)
+		if (effort) body.output_config = { effort }
 		if (params.temperature !== undefined) body.temperature = params.temperature
 		if (params.topP !== undefined) body.top_p = params.topP
 		if (params.topK !== undefined) body.top_k = params.topK

--- a/packages/providers/anthropic/src/thinking-capability.ts
+++ b/packages/providers/anthropic/src/thinking-capability.ts
@@ -1,0 +1,177 @@
+import type { ReasoningEffort, ThinkingConfig } from '@namzu/sdk'
+
+/**
+ * What a given model will actually accept for thinking.
+ *
+ * This exists because the vendor **rejects** a mismatched mode rather than
+ * degrading it. A request carrying `thinking: {type: "enabled"}` to a current
+ * model comes back 400 with `"thinking.type.enabled" is not supported for this
+ * model`; the same request with `"adaptive"` to an older one comes back
+ * `adaptive thinking is not supported on this model`. So sending one body to
+ * every model is not a compatibility compromise, it is a failed request — and
+ * the SDK's `ThinkingConfig` is deliberately a statement of *intent* that each
+ * driver resolves against the model it is about to call.
+ *
+ * The split, from the vendor's per-model table:
+ *
+ * - **Adaptive only** — Fable 5, Mythos 5, Opus 5, Sonnet 5, Opus 4.8, Opus
+ *   4.7. These reject `enabled`. Fable 5 and Mythos 5 additionally reject
+ *   `disabled` because they cannot stop thinking at all.
+ * - **Both** — Opus 4.6, Sonnet 4.6 (manual mode deprecated but working), and
+ *   Mythos Preview (which rejects `disabled`).
+ * - **Manual only** — Opus 4.5, Sonnet 4.5, Haiku 4.5, Opus 4.1. These reject
+ *   `adaptive`.
+ *
+ * Unknown models are treated as manual-only, which is the pre-existing
+ * behaviour and therefore the safe answer for a name this table has not seen:
+ * a third-party gateway serving an older model keeps working, and the failure
+ * mode for a newer one is a clear vendor 400 rather than a silently altered
+ * request.
+ */
+export interface ThinkingCapability {
+	readonly adaptive: boolean
+	readonly manual: boolean
+	/** False on models that cannot turn thinking off. */
+	readonly canDisable: boolean
+	readonly effort: boolean
+}
+
+const MANUAL_ONLY: ThinkingCapability = {
+	adaptive: false,
+	manual: true,
+	canDisable: true,
+	effort: false,
+}
+
+/**
+ * Parse `claude-<family>-<major>[.<minor>]`, tolerating a vendor prefix and a
+ * date suffix.
+ *
+ * Deliberately the same shape the driver's `shouldUseStrictToolInputs` already
+ * parses. A second, subtly different model matcher in the same file is how two
+ * capability decisions drift apart on the same model name.
+ */
+function parseModel(model: string): { family: string; major: number; minor: number } | undefined {
+	const normalized = model.toLowerCase()
+	const match = normalized.match(
+		/^(?:anthropic\/)?claude-(haiku|sonnet|opus|fable|mythos)-(\d+)(?:[-_.](\d+))?(?:-\d{8})?$/,
+	)
+	if (!match) return undefined
+	return {
+		family: match[1] as string,
+		major: Number(match[2]),
+		minor: Number(match[3] ?? 0),
+	}
+}
+
+export function resolveThinkingCapability(model: string): ThinkingCapability {
+	const normalized = model.toLowerCase()
+
+	// Named rather than versioned: the preview carries no version number the
+	// parser can compare, and it is the one model supporting both modes while
+	// refusing to be switched off.
+	if (/^(?:anthropic\/)?claude-mythos-preview$/.test(normalized)) {
+		return { adaptive: true, manual: true, canDisable: false, effort: true }
+	}
+
+	const parsed = parseModel(model)
+	if (!parsed) return MANUAL_ONLY
+
+	const { family, major, minor } = parsed
+
+	// Always-on families: thinking cannot be disabled at any version.
+	if (family === 'fable' || family === 'mythos') {
+		return { adaptive: true, manual: false, canDisable: false, effort: true }
+	}
+
+	// 4.7 and later dropped manual mode outright.
+	if (major > 4 || (major === 4 && minor >= 7)) {
+		return { adaptive: true, manual: false, canDisable: true, effort: true }
+	}
+
+	// 4.6 accepts both; manual is deprecated there but still functional.
+	if (major === 4 && minor === 6) {
+		return { adaptive: true, manual: true, canDisable: true, effort: true }
+	}
+
+	// 4.5 and earlier are manual-only. Opus 4.5 is the one that also takes
+	// effort, where effort shapes the answer and the budget sets depth.
+	const isOpus45 = family === 'opus' && major === 4 && minor === 5
+	return { ...MANUAL_ONLY, effort: isOpus45 }
+}
+
+/** The `thinking` body value, or `undefined` to send no thinking field. */
+export type ResolvedThinkingBody =
+	| { type: 'adaptive'; display?: 'summarized' | 'omitted' }
+	| { type: 'enabled'; budget_tokens?: number; display?: 'summarized' | 'omitted' }
+	| { type: 'disabled' }
+	| undefined
+
+/**
+ * Turn a declared intent into a body this model accepts, or into nothing.
+ *
+ * Omission is a real answer and the reason this returns `undefined` rather
+ * than throwing. A caller asking to disable thinking on a model that cannot
+ * disable it has asked for something impossible — but failing the request
+ * teaches nothing the vendor's own 400 would not, and it breaks a caller whose
+ * config is shared across models. Sending no `thinking` field leaves the model
+ * on its documented default, which is the closest honest reading of "I did not
+ * want to spend on this".
+ *
+ * The same holds in reverse: an `enabled` intent on an adaptive-only model
+ * becomes `adaptive`, because the caller asked for thinking and this model's
+ * way of thinking is adaptive. The budget is dropped with it — it has no
+ * meaning there, and `effort` is the depth control instead.
+ */
+export function resolveThinkingBody(
+	thinking: ThinkingConfig | undefined,
+	capability: ThinkingCapability,
+): ResolvedThinkingBody {
+	if (!thinking) return undefined
+
+	const display = thinking.display ? { display: thinking.display } : {}
+
+	if (thinking.type === 'disabled') {
+		return capability.canDisable ? { type: 'disabled' } : undefined
+	}
+
+	if (thinking.type === 'adaptive') {
+		if (capability.adaptive) return { type: 'adaptive', ...display }
+		// Manual-only model: honour the intent to think, with the one mode it
+		// has. No budget was given, so the vendor default applies.
+		return capability.manual ? { type: 'enabled', ...display } : undefined
+	}
+
+	// 'enabled'
+	if (capability.manual) {
+		return {
+			type: 'enabled',
+			...(thinking.budgetTokens !== undefined ? { budget_tokens: thinking.budgetTokens } : {}),
+			...display,
+		}
+	}
+	return capability.adaptive ? { type: 'adaptive', ...display } : undefined
+}
+
+/**
+ * Whether `effort` may ride on this request.
+ *
+ * One interaction the table alone does not cover: on Opus 5 and later,
+ * `thinking: {type: "disabled"}` is accepted at effort `high` or below and
+ * **rejected at `xhigh`/`max`**, enforced per request. Rather than encode
+ * "Opus 5 and later" as a second version comparison, this refuses the
+ * combination on every model that can disable thinking — the pairing is
+ * incoherent anyway, since it asks a model not to think and then to think as
+ * hard as possible.
+ */
+export function resolveEffort(
+	effort: ReasoningEffort | undefined,
+	thinkingBody: ResolvedThinkingBody,
+	capability: ThinkingCapability,
+): ReasoningEffort | undefined {
+	if (effort === undefined || !capability.effort) return undefined
+	if (thinkingBody?.type === 'disabled' && (effort === 'xhigh' || effort === 'max')) {
+		return undefined
+	}
+	return effort
+}

--- a/packages/providers/openai/src/client.ts
+++ b/packages/providers/openai/src/client.ts
@@ -102,9 +102,13 @@ function formatToolChoice(tc: ToolChoice | undefined): ChatCompletionToolChoiceO
  * a no-op, because that is the state the driver is already in.
  */
 export function assertThinkingSupported(params: {
-	thinking?: { type: 'enabled' | 'disabled' }
+	thinking?: { type: 'adaptive' | 'enabled' | 'disabled' }
 }): void {
-	if (params.thinking?.type !== 'enabled') return
+	// `adaptive` refuses for the same reason `enabled` does. It is a request
+	// to think, and this driver would answer it with an ordinary completion
+	// and an empty reasoning list — a silence that reads as "the model did
+	// not reason" rather than "this driver cannot ask it to".
+	if (params.thinking?.type !== 'enabled' && params.thinking?.type !== 'adaptive') return
 	throw new Error(
 		'This provider driver does not implement extended thinking, and silently ' +
 			'ignoring the request would return an ordinary completion with an empty ' +

--- a/packages/sdk/src/types/common/index.ts
+++ b/packages/sdk/src/types/common/index.ts
@@ -10,6 +10,19 @@ export interface TokenUsage {
 	totalTokens: number
 	cachedTokens: number
 	cacheWriteTokens: number
+
+	/**
+	 * Output tokens the model spent on internal reasoning.
+	 *
+	 * A SUBSET of `completionTokens`, not an addition to it — reasoning is
+	 * billed as output, so adding these to a total would double-count. Present
+	 * so a caller can see what share of a turn went to thinking, which is the
+	 * question budgeting and cost attribution actually ask.
+	 *
+	 * Optional because most drivers do not report it. Absent means unknown,
+	 * not zero.
+	 */
+	reasoningTokens?: number
 }
 
 export function accumulateTokenUsage(current: TokenUsage, addition: TokenUsage): TokenUsage {
@@ -19,6 +32,13 @@ export function accumulateTokenUsage(current: TokenUsage, addition: TokenUsage):
 		totalTokens: current.totalTokens + addition.totalTokens,
 		cachedTokens: current.cachedTokens + addition.cachedTokens,
 		cacheWriteTokens: current.cacheWriteTokens + addition.cacheWriteTokens,
+		// Summed only when at least one side reported it. Coercing absent to
+		// zero would turn 'this driver does not tell us' into 'it spent none',
+		// and a run mixing a reporting driver with a silent one would read as
+		// though the silent turns did no thinking.
+		...(current.reasoningTokens !== undefined || addition.reasoningTokens !== undefined
+			? { reasoningTokens: (current.reasoningTokens ?? 0) + (addition.reasoningTokens ?? 0) }
+			: {}),
 	}
 }
 

--- a/packages/sdk/src/types/provider/chat.ts
+++ b/packages/sdk/src/types/provider/chat.ts
@@ -76,18 +76,74 @@ export interface ChatCompletionParams {
 	 * Drivers that do not support it ignore the field.
 	 */
 	thinking?: ThinkingConfig
+
+	/**
+	 * How much work to put into the response. See {@link ReasoningEffort}.
+	 *
+	 * Drivers that do not support it ignore the field.
+	 */
+	effort?: ReasoningEffort
 }
 
 export interface ThinkingConfig {
-	type: 'enabled' | 'disabled'
-	/** Token allowance for the thinking pass. */
-	budgetTokens?: number
 	/**
-	 * Whether the provider should return full thinking text or a summary.
-	 * Purely a request hint; the runtime stores whatever comes back.
+	 * Which thinking mode to ask for.
+	 *
+	 * `'adaptive'` lets the model decide whether and how deeply to think per
+	 * request; depth is steered by {@link ChatCompletionParams.effort} rather
+	 * than a token budget. `'enabled'` is the older manual mode, where
+	 * {@link budgetTokens} fixes the depth and the model thinks on every
+	 * request.
+	 *
+	 * **These are not interchangeable, and a driver must not guess.** Vendors
+	 * reject the wrong one for a given model outright rather than degrading:
+	 * newer models refuse `'enabled'`, older ones refuse `'adaptive'`, and
+	 * some refuse `'disabled'` because they cannot stop thinking at all. A
+	 * driver that sends a mode the model does not accept produces a failed
+	 * request, not a worse answer — which is why this is a declared intent
+	 * that each driver resolves against the model it is about to call.
 	 */
-	display?: 'full' | 'summarized'
+	type: 'adaptive' | 'enabled' | 'disabled'
+
+	/**
+	 * Token allowance for the thinking pass. Manual mode only — the adaptive
+	 * mode has no budget, and depth is set by `effort`.
+	 */
+	budgetTokens?: number
+
+	/**
+	 * Whether the thinking text comes back or only its signature.
+	 *
+	 * `'omitted'` returns the blocks with an empty body and a signature, which
+	 * is enough to replay them on the next turn (see `replayReasoning`) while
+	 * keeping the text out of the response. `'summarized'` returns a summary
+	 * of the reasoning.
+	 *
+	 * Worth setting explicitly. This defaults to `'omitted'` on newer models,
+	 * so a caller that wants to show reasoning and does not ask for it gets
+	 * thinking blocks whose text is empty and no indication why.
+	 *
+	 * The values were `'full' | 'summarized'` here, and `'full'` was never a
+	 * value any vendor accepted — a declared option that could only ever have
+	 * been rejected, next to a real one that was missing.
+	 */
+	display?: 'summarized' | 'omitted'
 }
+
+/**
+ * How much work the model should put into a response.
+ *
+ * A sibling of {@link ChatCompletionParams.thinking}, not a field inside it,
+ * because it is not exclusively a thinking control: it shapes the whole
+ * response, and at least one manual-mode model accepts it alongside a token
+ * budget, where effort shapes the answer and the budget sets thinking depth.
+ * Nesting it under `thinking` would have made that combination unsayable.
+ *
+ * In adaptive mode it is the primary depth lever — low effort may skip
+ * thinking entirely on easy input. In manual mode `budgetTokens` sets depth
+ * and effort does not move it.
+ */
+export type ReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max'
 
 export interface ChatCompletionResponse {
 	id: string

--- a/packages/sdk/src/types/provider/index.ts
+++ b/packages/sdk/src/types/provider/index.ts
@@ -4,6 +4,7 @@ export type {
 	CacheControl,
 	ChatCompletionParams,
 	ChatCompletionResponse,
+	ReasoningEffort,
 	ThinkingConfig,
 } from './chat.js'
 export type { StreamChunk } from './stream.js'


### PR DESCRIPTION
Thinking on a current model was not a degraded request, it was a failed
one. The driver mapped `type: 'enabled'` straight to the wire and
everything else to `disabled`, and the vendor rejects a mismatched mode
with a 400 rather than falling back: `thinking.type.enabled` is refused
from Claude 4.7 onward, `adaptive` is refused on 4.5 and earlier, and the
always-on models refuse `disabled`.

`ThinkingConfig.type` gains `'adaptive'`, and the driver resolves the
declared intent against the model it is about to call. An `enabled` intent
on an adaptive-only model becomes `adaptive` and loses its budget, which
has no meaning there. An `adaptive` intent on a manual-only model becomes
`enabled`. A `disabled` intent on a model that cannot stop thinking omits
the field rather than throwing — failing there teaches nothing the vendor
400 would not, and breaks a caller whose config spans models. An
unrecognised model is manual-only, the previous behaviour, so a gateway
serving an older model keeps working.

The table is transcribed from the vendor reference and reuses the model
parser `shouldUseStrictToolInputs` already had. Two subtly different
matchers on the same model name in one file is how capability decisions
drift apart.

`display` is narrowed to `'summarized' | 'omitted'` and now actually
reaches the wire. It was `'full' | 'summarized'` — `'full'` is not a value
any vendor accepts, so it was an option that could only ever have been
rejected, sitting next to a real one we lacked. It was also never
serialized, which matters because `display` defaults to `'omitted'` on
newer models: a caller wanting to show reasoning got thinking blocks with
empty text and nothing explaining why.

`effort` is new, and rides as `output_config.effort` — a sibling of
`thinking`, not a field inside it. It shapes the whole response, and one
manual-mode model takes it alongside a token budget; nesting would have
made that combination unsayable. Dropped on models that do not accept it,
and refused in the one combination the vendor rejects: thinking disabled
at xhigh or max.

`TokenUsage.reasoningTokens` carries the vendor's thinking-token
breakdown. A subset of `completionTokens`, not an addition — reasoning is
billed as output. Absent means not reported, never zero: coercing would
claim every turn on every silent driver did no thinking, and a streamed
turn carries the breakdown only on its final delta.

The request-body tests drive the real `chatStream` because the resolver's
own tests pass whether or not the client calls it — which is precisely the
bug being fixed, `display` having been on the type all along while the
builder dropped it.

Not implemented: an accompanying report claimed temperature, top_p and
top_k are rejected on 5-series models and should be dropped by the driver.
No reference page documents that restriction. Silently dropping sampling
parameters that would have worked is its own defect.

BREAKING CHANGE: `ThinkingConfig.display: 'full'` no longer compiles — use
`'summarized'`, which is what it meant. `assertThinkingSupported` in
`@namzu/openai` now refuses `'adaptive'` as it already refused `'enabled'`.