### PR TITLE
feat(project): a project can declare delegates

### DIFF
--- a/.changeset/warm-otters-delegate.md
+++ b/.changeset/warm-otters-delegate.md
@@ -1,0 +1,42 @@
+---
+'@namzu/project': minor
+---
+
+A project can declare delegates, and `deriveSupervisorOptions` turns them into
+a `SupervisorAgent` configuration.
+
+`SupervisorAgent` needs an `agentIds` roster and a manager that can spawn them.
+Nothing led from a directory to either, so a multi-agent system could be
+described on disk and not run.
+
+A directory under `agents/` is read by the same loader that read the root — a
+delegate has the same shape as its parent, so this is recursion rather than a
+new concept.
+
+```
+agent/
+├── instructions.md
+└── agents/
+    ├── researcher/   ← its own agent.ts, instructions.md, tools/
+    └── writer/
+```
+
+`deriveSupervisorOptions` supplies the roster and leaves the manager to the
+host, the same contract `deriveRunOptions` follows: it converts, it does not
+run. Delegates come back as plans rather than registered agents, because
+registration mutates the host's manager and a function that quietly mutates an
+object it was handed for reference is the surprise this package avoids.
+
+A delegate may name its own model and inherits the coordinator's only when it
+does not — a cheap model for a narrow job is the common case, and inheriting
+unconditionally would bill every specialist at the coordinator's rate.
+
+**One level only.** A delegate may not declare delegates of its own. How deep a
+system fans out is a topology decision that belongs to whoever composes it, and
+answering it by default is how a directory layout ends up deciding a system's
+shape. It also removes the cycle: `agents/a/agents/b/agents/a` cannot be built
+if the second level is never read.
+
+A delegate that fails to load is reported in the parent's diagnostics, prefixed
+with its path, and is not offered in the roster. A caller reading one list
+should not have to walk the tree to find out the run will be short a specialist.

--- a/packages/project/README.md
+++ b/packages/project/README.md
@@ -12,9 +12,14 @@ my-agent/agent/
 ├── instructions.md   # optional — the system prompt
 ├── tools/
 │   └── search.ts     # default-exports defineTool(…)
-└── skills/
-    └── plan-a-trip/
-        └── SKILL.md
+├── skills/
+│   └── plan-a-trip/
+│       └── SKILL.md
+└── agents/            # optional — delegates, each a project of its own
+    └── researcher/
+        ├── agent.ts
+        ├── instructions.md
+        └── tools/
 ```
 
 ```ts
