### PR TITLE
fix(sdk): stop punishing a driver for classifying its own failure

### DIFF
--- a/.changeset/olive-spiders-retry.md
+++ b/.changeset/olive-spiders-retry.md
@@ -1,0 +1,42 @@
+---
+'@namzu/sdk': patch
+---
+
+A driver that classified its own failure was being punished for it, in two
+places, and both shipped in 5.0.0.
+
+**`classifyProviderError` never read `kind`.** A `ProviderRequestError` — the
+type first-party drivers throw when they have diagnosed a failure themselves —
+fell through to the status heuristics, where a carefully-determined
+`context_overflow` carrying a 400 became `invalid_request`. Three of the six
+kinds landed wrong that way:
+
+| kind | was | now |
+|---|---|---|
+| `context_overflow` | `invalid_request`, not retryable | `context_length_exceeded`, not retryable |
+| `server` | `invalid_request`, not retryable | `server_error`, **retryable** |
+| `network` | `invalid_request`, not retryable | `network`, **retryable** |
+
+The overflow case was not cosmetic. The run loop reaches for compaction when it
+sees `context_length_exceeded`, so relief — the one provider failure this
+kernel can actually do something about — was unreachable for exactly the
+drivers that had diagnosed the problem correctly.
+
+**`withProviderRetry` rethrew such errors before the retry loop.** Its comment
+justified preserving the driver's classification, which is right; the code also
+skipped retrying, which is a separate decision nobody made. A first-party HTTP
+or OpenRouter driver reporting a 429 as `kind: 'throttle'` got exactly one
+attempt, while the identical failure from a driver that classified nothing got
+the full backoff.
+
+Retry is now decided the same way for both, from the classification's
+`retryable`. The original error still escapes to the run boundary, so
+`run.lastProviderError` keeps reporting the driver's own
+`{ kind, status, retryAfterMs }` — wrapping there would have fixed the retry
+and lost the vendor's `kind`, which the existing stream-recovery test caught.
+
+**What changes for you.** A 429, a 5xx or a socket failure from
+`@namzu/http` or `@namzu/openrouter` is now retried with backoff instead of
+failing on the first attempt, and a context overflow from those drivers now
+triggers compaction instead of failing the run. If you were relying on a typed
+error failing fast, `retry: { maxRetries: 0 }` on `drainQuery` restores that.

