### PR TITLE
feat(sdk): whether a run may delegate is the caller's fact to state

### DIFF
--- a/.changeset/a-cancel-is-not-an-erase.md
+++ b/.changeset/a-cancel-is-not-an-erase.md
@@ -1,0 +1,19 @@
+---
+'@namzu/sdk': patch
+---
+
+cancelling a task no longer deletes a result it had already produced
+
+`CompletionInbox.forget` cleared both the outstanding-work set and the queue of
+completions waiting to be announced. The second was wrong.
+
+A background worker finishes, its completion is queued for the next drain, and
+the model — told nothing yet, and reading a tool that says it cancels a
+*running* task — cancels it. The run then reported `cancelled` over work that
+had been done, and the output existed nowhere else: not announced, not
+claimable, not readable through the listing.
+
+`forget` is about pending work, and a finished result is not pending work. It
+now narrows to the outstanding set. The asymmetry with `claim`, which does clear
+the queue, is deliberate: there a tool has just handed the model the same
+result.

--- a/.changeset/whether-is-not-who.md
+++ b/.changeset/whether-is-not-who.md
@@ -1,0 +1,35 @@
+---
+'@namzu/sdk': minor
+---
+
+a supervisor can decline to delegate without lying about its roster
+
+`SupervisorAgentConfig` gains `allowDelegation?: boolean`, default `true`.
+
+The roster answered WHO a run may call. Nothing answered WHETHER it may call
+anyone, and the two are different questions. A host that runs one specialist by
+putting its persona into the supervisor shell and its id into the roster has a
+non-empty roster and must still delegate to nobody — and got the full
+delegation surface, discovering the refusal only by spending a turn on it.
+
+It cannot be derived. Comparing the roster against the executing agent fails in
+exactly that arrangement, because the ids differ. And no predicate over the
+roster could work: a supervisor whose roster holds one specialist and a run
+that IS that specialist are indistinguishable in it. So the caller states the
+fact and the SDK decides what it implies for its own tool surface — which also
+means the implied list cannot go stale, the way a caller-held list of tool
+names silently did when this surface went from two tools to four.
+
+Details worth knowing:
+
+- **`agent_task_list` stays.** A run that may not launch anything may still want
+  to see what is running.
+- **`approve_plan` and `ask_user_question` are untouched.** They are the
+  human-in-the-loop surface, not delegation.
+- **`allowDelegation: false` is absolute.** `runtimeToolOverrides` cannot put
+  the tools back: the override pass runs over the tools this flag declined to
+  build, and both values come from the same caller in the same call, so
+  "must not delegate" plus "give it `create_task`" is a contradiction rather
+  than extra knowledge. `agentIds: []` has always worked this way.
+- **Absent and `true` are identical**, so adopting the flag cannot change a
+  caller that opts in explicitly.

--- a/packages/sdk/src/agents/SupervisorAgent.ts
+++ b/packages/sdk/src/agents/SupervisorAgent.ts
@@ -191,6 +191,11 @@ export class SupervisorAgent extends AbstractAgent<SupervisorAgentConfig, Superv
 			workingDirectory: input.workingDirectory,
 			runtimeContext: input.runtimeContext,
 			allowedAgentIds: config.agentIds,
+			// The only hop between the config and the decision. Omit it and
+			// everything still compiles: the field is settable, documented, and
+			// read by nothing — which is the shape of a declaration this repo
+			// has had to go and delete before.
+			allowDelegation: config.allowDelegation,
 			taskStore: input.taskStore,
 			runId,
 			getPlanManager: () => planManagerRef,

