### PR TITLE
fix(cli): a run that was stopped no longer exits 0

### DIFF
--- a/.changeset/completed-is-not-succeeded.md
+++ b/.changeset/completed-is-not-succeeded.md
@@ -1,0 +1,41 @@
+---
+'@namzu/sdk': minor
+'@namzu/cli': minor
+---
+
+completed is not succeeded — run_completed says why it stopped, and namzu run exits accordingly
+
+`run_failed` is emitted from exactly one place in the kernel: the throw path.
+Every other way a run can end badly arrives as `run_completed` — the token
+budget, the timeout, the iteration cap, a cancellation, a rejected plan, a
+refused structured output, and both guardrails.
+
+Measured: a `max_iterations` stop reports `status: 'completed'`, and the event
+carried nothing that distinguished it from an answered question.
+
+**SDK.** `run_completed` now carries `stopReason`. It is optional and additive,
+so nothing breaks; a consumer that wants to tell "answered" from "ran out of
+budget" no longer has to hold the `Run` alongside the event stream.
+
+**CLI — read this before upgrading if you script `namzu run`.** The command
+exited `0` for all of those. The sharp case is the output guardrail: an answer
+that was *refused* exited `0` with empty text, so
+
+```sh
+namzu run "write the release notes" > notes.md && publish notes.md
+```
+
+published an empty file and reported success. `namzu run` now exits `1` when
+the run did not finish normally, and names the reason on stderr. The text still
+prints — partial output is real output, and a caller who piped it wants what
+there is — but `$?` can now say it is partial.
+
+If you have a script that depends on `namzu run` exiting 0 for a truncated run,
+it was depending on not being told. Check `$?` and read the stderr line.
+
+Also in the CLI, internally: the `done` agent event's `finishReason?: string`
+had no producer and no reader anywhere in the package, and the name belonged to
+a different concept — a "finish reason" here is `MessageStopReason`, reported
+per model message, not the run-level `StopReason` a caller asks about at the end
+of a turn. Replaced by `stopReason`. The type is not exported from the package
+entry, so this is internal.

--- a/packages/cli/src/commands/__tests__/run-exit-code.test.ts
+++ b/packages/cli/src/commands/__tests__/run-exit-code.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { runCommand } from '../run.js'
+import type { CommandContext } from '../types.js'
+
+/**
+ * `namzu run` exited 0 for six ways of not finishing.
+ *
+ * `run_failed` is emitted only from the kernel's throw path, so a run stopped
+ * by its token budget, its timeout, its iteration cap, a cancellation, or a
+ * guardrail arrived as `run_completed` — which this command mapped to "print
+ * the text and return 0". The sharp case is the output guardrail: an answer
+ * that was REFUSED exited 0 with empty text, so `namzu run … > out.txt &&
+ * deploy` went ahead on the empty file.
+ */
+
+const sessionStub = {
+	hasProvider: true,
+	providerSummary: 'mock',
+	modelSummary: 'mock-model',
+	send: undefined as unknown,
+}
+
+vi.mock('../../tui/agent.js', () => ({
+	probeAgentSession: vi.fn(async () => ({
+		preferences: { version: 2, provider: 'mock', subagents: { active: [] } },
+		detected: [],
+	})),
+	createAgentSession: vi.fn(async () => sessionStub),
+}))
+
+function contextCapturing(): { ctx: CommandContext; printed: string[]; errors: string[] } {
+	const printed: string[] = []
+	const errors: string[] = []
+	const ctx = {
+		formatter: {
+			name: 'text' as const,
+			print: (d: unknown) => printed.push(String((d as { text?: string })?.text ?? d)),
+			info: () => {},
+			error: (e: unknown) => errors.push(String((e as { message?: string })?.message ?? e)),
+		},
+		config: {},
+	} as unknown as CommandContext
+	return { ctx, printed, errors }
+}
+
+function streaming(events: unknown[]): void {
+	sessionStub.send = () =>
+		(async function* () {
+			for (const e of events) yield e
+		})()
+}
+
+async function runWith(events: unknown[]): Promise<{
+	code: number
+	printed: string[]
+	errors: string[]
+}> {
+	streaming(events)
+	const { ctx, printed, errors } = contextCapturing()
+	const code = (await runCommand.handler({ rawArgs: ['hello'], ctx } as never)) as number
+	return { code, printed, errors }
+}
+
+describe('namzu run exit code reflects whether the run finished', () => {
+	it('exits 0 when the model answered', async () => {
+		const { code, printed } = await runWith([
+			{ kind: 'delta', text: 'the answer' },
+			{ kind: 'done', stopReason: 'end_turn' },
+		])
+
+		expect(code).toBe(0)
+		expect(printed.join('')).toContain('the answer')
+	})
+
+	it('exits 1 when an output guardrail refused the answer', async () => {
+		// The empty-output case. Exiting 0 here told a shell script the run had
+		// succeeded and handed it nothing.
+		const { code, errors } = await runWith([{ kind: 'done', stopReason: 'output_guardrail' }])
+
+		expect(code).toBe(1)
+		expect(errors.join('')).toContain('output_guardrail')
+	})
+
+	it('exits 1 but still prints what it got when the iteration cap cut it short', async () => {
+		// Partial output is real output — a caller who piped it wants what
+		// there is. What they also need is for `$?` to say it is partial.
+		const { code, printed, errors } = await runWith([
+			{ kind: 'delta', text: 'half an ans' },
+			{ kind: 'done', stopReason: 'max_iterations' },
+		])
+
+		expect(code).toBe(1)
+		expect(printed.join('')).toContain('half an ans')
+		expect(errors.join('')).toContain('partial')
+	})
+
+	it('still exits 1 on an explicit error event', async () => {
+		const { code } = await runWith([{ kind: 'error', message: 'provider exploded' }])
+
+		expect(code).toBe(1)
+	})
+})

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -11,6 +11,7 @@
  */
 
 import { configureLogger } from '@namzu/sdk'
