### PR TITLE
fix(cli): run-stream honours --cwd instead of saying it to the model

### DIFF
--- a/.changeset/honest-flags-run-stream.md
+++ b/.changeset/honest-flags-run-stream.md
@@ -1,0 +1,40 @@
+---
+'@namzu/cli': minor
+---
+
+run-stream honours --cwd, and stops reading unknown flags aloud to the model
+
+`run-stream` and `history` both advertise `--cwd <path>` in their own help
+text. Neither ever parsed it. Worse than ignored: the parser folded every
+argument it did not recognise into `rest`, and `rest.join(' ')` is the
+**prompt** — so the invocation our help teaches,
+
+```
+namzu run-stream --cwd /projects/foo "summarise this"
+```
+
+sent the model a prompt reading `--cwd /projects/foo summarise this` while
+silently using the process's own directory. For `history` the same omission
+meant a host asking about a session in another checkout was told `[]`, which
+is indistinguishable from a session that exists and has no messages.
+
+`--cwd` is now parsed and actually used — it selects the `.namzu` store the
+session is read from and the directory skills are discovered in.
+
+**Behaviour change worth reading before you upgrade.** An unrecognised
+`--flag` is now refused with an error event instead of becoming prompt text.
+This is what makes a typo — `--modell gpt-4o` — a message rather than
+something the model is asked to interpret. If you deliberately send a prompt
+that begins with a dash, put `--` in front of it:
+
+```
+namzu run-stream -- --force should be added to the docs
+```
+
+Everything after `--` is prompt, verbatim. A single leading `-` was never
+treated as an option and still is not.
+
+Classified `minor` rather than `major` because this package is `0.x`, where
+[SemVer §4](https://semver.org/#spec-item-4) states the public API should not
+be considered stable and anything may change. On a `1.x` package the refusal
+would owe a major.

--- a/packages/cli/src/commands/__tests__/run-stream-flags.test.ts
+++ b/packages/cli/src/commands/__tests__/run-stream-flags.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { openSessions } from '../../integrations/sessions/store.js'
+import { historyCommand, parseRunStreamFlags, runStreamCommand } from '../run-stream.js'
+import type { CommandContext } from '../types.js'
+
+// Mocked so the directory the store is opened at is observable. Nothing here
+// touches a real `.namzu` store; `resolveConversation` returning null is the
+// "no such session" path, which is what makes the handler terminate.
+vi.mock('../../integrations/sessions/store.js', () => ({
+	openSessions: vi.fn(async () => ({}) as never),
+	resolveConversation: vi.fn(async () => null),
+	loadConversation: vi.fn(async () => []),
+	appendMessages: vi.fn(async () => undefined),
+}))
+
+/**
+ * `run-stream` folded every argument it did not recognise into `rest`, and
+ * `rest.join(' ')` is the PROMPT. `--cwd <path>` was in this command's own help
+ * text and was never parsed, so the invocation our documentation teaches sent
+ * the model a prompt beginning `--cwd /path …` while silently reading the
+ * process's own directory.
+ *
+ * That is the same defect the sibling test in `passthrough-help.test.ts`
+ * describes one level up, where `--help` became the prompt. The fix there was
+ * to stop treating an option as content; the fix here is the same, plus
+ * actually honouring the flag that was advertised.
+ */
+
+const ctx = {} as unknown as CommandContext
+
+function capture(): { lines: string[]; restore: () => void } {
+	const lines: string[] = []
+	const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+		lines.push(String(chunk))
+		return true
+	})
+	return { lines, restore: () => spy.mockRestore() }
+}
+
+beforeEach(() => {
+	vi.mocked(openSessions).mockClear()
+})
+
+afterEach(() => {
+	vi.restoreAllMocks()
+})
+
+async function run(rawArgs: string[]): Promise<string[]> {
+	const { lines, restore } = capture()
+	try {
+		await runStreamCommand.handler({ rawArgs, ctx } as never)
+	} finally {
+		restore()
+	}
+	return lines
+}
+
+describe('run-stream does not turn options into prompt text', () => {
+	it('consumes --cwd instead of speaking it to the model', async () => {
+		// With `--cwd` unparsed these two tokens WERE the prompt, so the run
+		// proceeded. Reaching "no prompt" is what proves they were consumed.
+		const lines = await run(['--cwd', '/tmp/somewhere'])
+
+		expect(lines.join('')).toContain('no prompt')
+	})
+
+	it('refuses an option it does not know rather than saying it out loud', async () => {
+		const lines = await run(['--temperature', '0.5', 'hello'])
+
+		const joined = lines.join('')
+		expect(joined).toContain('unknown option')
+		expect(joined).toContain('--temperature')
+	})
+
+	it('refuses the flag form written with an equals sign', async () => {
+		const lines = await run(['--nope=1', 'hello'])
+
+		expect(lines.join('')).toContain('--nope')
+	})
+
+	it('still emits a terminal event when it refuses, so a host is not left hanging', async () => {
+		// The NDJSON contract is that every run ends with `done`. A refusal that
+		// skipped it would strand a host line-scanning stdout.
+		const lines = await run(['--bogus', 'hello'])
+
+		expect(lines.join('')).toContain('"kind":"done"')
+	})
+})
+
+describe('the flag parser itself', () => {
+	// Asserted here rather than through the handler: a valid prompt sends the
+	// handler on to stdin and a provider probe, so the first version of this
+	// case hung for five seconds and failed on a timeout rather than on the
+	// behaviour. A pure function deserves to be called.
+	it('lets `--` carry a prompt that begins with a dash', () => {
+		const flags = parseRunStreamFlags(['--', '--this-is-the-prompt'])
+
+		expect(flags.rest).toEqual(['--this-is-the-prompt'])
+		expect(flags.unknown).toEqual([])
+	})
+
+	it('stops interpreting options after `--`', () => {
+		const flags = parseRunStreamFlags(['--session', 'abc', '--', '--model', 'not-a-flag'])
+
+		expect(flags.session).toBe('abc')
+		expect(flags.model).toBeNull()
+		expect(flags.rest).toEqual(['--model', 'not-a-flag'])
+	})
+
+	it('reads --cwd in both spellings', () => {
+		expect(parseRunStreamFlags(['--cwd', '/a', 'hi']).cwd).toBe('/a')
+		expect(parseRunStreamFlags(['--cwd=/b', 'hi']).cwd).toBe('/b')
+		expect(parseRunStreamFlags(['--cwd', '/a', 'hi']).rest).toEqual(['hi'])
+	})
+
+	it('leaves a lone dash alone, since that is not an option', () => {
+		expect(parseRunStreamFlags(['-', 'hi']).unknown).toEqual([])
+		expect(parseRunStreamFlags(['-', 'hi']).rest).toEqual(['-', 'hi'])
+	})
+})
+
+describe('history reads the directory it was pointed at', () => {
+	it('opens the store at --cwd, not at the process directory', async () => {
+		// Parsing the flag is not the fix; USING it is. An assertion that the
+		// command merely survives `--cwd` would pass with the wiring reverted —
+		// `[]` is printed either way — which would leave the flag parsed and
+		// still undriven, the exact shape being repaired here.
+		const { lines, restore } = capture()
+		try {
+			await historyCommand.handler({
+				rawArgs: ['--cwd', '/tmp/elsewhere', '--session', 'some-key'],
+				ctx,
+			} as never)
+		} finally {
+			restore()
+		}
+
+		expect(openSessions).toHaveBeenCalledWith('/tmp/elsewhere')
+		expect(lines.join('').trim()).toBe('[]')
+	})
+
+	it('falls back to the process directory when --cwd is absent', async () => {
+		const { restore } = capture()
+		try {
+			await historyCommand.handler({ rawArgs: ['--session', 'some-key'], ctx } as never)
+		} finally {
+			restore()
+		}
+
+		expect(openSessions).toHaveBeenCalledWith(process.cwd())
+	})
+})

