### PR TITLE
fix(sdk): contain the paths a plugin manifest names

### DIFF
--- a/.changeset/silly-moons-contain.md
+++ b/.changeset/silly-moons-contain.md
@@ -1,0 +1,28 @@
+---
+'@namzu/sdk': patch
+---
+
+The plugin subsystem contains its paths. It had none, and it is the part of
+this SDK that loads third-party code.
+
+**A manifest could name any file on disk.** `PluginLifecycleManager` built its
+import path with `join(plugin.rootDir, toolPath)`, and `toolPath` comes out of
+the plugin's own manifest — a file the plugin author writes. A manifest reading
+`"tools": ["../../../../somewhere/evil.js"]` left the plugin directory entirely
+and was imported, which is to say executed, in-process. The same held for
+`hooks`. Both now resolve through `resolveWithinReal`, so a path that escapes
+the plugin root is refused before anything is imported.
+
+**Discovery followed symlinks.** `discoverPlugins` used `stat`, which reports
+on a link's *target*, so a symlinked entry pointing anywhere on disk was
+admitted as a plugin directory and its manifest read from there — the directory
+listed was not the directory loaded (CWE-59). It now uses `lstat` and refuses a
+link with a warning naming the path.
+
+Found by comparing the plugin loader against `@namzu/project`'s scanner, which
+was written this week with both protections. The subsystem that had them was
+the one loading code the repo's own reviewers wrote; the one without them was
+the one loading code from a home directory those reviewers never see.
+
+If you ship a plugin whose manifest points outside its own directory, it now
+fails at enable with a message naming the path. Move the file inside the plugin.

--- a/packages/sdk/src/plugin/__tests__/path-containment.test.ts
+++ b/packages/sdk/src/plugin/__tests__/path-containment.test.ts
@@ -1,0 +1,107 @@
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { PluginRegistry } from '../../registry/plugin/index.js'
+import { ToolRegistry } from '../../registry/tool/execute.js'
+import { getRootLogger } from '../../utils/logger.js'
+import { PluginLifecycleManager } from '../lifecycle.js'
+import { discoverPlugins } from '../loader.js'
+
+/**
+ * The plugin subsystem loads THIRD-PARTY code, which makes it the worst place
+ * in this repo to be missing the containment its filesystem tools got this
+ * week. It had none: zero `lstat`, zero `isSymbolicLink`, zero `resolveWithin`
+ * across the loader and the lifecycle manager.
+ *
+ * Two holes, and the second is the serious one.
+ *
+ * `discoverPlugins` used `stat`, which follows a link and reports on its
+ * TARGET — so a symlinked entry pointing anywhere on disk was admitted as a
+ * plugin directory. The directory listed was not the directory loaded.
+ *
+ * And `PluginLifecycleManager` built its import path with
+ * `join(plugin.rootDir, toolPath)` where `toolPath` comes out of the
+ * MANIFEST — a file the plugin author writes. `"tools": ["../../../evil.js"]`
+ * left the plugin directory entirely and was imported, which runs it.
+ */
+
+const CAN_SYMLINK = (() => {
+	try {
+		const probe = mkdtempSync(join(tmpdir(), 'namzu-plug-sym-'))
+		symlinkSync(probe, join(probe, 'self'), 'dir')
+		return true
+	} catch {
+		return false
+	}
+})()
+
+function pluginsDir(): string {
+	return mkdtempSync(join(tmpdir(), 'namzu-plugins-'))
+}
+
+function writePlugin(parent: string, name: string, manifest: Record<string, unknown>): string {
+	const dir = join(parent, name)
+	mkdirSync(dir, { recursive: true })
+	writeFileSync(
+		join(dir, 'plugin.json'),
+		JSON.stringify({ name, version: '1.0.0', description: 'test', ...manifest }),
+	)
+	return dir
+}
+
+describe('plugin discovery refuses a symlinked directory', () => {
+	it.skipIf(!CAN_SYMLINK)('does not admit a link as a plugin directory', async () => {
+		const outside = mkdtempSync(join(tmpdir(), 'namzu-outside-'))
+		writePlugin(outside, 'evil', { tools: [] })
+
+		const parent = pluginsDir()
+		writePlugin(parent, 'honest', { tools: [] })
+		symlinkSync(join(outside, 'evil'), join(parent, 'linked'), 'dir')
+
+		const found = await discoverPlugins(parent)
+
+		expect(found.map((p) => p.split(/[\\/]/).pop())).toEqual(['honest'])
+	})
+
+	it('still finds an ordinary plugin directory', async () => {
+		const parent = pluginsDir()
+		writePlugin(parent, 'ordinary', { tools: [] })
+
+		expect(await discoverPlugins(parent)).toHaveLength(1)
+	})
+})
+
+function managerFor(def: unknown): PluginLifecycleManager {
+	const pluginRegistry = new PluginRegistry()
+	pluginRegistry.register(def as never)
+	return new PluginLifecycleManager({
+		pluginRegistry,
+		toolRegistry: new ToolRegistry(),
+		log: getRootLogger(),
+	} as never)
+}
+
+describe('a manifest cannot name a file outside its own plugin', () => {
+	it('refuses a tool path that climbs out', async () => {
+		// The manifest is written by the plugin author. Without containment the
+		// named file was imported — which is to say, executed.
+		const outside = mkdtempSync(join(tmpdir(), 'namzu-outside-'))
+		writeFileSync(join(outside, 'evil.js'), 'export const tools = []')
+		const parent = pluginsDir()
+		const escaping = join('..', outside.split(/[\/]/).pop() as string, 'evil.js')
+		const dir = writePlugin(parent, 'sneaky', { tools: [escaping] })
+
+		const manager = managerFor({
+			id: 'sneaky',
+			manifest: { name: 'sneaky', version: '1.0.0', description: 't', tools: [escaping] },
+			scope: 'project',
+			status: 'installed',
+			rootDir: dir,
+			installedAt: 0,
+		})
+
+		await expect(manager.enable('sneaky' as never)).rejects.toThrow(/escapes the working directory/)
+	})
+})

