### PR TITLE
fix(sdk): a run outlives its own waiting

### DIFF
--- a/.changeset/a-run-outlives-its-own-waiting.md
+++ b/.changeset/a-run-outlives-its-own-waiting.md
@@ -1,0 +1,35 @@
+---
+'@namzu/sdk': patch
+---
+
+a run no longer kills its own process while waiting, mid-turn, and report success
+
+`namzu run` and `namzu run-stream` could not finish a turn. The first tool call
+completed and the process ended: no second turn, nothing written, no terminal
+event, **exit code 0**. A user asking for a two-step task was told nothing had
+gone wrong while nothing had been done.
+
+Every human-in-the-loop park went through a timer that was deliberately
+`unref`'d, so a pending park-recorder could never hold a process open after the
+run settled. The hazard is real and the intent was right; the scope was wrong.
+That promise is **awaited during the run**, on every park, including the
+automatic ones a headless run resolves instantly. An `unref`'d timer does not
+keep Node's event loop alive — so once the decision resolved and the run sat out
+the rest of the delay, the loop had nothing left in it that counted, and the
+process exited from under the run.
+
+The timer is cancelled now instead of unref'd. It stays ref'd while the run is
+genuinely waiting on it, and is cleared the moment the decision arrives, so
+nothing dangles past the run either. A park that had already begun recording is
+still awaited, so the unpark cannot race it.
+
+Measured before and after on the same command: before, three events and an
+unchanged file; after, the edit applied and a terminal event.
+
+**Why no test caught it.** A test runner holds the event loop open for the whole
+file, which is exactly the prop this bug hides behind — the entire suite passed
+throughout, including tests that drive real runs against a live provider. The
+regression test therefore spawns a real `node` process with nothing else in it,
+and lives in its own suite (`pnpm --filter @namzu/sdk test:proc`, run as its own
+CI step) because the spawn competes for CPU hard enough to flake the
+timing-sensitive tests beside it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,13 @@ jobs:
       # model instead of asking what this one is trying to achieve. Wire
       # values are exempt by path — a driver has to name the service it
       # drives — and the script says exactly where that line falls.
