### PR TITLE
fix(sdk): refuse an unexpressible strict schema at registration, not per request

### DIFF
--- a/.changeset/refuse-at-declaration.md
+++ b/.changeset/refuse-at-declaration.md
@@ -1,0 +1,49 @@
+---
+'@namzu/sdk': minor
+'@namzu/http': patch
+---
+
+a tool whose schema cannot carry the guarantee it asks for is refused at registration
+
+The previous release fixed the `edit` tool's schema and added a check in the
+Anthropic driver. That caught the bug, but in the wrong place: per request, in
+one of the **two** drivers that mark tools strict, and only once something
+actually ran.
+
+`ToolRegistry` already refused `enforceModelInput` without a
+`modelInputSchema`, and the comment above that check states the principle
+exactly — *"Refusing at registration puts the error where the author can fix it
+rather than at the first request."* The rule was written down; the new check was
+somewhere else.
+
+It is now beside its sibling. One asks whether a model schema **exists**; the
+other asks whether it can **carry the guarantee the tool just requested**. A
+tool that asks for constrained generation and supplies a schema the constrained
+dialect cannot express is wrong at the moment it is declared, whichever model it
+later meets — so it never registers, and can never reach a request.
+
+```
+Tool "edit" is marked for strict input validation, but its model-facing schema
+uses 1 construct(s) the strict subset does not accept…
+  edit.properties.insertLine.oneOf — use `anyOf` — for disjoint branches the two are equivalent
+```
+
+This is the only path that matters in practice: the kernel builds its tool list
+with `ToolRegistry.toLLMTools()`, so every tool reaching a driver through the
+normal loop passed the gate.
+
+**A tool that never asked for the guarantee is untouched.** Without
+`enforceModelInput` nothing is marked strict, the schema is sent as ordinary
+JSON Schema, and `oneOf` is perfectly legal there. Refusing it would break
+working setups for no reason.
+
+`@namzu/http` also marks tools strict and had no check at all — the same bug
+was reachable through it. It now has the driver-level check the Anthropic driver
+already carried. Both remain as a second boundary for a host that hand-builds
+`ChatCompletionParams` and calls a provider directly, bypassing the registry.
+
+**If you author a tool with `enforceModelInput: true`,** a schema using `oneOf`,
+`not`, `if`/`then`/`else`, numeric or length bounds, `patternProperties`, or an
+`additionalProperties` other than `false` now throws at registration instead of
+failing the first request that carries it. The message names the path and the
+replacement.