@@ -32,6 +37,37 @@ const { output } = await runAgent(
 `deriveRunOptions` produces ordinary `RunAgentOptions`. There is no second code
 path — a caller who outgrows the convention passes `overrides`, or stops using
 this package and keeps everything else.
+
+## Delegates
+
+A directory under `agents/` is read by the same loader that read the root — a
+delegate has the same shape as its parent, so this is recursion rather than a
+new concept. `deriveSupervisorOptions` turns that into a `SupervisorAgent`
+configuration:
+
+```ts
+const { manifest } = await loadProject('./agent')
+
+const { config, delegates } = deriveSupervisorOptions(manifest, {
+  provider,
+  agentManager, // yours — a lifecycle object, never built here
+})
+
+for (const d of delegates) agentManager.register(d.id, d)
+await new SupervisorAgent(metadata).run(input, config)
+```
+
+Delegates come back as plans rather than registered agents, because
+registration mutates your manager and a function that quietly mutates an object
+you handed it for reference is the surprise this package exists to avoid.
+
+A delegate may name its own model and inherits the coordinator's only when it
+does not — a cheap model for a narrow job is the common case, and inheriting
+unconditionally bills every specialist at the coordinator's rate.
+
+**One level only.** A delegate may not declare delegates of its own. How deep a
+system fans out is a topology decision, and a directory layout should not make
+it by default.
 
 ## Importing a directory runs it
 

--- a/packages/project/src/__tests__/subagents.test.ts
+++ b/packages/project/src/__tests__/subagents.test.ts
@@ -1,0 +1,155 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { deriveSupervisorOptions } from '../derive-supervisor.js'
+import { loadProject } from '../load.js'
+
+/**
+ * `SupervisorAgent` needs an `agentIds` roster and a manager that can spawn
+ * them. Nothing led from a directory to either, so a multi-agent system could
+ * be described on disk and not run.
+ *
+ * Delegates are loaded by recursion — a delegate directory has the same shape
+ * as its parent — capped at one level, because how deep a system may fan out
+ * is a topology decision and a directory layout should not make it by default.
+ */
+
+const provider = { id: 'mock', name: 'Mock' } as never
+const agentManager = { sendMessage: async () => ({}) } as never
+
+function tree(files: Record<string, string>): string {
+	const root = mkdtempSync(join(tmpdir(), 'namzu-sub-'))
+	for (const [relative, body] of Object.entries(files)) {
+		const full = join(root, relative)
+		mkdirSync(join(full, '..'), { recursive: true })
+		writeFileSync(full, body)
+	}
+	return root
+}
+
+const TOOL = (name: string) => `
+export default {
+  name: ${JSON.stringify(name)},
+  description: 'a tool',
+  inputSchema: { parse: (v) => v, safeParse: (v) => ({ success: true, data: v }) },
+  execute: async () => ({ success: true, output: 'ok' }),
+}
+`
+
+const SYSTEM = {
+	'instructions.md': 'You coordinate.',
+	'agent.js': 'export default { model: "coordinator-model" }',
+	'agents/researcher/instructions.md': 'You research.',
+	'agents/researcher/agent.js': 'export default { model: "cheap-model" }',
+	'agents/researcher/tools/search.js': TOOL('search'),
+	'agents/writer/instructions.md': 'You write.',
+}
+
+describe('a project that declares delegates', () => {
+	it('loads each one as a project in its own right', async () => {
+		const { manifest, ok, diagnostics } = await loadProject(tree(SYSTEM))
+
+		expect(ok, JSON.stringify(diagnostics)).toBe(true)
+		expect(manifest.agents.map((a) => a.id).sort()).toEqual(['researcher', 'writer'])
+
+		const researcher = manifest.agents.find((a) => a.id === 'researcher')
+		expect(researcher?.manifest.instructions).toBe('You research.')
+		expect(researcher?.manifest.tools.map((t) => t.definition.name)).toEqual(['search'])
+		expect(researcher?.manifest.config.model).toBe('cheap-model')
+	})
+
+	it('surfaces a delegate failure in the parent list', async () => {
+		// A delegate that could not load is a fact about THIS project. A caller
+		// reading one list should not have to walk the tree to discover the run
+		// will be short a specialist.
+		const { manifest, ok, diagnostics } = await loadProject(
+			tree({ ...SYSTEM, 'agents/writer/tools/bad.js': 'this is not valid !!!' }),
+		)
+
+		expect(ok).toBe(false)
+		expect(diagnostics.some((d) => d.message.startsWith('agents/writer:'))).toBe(true)
+		// The broken one is not offered as a delegate.
+		expect(manifest.agents.map((a) => a.id)).toEqual(['researcher'])
+	})
+
+	it('refuses to read a second level of delegates', async () => {
+		const { manifest, diagnostics } = await loadProject(
+			tree({
+				...SYSTEM,
+				'agents/researcher/agents/deeper/instructions.md': 'You are too deep.',
+			}),
+		)
+
+		const researcher = manifest.agents.find((a) => a.id === 'researcher')
+		expect(researcher?.manifest.agents).toHaveLength(0)
+		expect(diagnostics.some((d) => d.code === 'subagent_too_deep')).toBe(true)
+	})
+
+	it('imports nothing under modules: skip, delegates included', async () => {
+		const { manifest, ok } = await loadProject(
+			tree({
+				'instructions.md': 'hi',
+				'agents/x/instructions.md': 'hi',
+				'agents/x/tools/boom.js': 'throw new Error("executed")',
+			}),
+			{ modules: 'skip' },
+		)
+
+		expect(ok).toBe(true)
+		expect(manifest.sources.some((s) => s.slot === 'agents')).toBe(true)
+	})
+})
+
+describe('deriving supervisor options', () => {
+	it('builds the roster from the directory', async () => {
+		const { manifest } = await loadProject(tree(SYSTEM))
+
+		const { config, delegates } = deriveSupervisorOptions(manifest, { provider, agentManager })
+
+		expect(config.agentIds.sort()).toEqual(['researcher', 'writer'])
+		expect(config.systemPrompt).toBe('You coordinate.')
+		expect(config.model).toBe('coordinator-model')
+		expect(delegates).toHaveLength(2)
+	})
+
+	it('lets a delegate keep its own model and inherit when it has none', async () => {
+		// A cheap model for a narrow job is the common case; inheriting
+		// unconditionally would bill every specialist at the coordinator rate.
+		const { manifest } = await loadProject(tree(SYSTEM))
+		const { delegates } = deriveSupervisorOptions(manifest, { provider, agentManager })
+
+		expect(delegates.find((d) => d.id === 'researcher')?.model).toBe('cheap-model')
+		expect(delegates.find((d) => d.id === 'writer')?.model).toBe('coordinator-model')
+	})
+
+	it('carries each delegate its own instructions and tools', async () => {
+		const { manifest } = await loadProject(tree(SYSTEM))
+		const { delegates } = deriveSupervisorOptions(manifest, { provider, agentManager })
+
+		const researcher = delegates.find((d) => d.id === 'researcher')
+		expect(researcher?.systemPrompt).toBe('You research.')
+		expect(researcher?.tools.has('search')).toBe(true)
+	})
+
+	it('refuses a project with no delegates', async () => {
+		// An empty roster makes create_task unmountable, so the result would be
+		// a coordinator that cannot coordinate — and the caller asked for one.
+		const { manifest } = await loadProject(
+			tree({ 'instructions.md': 'hi', 'agent.js': 'export default { model: "m" }' }),
+		)
+
+		expect(() => deriveSupervisorOptions(manifest, { provider, agentManager })).toThrow(
+			/declares no delegates/,
+		)
+	})
+
+	it('refuses a manifest whose modules were never loaded', async () => {
+		const { manifest } = await loadProject(tree(SYSTEM), { modules: 'skip' })
+
+		expect(() => deriveSupervisorOptions(manifest, { provider, agentManager })).toThrow(
+			/modules: "skip"/,
+		)
+	})
+})

--- a/packages/project/src/derive-supervisor.ts
+++ b/packages/project/src/derive-supervisor.ts
@@ -1,0 +1,130 @@
+import { ToolRegistry } from '@namzu/sdk'
+import type { AgentIdentity, LLMProvider, SupervisorAgentConfig } from '@namzu/sdk'
+
+import type { ProjectManifest, SubAgentEntry } from './types.js'
+
+export interface DeriveSupervisorInput {
+	readonly provider: LLMProvider
+	/** Wins over `agent.ts`. Required when `agent.ts` names no model. */
+	readonly model?: string
+	readonly identity?: Required<AgentIdentity>
+	/**
+	 * The lifecycle object that actually spawns delegates.
+	 *
+	 * Supplied by the host and never built here. An `AgentManager` owns
+	 * running processes, budgets and cancellation — it is a thing with a
+	 * lifetime, not a description of one, and this package's whole boundary is
+	 * that it describes and does not run. Handing back options that carry a
+	 * manager we constructed would make it a runner wearing a loader's name.
+	 */
+	readonly agentManager: SupervisorAgentConfig['agentManager']
+	readonly overrides?: Partial<SupervisorAgentConfig>
+}
+
+export interface SupervisorPlan {
+	/** Ready for `new SupervisorAgent(...).run(input, config)`. */
+	readonly config: SupervisorAgentConfig
+	/**
+	 * What the host must register with its `AgentManager` before running,
+	 * one per delegate, keyed by the id the supervisor will name.
+	 *
+	 * Returned rather than registered: registration is a mutation of the
+	 * host's manager, and a function that quietly mutates an object it was
+	 * handed for reference is the kind of surprise this package exists to
+	 * avoid. The host does it, in one loop it can see.
+	 */
+	readonly delegates: readonly DelegatePlan[]
+}
+
+export interface DelegatePlan {
+	readonly id: string
+	readonly manifest: ProjectManifest
+	/** The delegate's own instructions, tools and model, already assembled. */
+	readonly systemPrompt: string
+	readonly tools: ToolRegistry
+	readonly model: string
+}
+
+function toolsOf(manifest: ProjectManifest): ToolRegistry {
+	const tools = new ToolRegistry()
+	for (const entry of manifest.tools) tools.register(entry.definition)
+	return tools
+}
+
+function delegatePlan(entry: SubAgentEntry, fallbackModel: string): DelegatePlan {
+	return {
+		id: entry.id,
+		manifest: entry.manifest,
+		systemPrompt: entry.manifest.instructions,
+		tools: toolsOf(entry.manifest),
+		// A delegate may name its own model — a cheap one for a narrow job is
+		// the common case — and inherits the supervisor's only when it does
+		// not. Inheriting unconditionally would silently bill every specialist
+		// at the coordinator's rate.
+		model: entry.manifest.config.model ?? fallbackModel,
+	}
+}
+
+/**
+ * Turn a project that declares delegates into a supervisor configuration.
+ *
+ * The counterpart to `deriveRunOptions` for the multi-agent shape, and the
+ * same contract: it converts, it does not run. `SupervisorAgent` needs an
+ * `agentIds` roster and a manager that can spawn them; this supplies the
+ * roster from the directory and leaves the manager to the host.
+ *
+ * The delegates come back as plans rather than registered agents because
+ * registration mutates the host's manager. Two lines in the host, and the host
+ * can see exactly what it just gained.
+ */
+export function deriveSupervisorOptions(
+	manifest: ProjectManifest,
+	input: DeriveSupervisorInput,
+): SupervisorPlan {
+	if (manifest.modules === 'skip') {
+		throw new Error(
+			'This manifest was loaded with modules: "skip", so no tool was imported and no delegate was evaluated. Load with modules: "evaluate" before deriving supervisor options.',
+		)
+	}
+	if (manifest.agents.length === 0) {
+		// Not a warning that degrades into a supervisor with nobody to call.
+		// An empty roster makes `create_task` unmountable by design, so the
+		// result would be a coordinator that cannot coordinate — and the
+		// caller asked for a supervisor, which means they expected delegates.
+		throw new Error(
+			`${manifest.root} declares no delegates, so there is nothing for a supervisor to coordinate. Add directories under agents/, or use deriveRunOptions for a single agent.`,
+		)
+	}
+
+	const model = input.model ?? manifest.config.model
+	if (!model) {
+		throw new Error(
+			`No model. Declare one in ${manifest.root}/agent.ts as \`export default { model: "…" }\`, or pass \`model\` here.`,
+		)
+	}
+
+	const delegates = manifest.agents.map((entry) => delegatePlan(entry, model))
+
+	const config = {
+		provider: input.provider,
+		model,
+		agentManager: input.agentManager,
+		agentIds: delegates.map((d) => d.id),
+		systemPrompt: manifest.instructions,
+		tools: toolsOf(manifest),
+		...(manifest.config.temperature !== undefined
+			? { temperature: manifest.config.temperature }
+			: {}),
+		...(manifest.config.maxIterations !== undefined
+			? { maxIterations: manifest.config.maxIterations }
+			: {}),
+		...(manifest.config.tokenBudget !== undefined
+			? { tokenBudget: manifest.config.tokenBudget }
+			: {}),
+		...(manifest.config.timeoutMs !== undefined ? { timeoutMs: manifest.config.timeoutMs } : {}),
+		...(input.identity ?? {}),
+		...(input.overrides ?? {}),
+	} as SupervisorAgentConfig
+
+	return { config, delegates }
+}

--- a/packages/project/src/index.ts
+++ b/packages/project/src/index.ts
@@ -1,5 +1,11 @@
 export { loadProject } from './load.js'
 export { deriveRunOptions } from './derive.js'
+export { deriveSupervisorOptions } from './derive-supervisor.js'
+export type {
+	DelegatePlan,
+	DeriveSupervisorInput,
+	SupervisorPlan,
+} from './derive-supervisor.js'
 export type {
 	DeriveRunOptionsInput,
 	DiagnosticCode,
@@ -15,6 +21,7 @@ export type {
 	SkillEntry,
 	SourceOutcome,
 	SourceRef,
+	SubAgentEntry,
 	ToolEntry,
 } from './types.js'
 export { ALL_SLOTS } from './types.js'

--- a/packages/project/src/load.ts
+++ b/packages/project/src/load.ts
@@ -16,6 +16,7 @@ import type {
 	SkillEntry,
 	SourceOutcome,
 	SourceRef,
+	SubAgentEntry,
 	ToolEntry,
 } from './types.js'
 import { ALL_SLOTS } from './types.js'
@@ -160,6 +161,26 @@ export async function loadProject(
 	dir: string,
 	options: LoadProjectOptions = {},
 ): Promise<ProjectLoadResult> {
+	return loadAt(dir, options, 0)
+}
+
+/**
+ * Depth 0 is the project the caller named; 1 is a delegate it declares.
+ *
+ * A delegate does not get delegates of its own. The cap is a real decision,
+ * not a missing feature: unbounded nesting is a topology question — who may
+ * spawn whom, and how deep a run may fan out — and answering it by default is
+ * how a directory layout ends up deciding a system's shape. It also removes
+ * the cycle: `agents/a/agents/b/agents/a` cannot be built if the second level
+ * is never read.
+ */
+const MAX_DEPTH = 1
+
+async function loadAt(
+	dir: string,
+	options: LoadProjectOptions,
+	depth: number,
+): Promise<ProjectLoadResult> {
 	if (typeof dir !== 'string' || dir.length === 0) {
 		throw new TypeError('loadProject(dir): dir must be a non-empty string.')
 	}
@@ -176,6 +197,7 @@ export async function loadProject(
 	const sources: SourceRef[] = []
 	const tools: ToolEntry[] = []
 	const skills: SkillEntry[] = []
+	const agents: SubAgentEntry[] = []
 	let config: ProjectConfig = {}
 	let instructions = ''
 
@@ -194,6 +216,7 @@ export async function loadProject(
 				config: {},
 				tools: [],
 				skills: [],
+				agents: [],
 				sources: [],
 				included,
 				modules,
@@ -395,6 +418,42 @@ export async function loadProject(
 		}
 	}
 
+	// ─── agents (delegates) ───────────────────────────────────────────────
+	if (included.includes('agents')) {
+		const scan = await scanSlot(root, 'agents', 'agents')
+		diagnostics.push(...scan.diagnostics)
+		for (const entry of scan.files) {
+			if (depth >= MAX_DEPTH) {
+				diagnostics.push({
+					code: 'subagent_too_deep',
+					severity: 'warning',
+					message:
+						entry.relativePath +
+						' was not loaded: a delegate may not declare delegates of its own.',
+					path: entry.path,
+				})
+				record(entry, 'agents', 'skipped')
+				continue
+			}
+			const child = await loadAt(entry.path, options, depth + 1)
+			// The child's diagnostics are the parent's. A delegate that could
+			// not load is a fact about THIS project, and a caller reading one
+			// list should not have to walk the tree to find out the run will be
+			// short a specialist.
+			for (const d of child.diagnostics) {
+				diagnostics.push({ ...d, message: entry.relativePath + ': ' + d.message })
+			}
+			if (!child.ok) {
+				record(entry, 'agents', 'failed')
+				continue
+			}
+			agents.push({
+				source: record(entry, 'agents', 'loaded'),
+				manifest: child.manifest,
+				id: entry.id,
+			})
+		}
+	}
 	const name = config.name ?? basenameOf(root)
 
 	return {
@@ -405,6 +464,7 @@ export async function loadProject(
 			config,
 			tools,
 			skills,
+			agents,
 			sources,
 			included,
 			modules,

--- a/packages/project/src/scan.ts
+++ b/packages/project/src/scan.ts
@@ -82,9 +82,12 @@ export async function scanSlot(
 			continue
 		}
 
+		// Two slots hold DIRECTORIES rather than files: a skill is a folder
+		// with a SKILL.md, and a delegate is a whole project directory.
+		const directorySlot = slot === 'skills' || slot === 'agents'
+
 		if (stats.isDirectory()) {
-			// `skills/` is the one slot whose entries ARE directories.
-			if (slot === 'skills') {
+			if (directorySlot) {
 				files.push({
 					path: candidate,
 					relativePath: `${dirName}/${name}`,
@@ -102,7 +105,9 @@ export async function scanSlot(
 		}
 
 		if (!stats.isFile()) continue
-		if (slot === 'skills') continue
+		// A loose file in a directory slot is not an error worth a diagnostic —
+		// a README beside the skill folders is normal.
+		if (directorySlot) continue
 
 		if (!CODE_EXTENSIONS.has(extname(name))) {
 			diagnostics.push({

--- a/packages/project/src/types.ts
+++ b/packages/project/src/types.ts
@@ -20,9 +20,15 @@ import type {
  * question — does a convention belong outside the kernel — was answered yes
  * and stands; the shape question had simply never been asked.
  */
-export type ProjectSlot = 'agent' | 'instructions' | 'tools' | 'skills'
+export type ProjectSlot = 'agent' | 'instructions' | 'tools' | 'skills' | 'agents'
 
-export const ALL_SLOTS: readonly ProjectSlot[] = ['agent', 'instructions', 'tools', 'skills']
+export const ALL_SLOTS: readonly ProjectSlot[] = [
+	'agent',
+	'instructions',
+	'tools',
+	'skills',
+	'agents',
+]
 
 /**
  * Whether the loader executes the project's code.
@@ -88,6 +94,8 @@ export type DiagnosticCode =
 	| 'path_escapes_root'
 	| 'unscanned_directory'
 	| 'root_missing'
+	| 'subagent_load_failed'
+	| 'subagent_too_deep'
 
 /**
  * Something the loader could not do, reported rather than dropped.
@@ -117,6 +125,24 @@ export interface ProjectDiagnostic {
 export interface ToolEntry {
 	readonly source: SourceRef
 	readonly definition: ToolDefinition
+}
+
+/**
+ * A delegate this project declares, loaded as a project in its own right.
+ *
+ * Recursion rather than a new concept: a sub-agent directory has the same
+ * shape as its parent, so `agents/researcher/` is read by the same loader
+ * that read the root. One level only — a delegate may not declare delegates of its
+ * own in this version. Unbounded nesting is a topology decision (who may
+ * spawn whom, and how deep) that belongs to whoever composes the system, and
+ * shipping it before that decision means shipping a default nobody chose.
+ */
+export interface SubAgentEntry {
+	readonly source: SourceRef
+	/** The delegate's own manifest — its instructions, tools and config. */
+	readonly manifest: ProjectManifest
+	/** Directory-derived, and the id a supervisor delegates to. */
+	readonly id: string
 }
 
 export interface SkillEntry {
@@ -167,6 +193,8 @@ export interface ProjectManifest {
 	readonly config: ProjectConfig
 	readonly tools: readonly ToolEntry[]
 	readonly skills: readonly SkillEntry[]
+	/** Delegates this project declares. Empty unless it has an `agents/` slot. */
+	readonly agents: readonly SubAgentEntry[]
 	/** Every file considered, with its outcome. An inspector's ground truth. */
 	readonly sources: readonly SourceRef[]
 	/** Which slots were scanned. What `ok` is scoped to. */


### PR DESCRIPTION
`SupervisorAgent` needs an `agentIds` roster and a manager that can spawn
them. Nothing led from a directory to either, so a multi-agent system could
be described on disk and not run.

A directory under `agents/` is read by the same loader that read the root —
a delegate has the same shape as its parent, so this is recursion rather
than a new concept.

`deriveSupervisorOptions` supplies the roster and leaves the manager to the
host, the contract `deriveRunOptions` already follows: convert, do not run.
An `AgentManager` owns running processes, budgets and cancellation — a
thing with a lifetime, not a description of one — and handing back options
carrying a manager this package constructed would make it a runner wearing
a loader's name.

Delegates come back as plans rather than registered agents. Registration
mutates the host's manager, and a function that quietly mutates an object
it was handed for reference is the surprise this package exists to avoid.

A delegate keeps its own model and inherits the coordinator's only when it
has none. A cheap model for a narrow job is the common case; inheriting
unconditionally bills every specialist at the coordinator's rate.

One level only. A delegate may not declare delegates of its own. How deep a
system fans out is a topology decision belonging to whoever composes it,
and answering it by default is how a directory layout ends up deciding a
system's shape. It also makes the cycle unbuildable: `agents/a/agents/b`
is never read, so `agents/a/agents/b/agents/a` cannot exist.

A delegate that fails to load is reported in the parent's diagnostics with
its path prefixed, and is not offered in the roster — a caller reading one
list should not have to walk the tree to learn the run will be short a
specialist.

Found while wiring: `scanSlot` treated only `skills` as directory-holding.
Two slots hold directories.