+import type { StopReason } from '@namzu/sdk'
 
 import type { DetectedProvider, Preferences } from '../integrations/providers/index.js'
 import type { CommandDef } from './types.js'
@@ -75,6 +76,7 @@ export const runCommand: CommandDef = {
 
 		let text = ''
 		let failed: string | null = null
+		let stopReason: StopReason | undefined
 		for await (const event of session.send([
 			{ role: 'user', content: prompt, timestamp: Date.now() },
 		])) {
@@ -82,13 +84,30 @@ export const runCommand: CommandDef = {
 			else if (event.kind === 'tool-start')
 				ctx.formatter.info(`⏺ ${event.toolName} ${event.summary}`)
 			else if (event.kind === 'error') failed = event.message
+			else if (event.kind === 'done') stopReason = event.stopReason
 		}
 
 		if (failed) {
 			ctx.formatter.error({ message: failed })
 			return 1
 		}
+
+		// The text prints either way. Partial output is real output, and a
+		// caller who piped it wants what there is — but `$?` has to be able to
+		// tell them it is partial, which it could not: `run_failed` is emitted
+		// only from the throw path, so a run stopped by its token budget, its
+		// timeout, its iteration cap, a cancellation, or a blocking output
+		// guardrail all arrived as `run_completed` and exited 0. Measured: a
+		// `max_iterations` stop reports `status: 'completed'`. The sharp case is
+		// the guardrail — a REFUSED answer exited 0 with empty text, so
+		// `namzu run … > out.txt && deploy` proceeded on the empty file.
 		ctx.formatter.print(ctx.formatter.name === 'json' ? { text: text.trim() } : text.trim())
+		if (stopReason && stopReason !== 'end_turn') {
+			ctx.formatter.error({
+				message: `run did not finish normally: ${stopReason}${text.trim() ? ' — the output above is partial' : ''}`,
+			})
+			return 1
+		}
 		return 0
 	},
 }

--- a/packages/cli/src/tui/__tests__/to-agent-event.test.ts
+++ b/packages/cli/src/tui/__tests__/to-agent-event.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import type { RunEvent, RunId } from '@namzu/sdk'
+
+import { toAgentEvent } from '../agent.js'
+
+/**
+ * The seam between the kernel and the command.
+ *
+ * The SDK test proves `run_completed` carries a stop reason and the `run` test
+ * proves the command acts on one, and both of those passed while this function
+ * threw the field away in between — the mutation that reverted it to a bare
+ * `{ kind: 'done' }` was caught by nothing. Two tested ends and an untested
+ * middle is the shape that lets a value be produced and consumed and still
+ * never arrive.
+ */
+
+const runId = 'run_test' as RunId
+
+describe('toAgentEvent carries the stop reason across', () => {
+	it('passes a non-normal stop through to the done event', () => {
+		const mapped = toAgentEvent({
+			type: 'run_completed',
+			runId,
+			result: '',
+			stopReason: 'output_guardrail',
+		} as RunEvent)
+
+		expect(mapped).toEqual({ kind: 'done', stopReason: 'output_guardrail' })
+	})
+
+	it('passes end_turn through rather than inventing it downstream', () => {
+		// The command treats a MISSING reason as success, so the difference
+		// between "finished normally" and "we did not say" must be preserved
+		// here rather than reconstructed by whoever reads it.
+		const mapped = toAgentEvent({
+			type: 'run_completed',
+			runId,
+			result: 'hi',
+			stopReason: 'end_turn',
+		} as RunEvent)
+
+		expect(mapped).toEqual({ kind: 'done', stopReason: 'end_turn' })
+	})
+
+	it('still maps a completion that carries no reason', () => {
+		const mapped = toAgentEvent({ type: 'run_completed', runId, result: 'hi' } as RunEvent)
+
+		expect(mapped).toEqual({ kind: 'done' })
+	})
+
+	it('maps a failure to an error, not to done', () => {
+		const mapped = toAgentEvent({
+			type: 'run_failed',
+			runId,
+			error: 'boom',
+		} as RunEvent)
+
+		expect(mapped).toEqual({ kind: 'error', message: 'boom' })
+	})
+})

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -34,6 +34,7 @@ import {
 	type RunId,
 	SearchToolsTool,
 	type SessionId,
+	type StopReason,
 	type TaskGateway,
 	type TaskStore,
 	type TenantId,
@@ -84,7 +85,17 @@ export type AgentEvent =
 	  }
 	| { readonly kind: 'usage'; readonly totalTokens: number; readonly costUsd: number }
 	| { readonly kind: 'task'; readonly subject: string; readonly status: string }
