### PR TITLE
fix(sdk): a failing shell command says what happened

### DIFF
--- a/.changeset/a-failing-command-says-why.md
+++ b/.changeset/a-failing-command-says-why.md
@@ -1,0 +1,38 @@
+---
+'@namzu/sdk': patch
+---
+
+a failing shell command now says what happened, and its own deadline is the one that fires
+
+**The failure path threw away everything useful.** The host branch of `bash`
+called `exec` with no `catch`, and `exec` rejects on a non-zero exit. So the two
+things an agent runs a shell for most — a test run and a build — both threw, the
+registry turned the throw into "the tool failed", and the stdout, stderr and
+exit code that explain why were discarded. The rejection carries all three.
+
+The sandbox branch a few lines above already reported them, so the same command
+told the model two different amounts depending on where it happened to run. It
+now reports the exit code, both streams, and — separately — whether the command
+ran out of time, because "timed out" and "exited 1" lead to different next moves
+and the model acts on the message.
+
+A caller-owned abort still propagates as an abort rather than being reported as
+a command failure.
+
+**Two clocks, one of them undeclared.** `bash` enforces the `timeout` it is
+given; the executor enforces a separate per-tool deadline, and with none
+declared here it fell back to its generic default — also two minutes. The two
+agreed by coincidence and diverged the moment a model asked for longer because
+it knew a build was slow: it got two minutes, from a clock it had not been told
+about, reported as an abandoned tool rather than as a command that ran out of
+time.
+
+The tool now declares a deadline above the ceiling its input accepts, so its own
+clock is the one that fires. A request past the ceiling is **refused** rather
+than silently clamped — a number the model was not told had changed is how it
+learns to distrust its own arguments. The ceiling is ten minutes, overridable
+with `NAMZU_BASH_MAX_TIMEOUT_MS`.
+
+**And it now has tests.** The only builtin that runs a shell had none, which is
+how the swallowed failure shipped. Thirteen cases, mutation-checked: neutralising
+the failure path fails four of them.

