### PR TITLE
fix(sdk): runAgent forwards the skills and the gate it was given

### DIFF
--- a/.changeset/quiet-doors-forward.md
+++ b/.changeset/quiet-doors-forward.md
@@ -1,0 +1,46 @@
+---
+'@namzu/sdk': minor
+'@namzu/project': patch
+---
+
+runAgent forwards skills and the verification gate
+
+`runAgent` built its `drainQuery` call with an `as never` cast. The cast was
+not load-bearing — removing it typechecks clean — but while it was there the
+kernel seam was unchecked in both directions, and two options the kernel
+accepts were never forwarded.
+
+**`skills`** is the one with a caller. `@namzu/project` reads a whole `skills/`
+directory, puts them on the options, and every one was dropped: the run was
+assembled without them and nothing reported it. If you passed `skills` to
+`runAgent` and wondered why the model behaved as though it had never seen them,
+this is why. No change needed on your side — the field now arrives.
+
+**`verificationGate`** is the safety one. The kernel builds a `VerificationGate`
+from it and consults it on every tool call; the front door had no way to supply
+one, so a `runAgent` run was strictly less mediated than a `drainQuery` run. A
+host that hands `runAgent` an agent directory it did not write should now set
+it.
+
+Both are optional and default to today's behaviour, so nothing breaks.
+
+Three fixes in `@namzu/project`, each a check that existed and read the wrong
+thing:
+
+- **A tool with no `inputSchema` is refused.** It used to pass `isToolDefinition`
+  — which checked only `name` and `execute` — register clean, then die inside
+  `toLLMTools()` on `inputSchema._def`, in a `TypeError` naming neither the tool
+  file nor the loader. The check is now the four fields `ToolDefinition`
+  declares as required, and no more: demanding `defineTool`'s extras would make
+  the loader refuse an object the SDK's own published type accepts. A directory
+  that previously loaded with `ok: true` and crashed on first use now loads with
+  `ok: false` and a `not_a_tool` diagnostic naming the file.
+- **Import failures explain themselves again.** `explainImportFailure` chose its
+  hint by matching Node's error code against `err.message`, and Node does not
+  put the code in the message — probed: `ERR_MODULE_NOT_FOUND` arrives as
+  "Cannot find module …". Every hint in the function was unreachable. It reads
+  `err.code` now, and a Node too old for type stripping gets a hint of its own.
+- **`metadata` values are checked.** Typed `Record<string, string>` and admitted
+  on `typeof === 'object'` alone, which an array also satisfies and which says
+  nothing about the values, so `{ count: 1 }` and `["a"]` both reached a
+  consumer that had been promised strings.