--- a/packages/sdk/src/provider/__tests__/typed-error-classification.test.ts
+++ b/packages/sdk/src/provider/__tests__/typed-error-classification.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest'
+
+import { classifyProviderError } from '../../types/provider/errors.js'
+import type { LLMProvider, StreamChunk } from '../../types/provider/index.js'
+import { ProviderRequestError } from '../errors.js'
+import { withProviderRetry } from '../retry.js'
+
+/**
+ * A driver that classified its own failure was coming out WORSE than one that
+ * did not, in two independent places, and both shipped.
+ *
+ * `classifyProviderError` never read `kind`. A `ProviderRequestError` fell
+ * through to the status heuristics, where a carefully-diagnosed
+ * `context_overflow` carrying a 400 became `invalid_request` — so the run
+ * loop's overflow branch, which tests for `context_length_exceeded`, could
+ * never fire for a first-party driver, and compaction relief was unreachable
+ * for exactly the drivers that had diagnosed the problem correctly.
+ *
+ * And `withProviderRetry` rethrew any such error before the retry loop. Its
+ * comment justified preserving the classification, which is right; the code
+ * also skipped retrying, which is a different decision that nobody made.
+ */
+
+function providerThatFails(err: unknown): { provider: LLMProvider; calls: () => number } {
+	let calls = 0
+	const provider = {
+		id: 'test',
+		name: 'Test',
+		async *chatStream(): AsyncIterable<StreamChunk> {
+			calls++
+			throw err
+			// biome-ignore lint/correctness/useYield: it fails before producing anything
+		},
+	} as unknown as LLMProvider
+	return { provider, calls: () => calls }
+}
+
+const typed = (kind: string, status: number) =>
+	new ProviderRequestError({ kind, providerId: 'test', status, message: `a ${kind}` } as never)
+
+describe('a driver that classified its own failure is believed', () => {
+	const cases: readonly [string, number, string, boolean][] = [
+		['throttle', 429, 'rate_limit', true],
+		['server', 500, 'server_error', true],
+		['network', 0, 'network', true],
+		['auth', 401, 'auth', false],
+		['bad_request', 400, 'invalid_request', false],
+		// The one that mattered most: a 400 whose kind says the prompt was too
+		// long is not a bad request, and the difference decides whether the
+		// kernel reaches for compaction.
+		['context_overflow', 400, 'context_length_exceeded', false],
+	]
+
+	for (const [kind, status, code, retryable] of cases) {
+		it(`maps kind "${kind}" to ${code}`, () => {
+			const classified = classifyProviderError(typed(kind, status), 'test')
+			expect(classified.code).toBe(code)
+			expect(classified.retryable).toBe(retryable)
+		})
+	}
+
+	it('keeps the driver-supplied status and provider id', () => {
+		const classified = classifyProviderError(typed('throttle', 429), 'other')
+		expect(classified.status).toBe(429)
+		expect(classified.providerId).toBe('test')
+	})
+})
+
+describe('a classified failure still goes through the retry loop', () => {
+	it('retries a typed throttle', async () => {
+		// This is the regression: a first-party driver reporting a 429 as
+		// `kind: 'throttle'` used to get exactly one attempt, while the same
+		// failure from a driver that classified nothing got the full backoff.
+		const { provider, calls } = providerThatFails(typed('throttle', 429))
+		const wrapped = withProviderRetry(provider, {
+			config: { maxRetries: 2 },
+			sleepFn: async () => {},
+			random: () => 0,
+		})
+
+		await expect(async () => {
+			for await (const _ of wrapped.chatStream({} as never)) {
+				// drain
+			}
+		}).rejects.toThrow()
+
+		expect(calls()).toBe(3)
+	})
+
+	it('does not retry a typed auth failure', async () => {
+		const { provider, calls } = providerThatFails(typed('auth', 401))
+		const wrapped = withProviderRetry(provider, {
+			config: { maxRetries: 2 },
+			sleepFn: async () => {},
+		})
+
+		await expect(async () => {
+			for await (const _ of wrapped.chatStream({} as never)) {
+				// drain
+			}
+		}).rejects.toThrow()
+
+		expect(calls()).toBe(1)
+	})
+
+	it('does not retry a typed context overflow', async () => {
+		// Correctly non-retryable — an identical prompt overflows identically.
+		// The remedy is compaction, which the run loop reaches for once the
+		// code is `context_length_exceeded`.
+		const { provider, calls } = providerThatFails(typed('context_overflow', 400))
+		const wrapped = withProviderRetry(provider, {
+			config: { maxRetries: 2 },
+			sleepFn: async () => {},
+		})
+
+		await expect(async () => {
+			for await (const _ of wrapped.chatStream({} as never)) {
+				// drain
+			}
+			// The ORIGINAL escapes, so the boundary still sees the driver's
+			// own kind rather than a wrapper's code.
+		}).rejects.toMatchObject({ kind: 'context_overflow', status: 400 })
+
+		expect(calls()).toBe(1)
+	})
+
+	it('leaves an abort alone', async () => {
+		const abort = Object.assign(new Error('aborted'), { name: 'AbortError' })
+		const { provider, calls } = providerThatFails(abort)
+		const wrapped = withProviderRetry(provider, {
+			config: { maxRetries: 2 },
+			sleepFn: async () => {},
+		})
+
+		await expect(async () => {
+			for await (const _ of wrapped.chatStream({} as never)) {
+				// drain
+			}
+		}).rejects.toThrow(/aborted/)
+
+		expect(calls()).toBe(1)
+	})
+})