--- a/packages/providers/http/src/client.ts
+++ b/packages/providers/http/src/client.ts
@@ -12,6 +12,7 @@ import type {
 } from '@namzu/sdk'
 import {
 	ProviderRequestError,
+	assertStrictSchema,
 	assertThinkingUnsupported,
 	isCallerAbortError,
 	modelVersionAtLeast,
@@ -309,12 +310,21 @@ function formatAnthropicRequest(
 	if (params.tools && params.tools.length > 0 && !toolsForbidden) {
 		const enforcedNames = new Set(params.enforceToolInputSchema ?? [])
 		const strictEnabled = shouldUseStrictToolInputs(model ?? '', strictToolUse)
-		body.tools = params.tools.map((t) => ({
-			name: t.function.name,
-			description: t.function.description ?? '',
-			input_schema: t.function.parameters ?? { type: 'object' },
-			...(strictEnabled && enforcedNames.has(t.function.name) ? { strict: true } : {}),
-		}))
+		body.tools = params.tools.map((t) => {
+			const strict = strictEnabled && enforcedNames.has(t.function.name)
+			// The registry refuses an unexpressible schema at declaration, which
+			// is where the fix belongs. This is the second boundary: a host may
+			// build `ChatCompletionParams` by hand and never touch the registry,
+			// and a strict flag on a schema the subset cannot express does not
+			// degrade one field — the vendor rejects the whole request.
+			if (strict) assertStrictSchema(t.function.name, t.function.parameters)
+			return {
+				name: t.function.name,
+				description: t.function.description ?? '',
+				input_schema: t.function.parameters ?? { type: 'object' },
+				...(strict ? { strict: true } : {}),
+			}
+		})
 	}
 
 	if (params.toolChoice !== undefined && !toolsForbidden) {

--- a/packages/sdk/src/registry/tool/__tests__/strict-registration.test.ts
+++ b/packages/sdk/src/registry/tool/__tests__/strict-registration.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import type { ToolDefinition } from '../../../types/tool/index.js'
+import { ToolRegistry } from '../execute.js'
+
+/**
+ * A tool that asks for constrained generation and hands over a schema the
+ * constrained dialect cannot express is wrong at the moment it is DECLARED,
+ * whichever model it later meets.
+ *
+ * The first attempt at this check lived in a provider driver. That caught the
+ * bug — but per request, in one of the two drivers that mark tools strict, and
+ * only once something actually ran. The registry already refused
+ * `enforceModelInput` without a `modelInputSchema`, with a comment stating the
+ * principle exactly: "Refusing at registration puts the error where the author
+ * can fix it rather than at the first request." The rule was written down; the
+ * check was in the wrong place.
+ *
+ * So the pair is here now. One asks whether a model schema EXISTS, the other
+ * whether it can carry the guarantee the tool just requested.
+ */
+
+function tool(overrides: Partial<ToolDefinition>): ToolDefinition {
+	return {
+		name: 'sample',
+		description: 'a tool',
+		inputSchema: z.object({}),
+		execute: async () => ({ success: true, output: 'ok' }),
+		...overrides,
+	} as ToolDefinition
+}
+
+describe('a tool cannot register a schema its own guarantee cannot carry', () => {
+	it('refuses a keyword outside the strict subset, naming the path', () => {
+		const registry = new ToolRegistry()
+
+		expect(() =>
+			registry.register(
+				tool({
+					name: 'edit',
+					enforceModelInput: true,
+					modelInputSchema: {
+						type: 'object',
+						properties: { insertLine: { oneOf: [{ type: 'integer' }, { const: 'end' }] } },
+					},
+				}),
+			),
+		).toThrow(/edit\.properties\.insertLine\.oneOf/)
+	})
+
+	it('names the remedy, not just the offence', () => {
+		const registry = new ToolRegistry()
+
+		expect(() =>
+			registry.register(
+				tool({ enforceModelInput: true, modelInputSchema: { properties: { n: { minimum: 0 } } } }),
+			),
+		).toThrow(/enforce at execution/)
+	})
+
+	it('admits the same union spelled the way the subset accepts', () => {
+		const registry = new ToolRegistry()
+
+		expect(() =>
+			registry.register(
+				tool({
+					enforceModelInput: true,
+					modelInputSchema: {
+						type: 'object',
+						properties: { insertLine: { anyOf: [{ type: 'integer' }, { const: 'end' }] } },
+						additionalProperties: false,
+					},
+				}),
+			),
+		).not.toThrow()
+	})
+
+	it('leaves a tool that never asked for the guarantee alone', () => {
+		// Without `enforceModelInput` nothing is marked strict, so the schema is
+		// sent as ordinary JSON Schema and `oneOf` is perfectly legal there.
+		// Refusing it would break working setups for no reason.
+		const registry = new ToolRegistry()
+
+		expect(() =>
+			registry.register(
+				tool({ modelInputSchema: { properties: { a: { oneOf: [{ type: 'string' }] } } } }),
+			),
+		).not.toThrow()
+	})
+
+	it('still refuses enforcement with no model schema at all', () => {
+		// The check this one was added beside. Kept in the same file so a
+		// future edit sees both halves of the pair together.
+		const registry = new ToolRegistry()
+
+		expect(() => registry.register(tool({ enforceModelInput: true }))).toThrow(
+			/does not define modelInputSchema/,
+		)
+	})
+
+	it('refuses through every registration shape', () => {
+		// `register` has three overloads and only one of them was exercised
+		// above; a check on the wrong one would look like coverage.
+		const bad = tool({
+			name: 'bad',
+			enforceModelInput: true,
+			modelInputSchema: { properties: { a: { oneOf: [] } } },
+		})
+
+		expect(() => new ToolRegistry().register(bad)).toThrow(/oneOf/)
+		expect(() => new ToolRegistry().register('bad', bad)).toThrow(/oneOf/)
+		expect(() => new ToolRegistry().register([bad])).toThrow(/oneOf/)
+	})
+})

--- a/packages/sdk/src/registry/tool/execute.ts
+++ b/packages/sdk/src/registry/tool/execute.ts
@@ -1,4 +1,5 @@
 import { SpanStatusCode, context as otelContext, trace } from '@opentelemetry/api'
+import { assertStrictSchema } from '../../provider/strict-schema.js'
 import { GENAI, NAMZU, toolSpanName } from '../../telemetry/attributes.js'
 import { recordToolCall } from '../../telemetry/metrics.js'
 import { getTracer } from '../../telemetry/runtime-accessors.js'
@@ -176,6 +177,21 @@ export class ToolRegistry extends ManagedRegistry<ToolDefinition> {
 			throw new Error(
 				`Tool "${id}" enables enforceModelInput but does not define modelInputSchema. Constrained input generation requires an explicit provider-safe model schema.`,
 			)
+		}
+		// …and the schema has to be one a constrained decoder can actually be
+		// given. The check above asks whether a model schema EXISTS; this asks
+		// whether it can carry the guarantee the tool just requested.
+		//
+		// Both belong here for the reason the comment above already states.
+		// Strict validation runs against a SUBSET of JSON Schema, and a keyword
+		// outside it is not degraded — the request is rejected whole, so one
+		// unexpressible field takes down every other tool in the call. The
+		// first version of this check lived in a provider driver, which meant
+		// it fired per request, in one driver, long after the author had moved
+		// on. A tool that asks for a guarantee its own schema cannot carry is
+		// wrong at the moment it is declared, whichever model it later meets.
+		if (tool.enforceModelInput) {
+			assertStrictSchema(id, tool.modelInputSchema)
 		}
 		if (tool.tier && this.tierConfig) {
 			const validIds = this.tierConfig.tiers.map((t) => t.id)


### PR DESCRIPTION
The previous change fixed the `edit` tool's schema and put a check in the Anthropic driver. **That caught the bug in the wrong place** — per request, in one of the *two* drivers that mark tools strict, and only once something actually ran. `@namzu/http` marks tools strict too and had no check at all, so the same failure was still reachable through it.

`ToolRegistry.registerOne` already refused `enforceModelInput` without a `modelInputSchema`, and the comment above that check states the principle verbatim:

> Refusing at registration puts the error where the author can fix it rather than at the first request.

The rule was already written down. The check was somewhere else.

## What changed

It now sits beside its sibling. One asks whether a model schema **exists**; the other asks whether it can **carry the guarantee the tool just requested**. A tool that asks for constrained generation and hands over a schema the constrained dialect cannot express is wrong at the moment it is declared, whichever model it later meets — so it never registers, and can never reach a request.

That is the only path that matters in practice: the kernel builds its tool list with `ToolRegistry.toLLMTools()`, so every tool reaching a driver through the normal loop passed the gate. Both drivers keep a check as a **second boundary**, for a host that hand-builds `ChatCompletionParams` and calls a provider directly.

**Deliberately not refused:** a tool *without* `enforceModelInput`. Nothing is marked strict there, `oneOf` is legal in ordinary JSON Schema, and refusing it would break working setups for no reason.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm test` green — 274 SDK test files, and no existing test broke, so no tool already in the tree fails the new gate.

Mutation: neutralising the registration check fails **exactly the three tests that assert a refusal**, and leaves the three that assert acceptance alone.

The first mutation harness for this was wrong twice and is worth recording. One arm asserted that removing the driver checks left the registration tests passing — which proves nothing, because those tests never touch driver code. The other deleted the registry call outright, leaving an unused import that failed `tsc` *before* the script reached its restore line, so it left the working tree mutated. Rewritten to neutralise the effect rather than the call, with the restore in a `finally`.