--- a/packages/project/src/__tests__/load-diagnostics.test.ts
+++ b/packages/project/src/__tests__/load-diagnostics.test.ts
@@ -1,0 +1,126 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { loadProject } from '../load.js'
+
+/**
+ * Three refusals this loader claimed to make and did not.
+ *
+ * Each is the same shape: a check that existed, read the wrong thing, and
+ * therefore reported the wrong answer while looking correct in review. A
+ * loader whose entire job is to say what is wrong with a directory has to be
+ * held to the diagnostics it actually emits, not the ones its code appears to
+ * emit.
+ */
+
+function project(files: Record<string, string>): string {
+	const root = mkdtempSync(join(tmpdir(), 'namzu-diag-'))
+	for (const [relative, body] of Object.entries(files)) {
+		const full = join(root, relative)
+		mkdirSync(join(full, '..'), { recursive: true })
+		writeFileSync(full, body)
+	}
+	return root
+}
+
+describe('a tool that would crash later is refused now', () => {
+	it('rejects a default export with no inputSchema', async () => {
+		// `name` and `execute` alone used to pass. The object then registered
+		// clean and died in `toLLMTools()` on `inputSchema._def` — a TypeError
+		// naming neither this file nor this loader.
+		const root = project({
+			'tools/broken.js': `
+export default {
+  name: 'broken',
+  description: 'no schema',
+  execute: async () => ({ success: true }),
+}
+`,
+		})
+
+		const { manifest, diagnostics, ok } = await loadProject(root)
+
+		expect(ok).toBe(false)
+		expect(diagnostics.map((d) => d.code)).toContain('not_a_tool')
+		expect(manifest.tools).toHaveLength(0)
+	})
+
+	it('still accepts a hand-written tool that satisfies the published type', async () => {
+		// The required set and no more: demanding `defineTool`'s extras would
+		// make this loader refuse an object the SDK's own type accepts.
+		const root = project({
+			'tools/fine.js': `
+export default {
+  name: 'fine',
+  description: 'a tool',
+  inputSchema: { parse: (v) => v },
+  execute: async () => ({ success: true }),
+}
+`,
+		})
+
+		const { manifest, ok } = await loadProject(root)
+
+		expect(ok).toBe(true)
+		expect(manifest.tools).toHaveLength(1)
+	})
+})
+
+describe('an import failure explains itself', () => {
+	it('gives the extension hint for a module it cannot resolve', async () => {
+		// The hint is chosen from Node's error CODE. It used to be matched
+		// against the message, which never contains the code, so every hint in
+		// the function was unreachable and every author got the bare error.
+		const root = project({
+			'tools/importer.js': `
+import './nowhere-at-all.js'
+export default { name: 'x', description: 'x', inputSchema: {}, execute: async () => ({}) }
+`,
+		})
+
+		const { diagnostics } = await loadProject(root)
+
+		const failed = diagnostics.find((d) => d.code === 'module_load_failed')
+		expect(failed).toBeDefined()
+		expect(failed?.cause).toContain('real extension')
+	})
+})
+
+describe('agent.ts metadata is checked, not assumed', () => {
+	it('refuses metadata values that are not strings', async () => {
+		// Typed `Record<string, string>` and admitted on `typeof === 'object'`,
+		// so the values were never looked at and the type was a promise this
+		// loader did not keep.
+		const root = project({
+			'agent.js': 'export default { model: "m", metadata: { count: 1 } }',
+		})
+
+		const { diagnostics, ok } = await loadProject(root)
+
+		expect(ok).toBe(false)
+		expect(diagnostics.some((d) => d.code === 'invalid_config')).toBe(true)
+	})
+
+	it('refuses an array, which typeof calls an object', async () => {
+		const root = project({
+			'agent.js': 'export default { model: "m", metadata: ["a", "b"] }',
+		})
+
+		const { ok } = await loadProject(root)
+
+		expect(ok).toBe(false)
+	})
+
+	it('accepts a metadata object of strings', async () => {
+		const root = project({
+			'agent.js': 'export default { model: "m", metadata: { team: "core" } }',
+		})
+
+		const { manifest, ok } = await loadProject(root)
+
+		expect(ok).toBe(true)
+		expect(manifest.config.metadata).toEqual({ team: 'core' })
+	})
+})

--- a/packages/project/src/derive.ts
+++ b/packages/project/src/derive.ts
@@ -66,5 +66,5 @@ export function deriveRunOptions(
 		...(manifest.config.timeoutMs !== undefined ? { timeoutMs: manifest.config.timeoutMs } : {}),
 		...(input.identity ?? {}),
 		...(input.overrides ?? {}),
-	} as RunAgentOptions
+	}
 }

--- a/packages/project/src/load.ts
+++ b/packages/project/src/load.ts
@@ -40,7 +40,8 @@ async function importWithDeadline(
 ): Promise<
 	| { status: 'loaded'; module: unknown }
 	| { status: 'abandoned' }