-	| { readonly kind: 'done'; readonly finishReason?: string }
+	/**
+	 * The turn ended without throwing — which is not the same as succeeding.
+	 *
+	 * `stopReason` replaces a `finishReason?: string` that had no producer and
+	 * no reader anywhere in this package. The name was also wrong for what is
+	 * needed here: a "finish reason" in this codebase is `MessageStopReason`,
+	 * reported per model message, while the question a caller has at the end of
+	 * a turn is the run-level `StopReason` — did it answer, or did it run out
+	 * of budget, iterations, time, or permission to say what it produced.
+	 */
+	| { readonly kind: 'done'; readonly stopReason?: StopReason }
 	| { readonly kind: 'error'; readonly message: string }
 
 /** A single tool the model wants to run, surfaced to the user for approval. */
@@ -713,7 +724,12 @@ export function toAgentEvent(event: RunEvent): AgentEvent | null {
 				? { kind: 'task', subject: event.subject, status: event.status }
 				: null
 		case 'run_completed':
-			return { kind: 'done' }
+			// Carried through rather than dropped: `run_failed` fires only from
+			// the throw path, so this event is also how a budget stop, a
+			// timeout, a cancellation and a blocked output guardrail arrive. A
+			// consumer that reads this as success reports one for a run whose
+			// answer was refused.
+			return { kind: 'done', ...(event.stopReason ? { stopReason: event.stopReason } : {}) }
 		case 'run_failed':
 			// The classification is now carried on the event rather than
 			// having been flattened away upstream. Shown because "rate

--- a/packages/sdk/src/agents/__tests__/run-completed-stop-reason.test.ts
+++ b/packages/sdk/src/agents/__tests__/run-completed-stop-reason.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { MockLLMProvider, registerMock } from '../../provider/index.js'
+import type { RunEvent } from '../../types/run/index.js'
+import { runAgent } from '../runAgent.js'
+
+/**
+ * `completed` is not `succeeded`.
+ *
+ * `run_failed` is emitted from exactly one place — the throw path in
+ * `result.ts` — so every other way a run can end badly arrives as
+ * `run_completed`: the token budget, the timeout, the iteration cap, a
+ * cancellation, and a blocking output guardrail. A consumer reading that event
+ * as success reported one for a run whose answer was refused, and the CLI did:
+ * it mapped `run_completed` to a bare `done` and exited 0.
+ *
+ * Measured before the fix: a `max_iterations` stop reports
+ * `status: 'completed'`, and the event carried nothing to distinguish it.
+ */
+
+registerMock()
+
+async function eventsOf(options: Parameters<typeof runAgent>[0]): Promise<RunEvent[]> {
+	const events: RunEvent[] = []
+	await runAgent({ ...options, listener: (e) => void events.push(e) })
+	return events
+}
+
+function completion(events: RunEvent[]): Extract<RunEvent, { type: 'run_completed' }> | undefined {
+	return events.find((e) => e.type === 'run_completed') as never
+}
+
+describe('run_completed says why the run stopped', () => {
+	it('reports end_turn when the model finished its answer', async () => {
+		const events = await eventsOf({
+			provider: new MockLLMProvider({ turns: [{ text: 'done' }] }),
+			model: 'mock-model',
+			prompt: 'x',
+		})
+
+		expect(completion(events)?.stopReason).toBe('end_turn')
+	})
+
+	it('reports max_iterations when the loop was cut short', async () => {
+		const events = await eventsOf({
+			provider: new MockLLMProvider({ turns: [{ toolCalls: [{ name: 'absent', args: {} }] }] }),
+			model: 'mock-model',
+			prompt: 'x',
+			maxIterations: 1,
+		})
+
+		const done = completion(events)
+		// The event that a consumer treats as "the run ended" — and the field
+		// that stops it being read as "the run succeeded".
+		expect(done).toBeDefined()
+		expect(done?.stopReason).toBe('max_iterations')
+		expect(events.some((e) => e.type === 'run_failed')).toBe(false)
+	})
+})

--- a/packages/sdk/src/runtime/query/result.ts
+++ b/packages/sdk/src/runtime/query/result.ts
@@ -47,6 +47,11 @@ export class ResultAssembler {
 			type: 'run_completed',
 			runId: runMgr.id,
 			result: runMgr.getRun().result ?? '',
+			// Read AFTER `markCompleted`, which is where a run that was stopped
+			// mid-flight has its reason settled. Carried on the event so a
+			// consumer can tell "answered" from "ran out of budget" without
+			// holding the `Run`.
+			...(runMgr.getRun().stopReason ? { stopReason: runMgr.getRun().stopReason } : {}),
 		})
 		yield* drainPending()
 

