### PR TITLE
fix(cli): the agent works in the directory it was sent to

### DIFF
--- a/.changeset/a-pipe-and-a-question-are-both-the-prompt.md
+++ b/.changeset/a-pipe-and-a-question-are-both-the-prompt.md
@@ -1,0 +1,41 @@
+---
+'@namzu/cli': patch
+---
+
+`namzu run` stops discarding piped input when a prompt is also given
+
+```
+cat notes.txt | namzu run "summarise this"
+```
+
+sent the model three words. The file was read by nothing: piped input was
+consulted only when there was no prompt argument at all. The run succeeded, exit
+0, and the answer was about nothing — a pipe and a question are the ordinary way
+to ask about a document, and taking only one of the two is the worst available
+reading of that command.
+
+Piped input is now used in both cases. With no prompt argument it IS the prompt,
+as before. Alongside one it is appended as the material the question is about,
+fenced so the model can tell the request from the content:
+
+```
+summarise this
+
+<stdin>
+…the file…
+</stdin>
+```
+
+`namzu run -` reads the prompt from stdin explicitly. Previously `-` was sent to
+the model as a one-character question.
+
+**On waiting.** Whether anything is being piped in cannot be answered without
+reading: a real pipe, an inherited-but-idle pipe and a test runner's stdin are
+indistinguishable to `fstat` on Windows — all three report neither FIFO nor
+file. So when the prompt came from an argument, the read waits up to 250ms for
+the first byte and then gives up; once a byte arrives it reads to end-of-input
+with no deadline, so a slow or large producer is never truncated. Without the
+bound, `namzu run "hello"` would hang forever in any context where stdin is open
+and silent, which is the ordinary state of a CI step. When there is no prompt
+argument the wait is unbounded, exactly as before — that path is a caller who
+has already said the prompt is coming.

--- a/.changeset/one-headless-command-in-two-spellings.md
+++ b/.changeset/one-headless-command-in-two-spellings.md
@@ -1,0 +1,45 @@
+---
+'@namzu/cli': minor
+---
+
+`namzu run` takes the options `run-stream` takes, instead of reading them out to the model
+
+The two headless one-shots are the same command with different output — `run`
+prints the reply for a shell, `run-stream` emits one JSON event per line for a
+host UI — and they accepted different input. `run` parsed nothing at all and
+joined every argument into the prompt, so
+
+```
+namzu run --cwd /projects/foo "fix the failing test"
+```
+
+sent the model a prompt beginning `--cwd /projects/foo` and ran in this
+directory anyway. That is the defect fixed in `run-stream` one release ago,
+still live in its sibling.
+
+`run` now accepts `--cwd`, `--provider`, `--model`, `--skills` and `--`, parsed
+by the same function `run-stream` uses, so the two cannot drift again.
+
+**What breaks.** `run` refuses an option it does not recognise instead of
+treating it as prompt text:
+
+- `namzu run --temperature 0.5 "hello"` used to run, with `--temperature 0.5` as
+  the first three words of the prompt, and exit 0. It now prints
+  `unknown option(s): --temperature` and exits **64**.
+- A prompt that genuinely starts with a dash needs `--` in front of it:
+  `namzu run -- --force means what?`. A single leading `-` was never an option
+  and still is not.
+
+To keep the old behaviour for a prompt containing flag-shaped text, put `--`
+before it. There is no way to get back the old reading of an unrecognised
+`--flag` as prompt text, and that is the point of the change.
+
+Classified minor, not major: SemVer §4 puts 0.x outside the stable-API
+guarantee, and this matches how the same narrowing was classified for
+`run-stream`.
+
+`--yolo` / `--dangerously-skip-permissions` are accepted on both commands and do
+nothing there, which is now stated in `--help` rather than left to be inferred:
+a headless turn has nobody to ask for approval, so it never prompts, so there is
+no prompt to skip. The safety gate that refuses catastrophic shell commands is
+unaffected and cannot be bypassed by either flag.

