### PR TITLE
chore(sdk): mark six declarations that drive nothing

### DIFF
--- a/.changeset/six-declarations-that-drive-nothing.md
+++ b/.changeset/six-declarations-that-drive-nothing.md
@@ -1,0 +1,31 @@
+---
+'@namzu/sdk': minor
+---
+
+six declarations that drive nothing are marked for removal
+
+An audit of the kernel found primitives that are declared, reachable from the
+published typings, and read by no code at all. None is deleted yet — they are
+on the public surface, so they get the deprecation release the repository's own
+policy asks for, and go in the next major.
+
+They are worth naming individually, because a dead declaration is not merely
+untidy. Each of these tells a reader something false:
+
+- `HOOK_MAX_CONCURRENT` reads as a concurrency cap that is in force. Hooks run
+  sequentially and always have, so a reviewer reasons about batching that does
+  not happen. Do not "fix" it by batching — ordering is the contract hooks are
+  written against.
+- `MAX_RECENT_ACTIVITIES` — no list is trimmed to it.
+- `AgentTask.progress` and the `progress_updated` lifecycle variant are a whole
+  reporting channel with **no producer**. A host that switches on the event has
+  written a branch that cannot run; one that waits for progress waits forever.
+- `IterationCheckpoint.planStatus` is never set, so a host restoring a
+  checkpoint to find out whether the plan was approved gets `undefined` for
+  every run — approved or not — and cannot tell the two apart. Ask the plan
+  manager.
+- `ProbeOptions.otel` is unimplemented: setting it changes nothing.
+
+Each now carries `@deprecated` and a note saying which of "unused",
+"no producer" or "unimplemented" applies, so the next reader does not have to
+re-derive it.

--- a/packages/sdk/src/constants/agent/index.ts
+++ b/packages/sdk/src/constants/agent/index.ts
@@ -1,6 +1,11 @@
 import type { AgentCapabilities } from '../../types/agent/base.js'
 import type { AgentManagerConfig } from '../../types/agent/task.js'
 
+/**
+ * **Nothing reads this.** No activity list is trimmed to it anywhere.
+ *
+ * @deprecated Unused. Removed in the next major.
+ */
 export const MAX_RECENT_ACTIVITIES = 5
 
 export const AGENT_MANAGER_DEFAULTS: Readonly<AgentManagerConfig> = {

--- a/packages/sdk/src/constants/plugin/index.ts
+++ b/packages/sdk/src/constants/plugin/index.ts
@@ -44,4 +44,19 @@ export const HOOK_TIMEOUT_MS = 5_000
  * can sort itself after.
  */
 export const DEFAULT_HOOK_PRIORITY = 100
+/**
+ * **Nothing reads this.** Hooks run sequentially and always have.
+ *
+ * It reads as a concurrency cap that is in force, which is the misleading
+ * kind of dead: a reviewer sees a bound, assumes hook execution is batched
+ * at ten, and reasons about plugin behaviour that does not exist.
+ *
+ * Kept for one release rather than deleted, because it is reachable from the
+ * published typings. Do not "make it work" by batching hook execution —
+ * ordering is the contract hooks are written against, and parallelising them
+ * to justify a constant would change behaviour to match a number nobody
+ * chose deliberately.
+ *
+ * @deprecated Unused. Removed in the next major.
+ */
 export const HOOK_MAX_CONCURRENT = 10

--- a/packages/sdk/src/types/agent/lifecycle-event.ts
+++ b/packages/sdk/src/types/agent/lifecycle-event.ts
@@ -11,6 +11,13 @@ export type AgentLifecycleEvent =
 			depth: number
 	  }
 	| { type: 'running'; taskId: TaskId }
+	/**
+	 * **Never emitted.** Nothing constructs this variant, so a host that
+	 * switches on it has written a branch that cannot run — and a host that
+	 * relies on progress arriving will wait for an event that never comes.
+	 *
+	 * @deprecated No producer. Removed in the next major.
+	 */
 	| { type: 'progress_updated'; taskId: TaskId; progress: AgentTaskProgress }
 	| { type: 'completed'; taskId: TaskId; result: BaseAgentResult }
 	| { type: 'failed'; taskId: TaskId; error: string }

