### PR TITLE
fix(sdk): a delegated child is not a file read, and a closed tuple stays closed

### DIFF
--- a/.changeset/a-child-is-not-a-file-read.md
+++ b/.changeset/a-child-is-not-a-file-read.md
@@ -1,0 +1,37 @@
+---
+'@namzu/sdk': patch
+---
+
+a delegated child is no longer strangled by a file-read deadline, and a closed tuple stays closed
+
+**The deadline.** `create_task` runs an entire agent and inherited the tool
+executor's generic two-minute default — the one whose own docstring says *"a
+tool that legitimately runs longer declares its own `timeoutMs`"*. It did not.
+
+Measured on real traffic: three delegated children finished in 4m21s, 5m58s and
+8m04s while all three parents timed out at 120s. The children were never killed
+— only the parent's wait was — so the blocking path was not occasionally missed,
+it was structurally unreachable, and the supervisor was left calling
+`agent_task_list` in a sleep loop because nothing else was available to it.
+
+`DELEGATION_TIMEOUT_MS` is now one hour, exported so it is greppable, and
+applied to `create_task`, `wait_for_task` and `continue_task`. An hour rather
+than "a bit more than eight minutes" because a generic stopwatch is the wrong
+instrument for a child that is making progress: a failure should come from what
+the child is doing. A wedged child is still caught, and the run budget and
+iteration ceiling both still apply above this.
+
+**The instruction to poll was ours.** `agent_task_list` described itself as the
+way to *"confirm every launched task reached `completed`"* and as *"safe to call
+repeatedly"* — an order to burn a turn on a listing whose answer a blocking
+`create_task` had already delivered. It now says the opposite, and points at the
+cases the listing is actually for. `create_task` gained the matching clause in
+the other direction: until a worker's result arrives, do not fabricate,
+summarise or predict it.
+
+**The tuple.** `toSchemaDialect` translated draft-07's `additionalItems: false`
+by dropping it, on the reasoning that 2020-12 closes a tuple by default. It does
+not — with `prefixItems` set and no `items`, elements past the tuple are
+unconstrained — so every closed tuple was silently widened into an open one. A
+schema written to forbid a third element began to allow any number. It now
+emits `items: false`, which the wire accepts.

--- a/.changeset/the-menu-and-the-kitchen-agree.md
+++ b/.changeset/the-menu-and-the-kitchen-agree.md
@@ -1,0 +1,39 @@
+---
+'@namzu/sdk': minor
+---
+
+a narrowed step now narrows what can RUN, not only what the model is shown
+
+`prepareStep.activeTools` documents itself as *"restrict which tools the model
+may call this step, by name"*, and run-level `allowedTools` makes the same
+promise for a whole run. Neither restricted anything.
+
+The list decided which schemas went into the request. It was then copied into
+the tool context and read by nothing on the execution path — the registry gated
+on availability and plan mode, and never on the allow-list. So the narrowing was
+a statement about the menu rather than about the kitchen: a model that named a
+withheld tool had it run.
+
+That is not a hypothetical. A model names a tool it was not offered whenever it
+repeats a call from earlier in the context, whenever a gateway carries its own
+tool list, and whenever a cached prompt prefix is replayed. A host using this to
+fence a step — the obvious use, and the one the type invites — was fenced by
+nothing.
+
+The check now sits where the call is made. A tool outside the list is answered
+with a refusal that names what IS available, so the model can route around it
+rather than guessing.
+
+Two details worth stating:
+
+- **Absent is not empty.** No list means no restriction; an empty list means the
+  step may call nothing. Reading an empty allow-list as "unrestricted" is the
+  fail-open this repository has already been bitten by once, in the delegate
+  roster.
+- **A step's list beats the run's,** matching the precedence the request already
+  used, so the two can no longer disagree.
+
+**If you pass `allowedTools` or `activeTools` today, calls that previously ran
+may now be refused.** That is the point of the change, but it is a real
+behavioural difference: a run that quietly depended on the leak will start
+seeing refusals. The refusal is a normal `tool_result`, so the turn continues.

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ packages/docs/
 # claude-code local launch config (per-machine)
 .claude/launch.json
 eval-report.json
+
+# Agent worktrees: a background agent gets its own checkout here. It is a
+# nested git repository, so committing it would embed a gitlink nobody can
+# clone.
+.claude/worktrees/

--- a/packages/sdk/src/gateway/__tests__/completion-inbox.test.ts
+++ b/packages/sdk/src/gateway/__tests__/completion-inbox.test.ts
@@ -153,6 +153,106 @@ describe('a completion the tool already delivered is never delivered twice', () 
 	})
 })
 