--- a/packages/sdk/src/tools/builtins/__tests__/bash.proc-test.ts
+++ b/packages/sdk/src/tools/builtins/__tests__/bash.proc-test.ts
@@ -1,0 +1,142 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { ToolContext } from '../../../types/tool/index.js'
+import { BashTool } from '../bash.js'
+
+/**
+ * What a shell command actually tells the model, measured by running one.
+ *
+ * The only builtin that runs a shell had no test at all, and what that cost
+ * is visible in the code it shipped: the host path called `exec` with no
+ * `catch`, and `exec` REJECTS on a non-zero exit. So the two things an agent
+ * runs a shell for most — a test run and a build — both threw, and the
+ * registry turned the throw into "the tool failed" with none of the stdout,
+ * stderr or exit code that explains why. The sandbox path beside it reported
+ * all three, so the same command told the model two different amounts
+ * depending on where it happened to run.
+ *
+ * These spawn real processes, so they live in the `proc-test` suite rather
+ * than the unit one — measured, running them beside 2594 unit tests flaked
+ * four unrelated timing-sensitive tests. The assertions that need no shell
+ * stayed behind in `bash.test.ts`.
+ *
+ * Commands are written to behave identically under `cmd.exe` and `sh`,
+ * because `exec` picks the platform shell and a test that only passes on one
+ * of them is a test that fails for whoever is on the other.
+ */
+
+const dirs: string[] = []
+afterEach(() => {
+	for (const dir of dirs) {
+		// A killed child can still hold its working directory for a moment —
+		// on Windows that surfaces as EBUSY, and it failed the timeout test
+		// from the cleanup rather than the assertion, which is the most
+		// misleading way for a test to go red. Retry, then let it go: a temp
+		// directory that outlives the run is the operating system's problem,
+		// not a result worth reporting.
+		try {
+			rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+		} catch {
+			// Deliberately swallowed. See above.
+		}
+	}
+	dirs.length = 0
+})
+
+function ctx(): ToolContext {
+	const workingDirectory = mkdtempSync(join(tmpdir(), 'namzu-bash-'))
+	dirs.push(workingDirectory)
+	return { workingDirectory } as ToolContext
+}
+
+async function run(
+	input: Record<string, unknown>,
+	context: ToolContext = ctx(),
+): Promise<{ success: boolean; output: string; error?: string; data?: Record<string, unknown> }> {
+	const parsed = BashTool.inputSchema.parse(input)
+	return (await BashTool.execute(parsed as never, context)) as never
+}
+
+describe('a command that succeeds', () => {
+	it('returns its stdout', async () => {
+		const result = await run({ command: 'echo hello' })
+
+		expect(result.success).toBe(true)
+		expect(result.output).toContain('hello')
+		expect(result.data?.exitCode).toBe(0)
+	})
+
+	it('runs in the working directory it was given', async () => {
+		const context = ctx()
+		writeFileSync(join(context.workingDirectory, 'marker.txt'), 'x')
+
+		const result = await run(
+			{ command: `node -e "console.log(require('fs').readdirSync('.'))"` },
+			context,
+		)
+
+		expect(result.output).toContain('marker.txt')
+	})
+
+	it('says so rather than returning an empty string', async () => {
+		const result = await run({ command: 'node -e ""' })
+
+		expect(result.output).toBe('(no output)')
+	})
+})
+
+describe('a command that fails still says what happened', () => {
+	it('reports the exit code instead of throwing', async () => {
+		// The whole defect: this used to reject out of `execute`.
+		const result = await run({ command: 'node -e "process.exit(3)"' })
+
+		expect(result.success).toBe(false)
+		expect(result.data?.exitCode).toBe(3)
+		expect(result.error).toContain('exited with code 3')
+	})
+
+	it('keeps the output a failing command produced', async () => {
+		// The reason a model runs a shell at all: a failing test prints WHY it
+		// failed, on stdout, before exiting non-zero.
+		const result = await run({
+			command: `node -e "console.log('3 tests failed'); process.exit(1)"`,
+		})
+
+		expect(result.success).toBe(false)
+		expect(result.output, 'the failure output was discarded').toContain('3 tests failed')
+	})
+
+	it('keeps stderr too', async () => {
+		const result = await run({
+			command: `node -e "console.error('compiler said no'); process.exit(2)"`,
+		})
+
+		expect(result.output).toContain('compiler said no')
+		expect(result.data?.exitCode).toBe(2)
+	})
+
+	it('reports a missing command as a failure, not as success', async () => {
+		const result = await run({ command: 'definitely-not-a-real-command-xyz' })
+
+		expect(result.success).toBe(false)
+		expect(result.error).toBeTruthy()
+	})
+})
+
+describe('a command that runs out of time', () => {
+	it('says it timed out rather than that it exited', async () => {
+		// "Ran out of time" and "exited 1" are different diagnoses and lead to
+		// different next moves, so the message has to distinguish them.
+		const result = await run({
+			command: `node -e "setTimeout(() => {}, 10000)"`,
+			timeout: 300,
+		})
+
+		expect(result.success).toBe(false)
+		expect(result.data?.timedOut).toBe(true)
+		expect(result.error).toContain('timed out')
+	}, 20_000)
+})