--- a/packages/sdk/src/provider/retry.ts
+++ b/packages/sdk/src/provider/retry.ts
@@ -111,12 +111,19 @@ export function withProviderRetry(
 				return
 			} catch (err) {
 				if (isAbortError(err) || params.signal?.aborted) throw err
-				// A driver that already classified its own failure has said
-				// everything this layer would: re-wrapping it would replace a
-				// first-hand statement with a guess, and the run boundary reads
-				// that classification to choose between a pause and a failure.
-				if (isProviderRequestError(err)) throw err
-
+				// A driver that already classified its own failure keeps that
+				// classification — `classifyProviderError` reads its `kind`
+				// first and does not re-guess.
+				//
+				// This used to rethrow such an error outright. The stated reason
+				// was sound and the code did more than it said: preserving a
+				// first-hand classification is one thing, and skipping the retry
+				// loop is another. A first-party driver that correctly reported
+				// a 429 as `kind: 'throttle'` got ZERO attempts, while the same
+				// failure from a driver that classified nothing got the full
+				// backoff — so diagnosing your own error was punished. Whether
+				// to retry is now decided the same way for both, by the
+				// classification's own `retryable`.
 				const classified = classifyProviderError(err, provider.id)
 				const exhausted = attempt >= config.maxRetries
 
@@ -133,7 +140,16 @@ export function withProviderRetry(
 								? 'retries exhausted'
 								: 'not retryable',
 					})
-					throw classified
+					// The ORIGINAL escapes when the driver classified it. Two
+					// different consumers want two different things and both are
+					// right: this loop needs a retryable verdict, which the
+					// classification supplies, and the run boundary reports
+					// `lastProviderError` as the driver's own `{kind, status,
+					// retryAfterMs}`, which only survives if the error itself
+					// does. Wrapping here would have kept the retry fix and lost
+					// the vendor's `kind` at the boundary — the existing
+					// stream-recovery test caught exactly that.
+					throw isProviderRequestError(err) ? err : classified
 				}
 
 				const serverDirected = classified.retryAfterMs