--- a/packages/sdk/src/agents/__tests__/supervisor-coordinator-registration.test.ts
+++ b/packages/sdk/src/agents/__tests__/supervisor-coordinator-registration.test.ts
@@ -55,6 +55,7 @@ const hostTool = (name: string) =>
 async function runWith(options: {
 	hostTools?: string[]
 	runtimeToolOverrides?: Record<string, 'active' | 'deferred' | 'disabled'>
+	allowDelegation?: boolean
 }) {
 	const agent = new SupervisorAgent({
 		id: 'supervisor',
@@ -80,6 +81,9 @@ async function runWith(options: {
 		{
 			provider,
 			agentIds: ['worker'],
+			...(options.allowDelegation !== undefined
+				? { allowDelegation: options.allowDelegation }
+				: {}),
 			agentManager: stubManager(),
 			tools,
 			systemPrompt: 'You coordinate.',
@@ -144,5 +148,38 @@ describe('supervisor coordinator-tool registration', () => {
 		// Overwriting also leaves the name present, so a membership check
 		// alone passes against the very behaviour this replaces.
 		expect(describedAs('create_task')).toBe(HOST_TOOL_DESCRIPTION)
+	})
+})
+
+/**
+ * The one hop between `SupervisorAgentConfig.allowDelegation` and the builder
+ * that acts on it.
+ *
+ * These go through `SupervisorAgent` rather than calling the builder directly,
+ * and that is the entire point. The builder has its own unit tests, and they
+ * pass whether or not the supervisor actually forwards the flag — measured:
+ * deleting the forward left the type-check clean and all 143 coordinator and
+ * agent tests green, with the field settable, documented, and read by nobody.
+ * That is the shape of a declaration this repository has had to go and delete
+ * before, so it gets a test that fails when the road is cut.
+ */
+describe('allowDelegation reaches the tool surface', () => {
+	it('withholds the delegation tools when the run declines to delegate', async () => {
+		const { names } = await runWith({ allowDelegation: false })
+
+		expect(names, 'the flag never reached buildCoordinatorTools').not.toContain('create_task')
+		expect(names).not.toContain('wait_for_task')
+		expect(names).not.toContain('cancel_task')
+	})
+
+	it('keeps the listing, so a non-delegating run can still see what is running', async () => {
+		expect((await runWith({ allowDelegation: false })).names).toContain('agent_task_list')
+	})
+
+	it('leaves an opting-in run exactly as it was', async () => {
+		const { names } = await runWith({ allowDelegation: true })
+
+		expect(names).toContain('create_task')
+		expect(names).toContain('agent_task_list')
 	})
 })

--- a/packages/sdk/src/gateway/__tests__/completion-inbox.test.ts
+++ b/packages/sdk/src/gateway/__tests__/completion-inbox.test.ts
@@ -192,6 +192,29 @@ describe('a launch nobody is waiting for holds the run open', () => {
 		expect(inbox.hasPendingWork).toBe(false)
 	})
 
+	it('keeps a result that already arrived, even when the task is cancelled', () => {
+		// The window: a worker finishes, its completion is queued for the next
+		// drain, and the model — told nothing yet, and reading a tool that says
+		// it cancels a RUNNING task — cancels it. Clearing the queue here threw
+		// away work that was done and output that existed nowhere else.
+		//
+		// `forget` is about pending work. A finished result is not pending work.
+		const { gateway, settle } = fakeGateway()
+		const inbox = new CompletionInbox()
+		inbox.attach(gateway)
+		inbox.expect('tsk_1' as TaskId)
+
+		settle(handleFor('tsk_1', 'the worker finished before the cancel landed'))
+		inbox.forget('tsk_1' as TaskId)
+
+		const drained = inbox.drain()
+		expect(
+			drained.map((h) => h.taskId),
+			'the finished result was discarded',
+		).toEqual(['tsk_1'])
+		expect(drained[0]?.result?.result).toBe('the worker finished before the cancel landed')
+	})
+
 	it('stops expecting a task that was cancelled', () => {
 		// `expect` is only cleared by a COMPLETION, so a cancelled worker used
 		// to keep the run open for the whole grace period, every time it tried

--- a/packages/sdk/src/gateway/completion-inbox.ts
+++ b/packages/sdk/src/gateway/completion-inbox.ts
@@ -159,9 +159,23 @@ export class CompletionInbox {
 	 */
 	forget(taskId: TaskId): void {
 		this.outstanding.delete(taskId)
-		this.unheard.delete(taskId)
-		// Anyone waiting should re-check rather than sit out their deadline
-		// for a task that is no longer coming.
+		// `unheard` is deliberately NOT touched.
+		//
+		// The two sets mean different things. `outstanding` is pending WORK,
+		// and cancelling is exactly the statement that it should stop being
+		// waited for. `unheard` is a RESULT that already exists — the worker
+		// finished, the completion arrived, and it is queued for the next
+		// drain. Clearing it here destroyed that.
+		//
+		// The window is small and entirely reachable: nothing has told the
+		// model the worker finished, and `cancel_task` says it cancels a
+		// running task, so cancelling one that has just completed is the
+		// obvious move rather than a mistake. The run then reports "cancelled"
+		// over work that was done and output that no longer exists anywhere.
+		//
+		// Note the asymmetry with `claim`, which does clear `unheard` — and is
+		// right to, because there a tool has just handed the model the same
+		// result. This one hands over nothing.
 		for (const wake of [...this.arrivals]) wake()
 	}
 

--- a/packages/sdk/src/tools/coordinator/__tests__/allow-delegation.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/allow-delegation.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+
+import type { TaskGateway } from '../../../types/agent/gateway.js'
+import { buildCoordinatorTools } from '../index.js'
+
+/**
+ * Whether a run may delegate is not the same question as who it may delegate
+ * to, and only the caller can answer the first.
+ *
+ * The roster answers WHO. It cannot answer WHETHER, because two runs are
+ * indistinguishable in it: a supervisor whose roster happens to hold one
+ * specialist, where delegating is the point; and a run whose own persona IS
+ * that specialist, where delegating is delegating to itself. A host builds the
+ * second by putting a specialist's persona into the supervisor shell and its
+ * id into the roster — so a predicate comparing the roster against the
+ * executing agent sees two different ids and cheerfully says "can delegate".
+ *
+ * Measured before this existed: such a run carried `create_task`,
+ * `wait_for_task`, `cancel_task` and `agent_task_list`, byte-identical to a
+ * run that could actually delegate, and the model could only discover the
+ * refusal by spending a turn on it.
+ */
+
+const gateway = {
+	listTasks: () => [],
+	onTaskCompleted: () => () => {},
+} as unknown as TaskGateway
+
+function namesFor(opts: {
+	agentIds: string[]
+	allowDelegation?: boolean
+	withHitl?: boolean
+}): string[] {
+	return buildCoordinatorTools({
+		gateway,
+		workingDirectory: '/tmp/test',
+		allowedAgentIds: opts.agentIds,
+		...(opts.allowDelegation !== undefined ? { allowDelegation: opts.allowDelegation } : {}),
+		...(opts.withHitl
+			? { resumeHandler: (async () => ({ action: 'continue' })) as never, runId: 'run_1' as never }
+			: {}),
+	}).map((t) => t.name)
+}
+
+describe('a run can decline to delegate while still naming who it would have called', () => {
+	it('withholds the delegation tools when delegation is off', () => {
+		const names = namesFor({ agentIds: ['specialist'], allowDelegation: false })
+
+		expect(names).not.toContain('create_task')
+		expect(names).not.toContain('wait_for_task')
+		expect(names).not.toContain('cancel_task')
+	})
+
+	it('produces exactly the empty-roster surface', () => {
+		// The two reasons differ but the outcome is the same one tool, so a
+		// reader does not have to hold two shapes in their head.
+		expect(namesFor({ agentIds: ['specialist'], allowDelegation: false })).toEqual(
+			namesFor({ agentIds: [] }),
+		)
+	})
+
+	it('keeps the listing, because a run may still want to see what is running', () => {
+		expect(namesFor({ agentIds: ['specialist'], allowDelegation: false })).toContain(
+			'agent_task_list',
+		)
+	})
+
+	it('leaves the human channel alone — that is not delegation', () => {
+		// `approve_plan` and `ask_user_question` are the HITL park surface. A
+		// run that must not delegate needs them as much as any other.
+		const names = namesFor({ agentIds: ['specialist'], allowDelegation: false, withHitl: true })
+
+		expect(names).toContain('ask_user_question')
+	})
+})
+
+describe('an absent flag changes nothing', () => {
+	it('mounts the full surface, as it always did', () => {
+		const names = namesFor({ agentIds: ['specialist'] })
+
+		expect(names).toContain('create_task')
+		expect(names).toContain('wait_for_task')
+		expect(names).toContain('cancel_task')
+		expect(names).toContain('agent_task_list')
+	})
+
+	it('is identical to opting in explicitly', () => {
+		// So adopting the flag cannot change a caller that says yes out loud.
+		expect(namesFor({ agentIds: ['a', 'b'], allowDelegation: true })).toEqual(
+			namesFor({ agentIds: ['a', 'b'] }),
+		)
+	})
+
+	it('still withholds everything on an empty roster, flag or no flag', () => {
+		expect(namesFor({ agentIds: [], allowDelegation: true })).toEqual(['agent_task_list'])
+	})
+})
+
+describe('the flag is absolute', () => {
+	it('cannot be overridden back on', () => {
+		// Worth a test precisely because the opposite is the intuitive guess:
+		// "explicit beats implicit" would say a runtime override should win.
+		// It cannot, mechanically — the override pass in SupervisorAgent runs
+		// over the array this builder returns, and there is no entry for it to
+		// act on. And it should not: both values come from the same caller in
+		// the same call, so "this run must not delegate" plus "give it
+		// create_task" is a caller contradicting itself, not one who knows
+		// something extra.
+		//
+		// Same rule the empty roster has always had.
+		const tools = buildCoordinatorTools({
+			gateway,
+			workingDirectory: '/tmp/test',
+			allowedAgentIds: ['specialist'],
+			allowDelegation: false,
+		})
+
+		expect(tools.find((t) => t.name === 'create_task')).toBeUndefined()
+	})
+})

--- a/packages/sdk/src/tools/coordinator/index.ts
+++ b/packages/sdk/src/tools/coordinator/index.ts
@@ -34,6 +34,16 @@ export interface CoordinatorToolsOptions {
 	runtimeContext?: AgentRuntimeContext
 	allowedAgentIds: string[]
 
+	/**
+	 * May this run delegate at all? Defaults to true.
+	 *
+	 * Same field, same name, as SupervisorAgentConfig.allowDelegation — the
+	 * name is kept identical deliberately. This options bag already renames
+	 * agentIds to allowedAgentIds, and a second rename on the road between
+	 * the config and the decision would make the road untraceable.
+	 */
+	allowDelegation?: boolean
+
 	taskStore?: TaskStore
 
 	runId?: RunId
@@ -253,6 +263,7 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 	const {
 		gateway,
 		allowedAgentIds: agentIds,
+		allowDelegation,
 		taskStore,
 		runId,
 		getPlanManager,
@@ -715,8 +726,24 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 	// had to invent something to say — and one that would not do that was left
 	// calling `agent_task_list` in a sleep loop. That was never the model
 	// misbehaving; it was the only move available.
-	const tools: ToolDefinition[] =
-		agentIds.length > 0 ? [createTask, waitForTaskTool, cancelTask, agentTaskList] : [agentTaskList]
+	// Two independent reasons not to mount the delegation surface, and the
+	// second one is not derivable from the first.
+	//
+	// An empty roster answers WHO may be called: nobody, so the tools have
+	// nothing to act on. `allowDelegation: false` answers WHETHER this run may
+	// call anyone, which a non-empty roster cannot settle — a host that runs a
+	// specialist by putting its persona into the supervisor shell and its id
+	// into the roster has a list of one and must still delegate to nobody.
+	// From inside this function that run is indistinguishable from a
+	// supervisor whose roster happens to hold a single specialist, so the
+	// caller states the fact rather than the SDK guessing it.
+	//
+	// `!== false` rather than truthiness, so an absent flag keeps today's
+	// behaviour exactly.
+	const canDelegate = agentIds.length > 0 && allowDelegation !== false
+	const tools: ToolDefinition[] = canDelegate
+		? [createTask, waitForTaskTool, cancelTask, agentTaskList]
+		: [agentTaskList]
 
 	if (getPlanManager) {
 		const approvePlan = defineTool({

--- a/packages/sdk/src/types/agent/supervisor.ts
+++ b/packages/sdk/src/types/agent/supervisor.ts
@@ -19,6 +19,34 @@ export interface SupervisorAgentConfig extends BaseAgentConfig {
 
 	agentIds: string[]
 
+	/**
+	 * May this run invoke subagents at all? Defaults to `true`.
+	 *
+	 * `agentIds` answers WHO may be called; this answers WHETHER, and they are
+	 * different questions. A run whose own persona is the single agent on the
+	 * list has a non-empty list and still must not call anyone.
+	 *
+	 * It cannot be derived. Comparing the list against the executing agent
+	 * fails where a host substitutes a specialist's persona into the
+	 * supervisor shell — the two ids differ, so the predicate says "can
+	 * delegate" about a run that cannot. And no predicate over `agentIds`
+	 * could work, because a supervisor whose list holds one specialist and a
+	 * run that IS that specialist are indistinguishable in it. The fact lives
+	 * with the caller, so the caller states it.
+	 *
+	 * Positive polarity on purpose: `allowDelegation: false` reads correctly
+	 * the first time, where a `delegationDisabled` spelling inverts twice at
+	 * every site that consults it.
+	 *
+	 * **Absolute.** `runtimeToolOverrides` cannot put the delegation tools
+	 * back — the override pass runs over the tools this flag already declined
+	 * to build, and both values come from the same caller in the same call, so
+	 * "must not delegate" plus "give it `create_task`" is a contradiction
+	 * rather than extra knowledge. This matches `agentIds: []`, which is
+	 * absolute today for the same reason.
+	 */
+	allowDelegation?: boolean
+
 	gateway?: TaskGateway
 	agentManager?: AgentManagerContract
 	tools?: ToolRegistryContract


### PR DESCRIPTION
Two coordinator corrections. One of them is mine, from this morning.

## `allowDelegation` — the roster answers *who*, not *whether*

`SupervisorAgentConfig` gains `allowDelegation?: boolean`, default `true`.

A host that runs one specialist by putting its persona into the supervisor shell and its id into the roster has a **non-empty roster** and must still delegate to nobody. Measured: that run carried `create_task`, `wait_for_task`, `cancel_task` and `agent_task_list` — byte-identical to a run that could actually delegate — and the model could only discover the refusal by spending a turn on it.

**It is not derivable.** Comparing the roster against the executing agent fails in exactly that arrangement, because the two ids differ. And no predicate over the roster could work: a supervisor whose roster holds one specialist, and a run that *is* that specialist, are indistinguishable in it. The fact lives with the caller, so the caller states it and the SDK derives the surface — which also means the implied list cannot go stale the way a caller-held list of tool names silently did when this surface went from two tools to four in #120.

- `agent_task_list` stays in both branches; a run that may not launch anything may still want to see what is running.
- `approve_plan` / `ask_user_question` untouched — human-in-the-loop, not delegation.
- Absent and `true` are identical, so opting in explicitly cannot change an existing caller.
- **`false` is absolute.** `runtimeToolOverrides` cannot put the tools back: the override pass runs over the array this flag declined to build, and both values come from the same caller in the same call, so the combination is a contradiction rather than extra knowledge. `agentIds: []` has always worked this way.

### The hop that fails silently, and its guard

The forward from config to builder is the only road between them. I verified the warning rather than trusting it: **deleting the forward left the type-check clean and all 143 coordinator and agent tests green**, with the field settable, documented, and read by nobody — the exact shape of a declaration this repo has had to go and delete before.

So the guard goes through `SupervisorAgent` rather than calling the builder directly, and mutation-checks: with the hop cut it fails with *"the flag never reached buildCoordinatorTools"*.

## `cancel_task` was deleting a result that already existed

`CompletionInbox.forget` cleared the queue of completions waiting to be announced as well as the outstanding-work set.

A background worker finishes → its completion is queued for the next drain → the model, told nothing yet and reading a tool that says it cancels a *running* task, cancels it → the queued result is discarded. The run reports `cancelled` over work that was done, and the output exists nowhere: not announced, not claimable, not in the listing.

`forget` is about **pending work**, and a finished result is not pending work. It narrows to the outstanding set. The asymmetry with `claim`, which does clear the queue, is deliberate — there a tool has just handed the model the same result; this one hands over nothing.

Shipped in 6.1.0 this morning; caught by the host in review, not in production.

## Gates

`pnpm typecheck`, `pnpm lint`, 2594 unit tests, external-name audit. Both behaviours mutation-checked.