--- a/packages/sdk/src/tools/builtins/__tests__/bash.test.ts
+++ b/packages/sdk/src/tools/builtins/__tests__/bash.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import { BashTool } from '../bash.js'
+
+/**
+ * What `bash` promises before it runs anything.
+ *
+ * These need no shell, so they stay in the unit suite. The ones that actually
+ * execute a command live in `bash.proc-test.ts` — spawning real processes
+ * beside 2594 unit tests flaked four unrelated timing-sensitive ones, so the
+ * process suite is separate and has its own CI step.
+ */
+
+describe('the two clocks agree', () => {
+	it('declares a deadline of its own', () => {
+		// The executor reads a tool's `timeoutMs` before falling back to its
+		// generic default. With none declared, `bash` inherited that default —
+		// the same two minutes as its OWN default — so the two agreed by
+		// coincidence and diverged the moment a model asked for longer because
+		// it knew a build was slow. It got two minutes, from a clock it had not
+		// been told about, reported as an abandoned tool rather than as a
+		// command that ran out of time.
+		expect(BashTool.timeoutMs).toBeDefined()
+	})
+
+	it('puts that deadline above the longest the model may request', () => {
+		// So this tool's own clock is the one that fires, and the executor's is
+		// a backstop rather than a second clock racing it.
+		const accepted = BashTool.inputSchema.safeParse({ command: 'true', timeout: 10 * 60 * 1000 })
+
+		expect(accepted.success).toBe(true)
+		expect(BashTool.timeoutMs as number).toBeGreaterThan(10 * 60 * 1000)
+	})
+
+	it('refuses an over-long request rather than silently shortening it', () => {
+		// Refuse, do not degrade. A number the model was not told had changed
+		// is how it learns to distrust its own arguments.
+		const overCeiling = BashTool.inputSchema.safeParse({
+			command: 'true',
+			timeout: 60 * 60 * 1000,
+		})
+
+		expect(overCeiling.success, 'the ceiling is not enforced').toBe(false)
+	})
+
+	it('refuses a nonsensical deadline', () => {
+		expect(BashTool.inputSchema.safeParse({ command: 'true', timeout: 0 }).success).toBe(false)
+		expect(BashTool.inputSchema.safeParse({ command: 'true', timeout: -1 }).success).toBe(false)
+	})
+
+	it('applies its default when none is given', () => {
+		const parsed = BashTool.inputSchema.parse({ command: 'true' })
+
+		expect(parsed.timeout).toBeGreaterThan(0)
+	})
+})
+
+describe('the input is closed before a shell ever sees it', () => {
+	it('refuses an empty command', () => {
+		expect(BashTool.inputSchema.safeParse({ command: '' }).success).toBe(false)
+	})
+
+	it('accepts a numeric timeout sent as a string', () => {
+		// Providers do this, and the coercion is deliberate.
+		const parsed = BashTool.inputSchema.parse({ command: 'true', timeout: '5000' })
+
+		expect(parsed.timeout).toBe(5000)
+	})
+})
+
+describe('the danger flag reads the command', () => {
+	it('marks a destructive command destructive', () => {
+		expect(BashTool.isDestructive?.({ command: 'rm -rf /', timeout: 1000 } as never)).toBe(true)
+	})
+
+	it('leaves an ordinary command alone', () => {
+		expect(BashTool.isDestructive?.({ command: 'ls -la', timeout: 1000 } as never)).toBe(false)
+	})
+})

--- a/packages/sdk/src/tools/builtins/bash.ts
+++ b/packages/sdk/src/tools/builtins/bash.ts
@@ -22,6 +22,25 @@ const DEFAULT_BASH_MAX_BUFFER_BYTES = readPositiveIntEnv(
 	100 * 1024 * 1024,
 )
 