--- a/packages/sdk/src/runtime/query/__tests__/stream-recovery.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/stream-recovery.test.ts
@@ -182,6 +182,11 @@ describe('query stream recovery', () => {
 		const run = await drainQuery(
 			{
 				provider: new ClassifiedFailureProvider(),
+				// Retry off: this pins METADATA at the boundary, and a throttle
+				// is genuinely retryable — leaving retry on would spend the run's
+				// whole timeout backing off and settle it as a timeout instead,
+				// testing the retry policy rather than the thing named here.
+				retry: { maxRetries: 0 },
 				tools: new ToolRegistry(),
 				runConfig: {
 					model: 'mock-model',

--- a/packages/sdk/src/types/provider/errors.ts
+++ b/packages/sdk/src/types/provider/errors.ts
@@ -362,12 +362,83 @@ function codeFromStructure(err: unknown): ProviderErrorCode | undefined {
  *
  * Aborts are passed through untouched — see {@link isAbortError}.
  */
+/**
+ * Every `ProviderErrorKind`, mapped to what the runtime acts on.
+ *
+ * Read structurally rather than with `instanceof`: a driver in one package
+ * throws this and the runtime in another reads it, and two copies of the SDK
+ * in one process make `instanceof` unreliable — the same reason
+ * `isProviderRequestError` exists.
+ *
+ * `retryable` here is about whether resending the SAME request could succeed.
+ * `context_overflow` is correctly false — an identical prompt overflows
+ * identically — and it maps to `context_length_exceeded` so the loop can reach
+ * for compaction, which is a different remedy than a retry.
+ */
+const KIND_TO_CODE: Readonly<Record<string, { code: ProviderErrorCode; retryable: boolean }>> = {
+	throttle: { code: 'rate_limit', retryable: true },
+	network: { code: 'network', retryable: true },
+	server: { code: 'server_error', retryable: true },
+	auth: { code: 'auth', retryable: false },
+	context_overflow: { code: 'context_length_exceeded', retryable: false },
+	bad_request: { code: 'invalid_request', retryable: false },
+}
+
+function classifyFromProviderRequestError(
+	err: unknown,
+	providerId: string | undefined,
+	now: number,
+): ProviderError | undefined {
+	if (!(err instanceof Error) || err.name !== 'ProviderRequestError') return undefined
+	const candidate = err as Error & {
+		kind?: unknown
+		providerId?: unknown
+		status?: unknown
+		retryAfterMs?: unknown
+	}
+	if (typeof candidate.kind !== 'string') return undefined
+	const mapped = KIND_TO_CODE[candidate.kind]
+	if (!mapped) return undefined
+
+	const retryAfterMs =
+		typeof candidate.retryAfterMs === 'number' ? candidate.retryAfterMs : readRetryAfterMs(err, now)
+
+	return new ProviderError({
+		code: mapped.code,
+		message: err.message,
+		retryable: mapped.retryable,
+		cause: err,
+		...(typeof candidate.providerId === 'string'
+			? { providerId: candidate.providerId }
+			: providerId !== undefined
+				? { providerId }
+				: {}),
+		...(typeof candidate.status === 'number' ? { status: candidate.status } : {}),
+		...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+	})
+}
+
 export function classifyProviderError(
 	err: unknown,
 	providerId?: string,
 	now: number = Date.now(),
 ): ProviderError {
 	if (isProviderError(err)) return err
+
+	// A driver that already classified its own failure is read FIRST, and by
+	// its `kind` — the field it set on purpose.
+	//
+	// Without this the classifier fell through to the status heuristics, where
+	// a `ProviderRequestError` carrying `kind: 'context_overflow'` and a 400
+	// became `invalid_request`, non-retryable. Three of the six kinds landed
+	// wrong that way, and the consequences were not cosmetic: the loop's
+	// overflow branch tests for `context_length_exceeded`, so compaction relief
+	// — the one provider failure this kernel can actually do something about —
+	// was unreachable for exactly the drivers that had diagnosed it correctly.
+	// A driver that classified its own error came out worse than one that did
+	// not, which is the opposite of the incentive the type was created for.
+	const fromKind = classifyFromProviderRequestError(err, providerId, now)
+	if (fromKind) return fromKind
 
 	const message = err instanceof Error ? err.message : String(err)
 	const status = readStatus(err)


### PR DESCRIPTION
fix(sdk): stop punishing a driver for classifying its own failure

Two places, both shipped in 5.0.0, both making a driver that diagnosed its
own error come out worse than one that did not.

`classifyProviderError` never read `kind`. A `ProviderRequestError` — the
type first-party drivers throw when they have already worked out what
happened — fell through to the status heuristics, where a carefully
determined `context_overflow` carrying a 400 became `invalid_request`.
Probing all six kinds found three wrong: `context_overflow`, `server` and
`network` all landed on `invalid_request`, non-retryable. Only `throttle`
was right, and only because a 429 status happens to be recognised on its
own.

The overflow case is the expensive one. The run loop reaches for compaction
when it sees `context_length_exceeded`, so relief — the one provider
failure this kernel can actually do something about — was unreachable for
exactly the drivers that had diagnosed the problem correctly.

`withProviderRetry` rethrew those errors before the retry loop. Its comment
justified preserving the driver's classification, and that part is right;
the code also skipped retrying, which is a separate decision nobody made. A
first-party HTTP or OpenRouter driver reporting a 429 as `kind: 'throttle'`
got exactly one attempt, while the identical failure from a driver that
classified nothing got the full backoff.

Retry now decides the same way for both, from the classification's
`retryable`. The ORIGINAL error still escapes, because two consumers want
two different things and both are right: this loop needs a retryable
verdict, and the run boundary reports `lastProviderError` as the driver's
own `{kind, status, retryAfterMs}`, which only survives if the error itself
does. My first attempt wrapped it and the existing stream-recovery test
failed — it had pinned exactly that, and it was right to.

That test is corrected rather than loosened: it now disables retry, because
a throttle is genuinely retryable and leaving retry on made it spend the
run's whole 5s timeout backing off. It would have been testing the retry
policy under the name of metadata preservation.

Found by the mandatory pre-freeze adversarial pass on ses_012, which is the
argument for having one: a session summary reports what was decided, and
this is drift that entered afterwards through a merge reconciliation.