--- a/packages/sdk/src/plugin/lifecycle.ts
+++ b/packages/sdk/src/plugin/lifecycle.ts
@@ -1,4 +1,3 @@
-import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { mcpToolToToolDefinition } from '../connector/mcp/adapter.js'
 import { MCPClient } from '../connector/mcp/client.js'
@@ -12,6 +11,7 @@ import {
 	PLUGIN_NAMESPACE_SEPARATOR,
 } from '../constants/plugin/index.js'
 import type { PluginRegistry } from '../registry/plugin/index.js'
+import { resolveWithinReal } from '../tools/paths.js'
 import type { PluginId } from '../types/ids/index.js'
 import type {
 	PluginDefinition,
@@ -218,7 +218,7 @@ export class PluginLifecycleManager {
 			// Load tools
 			if (manifest.tools && manifest.tools.length > 0) {
 				for (const toolPath of manifest.tools) {
-					const absolutePath = join(plugin.rootDir, toolPath)
+					const absolutePath = await resolveWithinReal(plugin.rootDir, toolPath)
 					const fileUrl = pathToFileURL(absolutePath).href
 					const mod = (await import(fileUrl)) as { tools?: ToolDefinition[] }
 
@@ -240,7 +240,7 @@ export class PluginLifecycleManager {
 			// Load hooks
 			if (manifest.hooks && manifest.hooks.length > 0) {
 				for (const hookPath of manifest.hooks) {
-					const absolutePath = join(plugin.rootDir, hookPath)
+					const absolutePath = await resolveWithinReal(plugin.rootDir, hookPath)
 					const fileUrl = pathToFileURL(absolutePath).href
 					const mod = (await import(fileUrl)) as { hooks?: PluginHookDefinition[] }
 

--- a/packages/sdk/src/plugin/loader.ts
+++ b/packages/sdk/src/plugin/loader.ts
@@ -1,4 +1,4 @@
-import { readFile, readdir, stat } from 'node:fs/promises'
+import { lstat, readFile, readdir, stat } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -23,7 +23,17 @@ export async function discoverPlugins(parentDir: string): Promise<string[]> {
 		for (const entry of entries) {
 			if (entry.startsWith('.') || entry.startsWith('_')) continue
 			const fullPath = join(parentDir, entry)
-			const s = await stat(fullPath)
+			// `lstat`, not `stat`: `stat` follows the link and reports on its
+			// TARGET, so a symlinked entry pointing anywhere on disk was
+			// admitted as a plugin directory and its manifest read from there.
+			// A plugins directory holds third-party code by definition, which
+			// makes following a link out of it the worse half of CWE-59 — the
+			// directory listed is not the directory loaded.
+			const s = await lstat(fullPath)
+			if (s.isSymbolicLink()) {
+				logger.warn('Refusing a symlinked plugin directory', { path: fullPath })
+				continue
+			}
 			if (!s.isDirectory()) continue
 
 			const manifestPath = join(fullPath, PLUGIN_MANIFEST_FILENAME)


### PR DESCRIPTION
The plugin subsystem had no path containment, and it is the part of this
SDK that loads third-party code.

A manifest could name any file on disk. `PluginLifecycleManager` built its
import path with `join(plugin.rootDir, toolPath)`, and `toolPath` comes out
of the plugin's own manifest — written by the plugin author. A manifest
reading `"tools": ["../../../../evil.js"]` left the plugin directory
entirely and was imported, which runs it, in this process. `hooks` had the
same shape. Both resolve through `resolveWithinReal` now.

Discovery followed symlinks: `discoverPlugins` used `stat`, which reports
on a link's target, so a symlinked entry pointing anywhere on disk was
admitted as a plugin directory and its manifest read from there. The
directory listed was not the directory loaded. It uses `lstat` now and
refuses a link, naming the path.

Found by comparing this loader against `@namzu/project`'s scanner, written
this week with both protections. The asymmetry is the point: the subsystem
that HAD containment reads a directory the user names, and the one without
it reads `~/.namzu/plugins`, which the repo's reviewers never see. The
protection was on the safer half.