--- a/packages/cli/src/commands/run-stream.ts
+++ b/packages/cli/src/commands/run-stream.ts
@@ -54,17 +54,39 @@ interface RunStreamFlags {
 	model: string | null
 	provider: string | null
 	instance: string | null
+	/** Where the session store and skills are read from. Defaults to `process.cwd()`. */
+	cwd: string | null
 	skills: string[]
+	/**
+	 * `--flags` this parser does not know.
+	 *
+	 * Collected rather than folded into `rest`, because `rest` becomes the
+	 * PROMPT. `--cwd` was in this command's own help text and never parsed, so
+	 * the documented invocation sent the model a prompt beginning
+	 * `--cwd /path …` and silently used the process's own directory. Anything
+	 * unrecognised is now refused instead of being quietly said out loud to a
+	 * model — a typo'd flag is a mistake, and reading it aloud is the worst
+	 * available response to one.
+	 */
+	unknown: string[]
 	rest: string[]
 }
 
-function parseRunStreamFlags(rawArgs: readonly string[]): RunStreamFlags {
+/**
+ * Exported for tests only — `src/index.ts` does not re-export it, so this is
+ * module visibility rather than public surface. Driving the handler far enough
+ * to observe a parse means reaching stdin and a provider probe, which is a
+ * worse test of a pure function than calling it.
+ */
+export function parseRunStreamFlags(rawArgs: readonly string[]): RunStreamFlags {
 	const out: RunStreamFlags = {
 		session: null,
 		model: null,
 		provider: null,
 		instance: null,
+		cwd: null,
 		skills: [],
+		unknown: [],
 		rest: [],
 	}
 	const take = (a: string, name: string, set: (v: string) => void, i: { v: number }): boolean => {
@@ -80,6 +102,24 @@ function parseRunStreamFlags(rawArgs: readonly string[]): RunStreamFlags {
 	}
 	for (const idx = { v: 0 }; idx.v < rawArgs.length; idx.v++) {
 		const a = rawArgs[idx.v]
+		// End of options. Everything after it is prompt, verbatim — the escape
+		// for a prompt that legitimately begins with a dash, which is the only
+		// case the refusal below would otherwise take away.
+		if (a === '--') {
+			out.rest.push(...rawArgs.slice(idx.v + 1))
+			break
+		}
+		if (
+			take(
+				a,
+				'cwd',
+				(v) => {
+					out.cwd = v.trim() || null
+				},
+				idx,
+			)
+		)
+			continue
 		if (
 			take(
 				a,
@@ -138,6 +178,10 @@ function parseRunStreamFlags(rawArgs: readonly string[]): RunStreamFlags {
 			)
 		)
 			continue
+		if (a.startsWith('--')) {
+			out.unknown.push(a.split('=')[0])
+			continue
+		}
 		out.rest.push(a)
 	}
 	return out
@@ -192,7 +236,13 @@ export const runStreamCommand: CommandDef = {
 		}
 
 		const flags = parseRunStreamFlags(rawArgs)
+		if (flags.unknown.length > 0) {
+			return fail(
+				`unknown option(s): ${flags.unknown.join(', ')} — pass \`--\` before a prompt that starts with a dash`,
+			)
+		}
 		const sessionKey = flags.session
+		const cwd = flags.cwd ?? process.cwd()
 		const prompt = flags.rest.join(' ').trim()
 		if (!prompt) return fail('no prompt — pass it as an argument')
 
@@ -204,7 +254,7 @@ export const runStreamCommand: CommandDef = {
 		let prior: Message[] = []
 		if (sessionKey) {
 			try {
-				cli = await openSessions(process.cwd())
+				cli = await openSessions(cwd)
 				conversationId = await resolveConversation(cli, sessionKey)
 				prior = await loadConversation(cli, conversationId as never)
 			} catch {
@@ -240,7 +290,7 @@ export const runStreamCommand: CommandDef = {
 				const { discoverSkills, loadSkillBody, composeSkillsPrompt } = await import(
 					'../skills/store.js'
 				)
-				const all = discoverSkills({ cwd: process.cwd() })
+				const all = discoverSkills({ cwd })
 				const wanted = new Set(flags.skills)
 				const active = all
 					.filter((s) => wanted.has(s.name))
@@ -299,13 +349,18 @@ export const historyCommand: CommandDef = {
 		'is not an error.',
 	].join('\n'),
 	handler: async ({ rawArgs }) => {
-		const key = parseRunStreamFlags(rawArgs).session
+		const flags = parseRunStreamFlags(rawArgs)
+		const key = flags.session
 		if (!key) {
 			process.stdout.write('[]\n')
 			return 0
 		}
 		try {
-			const cli = await openSessions(process.cwd())
+			// `--cwd` is in this command's help too, and picks the `.namzu` store
+			// the session is read from. Reading the process's own directory
+			// instead means a host asking about a session in another checkout is
+			// told `[]` — indistinguishable from a session with no messages.
+			const cli = await openSessions(flags.cwd ?? process.cwd())
 			const map = await import('../integrations/sessions/store.js')
 			// Resolve WITHOUT creating: only emit history for an existing mapping.
 			const existing = await resolveExisting(cli, key)


### PR DESCRIPTION
`run-stream` and `history` both advertise `--cwd <path>` in their **own help text**, and neither ever parsed it. Worse than ignored: the parser folded every unrecognised argument into `rest`, and `rest.join(' ')` is the **prompt**.

So the invocation our help teaches —

```
namzu run-stream --cwd /projects/foo "summarise this"
```

— sent the model a prompt reading `--cwd /projects/foo summarise this`, and used the process's own directory anyway. For `history` the same omission answers `[]` for a session in another checkout, which a host cannot tell apart from a session that exists and is empty.

This is the defect `passthrough-help.test.ts` already describes one level up, where `--help` reached `run` as the prompt to send to a model. Same shape, one layer down, in a parser that predates that fix.

## What changed

- `--cwd` selects the `.namzu` store the session is read from and the directory skills are discovered in.
- An unrecognised `--flag` is refused instead of becoming prompt text — what turns `--modell gpt-4o` into a message rather than something a model is asked to interpret.
- `--` is the end-of-options escape for a prompt that genuinely starts with a dash. A single leading `-` was never an option and still is not.

## Versioning

`minor`, not `major`: [SemVer §4](https://semver.org/#spec-item-4) puts `0.x` outside the stable-API guarantee, and this package is `0.4.2`. The changeset names the break and the escape rather than burying it.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm test` green. Five mutations, each caught.

Two of the five are corrections to my own tests, recorded because the process is the point: the first `history` case asserted only that the command *survived* `--cwd` — which prints `[]` with the wiring reverted too, so it would have left the flag parsed and still undriven, the exact defect being repaired. And a handler-level test hung 5s and failed on a timeout rather than on behaviour, because a valid prompt sends the handler on to stdin and a provider probe; those assertions moved to the parser.