+      # Spawns a real node process, so it cannot live in the unit suite: the
+      # spawn competes for CPU hard enough to flake the timing-sensitive tests
+      # beside it. It proves the one thing an in-process test cannot — that a
+      # run survives on its own event-loop footprint, with no test runner
+      # holding the loop open for it.
+      - name: Process-level regression tests
+        run: pnpm --filter @namzu/sdk test:proc
       - name: External-name audit
         run: node scripts/audit-external-names.mjs
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,70 +1,71 @@
 {
-  "name": "@namzu/sdk",
-  "version": "6.1.0",
-  "description": "Open-source AI agent SDK with a built-in runtime. Nothing between you and your agents.",
-  "license": "FSL-1.1-MIT",
-  "type": "module",
-  "packageManager": "pnpm@10.33.0",
-  "homepage": "https://github.com/cogitave/namzu#readme",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/cogitave/namzu.git"
-  },
-  "bugs": {
-    "url": "https://github.com/cogitave/namzu/issues"
-  },
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    }
-  },
-  "files": [
-    "dist",
-    "src",
-    "LICENSE.md",
-    "README.md",
-    "CHANGELOG.md"
-  ],
-  "sideEffects": [
-    "./dist/provider/mock-register.js"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "provenance": true
-  },
-  "scripts": {
-    "build": "tsc --build",
-    "dev": "tsc --build --watch",
-    "lint": "biome check src/",
-    "lint:fix": "biome check --write src/",
-    "format": "biome format --write src/",
-    "test": "vitest run --passWithNoTests",
-    "test:coverage": "vitest run --passWithNoTests --coverage",
-    "typecheck": "tsc --noEmit",
-    "knip": "knip",
-    "knip:production": "knip --production",
-    "prepublishOnly": "pnpm lint && pnpm typecheck && pnpm build"
-  },
-  "peerDependencies": {
-    "@opentelemetry/api": "^1.9.0",
-    "zod": "^3.23.0",
-    "zod-to-json-schema": "^3.23.0"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "^1.9.4",
-    "@opentelemetry/api": "^1.9.0",
-    "@types/node": "^22.19.17",
-    "@vitest/coverage-v8": "^3.2.6",
-    "fast-check": "^4.7.0",
-    "jsonschema": "^1.5.0",
-    "knip": "^6.4.1",
-    "typescript": "^5.5.0",
-    "vitest": "^3.2.6",
-    "zod": "^3.23.0",
-    "zod-to-json-schema": "^3.23.0"
-  }
+	"name": "@namzu/sdk",
+	"version": "6.1.0",
+	"description": "Open-source AI agent SDK with a built-in runtime. Nothing between you and your agents.",
+	"license": "FSL-1.1-MIT",
+	"type": "module",
+	"packageManager": "pnpm@10.33.0",
+	"homepage": "https://github.com/cogitave/namzu#readme",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/cogitave/namzu.git"
+	},
+	"bugs": {
+		"url": "https://github.com/cogitave/namzu/issues"
+	},
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist",
+		"src",
+		"LICENSE.md",
+		"README.md",
+		"CHANGELOG.md"
+	],
+	"sideEffects": [
+		"./dist/provider/mock-register.js"
+	],
+	"publishConfig": {
+		"access": "public",
+		"provenance": true
+	},
+	"scripts": {
+		"build": "tsc --build",
+		"dev": "tsc --build --watch",
+		"lint": "biome check src/",
+		"lint:fix": "biome check --write src/",
+		"format": "biome format --write src/",
+		"test": "vitest run --passWithNoTests",
+		"test:coverage": "vitest run --passWithNoTests --coverage",
+		"typecheck": "tsc --noEmit",
+		"knip": "knip",
+		"knip:production": "knip --production",
+		"prepublishOnly": "pnpm lint && pnpm typecheck && pnpm build",
+		"test:proc": "vitest run --config vitest.proc.config.ts"
+	},
+	"peerDependencies": {
+		"@opentelemetry/api": "^1.9.0",
+		"zod": "^3.23.0",
+		"zod-to-json-schema": "^3.23.0"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^1.9.4",
+		"@opentelemetry/api": "^1.9.0",
+		"@types/node": "^22.19.17",
+		"@vitest/coverage-v8": "^3.2.6",
+		"fast-check": "^4.7.0",
+		"jsonschema": "^1.5.0",
+		"knip": "^6.4.1",
+		"typescript": "^5.5.0",
+		"vitest": "^3.2.6",
+		"zod": "^3.23.0",
+		"zod-to-json-schema": "^3.23.0"
+	}
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -48,7 +48,7 @@
 		"knip": "knip",
 		"knip:production": "knip --production",
 		"prepublishOnly": "pnpm lint && pnpm typecheck && pnpm build",