+describe('a launch nobody is waiting for holds the run open', () => {
+	it('counts an expected task as pending work before it settles', () => {
+		// Without this the run settles while a background worker is still
+		// going and discards the result the launch existed to produce.
+		const { gateway } = fakeGateway()
+		const inbox = new CompletionInbox()
+		inbox.attach(gateway)
+
+		expect(inbox.hasPendingWork).toBe(false)
+		inbox.expect('tsk_1' as TaskId)
+		expect(inbox.hasPendingWork).toBe(true)
+	})
+
+	it('stops counting it once it settles', () => {
+		const { gateway, settle } = fakeGateway()
+		const inbox = new CompletionInbox()
+		inbox.attach(gateway)
+		inbox.expect('tsk_1' as TaskId)
+
+		settle(handleFor('tsk_1', 'done'))
+
+		// Still pending — as an UNHEARD completion now rather than an
+		// outstanding one, which is what the loop drains.
+		expect(inbox.hasPendingWork).toBe(true)
+		inbox.drain()
+		expect(inbox.hasPendingWork).toBe(false)
+	})
+
+	it('ignores a task already delivered inline', () => {
+		const { gateway } = fakeGateway()
+		const inbox = new CompletionInbox()
+		inbox.attach(gateway)
+
+		inbox.claim('tsk_1' as TaskId)
+		inbox.expect('tsk_1' as TaskId)
+
+		expect(inbox.hasPendingWork).toBe(false)
+	})
+
+	it('stops expecting a task that was cancelled', () => {
+		// `expect` is only cleared by a COMPLETION, so a cancelled worker used
+		// to keep the run open for the whole grace period, every time it tried
+		// to settle, waiting for a result that had been called off.
+		const { gateway } = fakeGateway()
+		const inbox = new CompletionInbox()
+		inbox.attach(gateway)
+		inbox.expect('tsk_1' as TaskId)
+
+		inbox.forget('tsk_1' as TaskId)
+
+		expect(inbox.hasPendingWork).toBe(false)
+	})
+
+	it('waits for an arrival and returns as soon as one lands', async () => {
+		const { gateway, settle } = fakeGateway()
+		const inbox = new CompletionInbox()
+		inbox.attach(gateway)
+		inbox.expect('tsk_1' as TaskId)
+
+		const waited = inbox.waitForArrival(5_000)
+		settle(handleFor('tsk_1', 'done'))
+		await waited
+
+		expect(inbox.drain().map((h) => h.taskId)).toEqual(['tsk_1'])
+	})
+
+	it('does not wait at all when there is nothing outstanding', async () => {
+		const { gateway } = fakeGateway()
+		const inbox = new CompletionInbox()
+		inbox.attach(gateway)
+
+		// A deadline this long would hang the suite if it were honoured.
+		await inbox.waitForArrival(600_000)
+	})
+
+	it('gives up at the deadline rather than holding a run forever', async () => {
+		// The bound is the point: a worker that never finishes must not keep
+		// the run open indefinitely.
+		const { gateway } = fakeGateway()
+		const inbox = new CompletionInbox()
+		inbox.attach(gateway)
+		inbox.expect('tsk_never' as TaskId)
+
+		await inbox.waitForArrival(10)
+
+		expect(inbox.hasPendingWork).toBe(true)
+	})
+
+	it('releases a waiter when the inbox closes', async () => {
+		const { gateway } = fakeGateway()
+		const inbox = new CompletionInbox()
+		inbox.attach(gateway)
+		inbox.expect('tsk_1' as TaskId)
+
+		const waited = inbox.waitForArrival(600_000)
+		inbox.close()
+		await waited
+	})
+})
+
 describe('the notification says which task and what it produced', () => {
 	it('carries the id, the agent, the state and the output', () => {
 		// All four matter. Without the id the supervisor cannot say which of
@@ -173,7 +273,7 @@ describe('the notification says which task and what it produced', () => {
 		expect(text).toContain('truncated')
 		// The id is repeated in the truncation notice, so the follow-up call
 		// does not require scrolling back up through 4 kB of output.
-		expect(text).toContain('agent_task_list with task_id "tsk_42"')
+		expect(text).toContain('wait_for_task with task_id "tsk_42"')
 		expect(text.length).toBeLessThan(4_500)
 	})
 

--- a/packages/sdk/src/gateway/completion-inbox.ts
+++ b/packages/sdk/src/gateway/completion-inbox.ts
@@ -148,6 +148,23 @@ export class CompletionInbox {
 		return handles
 	}
 
+	/**
+	 * Stop expecting a task that is never going to arrive.
+	 *
+	 * Cancelling is the case this exists for. `expect` puts a task on the
+	 * outstanding list and only a COMPLETION takes it off, so a cancelled
+	 * worker left `hasPendingWork` true for the rest of the run — and every
+	 * attempt to settle then paid the full grace period waiting for a result
+	 * that had been called off.
+	 */
+	forget(taskId: TaskId): void {
+		this.outstanding.delete(taskId)
+		this.unheard.delete(taskId)
+		// Anyone waiting should re-check rather than sit out their deadline
+		// for a task that is no longer coming.
+		for (const wake of [...this.arrivals]) wake()
+	}
+
 	/** Stop listening. Safe to call more than once. */
 	close(): void {
 		this.detach?.()
@@ -172,8 +189,10 @@ const NOTIFICATION_OUTPUT_LIMIT = 4_000
  * five workers this was, and it carries the output, because a notification
  * that only says "done" forces exactly the follow-up call this mechanism
  * exists to remove. Long output is truncated with the task id repeated in
- * the truncation notice, so the full text stays one `agent_task_list` away
- * and the model knows which id to ask for.
+ * the truncation notice, so the full text stays one `wait_for_task` away and
+ * the model knows which id to ask for — that tool takes a `task_id` and
+ * returns immediately for a task that has already finished, where the
+ * listing takes only a state filter and could not have been followed.
  */
 export function formatCompletionNotification(handles: readonly TaskHandle[]): string {
 	const blocks = handles.map((handle) => {
@@ -181,7 +200,11 @@ export function formatCompletionNotification(handles: readonly TaskHandle[]): st
 		const output = handle.result?.result ?? handle.result?.lastError ?? ''
 		const truncated =
 			output.length > NOTIFICATION_OUTPUT_LIMIT
-				? `${output.slice(0, NOTIFICATION_OUTPUT_LIMIT)}\n… truncated. Call agent_task_list with task_id "${handle.taskId}" for the full output.`
+				? // `wait_for_task`, not `agent_task_list` — the listing takes only a
+					// state filter, so an instruction to call it "with task_id" named
+					// a parameter that does not exist and could not be followed. On an
+					// already-finished task the wait returns immediately.
+					`${output.slice(0, NOTIFICATION_OUTPUT_LIMIT)}\n… truncated. Call wait_for_task with task_id "${handle.taskId}" for the full output.`
 				: output
 
 		const lines = [

--- a/packages/sdk/src/registry/tool/__tests__/dialect.test.ts
+++ b/packages/sdk/src/registry/tool/__tests__/dialect.test.ts
@@ -69,16 +69,19 @@ describe('saying a schema in the dialect a wire parses', () => {
 		})
 	})
 
-	it('drops `additionalItems: false`, which both dialects already imply', () => {
-		// Not a lossy shortcut: once `prefixItems` is set, a closed tuple is the
-		// default in 2020-12, so emitting `items: false` would add a byte to
-		// every request to say what was already true.
+	it('keeps a closed tuple closed', () => {
+		// This assertion used to be its own opposite, and the comment under it
+		// was wrong about the dialect: it claimed a closed tuple is 2020-12's
+		// default once `prefixItems` is set. It is not — with no `items`,
+		// elements past the tuple are UNCONSTRAINED. Dropping the `false`
+		// turned a schema written to forbid a third element into one that
+		// allows any, which is a silent widening rather than a saved byte.
 		expect(
 			toSchemaDialect(
 				{ type: 'array', items: [{ type: 'integer' }], additionalItems: false },
 				'2020-12',
 			),
-		).toEqual({ type: 'array', prefixItems: [{ type: 'integer' }] })
+		).toEqual({ type: 'array', prefixItems: [{ type: 'integer' }], items: false })
 	})
 
 	it('ignores `additionalItems` with no tuple to qualify', () => {

--- a/packages/sdk/src/registry/tool/dialect.ts
+++ b/packages/sdk/src/registry/tool/dialect.ts
@@ -116,10 +116,17 @@ function to2020(value: unknown): unknown {
 			continue
 		}
 		if (key === 'additionalItems') {
-			// Only meaningful alongside an array-form `items`, where 2020-12
-			// calls the same thing `items`. `false` is the default in both
-			// dialects once `prefixItems` is set, so it carries nothing.
-			if (Array.isArray(node.items) && child !== false) out.items = to2020(child)
+			// Only meaningful alongside an array-form `items`, and 2020-12
+			// calls the same thing `items`.
+			//
+			// `false` is carried across, and the first version of this dropped
+			// it on the reasoning that a closed tuple is 2020-12's default. It
+			// is not: with `prefixItems` set and no `items`, elements past the
+			// tuple are UNCONSTRAINED. Dropping the `false` therefore turned a
+			// closed tuple into an open one — a schema the author wrote to
+			// forbid a third element silently began to allow any. The wire
+			// accepts `items: false`, measured, so nothing was gained by it.
+			if (Array.isArray(node.items)) out.items = to2020(child)
 			continue
 		}
 		out[key] = to2020(child)

--- a/packages/sdk/src/registry/tool/execute.ts
+++ b/packages/sdk/src/registry/tool/execute.ts
@@ -438,6 +438,41 @@ Executable tool names, descriptions, and JSON input schemas are attached through
 					}
 				}
 
+				// A turn that was narrowed may only call what it was narrowed to.
+				//
+				// This used to be enforced nowhere. `allowedTools` decided which
+				// schemas went into the request and was then carried into this
+				// context and read by nothing, so the restriction was a statement
+				// about the menu rather than about the kitchen: a model that named
+				// a withheld tool — from earlier context, from a gateway holding
+				// its own tool list, from a replayed cache prefix — had it run.
+				// The type says "restrict which tools the model may call"; this is
+				// the line that makes that true.
+				//
+				// Absent means unrestricted. An EMPTY list does not: it is a turn
+				// that may call nothing, and treating it as "no restriction" is
+				// the fail-open reading this codebase has already been bitten by
+				// once, in the delegate roster.
+				const allowed = context.allowedTools
+				if (allowed !== undefined && !allowed.includes(toolName)) {
+					const msg = `Tool "${toolName}" is not available on this step. Available: ${allowed.length > 0 ? allowed.join(', ') : '(none)'}`
+					this.log.warn('Blocked a tool outside the step allow-list', {
+						tool: toolName,
+						allowed: allowed.length,
+					})
+					span.setAttributes({
+						[NAMZU.TOOL_SUCCESS]: false,
+						[NAMZU.TOOL_ERROR]: msg,
+					})
+					span.setStatus({ code: SpanStatusCode.ERROR, message: msg })
+					return {
+						success: false,
+						output: '',
+						error: msg,
+						permissionDenied: true,
+					}
+				}
+
 				const mode = context.permissionContext?.mode ?? 'auto'
 				if (mode === 'plan') {
 					const isReadOnly = tool.isReadOnly ? tool.isReadOnly(rawInput) : false

--- a/packages/sdk/src/runtime/query/__tests__/step-allow-list.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/step-allow-list.test.ts
@@ -1,0 +1,205 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { ToolRegistry } from '../../../registry/tool/execute.js'
+import { defineTool } from '../../../tools/defineTool.js'
+import type { SessionId, TenantId } from '../../../types/ids/index.js'
+import { createUserMessage } from '../../../types/message/index.js'
+import type { LLMProvider, StreamChunk } from '../../../types/provider/index.js'
+import type { ProjectId, ThreadId } from '../../../types/session/ids.js'
+import { drainQuery } from '../index.js'
+
+/**
+ * Narrowing a step has to narrow what RUNS, not only what is offered.
+ *
+ * `prepareStep.activeTools` says "restrict which tools the model may call
+ * this step, by name", and for a while it did nothing of the sort: it chose
+ * which schemas went into the request, was copied into the tool context, and
+ * was read by nobody on the execution path. A model that named a withheld
+ * tool had it run — and a model does name one, from a repeated call earlier
+ * in the context, from a gateway carrying its own tool list, or from a
+ * replayed cache prefix.
+ *
+ * These tests call the withheld tool deliberately, which is the only way to
+ * tell an enforced restriction from a presentational one. Every existing test
+ * asked the model nicely and so could not have caught this.
+ */
+
+const ZERO_USAGE = {
+	promptTokens: 0,
+	completionTokens: 0,
+	totalTokens: 0,
+	cachedTokens: 0,
+	cacheWriteTokens: 0,
+}
+
+let danger = 0
+
+const readOnly = defineTool({
+	name: 'read_only',
+	description: 'observes',
+	inputSchema: z.object({}),
+	category: 'analysis',
+	permissions: [],
+	readOnly: true,
+	destructive: false,
+	concurrencySafe: true,
+	async execute() {
+		return { success: true, output: 'observed' }
+	},
+})
+
+const dangerous = defineTool({
+	name: 'danger',
+	description: 'mutates',
+	inputSchema: z.object({}),
+	category: 'custom',
+	permissions: [],
+	readOnly: false,
+	destructive: true,
+	concurrencySafe: false,
+	async execute() {
+		danger += 1
+		return { success: true, output: 'the withheld tool ran' }
+	},
+})
+
+/** Calls whichever tool it is told to, then answers. */
+class NamesTool implements LLMProvider {
+	readonly id = 'names-tool'
+	readonly name = 'Names Tool Provider'
+	calls = 0
+	offered: string[][] = []
+
+	constructor(private readonly toolName: string) {}
+
+	async *chatStream(params: {
+		tools?: { function: { name: string } }[]
+	}): AsyncIterable<StreamChunk> {
+		this.calls += 1
+		this.offered.push((params.tools ?? []).map((t) => t.function.name))
+
+		if (this.calls === 1) {
+			yield {
+				id: 'msg_1',
+				delta: {
+					toolCalls: [
+						{
+							index: 0,
+							id: 'toolu_1',
+							type: 'function',
+							function: { name: this.toolName, arguments: '{}' },
+						},
+					],
+				},
+			}
+			yield { id: 'msg_1', delta: {}, finishReason: 'tool_calls', usage: ZERO_USAGE }
+			return
+		}
+
+		yield { id: 'msg_2', delta: { content: 'done' } }
+		yield { id: 'msg_2', delta: {}, finishReason: 'stop', usage: ZERO_USAGE }
+	}
+}
+
+const workdirs: string[] = []
+afterEach(async () => {
+	await Promise.all(workdirs.map((dir) => rm(dir, { recursive: true, force: true })))
+	workdirs.length = 0
+	danger = 0
+})
+
+async function run(opts: {
+	names: string
+	allowedTools?: string[]
+	activeTools?: string[]
+}): Promise<{ offered: string[][]; output: string }> {
+	const workingDirectory = await mkdtemp(join(tmpdir(), 'namzu-allow-'))
+	workdirs.push(workingDirectory)
+
+	const tools = new ToolRegistry()
+	tools.register(readOnly)
+	tools.register(dangerous)
+
+	const provider = new NamesTool(opts.names)
+	let output = ''
+
+	await drainQuery(
+		{
+			provider,
+			tools,
+			...(opts.allowedTools ? { allowedTools: opts.allowedTools } : {}),
+			...(opts.activeTools
+				? { prepareStep: () => ({ activeTools: opts.activeTools as string[] }) }
+				: {}),
+			agentId: 'agent_test',
+			agentName: 'Test Agent',
+			messages: [createUserMessage('go')],
+			workingDirectory,
+			runConfig: {
+				model: 'mock-model',
+				timeoutMs: 10_000,
+				tokenBudget: 100_000,
+				maxIterations: 3,
+				maxResponseTokens: 256,
+			},
+			sessionId: 'ses_allow' as SessionId,
+			threadId: 'thd_allow' as ThreadId,
+			projectId: 'prj_allow' as ProjectId,
+			tenantId: 'tnt_allow' as TenantId,
+		},
+		(event) => {
+			if (event.type === 'tool_completed') output += event.result ?? ''
+		},
+	)
+
+	return { offered: provider.offered, output }
+}
+
+describe('a narrowed step narrows what can run, not just what is shown', () => {
+	it('refuses a tool the step withheld, even when the model names it', async () => {
+		const { offered, output } = await run({ names: 'danger', activeTools: ['read_only'] })
+
+		// The request really was narrowed — otherwise this test proves nothing
+		// about enforcement, only about the model's manners.
+		expect(offered[0]).toEqual(['read_only'])
+		// And the call was refused rather than executed.
+		expect(danger, 'the withheld tool executed').toBe(0)
+		expect(output).toContain('not available on this step')
+	})
+
+	it('refuses a tool outside the run-level list too', async () => {
+		const { output } = await run({ names: 'danger', allowedTools: ['read_only'] })
+
+		expect(danger).toBe(0)
+		expect(output).toContain('not available on this step')
+	})
+
+	it('still runs a tool that is on the list', async () => {
+		const { output } = await run({ names: 'read_only', activeTools: ['read_only'] })
+
+		expect(output).toContain('observed')
+	})
+
+	it('leaves an unnarrowed run alone', async () => {
+		// Absent means unrestricted. A run that never narrows anything must not
+		// suddenly start refusing its own tools.
+		const { output } = await run({ names: 'danger' })
+
+		expect(danger).toBe(1)
+		expect(output).toContain('the withheld tool ran')
+	})
+
+	it('treats an empty list as "nothing", not as "no restriction"', async () => {
+		// The fail-open reading this codebase has already been bitten by once,
+		// in the delegate roster: an empty allow-list IS the answer, and
+		// degrading it to "unrestricted" is how a closed list becomes open.
+		const { output } = await run({ names: 'danger', activeTools: [] })
+
+		expect(danger).toBe(0)
+		expect(output).toContain('(none)')
+	})
+})

--- a/packages/sdk/src/runtime/query/executor.ts
+++ b/packages/sdk/src/runtime/query/executor.ts
@@ -205,6 +205,8 @@ export class ToolExecutor {
 	private workingStateManager?: WorkingStateManager
 	private probes: ProbeRegistry
 	private parentSpan?: Span
+	/** Set per turn by the orchestrator; see {@link setStepAllowedTools}. */
+	private stepAllowedTools?: readonly string[]
 	private readonly readPaths: Set<string> = new Set()
 	private readonly readFingerprints: Map<string, string> = new Map()
 	private readonly fileReadTracker: FileReadTracker = {
@@ -249,6 +251,21 @@ export class ToolExecutor {
 	 */
 	setParentSpan(span: Span | undefined): void {
 		this.parentSpan = span
+	}
+
+	/**
+	 * Narrow what this turn may call, or clear the narrowing.
+	 *
+	 * Re-set each turn by the orchestrator for the same reason the parent span
+	 * is: `prepareStep` can hand a different list to every step, and the run's
+	 * own `allowedTools` is only the default when a step names none.
+	 *
+	 * Without this the executor could only ever see the RUN-level list, so a
+	 * per-step narrowing reached the request that was sent and nothing else —
+	 * the model was shown fewer tools and could still call all of them.
+	 */
+	setStepAllowedTools(names: readonly string[] | undefined): void {
+		this.stepAllowedTools = names
 	}
 
 	/**
@@ -424,7 +441,10 @@ export class ToolExecutor {
 			},
 			invocationState: this.config.invocationState,
 			toolRegistry: this.config.tools,
-			allowedTools: this.config.allowedTools,
+			// The step's list wins where it has one; the run's is the default.
+			// Same precedence the request already uses when it decides which
+			// schemas to send, so the menu and the kitchen agree.
+			allowedTools: this.stepAllowedTools ?? this.config.allowedTools,
 			sandbox: this.config.sandbox,
 			fileReadTracker: this.fileReadTracker,
 			...(this.parentSpan ? { parentSpan: this.parentSpan } : {}),

--- a/packages/sdk/src/runtime/query/iteration/index.ts
+++ b/packages/sdk/src/runtime/query/iteration/index.ts
@@ -218,7 +218,13 @@ export class IterationOrchestrator {
 				// supplied no hook.
 				const step = await this.prepareStep(iterationNum)
 
-				const llmTools = this.ctx.tools.toLLMTools(step.allowedTools ?? this.ctx.allowedTools)
+				const stepAllowedTools = step.allowedTools ?? this.ctx.allowedTools
+				const llmTools = this.ctx.tools.toLLMTools(stepAllowedTools)
+				// The same list the request was built from now also bounds what
+				// may run. Narrowing only the request left the restriction
+				// presentational — the model was shown fewer tools and could
+				// still call any of them by name.
+				this.ctx.toolExecutor.setStepAllowedTools(stepAllowedTools)
 				const enforceToolInputSchema = enforcedModelInputToolNames(this.ctx.tools, llmTools)
 				const stepModel = step.model ?? model
 

--- a/packages/sdk/src/tools/coordinator/__tests__/completion-delivery.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/completion-delivery.test.ts
@@ -4,7 +4,7 @@ import { CompletionInbox } from '../../../gateway/completion-inbox.js'
 import type { TaskGateway, TaskHandle } from '../../../types/agent/gateway.js'
 import type { TaskId } from '../../../types/ids/index.js'
 import type { ToolDefinition } from '../../../types/tool/index.js'
-import { buildCoordinatorTools } from '../index.js'
+import { DELEGATION_TIMEOUT_MS, buildCoordinatorTools } from '../index.js'
 
 /**
  * Who claims a completion, and who is left to announce it.
@@ -131,14 +131,14 @@ describe('the supervisor has a tool for every move it needs', () => {
 		// takes longer, and every expiry past that point produced the state
 		// this whole change exists to repair. Not firing at all beats
 		// recovering well.
-		expect(toolNamed(harness().tools, 'create_task').timeoutMs).toBeGreaterThan(120_000)
+		expect(toolNamed(harness().tools, 'create_task').timeoutMs).toBe(DELEGATION_TIMEOUT_MS)
 	})
 
 	it('gives the waiting tool a deadline longer than the executor default', () => {
 		// A tool whose entire job is to wait must not be killed for waiting.
 		// `ToolExecutor` reads `timeoutMs` before falling back to the run
 		// default, so declaring one here is the supported way to say so.
-		expect(toolNamed(harness().tools, 'wait_for_task').timeoutMs).toBeGreaterThan(120_000)
+		expect(toolNamed(harness().tools, 'wait_for_task').timeoutMs).toBe(DELEGATION_TIMEOUT_MS)
 	})
 
 	it('mounts none of them when there is no roster to delegate to', () => {

--- a/packages/sdk/src/tools/coordinator/index.ts
+++ b/packages/sdk/src/tools/coordinator/index.ts
@@ -224,6 +224,31 @@ function delegateSchema(agentIds: readonly string[]): z.ZodType<string> {
  */
 const LISTED_RESULT_LIMIT = 2_000
 
+/**
+ * How long a coordinator tool may wait on a delegated agent.
+ *
+ * The executor's own default is two minutes, sized for a file read or a
+ * test run, and its docstring says outright that a tool which legitimately
+ * runs longer declares its own. This one runs an entire agent, and did not.
+ *
+ * Measured on real traffic: three delegated children took 4m21s, 5m58s and
+ * 8m04s; all three parents timed out at 120s. The children were never
+ * killed — only the parent's wait was — so the blocking path was not
+ * occasionally missed, it was structurally unreachable, and the model was
+ * left polling a listing because that was the only move left to it.
+ *
+ * An hour rather than "a bit more than eight minutes" because a generic
+ * stopwatch is the wrong instrument for a child that is making progress:
+ * a failure should come from what the child is doing, not from the clock
+ * the parent happens to be holding. Peer runtimes agree — the ones that
+ * bound a delegated child at all land on an hour, and several impose no
+ * wall-clock bound whatsoever, bounding turns or depth instead.
+ *
+ * A wedged child is still caught, an hour later, and the run budget and
+ * iteration ceiling both still apply above this.
+ */
+export const DELEGATION_TIMEOUT_MS = 60 * 60 * 1000
+
 export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefinition[] {
 	const {
 		gateway,
@@ -249,7 +274,7 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 
 	const createTask = defineTool({
 		name: 'create_task',
-		description: `Launch a task on a specialized agent. By default this BLOCKS and returns the agent's final output as this call's tool_result; pass background: true to get a task_id back immediately and receive the result later as a task notification. Available agents: ${agentIds.join(', ')}. Prefer compact assignments; for large context, write/read shared workspace files and pass filenames or references. To launch multiple tasks in parallel, call this tool multiple times in a single assistant turn — the runtime executes every tool_use block from one response concurrently and delivers all tool_results together, so 'fan out 8 specialists' is one assistant message with 8 create_task blocks.`,
+		description: `Launch a task on a specialized agent. By default this BLOCKS and returns the agent's final output as this call's tool_result; pass background: true to get a task_id back immediately and receive the result later as a task notification. Available agents: ${agentIds.join(', ')}. Prefer compact assignments; for large context, write/read shared workspace files and pass filenames or references. To launch multiple tasks in parallel, call this tool multiple times in a single assistant turn — the runtime executes every tool_use block from one response concurrently and delivers all tool_results together, so 'fan out 8 specialists' is one assistant message with 8 create_task blocks. Do not race: until a worker's result reaches you, you know nothing about it — never fabricate, summarise or predict what it will say, in any form.`,
 		inputSchema: z.object({
 			agent_id: agentIdEnum.describe('Which agent to run'),
 			prompt: z
@@ -276,14 +301,11 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 		readOnly: false,
 		destructive: false,
 		concurrencySafe: true,
-		// A delegated worker doing real work takes minutes, and the run
-		// default is two. Every expiry past that point produced the state
-		// this change exists to repair — the model told "it may still be
-		// running" with no id, and a finished result nothing could reach.
-		// The notification now recovers that, but not firing at all is
-		// better than recovering well, and `ToolExecutor` reads a tool's own
-		// deadline before the run default precisely so a tool can say this.
-		timeoutMs: 600_000,
+		// See DELEGATION_TIMEOUT_MS. Ten minutes was the first attempt at
+		// this and was still a guess dressed as a measurement — real
+		// children were observed at 8m04s, which it would have survived by
+		// under two minutes.
+		timeoutMs: DELEGATION_TIMEOUT_MS,
 		async execute({ agent_id, prompt, description, plan_task_id, background }, _context) {
 			let resolvedPlanTaskId = plan_task_id
 
@@ -430,6 +452,9 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 		readOnly: false,
 		destructive: false,
 		concurrencySafe: true,
+		// It waits on a child exactly as create_task does, so it inherits
+		// the same bound rather than the file-read default.
+		timeoutMs: DELEGATION_TIMEOUT_MS,
 		async execute({ task_id, message }, _context) {
 			await gateway.continueTask(task_id as TaskId, message)
 			// Mirror create_task's blocking pattern: await the new
@@ -484,10 +509,9 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 		readOnly: true,
 		destructive: false,
 		concurrencySafe: true,
-		// Deliberately longer than the executor's default deadline. A tool
-		// whose entire purpose is to wait should not be cut off for waiting;
-		// `ToolExecutor` reads this before falling back to the run default.
-		timeoutMs: 600_000,
+		// A tool whose entire purpose is to wait must not be cut off for
+		// waiting. Same bound as the launch it is waiting on.
+		timeoutMs: DELEGATION_TIMEOUT_MS,
 		async execute({ task_id }, _context) {
 			const known = gateway.getTask(task_id as TaskId)
 			if (!known) {
@@ -558,7 +582,7 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 	const agentTaskList = defineTool({
 		name: 'agent_task_list',
 		description:
-			"Inspect the live state of every agent task launched on this gateway via create_task: returns each task's id, agent, state (pending/running/completed/failed/canceled), and timing. Distinct from the plan-task store's `task_list` (which lists planning tasks): this tool lists running/completed worker invocations. Use it BEFORE declaring multi-worker work done — confirm every launched task reached `completed`, none still `running` or `failed`. Read-only and safe to call repeatedly.",
+			"Inspect the live state of every agent task launched on this gateway via create_task: returns each task's id, agent, state (pending/running/completed/failed/canceled), and timing. Distinct from the plan-task store's `task_list` (which lists planning tasks): this tool lists running/completed worker invocations. Do NOT call this to find out whether work finished: a blocking create_task has already returned each worker's output, and a backgrounded one arrives as a task notification. Use it when you need to see what is still running, or to re-read the output of a task whose launch you stopped waiting for.",
 		inputSchema: z.object({
 			state: z
 				.enum(['pending', 'running', 'completed', 'failed', 'canceled'])

--- a/packages/sdk/src/tools/coordinator/index.ts
+++ b/packages/sdk/src/tools/coordinator/index.ts
@@ -571,6 +571,12 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 		concurrencySafe: true,
 		async execute({ task_id }) {
 			gateway.cancelTask(task_id as TaskId)
+			// Stop holding the run open for it. `expect` put this task on the
+			// inbox's outstanding list at launch and only a completion takes it
+			// off — so without this a cancelled worker kept `hasPendingWork`
+			// true and every attempt to settle paid the full grace period
+			// waiting for a result that had just been called off.
+			completionInbox?.forget(task_id as TaskId)
 			return {
 				success: true,
 				output: `Task ${task_id} cancelled`,

--- a/packages/sdk/src/types/tool/index.ts
+++ b/packages/sdk/src/types/tool/index.ts
@@ -100,6 +100,19 @@ export interface ToolContext {
 	invocationState?: InvocationState
 
 	toolRegistry?: ToolRegistryRef
+	/**
+	 * The names this turn may call, if the turn was narrowed.
+	 *
+	 * Enforced at dispatch, not only used to decide which schemas the model is
+	 * shown. It was the latter alone for a while, which made the narrowing
+	 * presentational: a step could withhold a tool from the request and the
+	 * executor would still run it when the model named it anyway — from
+	 * repeated context, from a gateway with its own tool memory, or from a
+	 * replayed prefix.
+	 *
+	 * Absent means no narrowing, which is not the same as an empty list: an
+	 * empty list is a turn that may call nothing.
+	 */
 	allowedTools?: readonly string[]
 	sandbox?: Sandbox
 	fileReadTracker?: FileReadTracker


### PR DESCRIPTION
Closes items 1–3 of the host's 2026-08-05 report, plus a correction to my own dialect work from earlier in the same session.

## The child was being strangled by a file-read deadline

`create_task` runs an entire agent. It inherited `DEFAULT_TOOL_TIMEOUT_MS`, whose own docstring says the quiet part out loud:

> Long enough for a real build or test run, short enough that a wedged tool does not hold a turn open indefinitely. **A tool that legitimately runs longer declares its own `timeoutMs`.**

It did not declare one. Measured on staging:

```
06:04:34  three children start
06:06:33  all THREE create_task calls time out   {"timeoutMs":120000,"durationMs":120001}
06:08:55  child completes  (4m21s)
06:10:32  child completes  (5m58s)
06:12:38  child completes  (8m04s)
```

The children are never killed — only the parent's wait is. With children at 4–8 minutes and a 2-minute deadline, the blocking path was not occasionally missed, it was **structurally unreachable**, and the supervisor fell back to `agent_task_list → sleep → agent_task_list` because that was the only move left on the board.

`DELEGATION_TIMEOUT_MS` is one hour now, exported so it is greppable, applied to `create_task`, `wait_for_task` and `continue_task`.

An hour rather than "a bit past eight minutes" because a generic stopwatch is the wrong instrument for a child that is making progress — a failure should come from what the child is doing. The run budget and iteration ceiling still bound it from above, and a genuinely wedged child is still caught.

My own earlier attempt at this was `600_000`, which was a guess dressed as a measurement: the 8m04s child would have survived it by under two minutes.

## The instruction to poll was ours

Worth stating plainly, because the host was about to rewrite its manifest to remove a polling instruction — and the same order lived in our tool description, closer to the decision point:

> "Use it BEFORE declaring multi-worker work done — confirm every launched task reached `completed`… **Read-only and safe to call repeatedly.**"

After a blocking `create_task` every launched task is already terminal and its output is already in context, so that ordered a guaranteed no-op turn on every multi-worker run. It now says the opposite and names the cases the listing is actually for.

`create_task` gained the clause for the other direction, because removing a completion check without it trades busy-waiting for invented results:

> Do not race: until a worker's result reaches you, you know nothing about it — never fabricate, summarise or predict what it will say, in any form.

## A closed tuple was being silently opened

This one is mine, and it shipped in 6.0.0. `toSchemaDialect` translated draft-07's `additionalItems: false` by **dropping** it, with a comment claiming 2020-12 closes a tuple by default.

It does not. With `prefixItems` set and no `items`, elements past the tuple are unconstrained — so a schema written to forbid a third element began to allow any number of them. Measured against the wire: `items: false` is accepted, so nothing was bought by dropping it.

The test that asserted the drop is inverted, since it had locked the bug in.

## Deliberately not here

The report's §4 (replace the wall clock with an idle clock that refreshes on observable child progress) is the better shape and is left as follow-up — it is a design change, not a constant.

The report also says not to start with launch-and-notify. Agreed as a starting point, and noting that it already landed in #120 as an **opt-in** (`background: true`); the default is still blocking, and its open question — whether an out-of-band turn can be injected after the supervisor's turn ends — was answered by measurement there rather than left hanging.

## Gates

`pnpm typecheck`, `pnpm lint`, 2569 SDK tests, external-name audit.
