### PR TITLE
feat(bedrock): refuse a model this wire cannot serve

### DIFF
--- a/.changeset/tidy-pandas-reach.md
+++ b/.changeset/tidy-pandas-reach.md
@@ -1,0 +1,27 @@
+---
+'@namzu/bedrock': minor
+---
+
+Refuses a model id this driver's wire cannot serve, instead of letting AWS
+answer with a validation error that names neither the cause nor the fix.
+
+This driver speaks Bedrock's `Converse` API, which serves ARN-versioned model
+ids — `us.anthropic.claude-sonnet-4-5-20250929-v1:0` and friends, the
+integration documented for Claude 4.6 and earlier.
+
+The current generation is not on that wire. Claude Opus 5, Sonnet 5, Fable 5,
+Opus 4.8 and Opus 4.7 are served by a different Bedrock integration that speaks
+the Messages API shape, and their ids carry no version suffix at all
+(`anthropic.claude-opus-5`). The vendor's own legacy page gives the reason they
+are absent from its model table: they have no ARN-versioned ids.
+
+Passing one here now throws before any AWS call, naming both what this wire
+serves and where the newer models live.
+
+It is a check on the id SHAPE, not a model list. An unrecognised but versioned
+id passes untouched, and non-Claude models are not policed at all — a list that
+has to be edited for every new model is wrong before anyone reads it.
+
+Reaching the newer models needs a driver built for that endpoint. That is not
+in this release, and guessing at a wire is how a driver ends up confidently
+wrong; the reachability refusal is correct and complete on its own.

--- a/packages/providers/bedrock/src/__tests__/model-reachability.test.ts
+++ b/packages/providers/bedrock/src/__tests__/model-reachability.test.ts
@@ -1,0 +1,74 @@
+import type { ChatCompletionParams } from '@namzu/sdk'
+import { describe, expect, it } from 'vitest'
+
+import { BedrockProvider } from '../client.js'
+import { assertModelReachable } from '../model-reachability.js'
+
+/**
+ * This driver speaks Converse with ARN-versioned model ids. The current Claude
+ * generation is served by a different Bedrock integration whose ids carry no
+ * version suffix, and pointing this wire at one produced an opaque AWS
+ * validation error naming neither the cause nor the remedy.
+ */
+
+describe('model ids this wire can serve', () => {
+	const reachable = [
+		'anthropic.claude-sonnet-4-5-20250929-v1:0',
+		'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+		'eu.anthropic.claude-opus-4-5-20251101-v1:0',
+		'global.anthropic.claude-opus-4-6-v1',
+		'apac.anthropic.claude-sonnet-4-20250514-v1:0',
+		'anthropic.claude-haiku-4-5-20251001-v1:0',
+	]
+
+	for (const model of reachable) {
+		it(`accepts ${model}`, () => {
+			expect(() => assertModelReachable(model)).not.toThrow()
+		})
+	}
+
+	const unreachable = [
+		'anthropic.claude-opus-5',
+		'anthropic.claude-sonnet-5',
+		'anthropic.claude-fable-5',
+		'anthropic.claude-opus-4-8',
+		'anthropic.claude-opus-4-7',
+		'us.anthropic.claude-opus-5',
+	]
+
+	for (const model of unreachable) {
+		it(`refuses ${model} and says why`, () => {
+			expect(() => assertModelReachable(model)).toThrow(/cannot reach/)
+			expect(() => assertModelReachable(model)).toThrow(/Converse API/)
+		})
+	}
+
+	it('leaves a non-Claude model alone', () => {
+		// This driver serves whatever Bedrock serves. The check is about one
+		// vendor's id scheme, not about policing the catalogue.
+		expect(() => assertModelReachable('amazon.nova-pro-v1:0')).not.toThrow()
+		expect(() => assertModelReachable('meta.llama3-70b-instruct-v1:0')).not.toThrow()
+	})
+
+	it('accepts an unknown versioned Claude id', () => {
+		// A model this file has never heard of passes as long as its id has
+		// the shape this wire carries. A list that must be edited for every
+		// new model is a list that is wrong before anyone reads it.
+		expect(() => assertModelReachable('anthropic.claude-sonnet-9-20991231-v1:0')).not.toThrow()
+	})
+})
+
+describe('the driver refuses before it calls AWS', () => {
+	it('throws on an unreachable model with no credentials in play', async () => {
+		const provider = new BedrockProvider({ region: 'us-east-1' } as never)
+
+		await expect(async () => {
+			for await (const _ of provider.chatStream({
+				model: 'anthropic.claude-opus-5',
+				messages: [{ role: 'user', content: 'hi' }],
+			} as ChatCompletionParams)) {
+				// drain
+			}
+		}).rejects.toThrow(/cannot reach "anthropic\.claude-opus-5"/)
+	})
+})

--- a/packages/providers/bedrock/src/client.ts
+++ b/packages/providers/bedrock/src/client.ts
@@ -32,6 +32,7 @@ import {
 	isProviderRequestError,
 	providerVendorError,
 } from '@namzu/sdk'