-		"test:proc": "vitest run --config vitest.proc.config.ts"
+		"test:proc": "tsc --build && vitest run --config vitest.proc.config.ts"
 	},
 	"peerDependencies": {
 		"@opentelemetry/api": "^1.9.0",

--- a/packages/sdk/src/runtime/query/__tests__/run-survives-its-own-park.proc-test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/run-survives-its-own-park.proc-test.ts
@@ -1,0 +1,118 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+/**
+ * A run has to survive its own waiting.
+ *
+ * Every HITL park went through a timer that was deliberately `unref`'d, so a
+ * pending park-recorder could never hold a process open after the run
+ * settled. The intent was right and the scope was wrong: the run AWAITS that
+ * timer, mid-turn, on every park. An unref'd timer does not keep Node's loop
+ * alive — so once the decision resolved and the run sat out the rest of the
+ * delay, the loop had nothing ref'd left in it and the process exited. Mid
+ * turn. Exit code 0. No terminal event, no error, and nothing done.
+ *
+ * The headless surfaces could not finish a turn at all: the first tool call
+ * completed and the process ended.
+ *
+ * **This test spawns a child process on purpose.** In-process it is
+ * unwritable — a test runner holds the event loop open for the whole file,
+ * which is the exact prop that hid this for as long as it was hidden. Every
+ * existing test passed throughout. If you are tempted to rewrite this as an
+ * ordinary `drainQuery` call because spawning is slow, that rewrite is the
+ * bug coming back.
+ */
+
+const workdirs: string[] = []
+afterEach(() => {
+	for (const dir of workdirs) rmSync(dir, { recursive: true, force: true })
+	workdirs.length = 0
+})
+
+/**
+ * A scripted provider and a run, in a file with no test runner under it.
+ *
+ * Two turns: one tool call, then an answer. The park happens between them,
+ * which is where the process used to die.
+ */
+const SCRIPT = `
+import { pathToFileURL } from 'node:url'
+const sdk = await import(pathToFileURL(process.argv[2]).href)
+const { ToolRegistry, drainQuery, defineTool } = sdk
+const { z } = await import(pathToFileURL(process.argv[3]).href)
+
+const ZERO = { promptTokens: 0, completionTokens: 0, totalTokens: 0, cachedTokens: 0, cacheWriteTokens: 0 }
+
+let calls = 0
+const provider = {
+  id: 'scripted',
+  name: 'Scripted',
+  async *chatStream() {
+    calls += 1
+    if (calls === 1) {
+      yield { id: 'm1', delta: { toolCalls: [{ index: 0, id: 't1', type: 'function', function: { name: 'ping', arguments: '{}' } }] } }
+      yield { id: 'm1', delta: {}, finishReason: 'tool_calls', usage: ZERO }
+      return
+    }
+    yield { id: 'm2', delta: { content: 'answered' } }
+    yield { id: 'm2', delta: {}, finishReason: 'stop', usage: ZERO }
+  },
+}
+
+const tools = new ToolRegistry()
+tools.register(defineTool({
+  name: 'ping',
+  description: 'pings',
+  inputSchema: z.object({}),
+  category: 'analysis',
+  permissions: [],
+  readOnly: true,
+  destructive: false,
+  concurrencySafe: true,
+  async execute() { return { success: true, output: 'pong' } },
+}))
+
+let last = '(none)'
+drainQuery({
+  provider,
+  tools,
+  agentId: 'a',
+  agentName: 'A',
+  messages: [{ role: 'user', content: 'go', timestamp: Date.now() }],
+  workingDirectory: process.argv[4],
+  runConfig: { model: 'm', timeoutMs: 20000, tokenBudget: 10000, maxIterations: 4, maxResponseTokens: 128 },
+  sessionId: 'ses_x', threadId: 'thd_x', projectId: 'prj_x', tenantId: 'tnt_x',
+}, (e) => { last = e.type }).then(
+  (run) => console.log('RESULT ' + JSON.stringify({ status: run.status, stop: run.stopReason, last })),
+  (err) => console.log('THREW ' + (err?.message ?? err)),
+)
+process.on('exit', () => console.log('LAST ' + last))
+`
+
+describe('a run outlives its own HITL park', () => {
+	it('finishes in a process with nothing else holding the event loop open', () => {
+		const dir = mkdtempSync(join(tmpdir(), 'namzu-park-'))
+		workdirs.push(dir)
+		const script = join(dir, 'run.mjs')
+		writeFileSync(script, SCRIPT)
+
+		const sdkEntry = new URL('../../../../dist/index.js', import.meta.url).pathname.replace(
+			/^\//,
+			'',
+		)
+		const zodEntry = require.resolve('zod')
+
+		const out = execFileSync(process.execPath, [script, sdkEntry, zodEntry, dir], {
+			encoding: 'utf8',
+			timeout: 60_000,
+		})
+
+		// The run reached its own end rather than the process reaching it first.
+		expect(out, `the run did not complete:\n${out}`).toContain('RESULT ')
+		expect(out).toContain('"status":"completed"')
+		expect(out).toContain('"last":"run_completed"')
+	}, 90_000)
+})

--- a/packages/sdk/src/runtime/query/__tests__/run-survives-its-own-park.proc-test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/run-survives-its-own-park.proc-test.ts
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { afterEach, describe, expect, it } from 'vitest'
 
 /**
@@ -24,6 +25,12 @@ import { afterEach, describe, expect, it } from 'vitest'
  * existing test passed throughout. If you are tempted to rewrite this as an
  * ordinary `drainQuery` call because spawning is slow, that rewrite is the
  * bug coming back.
+ *
+ * It loads the BUILT entry point, because that is what a consumer loads and
+ * because a child process cannot resolve TypeScript. The `test:proc` script
+ * therefore builds first — a stale `dist` reports a failure that has nothing
+ * to do with the code under test, and would report a pass just as
+ * confidently.
  */
 
 const workdirs: string[] = []
@@ -99,10 +106,12 @@ describe('a run outlives its own HITL park', () => {
 		const script = join(dir, 'run.mjs')
 		writeFileSync(script, SCRIPT)
 
-		const sdkEntry = new URL('../../../../dist/index.js', import.meta.url).pathname.replace(
-			/^\//,
-			'',
-		)
+		// `fileURLToPath`, not `pathname` with the leading slash stripped. That
+		// stripping is right on Windows, where `pathname` is `/C:/…`, and wrong
+		// everywhere else, where it turns an absolute POSIX path into a
+		// relative one — which is how this passed locally and failed in CI with
+		// the repo root pasted in front of itself.
+		const sdkEntry = fileURLToPath(new URL('../../../../dist/index.js', import.meta.url))
 		const zodEntry = require.resolve('zod')
 
 		const out = execFileSync(process.execPath, [script, sdkEntry, zodEntry, dir], {

--- a/packages/sdk/src/runtime/query/iteration/phases/context.ts
+++ b/packages/sdk/src/runtime/query/iteration/phases/context.ts
@@ -209,16 +209,51 @@ export async function awaitDecisionDurably(
 		}
 	}
 
-	const recordIfSlow = (async (): Promise<void> => {
-		await sleep(delay)
-		if (settled) return
-		await record()
-	})()
+	// The wait for "is this park slow enough to be worth writing down", and
+	// the reason it is a cancellable timer rather than a slept-through one.
+	//
+	// It used to `await sleep(delay)` where `sleep` created its timer and
+	// UNREF'D it, so a pending recorder could never hold a process open after
+	// the run settled. That is a real hazard and the intent was right, but the
+	// scope was wrong: this promise is awaited *during* the run, below, on
+	// every park. An unref'd timer does not keep Node's event loop alive — so
+	// once the decision resolved and the run sat here waiting out the rest of
+	// the delay, the loop had nothing ref'd left in it and the process exited.
+	// Mid-turn. Exit code 0. Nothing written, no error, no terminal event.
+	//
+	// That shipped, and it made the headless surfaces unable to finish a turn
+	// at all: the first tool call would complete and the process would end.
+	// Every test passed because a test runner holds the loop open for the
+	// whole file, which is exactly the kind of prop that hides this.
+	//
+	// Cancelling gets both properties. The timer is ref'd, so the run cannot
+	// be killed by its own wait; and it is cleared the moment the decision
+	// arrives, so nothing dangles past the run either.
+	let parkTimer: ReturnType<typeof setTimeout> | undefined
+	// Set SYNCHRONOUSLY when the write begins, because `recorded` only turns
+	// true after it finishes — waiting on that instead would skip a write that
+	// is still in flight and let the unpark below race it.
+	let recording = false
+	const recordIfSlow = new Promise<void>((resolve) => {
+		parkTimer = setTimeout(() => {
+			if (settled) {
+				resolve()
+				return
+			}
+			recording = true
+			record().then(resolve, resolve)
+		}, delay)
+	})
 
 	try {
 		const decision = await decisionPromise
 		settled = true
-		await recordIfSlow
+		// Cancel the wait rather than sitting through it. If the timer already
+		// fired, `recordIfSlow` is the park write and is worth awaiting so the
+		// unpark below cannot race it; if it has not, there is nothing to wait
+		// for and clearing it is what lets the turn continue immediately.
+		if (parkTimer !== undefined) clearTimeout(parkTimer)
+		if (recording) await recordIfSlow
 
 		// `pause` is not an answer — it is "I am not answering now, hold
 		// this". It therefore ALWAYS gets recorded, even when it arrived too
@@ -247,15 +282,6 @@ export async function awaitDecisionDurably(
 	} finally {
 		settled = true
 	}
-}
-
-function sleep(ms: number): Promise<void> {
-	return new Promise((resolve) => {
-		const timer = setTimeout(resolve, ms)
-		// A pending park recorder must never be the reason a process stays
-		// alive after the run settles.
-		;(timer as { unref?: () => void }).unref?.()
-	})
 }
 
 /**

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
 	test: {
+		// `*.proc-test.ts` is deliberately OUT of the default run and has its
+		// own script and CI step. Those tests spawn a child process to prove
+		// something no in-process test can — that a run survives on its own
+		// event-loop footprint — and the spawn competes for CPU hard enough to
+		// flake the timing-sensitive tests around it. Excluded to keep the unit
+		// suite stable, NOT to make it optional: see `test:proc`.
 		include: ['src/**/*.test.ts'],
 		setupFiles: ['./src/test-setup.ts'],
 		coverage: {

--- a/packages/sdk/vitest.proc.config.ts
+++ b/packages/sdk/vitest.proc.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vitest/config'
+
+/**
+ * Tests that spawn a child process, run on their own.
+ *
+ * Some behaviour cannot be observed from inside a test runner. The one this
+ * exists for is whether a run keeps its own process alive: a runner holds the
+ * event loop open for the whole file, so a run that would die on its own
+ * footprint finishes happily under `vitest` and the bug ships. Proving it
+ * needs a real `node` process with nothing else in it.
+ *
+ * They are separated rather than merged into the unit suite because the spawn
+ * competes for CPU hard enough to flake the timing-sensitive tests running
+ * beside it — measured: three different tests failed across two runs of the
+ * full suite with this file in, and none with it out. Separated, not skipped:
+ * `pnpm --filter @namzu/sdk test:proc` runs them and CI runs that step.
+ */
+export default defineConfig({
+	test: {
+		include: ['src/**/*.proc-test.ts'],
+		setupFiles: ['./src/test-setup.ts'],
+		// One at a time. These measure what a process does when nothing else is
+		// in it; running two at once would put something else in it.
+		fileParallelism: false,
+	},
+})


### PR DESCRIPTION
`namzu run` and `run-stream` could not finish a turn. The first tool call completed and the process ended — no second turn, nothing written, no terminal event, **exit code 0**.

```
$ namzu --yolo run-stream "Read notes.txt then edit the TODO line"
{"kind":"tool-end","toolName":"read",...}     ← and it stops
$ echo $?        # 0
$ cat notes.txt  # unchanged
```

## Cause

Every HITL park awaited a timer that was deliberately `unref`'d, so a pending park-recorder could never hold a process open after the run settled. The hazard is real and the intent was right; the **scope** was wrong.

That promise is awaited *during* the run, on every park — including the automatic ones a headless run resolves instantly. An `unref`'d timer does not keep Node's event loop alive, so once the decision resolved and the run sat out the rest of the delay, the loop had nothing left in it that counted and the process exited from under the run.

Instrumented, the sequence is unambiguous: the review phase is entered, the checkpoint is written, the decision resolves as `approve_tools` — and then the process ends on `await recordIfSlow`.

The timer is **cancelled** now rather than unref'd: ref'd while the run genuinely waits on it, cleared the moment the decision arrives, so nothing dangles past the run either. A park that had already begun recording is still awaited so the unpark cannot race it. The `sleep` helper had no other caller and is gone.

Measured on the same command after the fix: three tool calls, the file edited, a terminal event.

## Why nothing caught it

**A test runner holds the event loop open for the whole file** — the exact prop this bug hides behind. All 2582 tests passed throughout, including ones that drive real runs against a live provider.

So the regression test spawns a real `node` process with nothing else in it. It lives in its own suite (`pnpm --filter @namzu/sdk test:proc`) and its own CI step, because the spawn competes for CPU hard enough to flake the timing-sensitive tests beside it — measured: three different tests failed across two full-suite runs with it in, none with it out. **Separated, not skipped**; making it opt-in would be the same trap one level down.

Mutation-checked: restoring the unref fails the new test and passes everything else.

## A correction worth recording

The first diagnosis of this was wrong for hours. The probe resolved `@namzu/sdk` through a directory that *looked* like a symlink and was a copy — Git Bash's `ln -s` does not create one on Windows — so every instrumented build being measured was a frozen snapshot, and an experiment that should have implicated this timer appeared to exonerate it. The probe imports `dist` by absolute path now.

## Gates

`pnpm typecheck`, `pnpm lint`, 2582 unit tests, the new process suite, external-name audit.