### PR TITLE
feat(evals): the kernel behaviour suites are publishable

### DIFF
--- a/.changeset/evals-goes-public.md
+++ b/.changeset/evals-goes-public.md
@@ -1,0 +1,34 @@
+---
+'@namzu/evals': minor
+---
+
+the kernel behaviour suites are publishable
+
+`@namzu/evals` was `private: true` and carried nothing a registry needs — no
+`license`, no `repository`, no `files`, no entry point. It is a real package
+now, so you can run Namzu's own CI gate against the kernel *you* installed:
+
+```sh
+npm install --save-dev @namzu/evals @namzu/cli
+npx namzu eval --dir node_modules/@namzu/evals
+```
+
+The suites run against a **scripted provider**, so nothing in them measures a
+model. That is the point — the turns are fixed, so a score that moves means the
+kernel changed its behaviour.
+
+`@namzu/sdk` moved from a direct dependency to a **peer** (`>=5.0.0`). A suite
+that pulled its own copy of the kernel would be scoring a kernel you are not
+shipping.
+
+Two things worth knowing about what ships. `files` is an explicit allowlist —
+`kernel/`, the licence, the README and the changelog, six files and 7.7 kB.
+This package's directory also accumulates `.namzu/` run state from dogfooding:
+199 transcripts, checkpoints and reports on a working machine. None of it is
+tracked by git, so a CI publish never saw it, but a publish from a developer's
+checkout could have. The allowlist is what makes that impossible rather than
+merely unlikely.
+
+If you are writing your own evals you do not need this package: the runner is
+`namzu eval` in `@namzu/cli` and the report types are in `@namzu/sdk`. This one
+is only the suites.

--- a/packages/evals/LICENSE.md
+++ b/packages/evals/LICENSE.md
@@ -1,0 +1,110 @@
+# Functional Source License, Version 1.1, MIT Future License
+
+## Abbreviation
+
+FSL-1.1-MIT
+
+## Notice
+
+Copyright 2026 Cogitave
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the MIT license that is effective on the second anniversary of the date we make
+the Software available. On or after that date, you may use the Software under
+the MIT license, in which case the following will apply:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -1,0 +1,51 @@
+# @namzu/evals
+
+Namzu's own kernel behaviour suites.
+
+These run against a **scripted provider**, so nothing here measures a model.
+That is the point: the turns are fixed, so a score that moves means the kernel
+changed its behaviour. A suite that calls a real provider measures two things
+at once and cannot say which one moved.
+
+## What it is for
+
+Namzu runs these as a required CI gate. Published so you can run the same gate
+against the kernel *you* installed — pin a version, run the suites, and see
+whether the loop still behaves the way the suites pin it.
+
+If you are writing your own evals, you do not need this package. The runner is
+`namzu eval` in [`@namzu/cli`](https://www.npmjs.com/package/@namzu/cli) and the
+report types are in [`@namzu/sdk`](https://www.npmjs.com/package/@namzu/sdk);
+this one is only the suites.
+
+## Running them
+
+```sh
+npm install --save-dev @namzu/evals @namzu/cli
+npx namzu eval --dir node_modules/@namzu/evals
+```
+
+Exit codes are the ones `namzu eval` defines: `0` passed, `1` failed, `2`
+inconclusive, `3` usage. A hung suite reports `2` rather than `1` — "we could
+not tell" is a different answer from "it was wrong", and a CI gate that
+conflates them fails for the wrong reason.
+
+## What a suite is
+
+A `*.eval.js` file that default-exports an async function returning an
+`ExperimentReport`. Plain JavaScript rather than TypeScript on purpose: the
+runner loads a suite with `import()`, and the supported Node range does not
+strip types everywhere.
+
+```js
+export default async function toolLoop() {
+  // …drive the kernel against a scripted provider, score what came back
+}
+```
+
+## Versioning
+
+The suites pin invariants of a specific kernel. `@namzu/sdk` is a **peer**
+dependency (`>=5.0.0`) rather than a direct one, so they run against the kernel
+your project already installed rather than pulling a second copy — which would
+mean scoring a kernel you are not shipping.

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -1,11 +1,38 @@
 {
   "name": "@namzu/evals",
   "version": "0.0.6",
-  "private": true,
+  "description": "Namzu's own kernel behaviour suites, runnable with `namzu eval` against an installed kernel.",
+  "license": "FSL-1.1-MIT",
   "type": "module",
-  "description": "First-party behaviour suites, run by `namzu eval` as a CI gate.",
+  "homepage": "https://github.com/cogitave/namzu#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cogitave/namzu.git",
+    "directory": "packages/evals"
+  },
+  "bugs": {
+    "url": "https://github.com/cogitave/namzu/issues"
+  },
+  "exports": {
+    "./kernel/*": "./kernel/*"
+  },
+  "files": [
+    "kernel",
+    "LICENSE.md",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "peerDependencies": {
+    "@namzu/sdk": ">=5.0.0"
+  },
   "dependencies": {
-    "@namzu/sdk": "workspace:*",
     "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@namzu/sdk": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,12 +93,13 @@ importers:
 
   packages/evals:
     dependencies:
-      '@namzu/sdk':
-        specifier: workspace:*
-        version: link:../sdk
       zod:
         specifier: ^3.25.76
         version: 3.25.76
+    devDependencies:
+      '@namzu/sdk':
+        specifier: workspace:*
+        version: link:../sdk
 
   packages/files:
     dependencies:


### PR DESCRIPTION
`@namzu/evals` was `private: true` and carried nothing a registry needs — no license, no repository, no `files` allowlist, no entry point.

```sh
npm install --save-dev @namzu/evals @namzu/cli
npx namzu eval --dir node_modules/@namzu/evals
```

## Why each field

**`repository`** is the one that matters most: a provenance publish is rejected without it, and only *at publish time*, after every sibling has already gone out. That is exactly how `@namzu/files@0.2.0` ended up tagged and released with nothing on the registry behind it. The publish-metadata gate now passes with 14 publishable packages.

**`@namzu/sdk` moves to a peer dependency** (`>=5.0.0`). A suite that pulled its own copy of the kernel would be scoring a kernel the consumer is not shipping.

**The `files` allowlist is load-bearing, not tidiness.** This package's directory accumulates `.namzu/` run state from dogfooding — **199** transcripts, checkpoints and reports against **4** real files. None of it is tracked by git, so a CI publish never saw it, but a publish from a developer's checkout could have. Verified rather than assumed:

```
npm notice total files: 6
npm notice package size: 7.7 kB
```

## One assumption I checked instead of asserting

I expected `namzu eval` to be unable to read from `node_modules`, since its directory walk skips that name. Wrong — the skip only applies to *nested* directories, so `--dir node_modules/@namzu/evals` works. The suites re-run green (4/4) against the peer-resolved kernel.

## Still blocked on the npm side

This is a **new** package in the `@namzu` scope, which is precisely what `@namzu/project` could never get past — `PUT … 404`. That is a registry permission, not a manifest problem, and it is the one thing this PR cannot fix.