-	| { status: 'failed'; cause: string }
+	/** `code` is Node's `err.code`, which its `message` does not contain. */
+	| { status: 'failed'; cause: string; code?: string }
 > {
 	let timer: ReturnType<typeof setTimeout> | undefined
 	const deadline = new Promise<{ status: 'abandoned' }>((resolve) => {
@@ -56,9 +57,11 @@ async function importWithDeadline(
 		])
 		return result
 	} catch (err) {
+		const code = (err as { code?: unknown } | null)?.code
 		return {
 			status: 'failed',
 			cause: err instanceof Error ? err.message : String(err),
+			...(typeof code === 'string' ? { code } : {}),
 		}
 	} finally {
 		if (timer) clearTimeout(timer)
@@ -73,24 +76,60 @@ async function importWithDeadline(
  * decorator, a parameter property) — stripping erases types, it does not
  * transform code, and no flag rescues those. That is a different problem from
  * a plain syntax error, and pointing at the wrong one costs an author an hour.
+ *
+ * That sentence was true and this function still matched on `cause`, which is
+ * `err.message` — and Node does not put the code in the message. Probed:
+ * `ERR_MODULE_NOT_FOUND` arrives as *"Cannot find module …"*, and
+ * `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX` as *"TypeScript enum is not supported in
+ * strip-only mode"*. Neither contains its code, so every branch below was
+ * unreachable and every author got the bare message the doc-comment was
+ * explaining why not to give them. The code is read from `err.code` now, which
+ * is where it always was.
  */
-function explainImportFailure(cause: string): string {
-	if (cause.includes('ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX')) {
+function explainImportFailure(cause: string, code?: string): string {
+	if (code === 'ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX') {
 		return `${cause}\n\nNode strips types, it does not compile them: enums, decorators, parameter properties and runtime namespaces have no stripped form. Rewrite as plain TypeScript, or pass \`importModule\` with a transforming loader.`
 	}
-	if (cause.includes('ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING')) {
+	if (code === 'ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING') {
 		return `${cause}\n\nNode refuses to strip types from any .ts file resolved under node_modules/. If this is a workspace package, have it ship built .js.`
 	}
-	if (cause.includes('ERR_MODULE_NOT_FOUND')) {
+	if (code === 'ERR_MODULE_NOT_FOUND') {
 		return `${cause}\n\nRelative imports need their real extension here — write "./util.ts", not "./util". tsconfig "paths" aliases are not resolved; pass \`importModule\` if you need them.`
+	}
+	// Node ≥20 but <22.6 has no type stripping at all, so the golden path — a
+	// `.ts` tool — dies here rather than at any of the codes above.
+	if (code === 'ERR_UNKNOWN_FILE_EXTENSION' && /\.[cm]?ts"?$/.test(cause)) {
+		return `${cause}\n\nThis Node cannot run TypeScript directly. Use Node 22.18 or newer, or pass \`importModule\` with a loader that transpiles.`
 	}
 	return cause
 }
 
+/**
+ * The fields `ToolDefinition` declares without a `?`.
+ *
+ * Checking `name` and `execute` alone was not a weaker version of this check,
+ * it was a check that let the failure through and moved it: a default export
+ * with no `inputSchema` passed here, registered clean, and then died inside
+ * `toLLMTools()` reading `inputSchema._def` — a `TypeError` naming a file this
+ * loader never mentions, at a point where the author is no longer looking at
+ * their tool. A loader whose job is to report bad files must reject the ones
+ * that crash later, not only the ones that are obviously not tools.
+ *
+ * Exactly the required set, and no more. `isReadOnly`, `isDestructive` and the
+ * other `defineTool` niceties are not on the interface, so demanding them would
+ * make this loader refuse a hand-written object that satisfies the SDK's own
+ * published type — the loader overruling the SDK.
+ */
 function isToolDefinition(value: unknown): value is ToolDefinition {
 	if (typeof value !== 'object' || value === null) return false
-	const candidate = value as { name?: unknown; execute?: unknown }
-	return typeof candidate.name === 'string' && typeof candidate.execute === 'function'
+	const c = value as Record<string, unknown>
+	return (
+		typeof c.name === 'string' &&
+		typeof c.description === 'string' &&
+		typeof c.execute === 'function' &&
+		typeof c.inputSchema === 'object' &&
+		c.inputSchema !== null
+	)
 }
 
 /** The default export, tolerating a namespace that only has named exports. */
@@ -142,7 +181,39 @@ function readConfig(value: unknown, diagnostics: ProjectDiagnostic[], path: stri
 	take('maxIterations', isNumber, 'finite number')
 	take('tokenBudget', isNumber, 'finite number')
 	take('timeoutMs', isNumber, 'finite number')
-	if (raw.metadata && typeof raw.metadata === 'object') config.metadata = raw.metadata
+
+	// `metadata` is typed `Record<string, string>` and was admitted on
+	// `typeof === 'object'` alone — which an array also satisfies, and which
+	// says nothing about the values. So `{ tags: ['a'] }` and `{ n: 1 }` both
+	// reached a consumer that had been promised strings, and the type was a
+	// claim this loader did not keep. Every other field here is checked; this
+	// one is the reason to check the values too, since it is the only field
+	// whose contents are forwarded verbatim to an inspector.
+	if (raw.metadata !== undefined) {
+		const m = raw.metadata
+		if (typeof m !== 'object' || m === null || Array.isArray(m)) {
+			diagnostics.push({
+				code: 'invalid_config',
+				severity: 'error',
+				message: `agent.ts: "metadata" must be an object of string values, received ${Array.isArray(m) ? 'array' : typeof m}.`,
+				path,
+			})
+		} else {
+			const bad = Object.entries(m).filter(([, v]) => typeof v !== 'string')
+			if (bad.length > 0) {
+				diagnostics.push({
+					code: 'invalid_config',
+					severity: 'error',
+					message: `agent.ts: "metadata" values must be strings; ${bad
+						.map(([k, v]) => `"${k}" is ${v === null ? 'null' : typeof v}`)
+						.join(', ')}.`,
+					path,
+				})
+			} else {
+				config.metadata = m
+			}
+		}
+	}
 	return config as ProjectConfig
 }
 
@@ -301,7 +372,7 @@ async function loadAt(
 						severity: 'error',
 						message: 'agent.ts could not be imported.',
 						path: found.path,
-						cause: explainImportFailure(outcome.cause),
+						cause: explainImportFailure(outcome.cause, outcome.code),
 					})
 					record(found, 'agent', 'failed')
 				}
@@ -341,7 +412,7 @@ async function loadAt(
 					severity: 'error',
 					message: `${file.relativePath} could not be imported.`,
 					path: file.path,
-					cause: explainImportFailure(outcome.cause),
+					cause: explainImportFailure(outcome.cause, outcome.code),
 				})
 				record(file, 'tools', 'failed')
 				continue

--- a/packages/sdk/src/agents/__tests__/run-agent-forwarding.test.ts
+++ b/packages/sdk/src/agents/__tests__/run-agent-forwarding.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { MockLLMProvider, registerMock } from '../../provider/index.js'
+import { ToolRegistry } from '../../registry/index.js'
+import { runAgent } from '../runAgent.js'
+
+/**
+ * The `drainQuery` call in `runAgent` was written `as never`.
+ *
+ * That cast was not load-bearing — removing it typechecks clean — but while it
+ * was there the kernel seam was unchecked in both directions: a field the
+ * kernel accepts and this door forgot to forward produced no error, and neither
+ * did a field spelled wrong. Two were already missing when it was removed.
+ *
+ * `skills` is the one with a caller in this repo. `@namzu/project` reads a
+ * whole `skills/` directory, put them on the options, and every one was dropped
+ * on the floor — the run was assembled without them and said nothing. These
+ * pin the forwarding rather than the cast, because the cast can come back and
+ * a test that only asserted its absence would not notice.
+ */
+
+registerMock()
+
+describe('runAgent forwards what the kernel takes', () => {
+	it('puts skills in front of the model', async () => {
+		const provider = new MockLLMProvider({ turns: [{ text: 'ok' }] })
+
+		await runAgent({
+			provider,
+			model: 'mock-model',
+			prompt: 'plan something',
+			skills: [
+				{
+					metadata: { name: 'plan-a-trip', description: 'Plan a trip end to end' },
+					body: 'Ask for dates first.',
+					dirPath: '/tmp/skills/plan-a-trip',
+				},
+			],
+		})
+
+		// Serialized rather than reached into: the prompt builder decides where a
+		// skill lands, and pinning that path here would make this test fail on a
+		// refactor that kept the behaviour. What matters is that it arrived.
+		expect(JSON.stringify(provider.requests[0])).toContain('plan-a-trip')
+	})
+
+	it('forwards the verification gate, so a denied tool does not run', async () => {
+		// The first version of this test asserted `run.status === 'completed'`
+		// with the gate set. It passed with the forwarding deleted — a run with
+		// no gate completes too — so it proved nothing. A gate is only observable
+		// through a call it stops, which means the assertion has to be about
+		// whether the tool body ran.
+		let ran = false
+
+		const tools = new ToolRegistry()
+		tools.register({
+			name: 'delete_everything',
+			description: 'Deletes everything.',
+			inputSchema: z.object({}),
+			execute: async () => {
+				ran = true
+				return { success: true, output: 'deleted' }
+			},
+		})
+
+		await runAgent({
+			provider: new MockLLMProvider({
+				turns: [{ toolCalls: [{ name: 'delete_everything', args: {} }] }, { text: 'done' }],
+			}),
+			model: 'mock-model',
+			prompt: 'clean up',
+			tools,
+			verificationGate: {
+				enabled: true,
+				rules: [{ type: 'deny_by_name', toolNames: ['delete_everything'] }],
+				allowReadOnlyTools: false,
+				denyDangerousPatterns: false,
+				logDecisions: false,
+			},
+		})
+
+		expect(ran).toBe(false)
+	})
+})

--- a/packages/sdk/src/agents/runAgent.ts
+++ b/packages/sdk/src/agents/runAgent.ts
@@ -4,7 +4,9 @@ import type { ProjectId, SessionId, TenantId, ThreadId } from '../types/ids/inde
 import type { Message } from '../types/message/index.js'
 import type { LLMProvider } from '../types/provider/index.js'
 import type { Run, RunEventListener } from '../types/run/index.js'
+import type { Skill } from '../types/skills/index.js'
 import type { ToolRegistryContract } from '../types/tool/index.js'
+import type { VerificationGateConfig } from '../types/verification/index.js'
 import {
 	generateProjectId,
 	generateSessionId,
@@ -50,6 +52,28 @@ export interface RunAgentOptions extends AgentIdentity {
 	model: string
 
 	tools?: ToolRegistryContract
+
+	/**
+	 * Skills to put in front of the model.
+	 *
+	 * The kernel has taken these since it had a prompt builder; this door did
+	 * not forward them, so a caller who assembled skills — `@namzu/project`
+	 * reads a whole `skills/` directory — handed them over and got a run that
+	 * had never heard of them. Silent, because the `drainQuery` call below was
+	 * cast, and a cast seam reports nothing when a field goes missing.
+	 */
+	skills?: Skill[]
+
+	/**
+	 * Operator policy for tool calls: which ones need review before they run.
+	 *
+	 * Absent means every tool runs unreviewed, which is the right default for a
+	 * library front door and the wrong one for a host that hands this an agent
+	 * directory it did not write. The kernel builds a `VerificationGate` from
+	 * this and consults it on every call; without it there is nothing to
+	 * consult, so a front-door run is strictly less mediated than a kernel one.
+	 */
+	verificationGate?: VerificationGateConfig
 
 	/** Defaults to the current working directory. */
 	workingDirectory?: string
@@ -170,8 +194,10 @@ export async function runAgent(options: RunAgentOptions): Promise<RunAgentResult
 			agentName: options.name ?? 'Agent',
 			...(options.instructions ? { systemPrompt: options.instructions } : {}),
 			...(options.signal ? { signal: options.signal } : {}),
+			...(options.skills ? { skills: options.skills } : {}),
+			...(options.verificationGate ? { verificationGate: options.verificationGate } : {}),
 			...identity,
-		} as never,
+		},
 		options.listener,
 	)
 


### PR DESCRIPTION
`runAgent` built its `drainQuery` call with `as never`. **Measured: the cast was not load-bearing** — removing it typechecks clean — so it suppressed the kernel seam in both directions for nothing, and two options the kernel drives were never forwarded.

`skills` had a caller. `@namzu/project` reads a whole `skills/` directory and puts them on the options, and `derive.ts` emitted them under its own `as RunAgentOptions` cast — **a cast at each end of the seam**, so neither compiler ever saw that the field had nowhere to land. Every skill was dropped and the run said nothing.

`verificationGate` is the safety half: the kernel builds a gate from it and consults it on every tool call, and the front door could not supply one — so a `runAgent` run was strictly less mediated than a `drainQuery` run.

Three fixes in `@namzu/project`, each a check that existed and read the wrong thing:

- `isToolDefinition` checked `name` and `execute` only; a tool with no `inputSchema` registered clean and died later in `toLLMTools()`.
- `explainImportFailure` matched Node's error **code** against `err.message`, which never contains it — probed, all three hints unreachable.
- `metadata` was admitted on `typeof === 'object'` (an array passes) and its values never checked.

## Provenance

Found by the CLI design workflow. Its verifier ran at `528349f`, **before #107/#108 merged**, so its rulings about `agents`/`derive-supervisor` describe a tree that no longer exists and were discarded; these four findings were re-verified against the real tree before being acted on.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm test` (2419 SDK tests) green. Five mutations, each caught by exactly one test.

Two of my own errors were caught by mutation rather than review, and are recorded because the process is the point: the first gate test asserted `run.status === 'completed'`, which passes with the forwarding deleted; and the mutation runner's ANSI stripper omitted the ESC byte, reporting NOT CAUGHT for all five while the suite was failing.