--- a/packages/sdk/src/types/run/events.ts
+++ b/packages/sdk/src/types/run/events.ts
@@ -16,7 +16,7 @@ import type { PlanStep } from '../plan/index.js'
 import type { PluginHookEvent, PluginHookResult } from '../plugin/index.js'
 import type { TaskStatus } from '../task/index.js'
 import type { Lineage } from './lineage.js'
-import type { MessageStopReason } from './stop-reason.js'
+import type { MessageStopReason, StopReason } from './stop-reason.js'
 import type {
 	SubsessionIdledEvent,
 	SubsessionMessagedEvent,
@@ -252,7 +252,20 @@ type CoreRunEvent =
 			guardrail?: string
 			reason?: string
 	  }
-	| { type: 'run_completed'; runId: RunId; result: string }
+	/**
+	 * The run reached its end without throwing.
+	 *
+	 * `completed` is not `succeeded`. A run stopped by its token budget, its
+	 * timeout, its iteration cap, a cancellation or a blocking output guardrail
+	 * all arrive here — `run_failed` is emitted only from the throw path — so a
+	 * consumer that treated this event as success reported one for a run whose
+	 * answer was refused. Measured: `max_iterations` produces
+	 * `status: 'completed'` with `result` holding whatever partial text existed.
+	 *
+	 * `stopReason` is what separates them, and it is on the event because the
+	 * alternative is asking every consumer to hold the `Run` as well.
+	 */
+	| { type: 'run_completed'; runId: RunId; result: string; stopReason?: StopReason }
 	/**
 	 * The run failed.
 	 *


### PR DESCRIPTION
`run_failed` is emitted from **exactly one place** in the kernel: the throw path. Every other way a run can end badly arrives as `run_completed` — the token budget, the timeout, the iteration cap, a cancellation, a rejected plan, a refused structured output, and both guardrails.

Probed rather than assumed:

| stop | `run.status` | `run.stopReason` |
|---|---|---|
| normal | `completed` | `end_turn` |
| iteration cap | `completed` | `max_iterations` |

The event carried neither, the CLI mapped `run_completed` to a bare `{ kind: 'done' }`, and `namzu run` printed whatever text had accumulated and returned **0**.

The sharp case is the output guardrail. An answer that was **refused** exited 0 with empty text:

```sh
namzu run "write the release notes" > notes.md && publish notes.md
```

published an empty file and reported success.

## Three links, all now driven

- `run_completed` carries `stopReason` (additive, optional).
- `toAgentEvent` passes it through instead of dropping it.
- `namzu run` exits 1 when the reason is not `end_turn`, and names it on stderr. The text still prints — partial output is real output — but `$?` can now say it is partial.

Found while wiring: the CLI's `done` event already carried `finishReason?: string` with **zero producers and zero readers**, under a name belonging to a different concept (a finish reason here is `MessageStopReason`, per model message; the run-level concept is `StopReason`). Replaced rather than populated; not exported from the package entry, so internal.

## The mutation that mattered

The first pass tested the two **ends** — the SDK emits `stopReason`, `run` acts on one — and both passed while the middle link threw the field away. Reverting the mapper to `{ kind: 'done' }` was caught by **nothing**. A seam test closes it; 3/3 caught now.

Two tested ends with an untested middle is the shape that lets a value be produced and consumed and still never arrive.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm test` green (270 SDK + 34 CLI test files).