+import { assertModelReachable } from './model-reachability.js'
 import type { BedrockConfig } from './types.js'
 
 function extractSystemBlocks(messages: ChatCompletionParams['messages']): SystemContentBlock[] {
@@ -283,6 +284,10 @@ export class BedrockProvider implements LLMProvider {
 
 	async *chatStream(params: ChatCompletionParams): AsyncIterable<StreamChunk> {
 		assertThinkingUnsupported('BedrockProvider', params)
+		// Before any AWS call: an unreachable model id fails here with the
+		// reason and the fix, rather than as an opaque validation error from
+		// a service that was asked for something this wire does not carry.
+		assertModelReachable(params.model)
 		const system = extractSystemBlocks(params.messages)
 		const messages = toBedrockMessages(params.messages)
 		const toolConfig = toBedrockToolConfig(params)

--- a/packages/providers/bedrock/src/model-reachability.ts
+++ b/packages/providers/bedrock/src/model-reachability.ts
@@ -1,0 +1,61 @@
+/**
+ * Whether this driver's wire can serve a given model id.
+ *
+ * This driver speaks `Converse` / `ConverseStream` with ARN-versioned model
+ * ids — `anthropic.claude-sonnet-4-5-20250929-v1:0`, usually behind an
+ * inference-profile prefix (`us.`, `eu.`, `global.`). That is the integration
+ * documented for Claude 4.6 and earlier.
+ *
+ * The current generation is not on it. Claude Opus 5, Sonnet 5, Fable 5, Opus
+ * 4.8 and Opus 4.7 are served by a different Bedrock integration that speaks
+ * the Messages API shape, and their ids carry no version suffix at all
+ * (`anthropic.claude-opus-5`). The vendor's own legacy page states the reason
+ * they are absent from its model table: they do not have ARN-versioned model
+ * ids.
+ *
+ * So a caller passing a 5-series id here is not making a small mistake that a
+ * shrug would absorb — they are pointing a wire at models it was not built
+ * for, and the answer they get back is an opaque AWS validation error naming
+ * neither the cause nor the fix. Refusing with both is the whole value of
+ * knowing this.
+ *
+ * **This is a reachability check, not a capability table.** It does not claim
+ * to know which models exist, only which id SHAPE this wire accepts. A new
+ * ARN-versioned model passes without this file changing, which is the correct
+ * failure direction for a list that will go stale.
+ */
+
+/** Inference-profile prefixes the Converse wire accepts on a model id. */
+const PROFILE_PREFIXES = ['global.', 'us.', 'eu.', 'jp.', 'apac.']
+
+function stripProfilePrefix(modelId: string): string {
+	for (const prefix of PROFILE_PREFIXES) {
+		if (modelId.startsWith(prefix)) return modelId.slice(prefix.length)
+	}
+	return modelId
+}
+
+/**
+ * A Claude id with no ARN version suffix — the shape the newer Bedrock
+ * integration uses, and the one this wire cannot serve.
+ *
+ * Matched positively rather than by excluding known-good names: the set of
+ * versioned models grows, and a check that has to be edited for every new
+ * model is a check that will be wrong before it is read.
+ */
+const UNVERSIONED_CLAUDE = /^anthropic\.claude-(?:haiku|sonnet|opus|fable|mythos)-[a-z0-9.-]*$/
+
+function hasArnVersion(modelId: string): boolean {
+	return /-v\d+(?::\d+)?$/.test(modelId)
+}
+
+export function assertModelReachable(modelId: string): void {
+	const bare = stripProfilePrefix(modelId.trim().toLowerCase())
+	if (!bare.startsWith('anthropic.')) return
+	if (hasArnVersion(bare)) return
+	if (!UNVERSIONED_CLAUDE.test(bare)) return
+
+	throw new Error(
+		`This driver cannot reach "${modelId}". It speaks Bedrock's Converse API, which serves ARN-versioned model ids such as "us.anthropic.claude-sonnet-4-5-20250929-v1:0" — Claude 4.6 and earlier. Models with no version suffix (Opus 5, Sonnet 5, Fable 5, Opus 4.8, Opus 4.7) are served by the newer Bedrock integration, which speaks the Messages API shape at a different endpoint and is not what this driver talks to. Use a versioned model id here, or reach the newer models through a driver built for that endpoint.`,
+	)
+}


### PR DESCRIPTION
This driver speaks Bedrock's `Converse` API, which serves ARN-versioned
model ids — `us.anthropic.claude-sonnet-4-5-20250929-v1:0` and friends, the
integration documented for Claude 4.6 and earlier.

The current generation is not on it. Opus 5, Sonnet 5, Fable 5, Opus 4.8
and Opus 4.7 are served by a different Bedrock integration speaking the
Messages API shape, and their ids carry no version suffix at all. The
vendor's legacy page says why they are missing from its table: they have no
ARN-versioned ids.

Pointing this wire at one produced an opaque AWS validation error naming
neither the cause nor the remedy. It now throws before any AWS call, naming
both.

A check on the id SHAPE, not a model list: an unrecognised but versioned id
passes untouched and non-Claude models are not policed, because a list that
must be edited for every new model is wrong before it is read.

Found while researching whether to port the anthropic driver's per-model
thinking table here. It could not have worked — that parser matches none of
the Bedrock id formats, the dot separator and the `-v1:0` suffix both break
it, so porting it would have silently done nothing.

Reaching the newer models needs a driver for that endpoint, where the body
is the first-party Messages shape and the thinking work would apply
unchanged. That wants new auth and a different SDK, and is a decision with
a cost rather than a detail — so it is not in this change. Guessing at a
wire is how a driver ends up confidently wrong.