--- a/packages/sdk/src/types/agent/task.ts
+++ b/packages/sdk/src/types/agent/task.ts
@@ -106,6 +106,11 @@ export interface AgentTask {
 	context: AgentTaskContext
 	state: AgentTaskState
 	result?: BaseAgentResult
+	/**
+	 * **Never populated.** Nothing in the SDK writes task progress.
+	 *
+	 * @deprecated No producer. Removed in the next major.
+	 */
 	progress?: AgentTaskProgress
 
 	/**

--- a/packages/sdk/src/types/hitl/index.ts
+++ b/packages/sdk/src/types/hitl/index.ts
@@ -180,6 +180,16 @@ export interface IterationCheckpoint {
 	messages: Message[]
 	tokenUsage: TokenUsage
 	costInfo: CostInfo
+	/**
+	 * **Never set.** No checkpoint is written with a plan status.
+	 *
+	 * It matters more than an unused field usually would: a host restoring a
+	 * checkpoint and reading this to decide whether the plan was approved
+	 * gets `undefined` for every run, approved or not, and cannot tell the
+	 * two apart. Ask the plan manager instead.
+	 *
+	 * @deprecated No producer. Removed in the next major.
+	 */
 	planStatus?: PlanStatus
 
 	/**

--- a/packages/sdk/src/types/probe/registry.ts
+++ b/packages/sdk/src/types/probe/registry.ts
@@ -31,6 +31,12 @@ export interface ProbeOptions<K extends ProbeEventKind = ProbeEventKind> {
 	readonly where?: (event: ProbeEventOf<K>) => boolean
 	readonly priority?: number
 	readonly name?: string
+	/**
+	 * **Not implemented.** Setting it changes nothing; no probe emits
+	 * telemetry because of it.
+	 *
+	 * @deprecated Unimplemented. Removed in the next major.
+	 */
 	readonly otel?: boolean
 	readonly override?: boolean
 }


### PR DESCRIPTION
Six primitives that are declared, reachable from the published typings, and read by **no code at all**. Each has exactly one reference — its own declaration. Verified by counting, not taken on the audit's word.

Nothing is deleted here. They sit on the public surface, so they get the deprecation release the repo's policy asks for and go in the next major.

## Why each one is worth naming

A dead declaration is not merely untidy. Each of these tells a reader something false:

| Declaration | What it implies | What is true |
|---|---|---|
| `HOOK_MAX_CONCURRENT` | hook execution is batched at ten | hooks run sequentially, always have |
| `MAX_RECENT_ACTIVITIES` | some list is trimmed to five | none is |
| `AgentTask.progress` + `progress_updated` | workers report progress | **no producer** — a host that switches on the event wrote a branch that cannot run; one that waits for progress waits forever |
| `IterationCheckpoint.planStatus` | a restored checkpoint says whether the plan was approved | never set, so it is `undefined` for every run and approved is indistinguishable from not |
| `ProbeOptions.otel` | probes can emit telemetry | unimplemented; setting it changes nothing |

Each note now says **which kind of dead** it is — unused, no producer, or unimplemented — so the next reader does not have to re-derive it.

## On `HOOK_MAX_CONCURRENT` specifically

The tempting repair is to make it true by batching hook execution. **Do not.** Ordering is the contract hooks are written against, and parallelising them to justify a constant would change behaviour to match a number nobody chose deliberately. The comment says so at the site.

## Why deprecate rather than delete

The policy allows a straight major for provably-dead code, and that would be defensible. 6.2.0 had just shipped, and two of these are on the public-surface baseline while the rest sit on exported types — so this is the compatible half of the same decision, with the removal named for the next major.

## Gates

`pnpm typecheck`, `pnpm lint`, 2603 tests, external-name audit, public surface intact (1210 declared, unchanged — deprecation adds no names).