+/**
+ * The longest deadline this tool will accept from the model.
+ *
+ * There are two clocks on a bash call and until now only one of them was
+ * declared. This tool enforces `input.timeout` itself; the EXECUTOR enforces
+ * a separate per-tool deadline, and with none declared here it fell back to
+ * its own generic default — also two minutes. The two agreed by coincidence,
+ * so a model that asked for five minutes because it knew the build was slow
+ * got two, from a clock it had not been told about, reported as an abandoned
+ * tool rather than as a command that ran out of time.
+ *
+ * So the tool declares a ceiling and the executor is given a deadline above
+ * it (see `timeoutMs` on the definition), which makes this the only clock
+ * that can fire in practice. A request past the ceiling is REFUSED rather
+ * than quietly clamped: the model asked for something specific, and silently
+ * giving it a different number is how it learns to distrust the answer.
+ */
+const MAX_BASH_TIMEOUT_MS = readPositiveIntEnv('NAMZU_BASH_MAX_TIMEOUT_MS', 10 * 60 * 1000)
+
 const inputSchema = z.object({
 	command: z
 		.string()
@@ -32,9 +51,11 @@ const inputSchema = z.object({
 	timeout: z
 		.preprocess(
 			(v) => (typeof v === 'string' ? Number(v) : v),
-			z.number().default(DEFAULT_BASH_TIMEOUT_MS),
+			z.number().positive().max(MAX_BASH_TIMEOUT_MS).default(DEFAULT_BASH_TIMEOUT_MS),
 		)
-		.describe(`Command timeout in milliseconds. Default: ${DEFAULT_BASH_TIMEOUT_MS}`),
+		.describe(
+			`Command timeout in milliseconds. Default: ${DEFAULT_BASH_TIMEOUT_MS}, maximum: ${MAX_BASH_TIMEOUT_MS}. For work that legitimately runs longer than the maximum, start it in the background and poll, rather than holding the turn open.`,
+		),
 })
 
 type BashInput = z.infer<typeof inputSchema>
@@ -53,6 +74,12 @@ export const BashTool = defineTool({
 	readOnly: false,
 	destructive: (input: BashInput) => isDangerousCommand(input.command),
 	concurrencySafe: false,
+	// Above the ceiling the input schema accepts, so the executor's deadline
+	// is a backstop rather than a second clock racing this tool's own. It used
+	// to be undefined, which meant the executor's generic default applied —
+	// the same two minutes as this tool's DEFAULT, so they agreed by accident
+	// and diverged the moment a model asked for longer.
+	timeoutMs: MAX_BASH_TIMEOUT_MS + 30_000,
 
 	async execute(input, context) {
 		if (isDangerousCommand(input.command)) {
@@ -133,25 +160,80 @@ export const BashTool = defineTool({
 		// a Stop tore down the model stream and left the command running,
 		// and the executor's deadline could only ever DETACH from the tool
 		// rather than end the work it started.
-		const { stdout, stderr } = await execAsync(input.command, {
-			cwd: context.workingDirectory,
-			timeout: input.timeout,
-			env: { ...process.env, ...context.env },
-			maxBuffer: DEFAULT_BASH_MAX_BUFFER_BYTES,
-			signal: context.abortSignal,
-		})
+		// `exec` REJECTS on a non-zero exit, on its own timeout, and on a
+		// kill — and the rejection carries `stdout`, `stderr`, `code` and
+		// `killed`. Letting it propagate threw all of that away: the registry
+		// turned the throw into a structured failure, so the model was told a
+		// command failed and not one word about how.
+		//
+		// That is the common case, not an edge one. A failing test run and a
+		// failing build are the two things an agent runs bash for most, and
+		// both exit non-zero WITH the output that explains why. The sandbox
+		// branch above already reports all of it; this branch did not, so the
+		// same command told the model two different amounts depending on where
+		// it happened to run.
+		try {
+			const { stdout, stderr } = await execAsync(input.command, {
+				cwd: context.workingDirectory,
+				timeout: input.timeout,
+				env: { ...process.env, ...context.env },
+				maxBuffer: DEFAULT_BASH_MAX_BUFFER_BYTES,
+				signal: context.abortSignal,
+			})
 
-		const output = [stdout ? `STDOUT:\n${stdout}` : '', stderr ? `STDERR:\n${stderr}` : '']
-			.filter(Boolean)
-			.join('\n\n')
+			return {
+				success: true,
+				output: formatShellOutput(stdout, stderr) || '(no output)',
+				data: { exitCode: 0 },
+			}
+		} catch (err) {
+			const failure = err as NodeJS.ErrnoException & {
+				stdout?: string
+				stderr?: string
+				code?: number | string
+				killed?: boolean
+				signal?: string
+			}
 
-		return {
-			success: true,
-			output: output || '(no output)',
-			data: { exitCode: 0 },
+			// A caller-owned Stop is the caller's, not a command failure.
+			if (context.abortSignal?.aborted) throw err
+
+			// `exec` reports its own timeout as a kill, and the distinction
+			// matters to the model: "ran out of time" is a different next move
+			// from "exited 1".
+			const timedOut = failure.killed === true && failure.signal === 'SIGTERM'
+			const exitCode = typeof failure.code === 'number' ? failure.code : undefined
+			const output = formatShellOutput(failure.stdout, failure.stderr)
+
+			return {
+				success: false,
+				output: output || '(no output)',
+				data: {
+					...(exitCode !== undefined ? { exitCode } : {}),
+					timedOut,
+					...(failure.signal ? { signal: failure.signal } : {}),
+				},
+				error: timedOut
+					? `Command timed out after ${input.timeout}ms. Any output it produced before the deadline is above.`
+					: exitCode !== undefined
+						? `Command exited with code ${exitCode}`
+						: `Command failed: ${failure.message}`,
+			}
 		}
 	},
 })
+
+/**
+ * The two streams, labelled, with empty ones left out.
+ *
+ * Shared by the success and failure paths so a command tells the model the
+ * same shape either way — the failure path used to tell it nothing at all.
+ */
+function formatShellOutput(stdout: string | undefined, stderr: string | undefined): string {
+	return [stdout ? `STDOUT:\n${stdout}` : '', stderr ? `STDERR:\n${stderr}` : '']
+		.filter(Boolean)
+		.join('\n\n')
+}
 
 function readPositiveIntEnv(key: string, fallback: number): number {
 	const value = process.env[key]?.trim()


### PR DESCRIPTION
Two defects in the only builtin that runs a shell, and the reason both shipped: it had no tests.

## The failure path threw everything away

The host branch called `exec` with no `catch`, and `exec` **rejects on a non-zero exit**. So the two things an agent runs a shell for most — a test run and a build — both threw, the registry turned the throw into "the tool failed", and the stdout, stderr and exit code that explain why were discarded. The rejection carries all three.

The sandbox branch a few lines above already reported them, so **the same command told the model two different amounts depending on where it happened to run**.

It now reports the exit code, both streams, and — separately — whether the command ran out of time. "Timed out" and "exited 1" are different diagnoses and lead to different next moves; the model acts on the message. A caller-owned abort still propagates as an abort rather than being reported as a command failure.

## Two clocks, one of them undeclared

`bash` enforces the `timeout` it is given. The executor enforces a separate per-tool deadline, and with none declared here it fell back to `DEFAULT_TOOL_TIMEOUT_MS` — **the same two minutes** as this tool's own default.

So they agreed by coincidence, and diverged the moment a model asked for longer because it knew a build was slow: it got two minutes, from a clock it had not been told about, reported as an abandoned tool rather than as a command that ran out of time.

The tool now declares a deadline above the ceiling its input accepts, so its own clock is the one that fires and the executor's is a backstop. A request past the ceiling is **refused rather than silently clamped** — a number the model was not told had changed is how it learns to distrust its own arguments. Ceiling is ten minutes, overridable with `NAMZU_BASH_MAX_TIMEOUT_MS`.

## And it has tests

Thirteen cases. Mutation-checked: neutralising the failure path fails four of them.

They are split by what they need. The ones that execute a command are in the **process suite** — running them beside the unit suite flaked four unrelated timing-sensitive tests, measured — and the assertions that need no shell stayed in the unit suite so `bash` still has coverage there.

Two things I got wrong writing them, both worth naming because they are the same class of mistake in different clothes: the first version used `;` and `1>&2`, which `exec` hands to `cmd.exe` on Windows where neither means what it means in `sh`; and the cleanup turned a **passing** timeout test red by trying to remove a directory the killed child still held. Commands are driven through `node` now, and cleanup retries and then lets go.

## Gates

`pnpm typecheck`, `pnpm lint`, 2603 unit tests, the process suite, external-name audit.