--- a/.changeset/the-agent-works-where-it-was-sent.md
+++ b/.changeset/the-agent-works-where-it-was-sent.md
@@ -1,0 +1,44 @@
+---
+'@namzu/cli': patch
+---
+
+the agent works in the directory `--cwd` names, instead of searching this one and reporting nothing
+
+`--cwd` reached the session store and the skill search and stopped there. The
+run itself was started with the process's own directory, so:
+
+```
+namzu run-stream --cwd /projects/foo "read notes.txt and edit it"
+```
+
+made the model call `glob`, which answered
+
+```
+No files found matching pattern "**/notes.txt" in /wherever/namzu/was/launched
+```
+
+`notes.txt` exists. The agent looked somewhere else and reported the file
+missing, which is the worst available way to be wrong about a path — a user
+reads it as "that file is not there" rather than "I searched the wrong tree".
+Nothing was edited and the run still exited 0.
+
+The resolved directory is now what the whole session is built on: every
+filesystem tool, the sub-agent runtime, the task store and the memory store. It
+is threaded in as an argument (`createAgentSession(prefs, detected, { cwd })`)
+rather than read from `process.cwd()` at each of those four points, which is how
+the value went missing at exactly one of them.
+
+`--cwd` is also resolved to an absolute path and checked before the run starts.
+A path that is not there is refused instead of falling back to this directory —
+the silent fallback is what turned a typo into a run that searched somewhere
+else and found nothing.
+
+`namzu skills-json --cwd <path>` reads that directory's project skills too. It
+was the last command still ignoring the flag, so a host could be offered a skill
+for one checkout and then find that a turn in that same checkout could not load
+it.
+
+**Why no test caught it.** No test ran a file tool against a directory that was
+not the process's own, so the two were the same string in every assertion. The
+regression test executes the real `glob` builtin against a temporary directory
+and asserts it finds a file that exists nowhere else.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -14,6 +14,7 @@ related_packages: ["@namzu/cli", "@namzu/sdk", "@namzu/anthropic", "@namzu/opena
 namzu                      # launch the interactive TUI
 namzu run "fix the build"  # headless one-shot — prints the reply (for scripts/CI)
 echo "..." | namzu run     # prompt from stdin; add --format json for {"text": "..."}
+namzu run --cwd ../other "which tests fail?"   # work in another checkout
 namzu --help               # utility subcommands (doctor, providers, run, …)
 ```
 
@@ -31,6 +32,7 @@ namzu --help               # utility subcommands (doctor, providers, run, …)
 | Page | What it covers |
 | --- | --- |
 | [The TUI](./tui.md) | Header, transcript/composer, slash commands + autocomplete, queuing, `/resume`, Ctrl+O, interrupting |
+| [Headless runs](./headless.md) | `run` and `run-stream`, their shared options, `--cwd`, exit codes, the NDJSON event stream |
 | [Providers & credentials](./providers.md) | How credentials are discovered, the first-run picker, switching providers |
 | [Tools & permission](./tools.md) | Builtin + memory + task tools, deferred clawtool, the permission prompt, the safety gate, bypass mode |
 | [Memory](./memory.md) | `USER.md` / `MEMORY.md` injection, `/remember`, `/memory`, the agent's structured memory |

--- a/docs/cli/headless.md
+++ b/docs/cli/headless.md
@@ -1,0 +1,145 @@
+---
+title: Headless runs
+description: namzu run and namzu run-stream — one prompt, no terminal. Shared options, the working directory, exit codes, and the NDJSON event stream.
+last_updated: 2026-08-05
+status: current
+related_packages: ["@namzu/cli"]
+---
+
+# Headless runs
+
+Two commands run a single prompt without a terminal. They are the same one-shot
+and differ only in how they report:
+
+| Command | Output | Written for |
+| --- | --- | --- |
+| `namzu run` | The reply on stdout, status lines on stderr | Shells, scripts, CI |
+| `namzu run-stream` | One JSON event per line on stdout, as the turn unfolds | A host UI rendering progress |
+
+```bash
+namzu run "fix the failing test"
+echo "summarise this" | namzu run
+namzu run-stream --session ses_42 "what changed?"
+```
+
+Both need a provider. Set a credential in the environment, or run `namzu` once
+and pick one — see [Providers & credentials](./providers.md).
+
+## Options
+
+Both commands take the same options, parsed by the same code. Everything that is
+not an option is the prompt.
+
+| Option | Effect |
+| --- | --- |
+| `--cwd <path>` | The directory the agent works in. Defaults to the current one. |
+| `--provider <id>` | Answer with this provider instead of the stored preference. |
+| `--model <id>` | Answer with this model instead of the stored preference. |
+| `--skills <a,b,c>` | Load these skills as context for the turn. See [Skills](./skills.md). |
+| `--session <key>` | Bind the turn to a persisted conversation (see below). |
+| `--` | End of options. Everything after it is prompt text, verbatim. |
+
+An option that is not on this list is refused. It is not passed to the model:
+
+```console
+$ namzu run --temperature 0.5 "hello"
+Error: unknown option(s): --temperature — pass `--` before a prompt that starts with a dash
+$ echo $?
+64
+```
+
+Use `--` when the prompt itself starts with a dash:
+
+```bash
+namzu run -- --force means what in this codebase?
+```
+
+### Tool approval
+
+A headless turn never prompts for approval — there is nobody to ask — so tools
+run without asking. The safety gate that refuses catastrophic shell commands
+still applies and cannot be turned off. `--yolo` and
+`--dangerously-skip-permissions` are accepted for symmetry with the interactive
+launch and do nothing here, because there is no prompt to skip. See
+[Tools & permission](./tools.md).
+
+## The working directory
+
+`--cwd` is the directory the whole run is built on: what `glob`, `read`, `edit`
+and `bash` resolve a relative path against, where sub-agents run, where project
+skills are discovered, and where the `.namzu` session and task stores live.
+
+```bash
+namzu run --cwd ../other-checkout "which tests are failing?"
+```
+
+A relative path resolves against the current directory. A path that does not
+exist, or is not a directory, is refused before the run starts — namzu will not
+quietly fall back to the current directory, because a run that searches the
+wrong tree reports that your files are missing rather than that it looked in the
+wrong place.
+
+## Sessions and history
+
+Without `--session`, a run is stateless: nothing is persisted, and it does not
+appear in `/resume`. `run-stream` will read prior history from stdin as a JSON
+`Message[]` if you pipe it.
+
+With `--session <key>`, the turn is bound to a persisted conversation in the
+working directory's `.namzu` store, keyed by an id you choose. Prior turns are
+loaded as context and the new pair is appended, so a host can reopen a
+conversation later:
+
+```bash
+namzu history --session <key> [--cwd <path>]
+```
+
+`history` prints the conversation's user and assistant messages as a JSON array.
+An empty array means the session exists and has no messages — it is not an
+error.
+
+## Exit codes
+
+`namzu run` is written for `$?`:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | The model answered and the run finished normally. |
+| `1` | The run failed, or stopped early — a token budget, a timeout, the iteration cap, a cancellation, or a refused answer. Any partial output is still printed, and the reason goes to stderr. |
+| `2` | No prompt was supplied. |
+| `64` | An argument is wrong (unknown option, bad `--cwd`). |
+
+A stopped run exits 1 even though it produced text, so
+`namzu run … > out.txt && deploy` cannot proceed on a partial or refused answer.
+
+`namzu run-stream` answers a host that is line-scanning stdout, not a shell, so
+it reports the same conditions **in band** and exits 0. Every run ends with a
+terminal event, including a refusal:
+
+```json
+{"kind":"error","message":"--cwd does not exist: /projects/typo"}
+{"kind":"done"}
+```
+
+## The event stream
+
+`run-stream` writes one JSON object per line. Status logging is silenced, so
+every line on stdout is a valid event.
+
+| `kind` | Carries |
+| --- | --- |
+| `delta` | `text` — a fragment of the reply |
+| `tool-start` | `toolUseId`, `toolName`, `summary`, optional `detail` lines |
+| `tool-end` | `toolUseId`, `toolName`, `isError`, `summary`, optional `detail` lines |
+| `usage` | `totalTokens`, `costUsd` |
+| `task` | `subject`, `status` — the agent's own plan items |
+| `error` | `message` |
+| `done` | optional `stopReason` |
+
+Two read-only helpers exist for a host building pickers, both taking `--cwd` and
+both printing `[]` rather than failing:
+
+```bash
+namzu skills-json --cwd <path>     # [{name, description, source}]
+namzu providers-json               # [{provider, label, detected, default, models}]
+```

--- a/docs/cli/headless.md
+++ b/docs/cli/headless.md
@@ -19,8 +19,36 @@ and differ only in how they report:
 ```bash
 namzu run "fix the failing test"
 echo "summarise this" | namzu run
+cat notes.txt | namzu run "summarise this"
 namzu run-stream --session ses_42 "what changed?"
 ```
+
+### Piped input
+
+`namzu run` uses a pipe and a prompt argument together, rather than choosing
+between them:
+
+| Invocation | Prompt the model receives |
+| --- | --- |
+| `namzu run "question"` | the argument |
+| `echo "question" \| namzu run` | the piped text |
+| `cat file \| namzu run "question"` | the argument, then the file fenced in a `<stdin>` block |
+| `namzu run -` | the piped text (explicit stdin sentinel) |
+
+Fencing is what lets the model tell the request from the material it is about;
+without a boundary the last line of a long paste runs into the question.
+
+When the prompt came from an argument, namzu waits up to 250ms for the first
+byte of piped input and then proceeds without it — otherwise `namzu run "hello"`
+would wait forever in any context where stdin is open and silent, such as a CI
+step. Once input starts arriving it is read to the end with no deadline, so a
+large or slow producer is never truncated. With no prompt argument the wait is
+unbounded, because the caller has said the prompt is coming.
+
+`run-stream` reads stdin differently on purpose: without `--session` it expects a
+JSON `Message[]` of prior conversation there, not prompt text. That is the one
+input channel the two commands do not share, because it means two different
+things to their two different callers.
 
 Both need a provider. Set a credential in the environment, or run `namzu` once
 and pick one — see [Providers & credentials](./providers.md).

--- a/docs/cli/meta.json
+++ b/docs/cli/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "CLI",
-  "pages": ["index", "tui", "providers", "tools", "memory", "skills"]
+  "pages": ["index", "tui", "headless", "providers", "tools", "memory", "skills"]
 }

--- a/packages/cli/src/commands/__tests__/run-flags.test.ts
+++ b/packages/cli/src/commands/__tests__/run-flags.test.ts
@@ -1,0 +1,143 @@
+/**
+ * `namzu run` accepts what `namzu run-stream` accepts.
+ *
+ * The two are the same headless one-shot and differ only in how they print, so
+ * an option one takes and the other reads aloud to the model is a defect, not a
+ * design. `run` joined every argument into the prompt, which is the exact shape
+ * already fixed once in the streaming sibling — `--cwd` was documented there,
+ * unparsed, and silently ran in the process's own directory.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+
+import { EXIT_USAGE } from '../../exit-codes.js'
+import { runCommand } from '../run.js'
+import type { CommandContext } from '../types.js'
+
+const seen: {
+	prompt: string | null
+	cwd: string | undefined
+	provider: string | undefined
+	model: string | undefined
+} = { prompt: null, cwd: undefined, provider: undefined, model: undefined }
+
+vi.mock('../../tui/agent.js', () => ({
+	probeAgentSession: vi.fn(async () => ({
+		preferences: { version: 2, provider: 'mock', subagents: { active: [] } },
+		needsRepickReason: null,
+		detected: [],
+	})),
+	createAgentSession: vi.fn(
+		async (
+			prefs: { provider?: string; model?: string },
+			_detected: unknown,
+			opts?: { cwd?: string },
+		) => {
+			seen.cwd = opts?.cwd
+			seen.provider = prefs.provider
+			seen.model = prefs.model
+			return {
+				hasProvider: true,
+				providerSummary: 'mock',
+				modelSummary: 'mock-model',
+				toolNames: [],
+				deferredToolCount: 0,
+				errorHint: null,
+				send: (messages: Array<{ content: string }>) => {
+					seen.prompt = messages[0]?.content ?? null
+					return (async function* () {
+						yield { kind: 'done', stopReason: 'end_turn' }
+					})()
+				},
+			}
+		},
+	),
+}))
+
+function context(): { ctx: CommandContext; printed: string[]; errors: string[] } {
+	const printed: string[] = []
+	const errors: string[] = []
+	const ctx = {
+		formatter: {
+			name: 'text' as const,
+			print: (d: unknown) => printed.push(String((d as { text?: string })?.text ?? d)),
+			info: () => {},
+			error: (e: unknown) => errors.push(String((e as { message?: string })?.message ?? e)),
+		},
+		config: {},
+	} as unknown as CommandContext
+	return { ctx, printed, errors }
+}
+
+async function run(rawArgs: string[]): Promise<{ code: number; errors: string[] }> {
+	seen.prompt = null
+	seen.cwd = undefined
+	seen.provider = undefined
+	seen.model = undefined
+	const { ctx, errors } = context()
+	const code = (await runCommand.handler({ rawArgs, ctx } as never)) as number
+	return { code, errors }
+}
+
+describe('namzu run reads its options instead of reciting them', () => {
+	it('works in --cwd and keeps it out of the prompt', async () => {
+		const elsewhere = mkdtempSync(join(tmpdir(), 'namzu-run-cwd-'))
+		try {
+			const { code } = await run(['--cwd', elsewhere, 'fix', 'the', 'test'])
+
+			expect(code).toBe(0)
+			expect(seen.cwd).toBe(elsewhere)
+			// The whole point: the flag was previously the first two words the
+			// model was asked to act on.
+			expect(seen.prompt).toBe('fix the test')
+		} finally {
+			rmSync(elsewhere, { recursive: true, force: true })
+		}
+	})
+
+	it('takes --provider and --model over the stored preference', async () => {
+		const { code } = await run(['--provider', 'openai', '--model', 'some-model', 'hello'])
+
+		expect(code).toBe(0)
+		expect(seen.provider).toBe('openai')
+		expect(seen.model).toBe('some-model')
+		expect(seen.prompt).toBe('hello')
+	})
+
+	it('refuses an option it does not know, with a usage exit code', async () => {
+		// A shell caller reads `$?`; saying "--temperature 0.5" to the model and
+		// exiting 0 is the failure this replaces.
+		const { code, errors } = await run(['--temperature', '0.5', 'hello'])
+
+		expect(code).toBe(EXIT_USAGE)
+		expect(errors.join('')).toContain('--temperature')
+		expect(seen.prompt).toBeNull()
+	})
+
+	it('refuses a --cwd that is not there rather than running in this one', async () => {
+		const { code, errors } = await run(['--cwd', join(tmpdir(), 'namzu-run-no-such'), 'hello'])
+
+		expect(code).toBe(EXIT_USAGE)
+		expect(errors.join('')).toContain('--cwd does not exist')
+		expect(seen.prompt).toBeNull()
+	})
+
+	it('lets `--` carry a prompt that begins with a dash', async () => {
+		const { code } = await run(['--', '--force', 'is', 'part', 'of', 'the', 'question'])
+
+		expect(code).toBe(0)
+		expect(seen.prompt).toBe('--force is part of the question')
+	})
+
+	it('accepts --yolo and does not put it in the prompt', async () => {
+		// Headless turns never prompt for approval, so there is nothing to skip.
+		// Accepting it silently is what keeps `namzu --yolo run …` working.
+		const { code } = await run(['--yolo', 'hello'])
+
+		expect(code).toBe(0)
+		expect(seen.prompt).toBe('hello')
+	})
+})

--- a/packages/cli/src/commands/__tests__/run-flags.test.ts
+++ b/packages/cli/src/commands/__tests__/run-flags.test.ts
@@ -11,10 +11,11 @@
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { Readable } from 'node:stream'
 import { describe, expect, it, vi } from 'vitest'
 
 import { EXIT_USAGE } from '../../exit-codes.js'
-import { runCommand } from '../run.js'
+import { composePrompt, runCommand } from '../run.js'
 import type { CommandContext } from '../types.js'
 
 const seen: {
@@ -139,5 +140,78 @@ describe('namzu run reads its options instead of reciting them', () => {
 
 		expect(code).toBe(0)
 		expect(seen.prompt).toBe('hello')
+	})
+})
+
+describe('a pipe and a question are both the prompt', () => {
+	// `cat notes.txt | namzu run "summarise this"` read the three words and
+	// silently dropped the file: piped input was consulted only when there was
+	// no argument prompt. The run succeeded and answered about nothing.
+	it('keeps piped material alongside the question', () => {
+		const prompt = composePrompt('summarise this', 'line one\nline two\n')
+
+		expect(prompt).toContain('summarise this')
+		expect(prompt).toContain('line one')
+		expect(prompt).toContain('line two')
+	})
+
+	it('fences the piped material so it cannot read as part of the question', () => {
+		// Without a boundary the last line of a long paste runs into the
+		// instruction, and the model cannot tell the request from the material.
+		const prompt = composePrompt('what is wrong here?', 'const x = 1')
+
+		expect(prompt).toBe('what is wrong here?\n\n<stdin>\nconst x = 1\n</stdin>')
+	})
+
+	it('is just the pipe when no question was given', () => {
+		expect(composePrompt('', 'do the thing')).toBe('do the thing')
+	})
+
+	it('is just the question when nothing was piped', () => {
+		expect(composePrompt('do the thing', '')).toBe('do the thing')
+		// No empty tag block either — a model shown `<stdin></stdin>` is being
+		// told something was attached when nothing was.
+		expect(composePrompt('do the thing', '   \n  ')).toBe('do the thing')
+	})
+
+	it('is empty when neither was given, so the caller can report it', () => {
+		expect(composePrompt('', '')).toBe('')
+	})
+})
+
+describe('the pipe reaches the model, not just the composer', () => {
+	// composePrompt is pure and proves the shape. This proves the plumbing:
+	// that piped bytes are actually READ when a prompt argument is present.
+	// They were not — stdin was consulted only when the argument was absent —
+	// and a unit test of the composer alone would pass with that defect intact.
+	function withStdin(text: string | null, fn: () => Promise<void>): Promise<void> {
+		const real = Object.getOwnPropertyDescriptor(process, 'stdin')
+		const fake = text === null ? Readable.from([]) : Readable.from([Buffer.from(text)])
+		Object.defineProperty(process, 'stdin', {
+			configurable: true,
+			get: () => Object.assign(fake, { isTTY: text === null }),
+		})
+		return fn().finally(() => {
+			if (real) Object.defineProperty(process, 'stdin', real)
+		})
+	}
+
+	it('sends the piped file alongside the question', async () => {
+		await withStdin('the contents of notes.txt', async () => {
+			const { code } = await run(['summarise this'])
+
+			expect(code).toBe(0)
+			expect(seen.prompt).toContain('summarise this')
+			expect(seen.prompt).toContain('the contents of notes.txt')
+		})
+	})
+
+	it('reads the pipe as the whole prompt for the `-` sentinel', async () => {
+		await withStdin('the question is in here', async () => {
+			const { code } = await run(['-'])
+
+			expect(code).toBe(0)
+			expect(seen.prompt).toBe('the question is in here')
+		})
 	})
 })

--- a/packages/cli/src/commands/__tests__/run-stream-flags.test.ts
+++ b/packages/cli/src/commands/__tests__/run-stream-flags.test.ts
@@ -1,7 +1,11 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { openSessions } from '../../integrations/sessions/store.js'
-import { historyCommand, parseRunStreamFlags, runStreamCommand } from '../run-stream.js'
+import { parseRunFlags } from '../run-flags.js'
+import { historyCommand, runStreamCommand, skillsJSONCommand } from '../run-stream.js'
 import type { CommandContext } from '../types.js'
 
 // Mocked so the directory the store is opened at is observable. Nothing here
@@ -12,6 +16,32 @@ vi.mock('../../integrations/sessions/store.js', () => ({
 	resolveConversation: vi.fn(async () => null),
 	loadConversation: vi.fn(async () => []),
 	appendMessages: vi.fn(async () => undefined),
+}))
+
+// Stubbed so a turn can be driven to completion without a credential, and so
+// the directory the SESSION is created in is observable. What the session then
+// does with that directory is asserted in `src/tui/__tests__/`.
+const sessionOptions: Array<{ cwd?: string } | undefined> = []
+vi.mock('../../tui/agent.js', () => ({
+	probeAgentSession: vi.fn(async () => ({
+		preferences: { version: 2, provider: 'anthropic', subagents: { active: [] } },
+		needsRepickReason: null,
+		detected: [],
+	})),
+	createAgentSession: vi.fn(
+		async (_prefs: unknown, _detected: unknown, opts?: { cwd?: string }) => {
+			sessionOptions.push(opts)
+			return {
+				hasProvider: true,
+				providerSummary: 'stub',
+				modelSummary: 'stub',
+				toolNames: [],
+				deferredToolCount: 0,
+				errorHint: null,
+				send: async function* () {},
+			}
+		},
+	),
 }))
 
 /**
@@ -40,6 +70,7 @@ function capture(): { lines: string[]; restore: () => void } {
 
 beforeEach(() => {
 	vi.mocked(openSessions).mockClear()
+	sessionOptions.length = 0
 })
 
 afterEach(() => {
@@ -88,20 +119,47 @@ describe('run-stream does not turn options into prompt text', () => {
 	})
 })
 
+describe('run-stream works in the directory it was pointed at', () => {
+	it('hands --cwd to the agent session, not only to the session store', async () => {
+		// `--session` keeps the turn off stdin: without a session key the command
+		// reads prior history from a pipe, and in a test runner that pipe never
+		// closes.
+		const elsewhere = mkdtempSync(join(tmpdir(), 'namzu-run-stream-'))
+		try {
+			await run(['--cwd', elsewhere, '--session', 'k', 'read', 'notes.txt'])
+		} finally {
+			rmSync(elsewhere, { recursive: true, force: true })
+		}
+
+		expect(sessionOptions).toEqual([{ cwd: elsewhere }])
+	})
+
+	it('refuses a --cwd that is not there instead of quietly using this one', async () => {
+		// The silent fallback is the whole defect: the run proceeds, searches the
+		// wrong tree, finds nothing, and reports that the file does not exist.
+		const lines = await run(['--cwd', join(tmpdir(), 'namzu-no-such-dir'), 'hello'])
+
+		const joined = lines.join('')
+		expect(joined).toContain('--cwd does not exist')
+		expect(joined).toContain('"kind":"done"')
+		expect(sessionOptions).toEqual([])
+	})
+})
+
 describe('the flag parser itself', () => {
 	// Asserted here rather than through the handler: a valid prompt sends the
 	// handler on to stdin and a provider probe, so the first version of this
 	// case hung for five seconds and failed on a timeout rather than on the
 	// behaviour. A pure function deserves to be called.
 	it('lets `--` carry a prompt that begins with a dash', () => {
-		const flags = parseRunStreamFlags(['--', '--this-is-the-prompt'])
+		const flags = parseRunFlags(['--', '--this-is-the-prompt'])
 
 		expect(flags.rest).toEqual(['--this-is-the-prompt'])
 		expect(flags.unknown).toEqual([])
 	})
 
 	it('stops interpreting options after `--`', () => {
-		const flags = parseRunStreamFlags(['--session', 'abc', '--', '--model', 'not-a-flag'])
+		const flags = parseRunFlags(['--session', 'abc', '--', '--model', 'not-a-flag'])
 
 		expect(flags.session).toBe('abc')
 		expect(flags.model).toBeNull()
@@ -109,15 +167,50 @@ describe('the flag parser itself', () => {
 	})
 
 	it('reads --cwd in both spellings', () => {
-		expect(parseRunStreamFlags(['--cwd', '/a', 'hi']).cwd).toBe('/a')
-		expect(parseRunStreamFlags(['--cwd=/b', 'hi']).cwd).toBe('/b')
-		expect(parseRunStreamFlags(['--cwd', '/a', 'hi']).rest).toEqual(['hi'])
+		expect(parseRunFlags(['--cwd', '/a', 'hi']).cwd).toBe('/a')
+		expect(parseRunFlags(['--cwd=/b', 'hi']).cwd).toBe('/b')
+		expect(parseRunFlags(['--cwd', '/a', 'hi']).rest).toEqual(['hi'])
 	})
 
 	it('leaves a lone dash alone, since that is not an option', () => {
-		expect(parseRunStreamFlags(['-', 'hi']).unknown).toEqual([])
-		expect(parseRunStreamFlags(['-', 'hi']).rest).toEqual(['-', 'hi'])
+		expect(parseRunFlags(['-', 'hi']).unknown).toEqual([])
+		expect(parseRunFlags(['-', 'hi']).rest).toEqual(['-', 'hi'])
 	})
+})
+
+describe('skills-json lists the directory it was pointed at', () => {
+	// A host that lists skills for one checkout and then runs a turn in that
+	// same checkout has to be told about the same skills both times. It was
+	// not: this command read the process directory whatever `--cwd` said, so
+	// it could offer a skill that `run-stream --cwd <there>` then could not
+	// find, and hide one that was actually available.
+	function skillIn(root: string, name: string): void {
+		mkdirSync(join(root, 'skills', name), { recursive: true })
+		writeFileSync(
+			join(root, 'skills', name, 'SKILL.md'),
+			`---\nname: ${name}\ndescription: only in this checkout\n---\n\nbody\n`,
+		)
+	}
+
+	it('discovers the project skills under --cwd', async () => {
+		const elsewhere = mkdtempSync(join(tmpdir(), 'namzu-skills-'))
+		skillIn(elsewhere, 'only-over-there')
+		const { lines, restore } = capture()
+		try {
+			await skillsJSONCommand.handler({ rawArgs: ['--cwd', elsewhere], ctx } as never)
+		} finally {
+			restore()
+			rmSync(elsewhere, { recursive: true, force: true })
+		}
+
+		const names = (JSON.parse(lines.join('').trim()) as Array<{ name: string }>).map((s) => s.name)
+		expect(names).toContain('only-over-there')
+	})
+
+	// There is deliberately no paired "and not from anywhere else" case: with
+	// the flag ignored the command read `packages/cli`, which has no skills
+	// directory, so a negative assertion passes with the defect still in place
+	// and would only look like coverage.
 })
 
 describe('history reads the directory it was pointed at', () => {
@@ -126,18 +219,37 @@ describe('history reads the directory it was pointed at', () => {
 		// command merely survives `--cwd` would pass with the wiring reverted —
 		// `[]` is printed either way — which would leave the flag parsed and
 		// still undriven, the exact shape being repaired here.
+		//
+		// A real directory, because `--cwd` is now resolved and checked before
+		// the store is opened: a path that is not there cannot be told apart
+		// from a session with no messages, so it never reaches the store.
+		const elsewhere = mkdtempSync(join(tmpdir(), 'namzu-history-'))
 		const { lines, restore } = capture()
 		try {
 			await historyCommand.handler({
-				rawArgs: ['--cwd', '/tmp/elsewhere', '--session', 'some-key'],
+				rawArgs: ['--cwd', elsewhere, '--session', 'some-key'],
 				ctx,
 			} as never)
 		} finally {
 			restore()
+			rmSync(elsewhere, { recursive: true, force: true })
 		}
 
-		expect(openSessions).toHaveBeenCalledWith('/tmp/elsewhere')
+		expect(openSessions).toHaveBeenCalledWith(elsewhere)
 		expect(lines.join('').trim()).toBe('[]')
+	})
+
+	it('resolves a relative --cwd against the process directory', async () => {
+		// A host that passes `.` or `../sibling` gets the directory it meant,
+		// and the agent downstream gets an absolute path it cannot misread.
+		const { restore } = capture()
+		try {
+			await historyCommand.handler({ rawArgs: ['--cwd', '.', '--session', 'k'], ctx } as never)
+		} finally {
+			restore()
+		}
+
+		expect(openSessions).toHaveBeenCalledWith(resolve(process.cwd(), '.'))
 	})
 
 	it('falls back to the process directory when --cwd is absent', async () => {

--- a/packages/cli/src/commands/run-flags.ts
+++ b/packages/cli/src/commands/run-flags.ts
@@ -1,0 +1,213 @@
+/**
+ * The input surface shared by the two headless one-shots, `run` and
+ * `run-stream`.
+ *
+ * They are the same command with different OUTPUT — `run` prints the reply for
+ * a shell, `run-stream` emits one JSON event per line for a host UI — so they
+ * have no business accepting different INPUT. They did: `run-stream` learned to
+ * parse `--cwd`, `--model`, `--provider`, `--session` and `--skills`, while
+ * `run` parsed nothing at all and joined every argument into the prompt. So
+ * `namzu run --cwd /elsewhere "fix the test"` sent the model a prompt beginning
+ * `--cwd /elsewhere` and ran in this directory, which is the defect that was
+ * already fixed once, in the sibling command.
+ *
+ * One parser, so the two cannot drift again.
+ *
+ * What they still differ on is how a bad argument is REPORTED, and that is
+ * deliberate: `run` answers a shell, so it exits non-zero; `run-stream` answers
+ * a line-scanning host, so it emits an error event and exits 0. Each is the
+ * only signal its caller is listening for.
+ */
+
+import { statSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+export interface RunFlags {
+	session: string | null
+	model: string | null
+	provider: string | null
+	instance: string | null
+	/** Where the agent works: filesystem tools, sub-agents, session store, skills. */
+	cwd: string | null
+	skills: string[]
+	/**
+	 * `--flags` this parser does not know.
+	 *
+	 * Collected rather than folded into `rest`, because `rest` becomes the
+	 * PROMPT. Anything unrecognised is refused instead of being quietly said
+	 * out loud to a model — a typo'd flag is a mistake, and reading it aloud is
+	 * the worst available response to one.
+	 */
+	unknown: string[]
+	rest: string[]
+}
+
+export function parseRunFlags(rawArgs: readonly string[]): RunFlags {
+	const out: RunFlags = {
+		session: null,
+		model: null,
+		provider: null,
+		instance: null,
+		cwd: null,
+		skills: [],
+		unknown: [],
+		rest: [],
+	}
+	const take = (a: string, name: string, set: (v: string) => void, i: { v: number }): boolean => {
+		if (a === `--${name}` && i.v + 1 < rawArgs.length) {
+			set(rawArgs[++i.v])
+			return true
+		}
+		if (a.startsWith(`--${name}=`)) {
+			set(a.slice(name.length + 3))
+			return true
+		}
+		return false
+	}
+	const trimmed = (assign: (v: string | null) => void) => (v: string) => assign(v.trim() || null)
+	for (const idx = { v: 0 }; idx.v < rawArgs.length; idx.v++) {
+		const a = rawArgs[idx.v]
+		// End of options. Everything after it is prompt, verbatim — the escape
+		// for a prompt that legitimately begins with a dash, which is the only
+		// case the refusal below would otherwise take away.
+		if (a === '--') {
+			out.rest.push(...rawArgs.slice(idx.v + 1))
+			break
+		}
+		if (
+			take(
+				a,
+				'cwd',
+				trimmed((v) => {
+					out.cwd = v
+				}),
+				idx,
+			)
+		)
+			continue
+		if (
+			take(
+				a,
+				'session',
+				trimmed((v) => {
+					out.session = v
+				}),
+				idx,
+			)
+		)
+			continue
+		if (
+			take(
+				a,
+				'model',
+				trimmed((v) => {
+					out.model = v
+				}),
+				idx,
+			)
+		)
+			continue
+		if (
+			take(
+				a,
+				'provider',
+				trimmed((v) => {
+					out.provider = v
+				}),
+				idx,
+			)
+		)
+			continue
+		if (
+			take(
+				a,
+				'instance',
+				trimmed((v) => {
+					out.instance = v
+				}),
+				idx,
+			)
+		)
+			continue
+		if (
+			take(
+				a,
+				'skills',
+				(v) => {
+					out.skills = v
+						.split(',')
+						.map((s) => s.trim())
+						.filter(Boolean)
+				},
+				idx,
+			)
+		)
+			continue
+		// Accepted and ignored: the headless commands never prompt for tool
+		// approval, so there is nothing for a bypass flag to bypass. Refusing it
+		// would break `namzu --yolo run …`, which reads as reasonable and is
+		// already how the interactive launch is spelled.
+		if (a === '--yolo' || a === '--dangerously-skip-permissions') continue
+		if (a.startsWith('--')) {
+			out.unknown.push(a.split('=')[0])
+			continue
+		}
+		out.rest.push(a)
+	}
+	return out
+}
+
+/**
+ * Absolute path for a `--cwd`, or an error naming what is wrong with it.
+ *
+ * Relative values resolve against the process's own directory, which is the
+ * only base a caller can predict. A path that is missing or is not a directory
+ * is refused rather than silently falling back: falling back is how a typo'd
+ * `--cwd` becomes a run that searched somewhere else and reported finding
+ * nothing, which reads as "the file isn't there".
+ */
+export function resolveWorkingDirectory(raw: string | null): { cwd: string } | { error: string } {
+	if (!raw) return { cwd: process.cwd() }
+	const cwd = resolve(process.cwd(), raw)
+	try {
+		if (!statSync(cwd).isDirectory()) return { error: `--cwd is not a directory: ${cwd}` }
+	} catch {
+		return { error: `--cwd does not exist: ${cwd}` }
+	}
+	return { cwd }
+}
+
+/**
+ * The `--skills a,b,c` system block for a turn, or undefined when none were
+ * asked for or none of them exist.
+ *
+ * Lives beside the parser because resolving the names IS what the flag means,
+ * and because the skills a turn can load are the ones under its `--cwd` — the
+ * two flags have to be read together or a host is offered a skill in one
+ * directory and denied it in another.
+ *
+ * Best-effort: a skill that cannot be read costs its guidance, not the turn.
+ */
+export async function loadSkillsContext(
+	cwd: string,
+	names: readonly string[],
+): Promise<string | undefined> {
+	if (names.length === 0) return undefined
+	try {
+		const { discoverSkills, loadSkillBody, composeSkillsPrompt } = await import(
+			'../skills/store.js'
+		)
+		const wanted = new Set(names)
+		const active = discoverSkills({ cwd })
+			.filter((s) => wanted.has(s.name))
+			.map((s) => ({ name: s.name, body: loadSkillBody(s) }))
+		return composeSkillsPrompt(active) ?? undefined
+	} catch {
+		return undefined
+	}
+}
+
+/** The `--flags` refusal message both commands use, so they word it the same. */
+export function unknownOptionMessage(unknown: readonly string[]): string {
+	return `unknown option(s): ${unknown.join(', ')} — pass \`--\` before a prompt that starts with a dash`
+}

--- a/packages/cli/src/commands/run-stream.ts
+++ b/packages/cli/src/commands/run-stream.ts
@@ -29,6 +29,12 @@ import {
 	openSessions,
 	resolveConversation,
 } from '../integrations/sessions/store.js'
+import {
+	loadSkillsContext,
+	parseRunFlags,
+	resolveWorkingDirectory,
+	unknownOptionMessage,
+} from './run-flags.js'
 import type { CommandDef } from './types.js'
 
 async function readStdin(): Promise<string> {
@@ -41,150 +47,6 @@ async function readStdin(): Promise<string> {
 function defaultPrefs(detected: readonly DetectedProvider[]): Preferences | null {
 	const first = detected[0]
 	return first ? { version: 2, provider: first.entry.id, subagents: { active: [] } } : null
-}
-
-/**
- * Parsed run-stream flags. A host UI (the clawtool desktop's Namzu tab) drives
- * which namzu persona answers (--instance), with which model (--model) and
- * skills (--skills a,b,c), bound to a persisted conversation (--session).
- * Everything else is the prompt.
- */
-interface RunStreamFlags {
-	session: string | null
-	model: string | null
-	provider: string | null
-	instance: string | null
-	/** Where the session store and skills are read from. Defaults to `process.cwd()`. */
-	cwd: string | null
-	skills: string[]
-	/**
-	 * `--flags` this parser does not know.
-	 *
-	 * Collected rather than folded into `rest`, because `rest` becomes the
-	 * PROMPT. `--cwd` was in this command's own help text and never parsed, so
-	 * the documented invocation sent the model a prompt beginning
-	 * `--cwd /path …` and silently used the process's own directory. Anything
-	 * unrecognised is now refused instead of being quietly said out loud to a
-	 * model — a typo'd flag is a mistake, and reading it aloud is the worst
-	 * available response to one.
-	 */
-	unknown: string[]
-	rest: string[]
-}
-
-/**
- * Exported for tests only — `src/index.ts` does not re-export it, so this is
- * module visibility rather than public surface. Driving the handler far enough
- * to observe a parse means reaching stdin and a provider probe, which is a
- * worse test of a pure function than calling it.
- */
-export function parseRunStreamFlags(rawArgs: readonly string[]): RunStreamFlags {
-	const out: RunStreamFlags = {
-		session: null,
-		model: null,
-		provider: null,
-		instance: null,
-		cwd: null,
-		skills: [],
-		unknown: [],
-		rest: [],
-	}
-	const take = (a: string, name: string, set: (v: string) => void, i: { v: number }): boolean => {
-		if (a === `--${name}` && i.v + 1 < rawArgs.length) {
-			set(rawArgs[++i.v])
-			return true
-		}
-		if (a.startsWith(`--${name}=`)) {
-			set(a.slice(name.length + 3))
-			return true
-		}
-		return false
-	}
-	for (const idx = { v: 0 }; idx.v < rawArgs.length; idx.v++) {
-		const a = rawArgs[idx.v]
-		// End of options. Everything after it is prompt, verbatim — the escape
-		// for a prompt that legitimately begins with a dash, which is the only
-		// case the refusal below would otherwise take away.
-		if (a === '--') {
-			out.rest.push(...rawArgs.slice(idx.v + 1))
-			break
-		}
-		if (
-			take(
-				a,
-				'cwd',
-				(v) => {
-					out.cwd = v.trim() || null
-				},
-				idx,
-			)
-		)
-			continue
-		if (
-			take(
-				a,
-				'session',
-				(v) => {
-					out.session = v.trim() || null
-				},
-				idx,
-			)
-		)
-			continue
-		if (
-			take(
-				a,
-				'model',
-				(v) => {
-					out.model = v.trim() || null
-				},
-				idx,
-			)
-		)
-			continue
-		if (
-			take(
-				a,
-				'provider',
-				(v) => {
-					out.provider = v.trim() || null
-				},
-				idx,
-			)
-		)
-			continue
-		if (
-			take(
-				a,
-				'instance',
-				(v) => {
-					out.instance = v.trim() || null
-				},
-				idx,
-			)
-		)
-			continue
-		if (
-			take(
-				a,
-				'skills',
-				(v) => {
-					out.skills = v
-						.split(',')
-						.map((s) => s.trim())
-						.filter(Boolean)
-				},
-				idx,
-			)
-		)
-			continue
-		if (a.startsWith('--')) {
-			out.unknown.push(a.split('=')[0])
-			continue
-		}
-		out.rest.push(a)
-	}
-	return out
 }
 
 /** Parse stdin as a prior Message[]; tolerate the UI's {role,content} shape. */
@@ -235,16 +97,14 @@ export const runStreamCommand: CommandDef = {
 			return 0
 		}
 
-		const flags = parseRunStreamFlags(rawArgs)
-		if (flags.unknown.length > 0) {
-			return fail(
-				`unknown option(s): ${flags.unknown.join(', ')} — pass \`--\` before a prompt that starts with a dash`,
-			)
-		}
+		const flags = parseRunFlags(rawArgs)
+		if (flags.unknown.length > 0) return fail(unknownOptionMessage(flags.unknown))
 		const sessionKey = flags.session
-		const cwd = flags.cwd ?? process.cwd()
 		const prompt = flags.rest.join(' ').trim()
 		if (!prompt) return fail('no prompt — pass it as an argument')
+		const resolved = resolveWorkingDirectory(flags.cwd)
+		if ('error' in resolved) return fail(resolved.error)
+		const cwd = resolved.cwd
 
 		// Resolve the persisted conversation (if a session key was given) so we
 		// load prior turns as context and can append this turn afterward. Falls
@@ -279,27 +139,15 @@ export const runStreamCommand: CommandDef = {
 		if (flags.provider) prefs = { ...prefs, provider: flags.provider as ProviderId }
 		if (flags.model) prefs = { ...prefs, model: flags.model }
 
-		const session = await createAgentSession(prefs, probe.detected)
+		// The resolved `--cwd` is what the agent's tools resolve against, not
+		// just where the session store lives — a run told to work in another
+		// checkout has to glob, read and edit files there.
+		const session = await createAgentSession(prefs, probe.detected, { cwd })
 		if (!session.hasProvider) return fail(session.errorHint ?? 'agent is not ready')
 
 		// --skills <a,b,c>: load the named skills' bodies and inject them as the
 		// turn's extra system context (the same channel the TUI's /skill uses).
-		let extraSystem: string | undefined
-		if (flags.skills.length > 0) {
-			try {
-				const { discoverSkills, loadSkillBody, composeSkillsPrompt } = await import(
-					'../skills/store.js'
-				)
-				const all = discoverSkills({ cwd })
-				const wanted = new Set(flags.skills)
-				const active = all
-					.filter((s) => wanted.has(s.name))
-					.map((s) => ({ name: s.name, body: loadSkillBody(s) }))
-				extraSystem = composeSkillsPrompt(active) ?? undefined
-			} catch {
-				// skills unavailable — run without them rather than fail the turn.
-			}
-		}
+		const extraSystem = await loadSkillsContext(cwd, flags.skills)
 
 		const userMessage: Message = { role: 'user', content: prompt, timestamp: Date.now() } as Message
 		const messages: Message[] = [...prior, userMessage]
@@ -349,7 +197,7 @@ export const historyCommand: CommandDef = {
 		'is not an error.',
 	].join('\n'),
 	handler: async ({ rawArgs }) => {
-		const flags = parseRunStreamFlags(rawArgs)
+		const flags = parseRunFlags(rawArgs)
 		const key = flags.session
 		if (!key) {
 			process.stdout.write('[]\n')
@@ -360,7 +208,12 @@ export const historyCommand: CommandDef = {
 			// the session is read from. Reading the process's own directory
 			// instead means a host asking about a session in another checkout is
 			// told `[]` — indistinguishable from a session with no messages.
-			const cli = await openSessions(flags.cwd ?? process.cwd())
+			const resolved = resolveWorkingDirectory(flags.cwd)
+			if ('error' in resolved) {
+				process.stdout.write('[]\n')
+				return 0
+			}
+			const cli = await openSessions(resolved.cwd)
 			const map = await import('../integrations/sessions/store.js')
 			// Resolve WITHOUT creating: only emit history for an existing mapping.
 			const existing = await resolveExisting(cli, key)
@@ -390,10 +243,29 @@ export const skillsJSONCommand: CommandDef = {
 	name: 'skills-json',
 	description: 'Print discovered skills as JSON (for host UIs)',
 	passThrough: true,
-	handler: async () => {
+	help: [
+		'Usage: namzu skills-json [--cwd <path>]',
+		'',
+		'Print the skills discovered for a working directory as JSON. Project',
+		'skills come from that directory; user skills come from the home',
+		'directory either way.',
+		'',
+		'An empty array means no skills were found — it is not an error.',
+	].join('\n'),
+	handler: async ({ rawArgs }) => {
+		// Project skills live under the working directory, so a host listing the
+		// skills for one checkout while the process sits in another was shown
+		// the wrong project's chips — and then `run-stream --cwd <that
+		// checkout> --skills <name>` could not find the skill it had just
+		// offered. Same flag, same directory, both ends.
+		const resolved = resolveWorkingDirectory(parseRunFlags(rawArgs).cwd)
+		if ('error' in resolved) {
+			process.stdout.write('[]\n')
+			return 0
+		}
 		try {
 			const { discoverSkills } = await import('../skills/store.js')
-			const skills = discoverSkills({ cwd: process.cwd() }).map((s) => ({
+			const skills = discoverSkills({ cwd: resolved.cwd }).map((s) => ({
 				name: s.name,
 				description: s.description,
 				source: s.source,

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -8,12 +8,25 @@
  * Non-interactive, so there's no approval prompt — tools auto-run, but the
  * safety gate still hard-denies catastrophic commands. One-shots use an
  * ephemeral session and are not added to `/resume` history.
+ *
+ * Options are parsed, not spoken: this command joined every argument into the
+ * prompt, so the flags its streaming sibling accepts — `--cwd` above all —
+ * were read aloud to the model while the run used this directory anyway. Both
+ * commands now share one parser (`./run-flags.js`), because they are the same
+ * one-shot differing only in how they print.
  */
 
 import { configureLogger } from '@namzu/sdk'
 import type { StopReason } from '@namzu/sdk'
 
-import type { DetectedProvider, Preferences } from '../integrations/providers/index.js'
+import { EXIT_USAGE } from '../exit-codes.js'
+import type { DetectedProvider, Preferences, ProviderId } from '../integrations/providers/index.js'
+import {
+	loadSkillsContext,
+	parseRunFlags,
+	resolveWorkingDirectory,
+	unknownOptionMessage,
+} from './run-flags.js'
 import type { CommandDef } from './types.js'
 
 async function readStdin(): Promise<string> {
@@ -33,30 +46,54 @@ export const runCommand: CommandDef = {
 	description: 'Run a single prompt headlessly and print the reply (for scripts/CI)',
 	passThrough: true,
 	help: [
-		'Usage: namzu run <prompt...>',
+		'Usage: namzu run [options] <prompt...>',
 		'       echo "<prompt>" | namzu run',
 		'',
-		'Run a single prompt headlessly and print the reply. Everything after',
-		'the command name is the prompt; when none is given it is read from',
-		'stdin, so this composes with a pipe.',
+		'Run a single prompt headlessly and print the reply. Everything that is',
+		'not an option is the prompt; when none is given it is read from stdin,',
+		'so this composes with a pipe.',
+		'',
+		'Options (the same ones run-stream takes):',
+		'  --cwd <path>          Directory the agent works in (default: this one)',
+		'  --provider <id>       Provider to answer with',
+		'  --model <id>          Model to answer with',
+		'  --skills <a,b,c>      Load these skills as context for the turn',
+		'  --                    End of options; the rest is the prompt verbatim',
+		'',
+		'Tools run without asking, because there is nobody to ask — the safety',
+		'gate still refuses catastrophic commands. `--yolo` is accepted and does',
+		'nothing here for the same reason.',
 		'',
 		'Needs a provider. Set a credential in the environment, or run namzu',
 		'once to pick one interactively.',
 		'',
-		'Exit codes: 0 on a reply, 2 when no prompt was supplied.',
+		'Exit codes: 0 on a reply, 1 on a failed or unfinished run, 2 when no',
+		'prompt was supplied, 64 when an argument is wrong.',
 	].join('\n'),
 	handler: async ({ ctx, rawArgs }) => {
-		let prompt = rawArgs.join(' ').trim()
+		const flags = parseRunFlags(rawArgs)
+		if (flags.unknown.length > 0) {
+			// A shell caller learns about a bad argument from `$?`, so this is 64
+			// rather than the in-band error event the streaming sibling emits.
+			ctx.formatter.error({ message: unknownOptionMessage(flags.unknown) })
+			return EXIT_USAGE
+		}
+		let prompt = flags.rest.join(' ').trim()
 		if (!prompt) prompt = (await readStdin()).trim()
 		if (!prompt) {
 			ctx.formatter.error({ message: 'no prompt — pass it as an argument or pipe it via stdin' })
 			return 2
 		}
+		const resolved = resolveWorkingDirectory(flags.cwd)
+		if ('error' in resolved) {
+			ctx.formatter.error({ message: resolved.error })
+			return EXIT_USAGE
+		}
 
 		configureLogger({ level: 'silent' })
 		const { probeAgentSession, createAgentSession } = await import('../tui/agent.js')
 		const probe = await probeAgentSession()
-		const prefs = probe.preferences ?? defaultPrefs(probe.detected)
+		let prefs = probe.preferences ?? defaultPrefs(probe.detected)
 		if (!prefs) {
 			ctx.formatter.error({
 				message:
@@ -64,8 +101,10 @@ export const runCommand: CommandDef = {
 			})
 			return 1
 		}
+		if (flags.provider) prefs = { ...prefs, provider: flags.provider as ProviderId }
+		if (flags.model) prefs = { ...prefs, model: flags.model }
 
-		const session = await createAgentSession(prefs, probe.detected)
+		const session = await createAgentSession(prefs, probe.detected, { cwd: resolved.cwd })
 		if (!session.hasProvider) {
 			ctx.formatter.error({ message: session.errorHint ?? 'agent is not ready' })
 			return 1
@@ -74,12 +113,15 @@ export const runCommand: CommandDef = {
 			`namzu · ${session.providerSummary}${session.modelSummary ? ` · ${session.modelSummary}` : ''}`,
 		)
 
+		const extraSystem = await loadSkillsContext(resolved.cwd, flags.skills)
+
 		let text = ''
 		let failed: string | null = null
 		let stopReason: StopReason | undefined
-		for await (const event of session.send([
-			{ role: 'user', content: prompt, timestamp: Date.now() },
-		])) {
+		for await (const event of session.send(
+			[{ role: 'user', content: prompt, timestamp: Date.now() }],
+			extraSystem ? { extraSystem } : undefined,
+		)) {
 			if (event.kind === 'delta') text += event.text
 			else if (event.kind === 'tool-start')
 				ctx.formatter.info(`⏺ ${event.toolName} ${event.summary}`)

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -29,11 +29,70 @@ import {
 } from './run-flags.js'
 import type { CommandDef } from './types.js'
 
-async function readStdin(): Promise<string> {
+/**
+ * How long to wait for the FIRST byte of piped input when the prompt was
+ * already given as an argument.
+ *
+ * Once a byte arrives the read runs to end-of-input with no deadline, so a
+ * slow or large producer is never truncated. The bound only covers the case
+ * where nothing is coming at all.
+ *
+ * It exists because "is anything being piped in?" is not answerable without
+ * reading: on Windows a real pipe, an inherited-but-idle pipe, and a test
+ * runner's stdin are indistinguishable to `fstat` — all three report neither
+ * FIFO nor file. Measured. So a command that unconditionally waited for
+ * end-of-input would hang forever whenever stdin was open and silent, which is
+ * the ordinary state of a CI step or a test process. Waiting a quarter second
+ * is invisible to a person and instant for a pipe that has data ready.
+ */
+const FIRST_BYTE_DEADLINE_MS = 250
+
+async function readStdin(opts: { readonly deadline?: boolean } = {}): Promise<string> {
 	if (process.stdin.isTTY) return ''
 	const chunks: Buffer[] = []
-	for await (const chunk of process.stdin) chunks.push(chunk as Buffer)
+	const collect = async (): Promise<void> => {
+		for await (const chunk of process.stdin) chunks.push(chunk as Buffer)
+	}
+	if (!opts.deadline) {
+		await collect()
+		return Buffer.concat(chunks).toString('utf8')
+	}
+	let timer: NodeJS.Timeout | undefined
+	const firstByte = new Promise<void>((resolve) => {
+		timer = setTimeout(() => resolve(), FIRST_BYTE_DEADLINE_MS)
+		process.stdin.once('readable', () => resolve())
+		process.stdin.once('end', () => resolve())
+	})
+	await firstByte
+	if (timer) clearTimeout(timer)
+	if (process.stdin.readableEnded || process.stdin.readableLength > 0) await collect()
 	return Buffer.concat(chunks).toString('utf8')
+}
+
+/**
+ * The prompt, from the arguments and the pipe together.
+ *
+ * Piped input used to be read only when there was no argument prompt, so
+ *
+ *     cat notes.txt | namzu run "summarise this"
+ *
+ * sent the model three words and silently dropped the file. Nothing reported
+ * it: the run succeeded, and the answer was about nothing. A pipe and a
+ * question are the ordinary way to ask about a document, and taking only one
+ * of the two is the worst reading of that command.
+ *
+ * The piped text is fenced in a tag so the model can tell the instruction from
+ * the material it is about — without a boundary, a long paste runs into the
+ * question and the last line of a file reads as part of the request.
+ *
+ * Pure so it can be tested without a pipe; the reading happens in the handler.
+ */
+export function composePrompt(fromArgs: string, piped: string): string {
+	const question = fromArgs.trim()
+	const material = piped.trim()
+	if (!question) return material
+	if (!material) return question
+	return `${question}\n\n<stdin>\n${material}\n</stdin>`
 }
 
 function defaultPrefs(detected: readonly DetectedProvider[]): Preferences | null {
@@ -48,10 +107,14 @@ export const runCommand: CommandDef = {
 	help: [
 		'Usage: namzu run [options] <prompt...>',
 		'       echo "<prompt>" | namzu run',
+		'       cat file.txt | namzu run "summarise this"',
 		'',
 		'Run a single prompt headlessly and print the reply. Everything that is',
-		'not an option is the prompt; when none is given it is read from stdin,',
-		'so this composes with a pipe.',
+		'not an option is the prompt.',
+		'',
+		'Piped input is used too, not discarded: with no prompt argument it IS',
+		'the prompt, and alongside one it is appended as material the question',
+		'is about. `namzu run -` reads the prompt from stdin explicitly.',
 		'',
 		'Options (the same ones run-stream takes):',
 		'  --cwd <path>          Directory the agent works in (default: this one)',
@@ -78,8 +141,17 @@ export const runCommand: CommandDef = {
 			ctx.formatter.error({ message: unknownOptionMessage(flags.unknown) })
 			return EXIT_USAGE
 		}
-		let prompt = flags.rest.join(' ').trim()
-		if (!prompt) prompt = (await readStdin()).trim()
+		// `-` on its own means "the prompt is on stdin", the usual spelling for
+		// it. Before, it was sent to the model as a one-character question.
+		const fromArgs = flags.rest.join(' ').trim() === '-' ? '' : flags.rest.join(' ').trim()
+		// With no prompt argument, piped input IS the prompt and is waited for
+		// as long as it takes — that is the existing contract for `echo … |
+		// namzu run` and for the `-` sentinel. Alongside a prompt it is extra
+		// material, so it gets the first-byte deadline instead: a caller who
+		// asked a complete question should never be left waiting on a pipe
+		// they did not mean to open.
+		const piped = await readStdin({ deadline: Boolean(fromArgs) })
+		const prompt = composePrompt(fromArgs, piped)
 		if (!prompt) {
 			ctx.formatter.error({ message: 'no prompt — pass it as an argument or pipe it via stdin' })
 			return 2

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -198,7 +198,7 @@ export function App({ ctx }: AppProps) {
 	const hydrateSession = useCallback(
 		async (prefs: Preferences, detectedNow: readonly DetectedProvider[]) => {
 			const scope = await ensureSessions()
-			const s = await createAgentSession(prefs, detectedNow, scope)
+			const s = await createAgentSession(prefs, detectedNow, { scope, cwd: ctx.cwd })
 			setSession(s)
 			setCurrentProvider(prefs.provider)
 			if (s.hasProvider) {
@@ -212,7 +212,7 @@ export function App({ ctx }: AppProps) {
 				if (s.errorHint) pushMessage('system', s.errorHint)
 			}
 		},
-		[pushMessage],
+		[ctx.cwd, pushMessage],
 	)
 
 	const runProbe = useCallback(async () => {
@@ -588,7 +588,11 @@ export function App({ ctx }: AppProps) {
 						return
 					}
 					case 'list-skills': {
-						const skills = discoverSkills()
+						// The session's directory, not the process's — the same
+						// distinction the headless commands get from `--cwd`. They are
+						// the same value today, and were the same value in `run-stream`
+						// too until they were not.
+						const skills = discoverSkills({ cwd: ctx.cwd })
 						if (skills.length === 0) {
 							pushMessage(
 								'system',
@@ -604,7 +608,7 @@ export function App({ ctx }: AppProps) {
 						return
 					}
 					case 'load-skill': {
-						const info = discoverSkills().find((s) => s.name === slash.name)
+						const info = discoverSkills({ cwd: ctx.cwd }).find((s) => s.name === slash.name)
 						if (!info) {
 							pushMessage('system', `No skill named "${slash.name}". See /skills.`)
 							return

--- a/packages/cli/src/tui/__tests__/working-directory.test.ts
+++ b/packages/cli/src/tui/__tests__/working-directory.test.ts
@@ -1,0 +1,136 @@
+/**
+ * The directory the agent actually works in.
+ *
+ * `--cwd` was parsed, and reached the session store and the skill search, and
+ * stopped there: the agent run itself was started with the PROCESS's directory,
+ * so a run pointed at another checkout globbed this one and reported finding
+ * nothing — which reads as "the file isn't there" rather than "I looked in the
+ * wrong place". Nothing caught it because no test ran a file tool against a
+ * directory that was not the process's own, so both directories were the same
+ * string in every assertion. These two do.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getBuiltinTools } from '@namzu/sdk'
+import type { RunId, ToolContext } from '@namzu/sdk'
+
+import type { DetectedProvider, Preferences } from '../../integrations/providers/index.js'
+
+// The clawtool catalog is a live probe of another process. Nothing here is
+// about it, and an absent daemon costs the load timeout, so it is stubbed to
+// the empty catalog it degrades to anyway.
+vi.mock('../../integrations/clawtool/tooling.js', () => ({
+	loadClawtoolToolDefinitions: vi.fn(async () => []),
+}))
+
+// Only `query` is replaced; everything else the module under test imports —
+// the tool registry, the disk stores, the provider registry the vendor package
+// registers into — stays real, because a fake of those would not be able to
+// tell us which directory the real ones were handed.
+const queryCalls: Record<string, unknown>[] = []
+vi.mock('@namzu/sdk', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@namzu/sdk')>()
+	return {
+		...actual,
+		query: (params: Record<string, unknown>) => {
+			queryCalls.push(params)
+			return (async function* () {})()
+		},
+	}
+})
+
+let workDir: string
+
+beforeEach(() => {
+	queryCalls.length = 0
+	workDir = mkdtempSync(join(tmpdir(), 'namzu-cwd-'))
+	writeFileSync(join(workDir, 'notes.txt'), 'a file that only exists in the --cwd\n')
+})
+
+afterEach(() => {
+	rmSync(workDir, { recursive: true, force: true })
+})
+
+function toolContext(workingDirectory: string): ToolContext {
+	return {
+		runId: 'run_test' as RunId,
+		workingDirectory,
+		abortSignal: new AbortController().signal,
+		env: {},
+		log: () => {},
+	}
+}
+
+describe('a file tool resolves against the working directory it is given', () => {
+	it('finds a file that exists only outside the process directory', async () => {
+		const glob = getBuiltinTools().find((t) => t.name === 'glob')
+		expect(glob, 'the glob builtin is what the reported run called').toBeDefined()
+
+		const found = await glob?.execute({ pattern: '**/notes.txt' }, toolContext(workDir))
+		expect(found?.success).toBe(true)
+		expect(found?.data).toMatchObject({ count: 1 })
+
+		// The same call in the process's own directory is the reported failure:
+		// the file is real, and the answer is that there is no file. Asserted on
+		// the count, because the "no files found" text quotes the pattern back
+		// and so contains the filename either way.
+		const missed = await glob?.execute({ pattern: '**/notes.txt' }, toolContext(process.cwd()))
+		expect(missed?.data).toMatchObject({ count: 0 })
+	})
+})
+
+describe('createAgentSession runs where it is told to', () => {
+	const prefs: Preferences = {
+		version: 2,
+		provider: 'anthropic',
+		subagents: { active: [] },
+	} as Preferences
+
+	function detectedAnthropic(): DetectedProvider[] {
+		return [
+			{
+				entry: {
+					id: 'anthropic',
+					label: 'Anthropic',
+					defaultModel: 'claude-sonnet-4-5',
+					requiresApiKey: true,
+					envVars: ['ANTHROPIC_API_KEY'],
+				},
+				source: 'env',
+				apiKey: 'sk-ant-not-a-real-key',
+				alternatives: [],
+			} as unknown as DetectedProvider,
+		]
+	}
+
+	it('passes the caller-supplied cwd to the run, not the process directory', async () => {
+		const { createAgentSession } = await import('../agent.js')
+		const session = await createAgentSession(prefs, detectedAnthropic(), { cwd: workDir })
+		expect(session.hasProvider).toBe(true)
+
+		for await (const _ of session.send([
+			{ role: 'user', content: 'read notes.txt', timestamp: 0 },
+		])) {
+			// drained; the assertion is on what `query` was handed
+		}
+
+		expect(queryCalls).toHaveLength(1)
+		expect(queryCalls[0].workingDirectory).toBe(workDir)
+		expect(queryCalls[0].workingDirectory).not.toBe(process.cwd())
+	})
+
+	it('falls back to the process directory when no cwd is supplied', async () => {
+		const { createAgentSession } = await import('../agent.js')
+		const session = await createAgentSession(prefs, detectedAnthropic())
+
+		for await (const _ of session.send([{ role: 'user', content: 'hello', timestamp: 0 }])) {
+			// drained
+		}
+
+		expect(queryCalls[0].workingDirectory).toBe(process.cwd())
+	})
+})

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -227,24 +227,43 @@ const NAMZU_IDENTITY = [
 	'- A reply from a tool that delegates to ANOTHER agent (e.g. clawtool `agent.run`, an A2A `tasks/send`, a remote peer) is that agent\'s unverified CLAIM, not fact — another model can hallucinate. If it says it ran a command, wrote a file, or "here is the output", treat that as narrative and confirm it yourself with a deterministic tool (a real shell like `bash.run`, a file read) before reporting it as done. Distinguish such conversational agent calls from deterministic tools, and never present another agent\'s prose as your own verified result.',
 ].join('\n')
 
-function buildToolRegistry(): ToolRegistry {
+function buildToolRegistry(cwd: string): ToolRegistry {
 	const registry = new ToolRegistry()
 	registry.register(getBuiltinTools().filter((t) => !EXCLUDED_BUILTINS.has(t.name)))
 	// SDK memory: the agent gets search_memory / read_memory / save_memory over
 	// a structured store at ~/.namzu/memory (separate from the user-curated
 	// MEMORY.md that's injected into the prompt).
-	const memoryStore = new DiskMemoryStore({ baseDir: join(process.cwd(), '.namzu') })
+	const memoryStore = new DiskMemoryStore({ baseDir: join(cwd, '.namzu') })
 	registry.register(buildMemoryTools(memoryStore, memoryStore.getIndex()))
 	// `search_tools` lets the model load deferred (clawtool) tools on demand.
 	registry.register([SearchToolsTool])
 	return registry
 }
 
+export interface AgentSessionOptions {
+	/** Session/thread/project/tenant identity for this run. Minted when absent. */
+	readonly scope?: RunScope
+	/**
+	 * The directory the agent works in: what every filesystem tool resolves a
+	 * relative path against, where sub-agents run, and where the task and
+	 * memory stores put `.namzu`. Defaults to the process's own directory.
+	 *
+	 * Taken as an argument rather than read from `process.cwd()` at each of
+	 * those four points, which is what let `--cwd` reach the session store and
+	 * the skill search and stop there: the caller parsed a directory, the agent
+	 * globbed a different one, and the run reported finding nothing rather than
+	 * having looked in the wrong place.
+	 */
+	readonly cwd?: string
+}
+
 export async function createAgentSession(
 	prefs: Preferences,
 	detected: readonly DetectedProvider[],
-	scope: RunScope = mintScope(),
+	options: AgentSessionOptions = {},
 ): Promise<AgentSession> {
+	const scope = options.scope ?? mintScope()
+	const cwd = options.cwd ?? process.cwd()
 	const entry = PROVIDER_REGISTRY[prefs.provider]
 	if (!entry) {
 		return emptySession(`Unknown provider "${prefs.provider}" — pick another.`)
@@ -297,7 +316,7 @@ export async function createAgentSession(
 			// Keep the previous client; the turn may still 401 but won't crash.
 		}
 	}
-	const registry = buildToolRegistry()
+	const registry = buildToolRegistry(cwd)
 	// clawtool's catalog (~70 tools) is registered DEFERRED: each costs only a
 	// name line in the prompt (no JSON schema), so it never balloons a turn —
 	// the model loads what it needs via `search_tools`. Best-effort: absent /
@@ -315,7 +334,7 @@ export async function createAgentSession(
 	const childSteps: string[] = []
 	try {
 		const sub = await createSubagentRuntime({
-			cwd: process.cwd(),
+			cwd,
 			model,
 			buildProvider: () =>
 				constructProvider(
@@ -328,7 +347,7 @@ export async function createAgentSession(
 				// memory + search_tools, plus clawtool's catalog (deferred) so they
 				// can load research / peer-dispatch tools on demand. Without this a
 				// sub-agent has no way to do real work beyond local files.
-				const r = buildToolRegistry()
+				const r = buildToolRegistry(cwd)
 				if (clawtoolTools.length > 0) r.register(clawtoolTools, 'deferred')
 				return r
 			},
@@ -350,7 +369,7 @@ export async function createAgentSession(
 	// and emits task_created/task_updated, so the agent can track a plan for the
 	// current request. Tasks are run-scoped.
 	const taskStore: TaskStore = new DiskTaskStore({
-		baseDir: join(process.cwd(), '.namzu'),
+		baseDir: join(cwd, '.namzu'),
 		defaultRunId: 'run_namzu-cli' as RunId,
 		tenantId: scope.tenantId,
 	})
@@ -376,19 +395,20 @@ export async function createAgentSession(
 				[NAMZU_IDENTITY, memoryPrompt, opts?.extraSystem]
 					.filter((s): s is string => Boolean(s))
 					.join('\n\n') || undefined
-			yield* runTurn(
+			yield* runTurn({
 				provider,
 				model,
-				registry,
+				tools: registry,
 				scope,
+				workingDirectory: cwd,
 				approval,
 				taskStore,
 				systemPrompt,
 				messages,
 				opts,
-				subagentGateway,
+				taskGateway: subagentGateway,
 				childSteps,
-			)
+			})
 		},
 	}
 }
@@ -537,19 +557,41 @@ const COMPACTION_CONFIG = {
 	maxCharsPerTask: 400,
 }
 
-async function* runTurn(
-	provider: LLMProvider,
-	model: string,
-	tools: ToolRegistry,
-	scope: RunScope,
-	approval: { all: boolean },
-	taskStore: TaskStore,
-	systemPrompt: string | undefined,
-	messages: readonly Message[],
-	opts: SendOptions | undefined,
-	taskGateway: TaskGateway | undefined,
-	childSteps: string[],
-): AsyncIterable<AgentEvent> {
+/**
+ * Named rather than positional: the parameters are eleven long and four of
+ * them are strings, so `workingDirectory` and `systemPrompt` would sit next
+ * to each other with nothing but call order to keep them apart.
+ */
+interface RunTurnParams {
+	readonly provider: LLMProvider
+	readonly model: string
+	readonly tools: ToolRegistry
+	readonly scope: RunScope
+	/** Directory every filesystem tool in this turn resolves against. */
+	readonly workingDirectory: string
+	readonly approval: { all: boolean }
+	readonly taskStore: TaskStore
+	readonly systemPrompt: string | undefined
+	readonly messages: readonly Message[]
+	readonly opts: SendOptions | undefined
+	readonly taskGateway: TaskGateway | undefined
+	readonly childSteps: string[]
+}
+
+async function* runTurn({
+	provider,
+	model,
+	tools,
+	scope,
+	workingDirectory,
+	approval,
+	taskStore,
+	systemPrompt,
+	messages,
+	opts,
+	taskGateway,
+	childSteps,
+}: RunTurnParams): AsyncIterable<AgentEvent> {
 	const signal = opts?.signal
 	try {
 		const events = query({
@@ -575,7 +617,7 @@ async function* runTurn(
 			agentName: 'namzu',
 			...(systemPrompt ? { systemPrompt } : {}),
 			messages: [...messages],
-			workingDirectory: process.cwd(),
+			workingDirectory,
 			resumeHandler: makeResumeHandler(approval, opts?.onPermission),
 			signal,
 			...scope,


### PR DESCRIPTION
Three fixes to the headless CLI surface, each with a regression test that fails without it. The first is the one that mattered: an agent pointed at another directory searched this one and reported the user's files missing.

Written by reading peer terminal coding agents' source rather than from memory. Revisions and `file:line` citations below, on both sides.

## What a user experiences differently

| Before | After |
|---|---|
| `namzu run-stream --cwd /projects/foo "read notes.txt"` globs the **launch** directory and answers "no files found" | globs `/projects/foo`, finds and edits the file |
| `namzu run --cwd ../other "fix it"` sends the model a prompt beginning `--cwd ../other` and runs here | works in `../other`; the flag is an option, not part of the question |
| `namzu run --temperature 0.5 "hello"` runs, with the flag as the first three words, exit 0 | `unknown option(s): --temperature`, exit 64 |
| `cat notes.txt \| namzu run "summarise this"` sends three words and silently drops the file | sends the question and the file, fenced in a `<stdin>` block |
| `namzu run -` asks the model about the character `-` | reads the prompt from stdin |

## The commits

**`b6adb01` fix(cli): the agent works in the directory `--cwd` names**

`--cwd` reached the session store and the skill search and stopped there. The run itself was started with the process's own directory, so `glob` answered `No files found matching pattern "**/notes.txt" in <the launch dir>` for a file that exists. Nothing was edited and the run still exited 0. This is commit fdbbfb2 one layer on — that one fixed the *parsing* and wired the session store, and left the working directory behind.

The resolved directory now drives every filesystem tool, the sub-agent runtime, the task store and the memory store. Threaded as an argument, `createAgentSession(prefs, detected, { cwd })`, rather than read from `process.cwd()` at each of those four points — which is how it came to be missing at exactly one of them. `--cwd` is resolved to an absolute path and refused if it is not a directory; the silent fallback is what turns a typo into a run that searched elsewhere and found nothing. `skills-json` honours it too. `runTurn` went from eleven positional parameters to a named object, because `workingDirectory` and `systemPrompt` are both strings and would have sat adjacent with nothing but call order between them.

**`9799985` feat(cli)!: run takes the options run-stream takes** — see *Breaking change* below.

**`fa66817` fix(cli): a pipe and a question are both the prompt**

Piped input was consulted only when there was no prompt argument, so a pipe plus a question used one and discarded the other.

## Breaking change

`namzu run` refuses an option it does not recognise instead of treating it as prompt text. `namzu run --temperature 0.5 "hello"` used to run and exit 0; it now exits **64**. A prompt that genuinely starts with a dash needs `--` in front of it: `namzu run -- --force means what?`. A single leading `-` was never an option and still is not.

Classified **minor**, matching how the same narrowing was classified for `run-stream` in fdbbfb2: SemVer §4 puts 0.x outside the stable-API guarantee.

## How this compares to peer agents

Read at pinned revisions, not from memory:

| Peer | Revision | Version |
|---|---|---|
| Pi | `6bfd502` | packages 0.83.0 |
| opencode | `4a57013` | `packages/opencode` 1.18.13 |
| Codex | `5c44f11` | Rust workspace |
| gemini-cli | `ac42fb0` | 0.55.0-nightly — read only for its workspace-directory model |

**Where namzu was genuinely worse.** Both close peers resolve the working directory **once** at the top of the process and pass it down: Pi at `main.ts:541` with `core/sdk.ts:170` as the single defaulting site; opencode at `cli/cmd/run.ts:134`, and for local runs it `process.chdir`s outright (`:339`) and dies loudly on a bad directory (`:342`). Neither reads the process directory at a leaf. namzu read it at four leaves and missed one. Pi has no `--cwd` flag at all — you `cd` first — which is a defensible design namzu chose against; having the flag and honouring it at two of six consumers is not.

On argument parsing, opencode uses yargs with `.strict()` (`src/index.ts:113`); Pi collects unknown flags for extensions to claim and reports diagnostics before running (`cli/args.ts:204-219`). namzu's `run` had no parser at all.

The piped-input fix is a direct port of Codex: `codex-rs/exec/src/cli.rs:76-77` documents the behaviour, `exec/src/lib.rs:1968-1972` builds the combined string, and `lib.rs:177-187` is a three-way `StdinPromptBehavior` enum making the policy explicit.

**Where the port had to diverge.** Codex gates purely on `is_terminal()` and accepts an unbounded wait. Copying that verbatim wedged five existing tests, and the hang is real rather than a test artifact — any context with an open, silent stdin (a CI step) would wait forever on `namzu run "hello"`. Detecting a genuine pipe instead is not portable: measured `fstatSync(0)` on Windows across a real pipe, a file redirect, `/dev/null` and a test runner, and a real pipe reports neither FIFO nor file, identical to the test runner. So the read waits 250ms for the first byte when the prompt came from an argument, then runs to end-of-input with no deadline, so a slow or large producer is never truncated. Verified against a live pipe: `sleep 5 | namzu run "hello"` answers at +1799ms, not 5s.

**Deliberate differences, not gaps.** opencode runs an HTTP server and SDK; Pi has `--mode rpc`. namzu exposes `run-stream` NDJSON plus `skills-json`/`providers-json`. Thinner, and correct here — `commands/stubs.ts:28-36` states that coordination is clawtool's job and there is no namzu daemon. Pi ships four builtin tools behind an extension system where namzu ships SDK builtins plus a deferred catalog loaded via `search_tools`; different answers to the same context-budget problem.

**Where namzu is better.** Pi's print mode exits 1 only on `stopReason == "error" | "aborted"` (`modes/print-mode.ts:143-148`), so an iteration-capped run exits 0. namzu exits 1 on any `stopReason != 'end_turn'` and says the output is partial (`commands/run.ts:147-152`).

**Recommended next, in order.** A configurable permission model is the largest remaining gap — namzu has a hardcoded allowlist (`tui/agent.ts:705-723`) and one session-wide "approve all", against opencode's declarative per-tool `ask | allow | deny` with pattern rules and a dedicated `external_directory` permission (`core/src/v1/config/permission.ts:5-35`). Then `--continue`/`--resume` from the command line: sessions are already persisted and `history` already reads them, only the entry point is missing. Then `/compact` and context visibility. Not recommended: a server/RPC mode, an extension system, themes.

## Testing

`--cwd`: executes the **real SDK `glob` builtin** against a temp directory holding a file that exists nowhere else, and asserts the CLI hands that directory to the run. No prior test ran a file tool against a directory that was not the process's own, so the two were the same string in every assertion — which is exactly why this shipped.

Piped input: a pure composer plus two driving the real handler with a stubbed `process.stdin`. The second pair is load-bearing; the composer was never the bug, not calling it was, and a composer-only test passes with the defect intact.

Both mutation-checked. Restoring `workingDirectory: process.cwd()` fails the session test and nothing else; restoring the old stdin read fails exactly the plumbing test.

I also **deleted** a `skills-json` negative test I had written, because `packages/cli` has no `skills/` directory and so it passed with the defect in place. A comment records why there is no paired case.

Gates: typecheck, **316 tests**, `biome check src/` from inside the package, and `scripts/audit-external-names.mjs` — all green.

## Not verified

No live-provider run: the fixes are verified by the real `glob` builtin, stubbed-stdin handler tests and a live pipe, not by a turn against a real model. Peer claims are source citations at the revisions above; I read those repositories, I did not run them.

## Note for the next agent

A fresh worktree needs `pnpm install` **and** `pnpm build` — `@namzu/cli` typechecks against built provider packages, and without the build it fails with `Cannot find module '@namzu/openai'` plus three cascading type errors.
