### PR TITLE
feat(cli): an operator can say which tools may run without asking

### DIFF
--- a/.changeset/an-operator-can-say-what-runs-without-asking.md
+++ b/.changeset/an-operator-can-say-what-runs-without-asking.md
@@ -1,0 +1,35 @@
+---
+'@namzu/cli': minor
+---
+
+an operator can say which tools may run without asking
+
+The kernel has had a permission engine for as long as the gate has existed —
+`VerificationRule[]` with allow/deny/review, seven rule types, evaluated
+first-match-wins. The CLI passed `rules: []`. So the engine ran with nothing in
+it and every mutating call fell through to the same prompt, whether it was
+`git status` or `rm -rf`.
+
+A `[permissions]` table in the CLI config is now compiled into that array:
+
+```toml
+[permissions]
+read = "allow"
+bash = { "git status*" = "allow", "git push*" = "deny", "*" = "ask" }
+```
+
+**A tool nobody wrote a rule about is still asked about.** `ask` deliberately
+emits no rule, because the gate's fallback for an unmatched call is already
+`review` — if `ask` emitted something it would have to mean something different
+from silence, and it does not. There is no way to spell "allow by omission":
+widening the default has to be something an operator typed. A newly bridged
+tool that appears tomorrow prompts, exactly as it did before this existed.
+
+Patterns are ordered most-specific-first at compile time, because the kernel
+stops at the first match — `{ "*" = "ask", "git push*" = "deny" }` would
+otherwise read as a prohibition while being none. A trailing `" *"` also matches
+the bare command, so `git push *` catches `git push`.
+
+A line that cannot be read is reported and the rest still load. A permission
+someone wrote and which was silently dropped is the worst outcome available
+here: they believe a control is in force and it is not.

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -2,7 +2,7 @@ import type { DoctorCategory, DoctorCheckRecord, DoctorReport, DoctorStatus } fr
 
 import { builtInDoctorChecks } from '../doctor/checks/index.js'
 import { type RunDoctorOptions, createDoctorRegistry, runDoctor } from '../doctor/registry.js'
-import { EXIT_INTERNAL_ERROR, EXIT_USAGE } from '../exit-codes.js'
+import { EXIT_USAGE } from '../exit-codes.js'
 import type { CommandDef } from './types.js'
 
 const VALID_CATEGORIES: readonly DoctorCategory[] = [

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -21,6 +21,7 @@ import type { StopReason } from '@namzu/sdk'
 
 import { EXIT_USAGE } from '../exit-codes.js'
 import type { DetectedProvider, Preferences, ProviderId } from '../integrations/providers/index.js'
+import { compilePermissions } from '../permissions/rules.js'
 import {
 	loadSkillsContext,
 	parseRunFlags,
@@ -176,7 +177,19 @@ export const runCommand: CommandDef = {
 		if (flags.provider) prefs = { ...prefs, provider: flags.provider as ProviderId }
 		if (flags.model) prefs = { ...prefs, model: flags.model }
 
-		const session = await createAgentSession(prefs, probe.detected, { cwd: resolved.cwd })
+		// A permission the operator wrote and which was silently dropped is the
+		// worst outcome available here: they believe a control is in force and it
+		// is not. So a bad line is reported and the rest still load.
+		const permissions = compilePermissions(ctx.config.permissions)
+		for (const d of permissions.diagnostics) {
+			const where = d.pattern ? `permissions.${d.tool}."${d.pattern}"` : `permissions.${d.tool}`
+			ctx.formatter.error({ message: `${where}: ${d.message}` })
+		}
+
+		const session = await createAgentSession(prefs, probe.detected, {
+			cwd: resolved.cwd,
+			rules: permissions.rules,
+		})
 		if (!session.hasProvider) {
 			ctx.formatter.error({ message: session.errorHint ?? 'agent is not ready' })
 			return 1

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -8,6 +8,7 @@
  */
 
 import type { FormatName } from '../output/index.js'
+import type { PermissionsConfig } from '../permissions/rules.js'
 
 export interface ClawtoolConfig {
 	/** Absolute path to the clawtool binary; overrides PATH lookup. */
@@ -27,6 +28,14 @@ export interface NamzuCliConfig {
 	readonly quiet?: boolean
 	/** Clawtool integration overrides; defaults work zero-config. */
 	readonly clawtool?: ClawtoolConfig
+	/**
+	 * Which tools may run without asking, keyed by tool name.
+	 *
+	 * A value is `"allow" | "ask" | "deny"`, or a table of argument patterns
+	 * mapping to those. Absent means every mutating tool prompts, which is what
+	 * it meant before this existed — the absence of a policy never widens one.
+	 */
+	readonly permissions?: PermissionsConfig
 }
 
 export const DEFAULT_CONFIG: NamzuCliConfig = Object.freeze({

--- a/packages/cli/src/permissions/__tests__/rules.test.ts
+++ b/packages/cli/src/permissions/__tests__/rules.test.ts
@@ -1,0 +1,198 @@
+/**
+ * The rule compiler.
+ *
+ * The load-bearing case is the LAST one: a tool nobody wrote a rule for must
+ * still be asked about. A declarative permission model that quietly widened the
+ * default would be a security downgrade wearing a feature's clothes, and it
+ * would look exactly like this change from the outside.
+ */
+
+import { VerificationGate, configureLogger, getRootLogger } from '@namzu/sdk'
+import { describe, expect, it } from 'vitest'
+
+import {
+	bySpecificity,
+	compilePermissions,
+	matchesPattern,
+	patternToRegExpSource,
+} from '../rules.js'
+
+describe('pattern matching', () => {
+	it('matches a literal command exactly', () => {
+		expect(matchesPattern('git status', 'git status')).toBe(true)
+		expect(matchesPattern('git statuses', 'git status')).toBe(false)
+	})
+
+	it('lets * stand for any run of characters and ? for one', () => {
+		expect(matchesPattern('git push --force', 'git push*')).toBe(true)
+		expect(matchesPattern('cat a.ts', 'cat ?.ts')).toBe(true)
+		expect(matchesPattern('cat ab.ts', 'cat ?.ts')).toBe(false)
+	})
+
+	it('matches the bare command for a trailing " *"', () => {
+		// `git push *` is the obvious way to write "any git push". Without this
+		// the rule silently misses the exact invocation it was written for.
+		expect(matchesPattern('git push', 'git push *')).toBe(true)
+		expect(matchesPattern('git push origin main', 'git push *')).toBe(true)
+	})
+
+	it('treats a backslash path as its forward-slash self, both sides', () => {
+		// One rule has to work on every platform; an operator should not have to
+		// write the same path twice.
+		expect(matchesPattern('src\\index.ts', 'src/*.ts')).toBe(true)
+		expect(matchesPattern('src/index.ts', 'src\\*.ts')).toBe(true)
+	})
+
+	it('does not let a pattern character smuggle in a regex', () => {
+		// `.` is a literal dot, not "any character", or a rule meant to allow
+		// `a.ts` would also allow `axts`.
+		expect(matchesPattern('axts', 'a.ts')).toBe(false)
+		expect(matchesPattern('a.ts', 'a.ts')).toBe(true)
+		expect(patternToRegExpSource('a+b')).toBe('^a\\+b$')
+	})
+
+	it('anchors, so a pattern is not a substring search', () => {
+		expect(matchesPattern('sudo git status', 'git status')).toBe(false)
+	})
+})
+
+describe('specificity ordering', () => {
+	// The kernel evaluates first-match-wins, so order decides meaning: a bare
+	// `*` sorted first would make every rule after it dead config.
+	it('puts a bare star last', () => {
+		expect(['*', 'git push*', 'git status'].sort(bySpecificity)).toEqual([
+			'git status',
+			'git push*',
+			'*',
+		])
+	})
+
+	it('puts a longer literal prefix first', () => {
+		expect(['git*', 'git push*'].sort(bySpecificity)).toEqual(['git push*', 'git*'])
+	})
+
+	it('is stable for two patterns of equal specificity', () => {
+		expect(['b*', 'a*'].sort(bySpecificity)).toEqual(['a*', 'b*'])
+	})
+})
+
+describe('compiling a permissions table', () => {
+	it('turns a bare allow and deny into by-name rules', () => {
+		const { rules } = compilePermissions({ read: 'allow', bash: 'deny' })
+
+		expect(rules).toEqual([
+			{ type: 'allow_by_name', toolNames: ['read'] },
+			{ type: 'deny_by_name', toolNames: ['bash'] },
+		])
+	})
+
+	it('emits pattern rules most-specific-first', () => {
+		const { rules } = compilePermissions({ bash: { '*': 'deny', 'git status*': 'allow' } })
+
+		expect(rules.map((r) => ('decision' in r ? r.decision : r.type))).toEqual(['allow', 'deny'])
+	})
+
+	it('emits nothing for ask, because the gate already asks by default', () => {
+		// If "ask" emitted a rule it would have to mean something different from
+		// the absence of a rule, and it does not.
+		const { rules } = compilePermissions({ edit: 'ask', bash: { 'rm *': 'ask' } })
+
+		expect(rules).toEqual([])
+	})
+
+	it('reports a bad effect instead of dropping it in silence', () => {
+		// A permission someone believes is in force and which was quietly
+		// discarded is the worst outcome here — worse than refusing to start.
+		const { rules, diagnostics } = compilePermissions({
+			bash: { 'git push*': 'maybe' } as never,
+		})
+
+		expect(rules).toEqual([])
+		expect(diagnostics).toHaveLength(1)
+		expect(diagnostics[0]?.tool).toBe('bash')
+		expect(diagnostics[0]?.pattern).toBe('git push*')
+	})
+
+	it('keeps the other rules when one line is unreadable', () => {
+		const { rules, diagnostics } = compilePermissions({
+			read: 'allow',
+			bash: 7 as never,
+			glob: 'allow',
+		})
+
+		expect(rules).toHaveLength(2)
+		expect(diagnostics).toHaveLength(1)
+	})
+
+	it('a tool nobody wrote a rule for produces no rule, so the gate asks', () => {
+		// THE case. The kernel's fallback for an unmatched call is `review`, so
+		// emitting nothing is what makes an unconfigured or newly bridged tool
+		// prompt. There is deliberately no way to spell "allow by omission":
+		// widening the default has to be something an operator typed.
+		const { rules } = compilePermissions({ read: 'allow' })
+
+		expect(rules.some((r) => 'toolNames' in r && r.toolNames.includes('some_new_tool'))).toBe(false)
+		expect(rules).toHaveLength(1)
+	})
+
+	it('is empty for absent config, which is the same as asking about everything', () => {
+		expect(compilePermissions(undefined)).toEqual({ rules: [], diagnostics: [] })
+	})
+})
+
+configureLogger({ level: 'silent' })
+
+describe('the rules actually decide a real call', () => {
+	// The compiler tests above assert the SHAPE of the emitted rules. Shape is
+	// not behaviour: the first version of this compiler emitted `target: 'args'`
+	// with an anchored pattern, which matches `JSON.stringify(input)` — so
+	// `^git push.*$` could never match `{"command":"git push origin main"}` and
+	// every pattern rule decided nothing at all. It looked correct in every
+	// shape assertion. These drive the kernel's own gate instead.
+	function decide(config: Parameters<typeof compilePermissions>[0], tool: string, input: unknown) {
+		const { rules } = compilePermissions(config)
+		const gate = new VerificationGate(
+			{
+				enabled: true,
+				rules: [...rules],
+				allowReadOnlyTools: false,
+				denyDangerousPatterns: false,
+				logDecisions: false,
+			},
+			getRootLogger(),
+		)
+		return gate.evaluate({ toolName: tool, toolInput: input, toolDef: undefined }).decision
+	}
+
+	it('allows the command an operator allowed', () => {
+		expect(decide({ bash: { 'git status*': 'allow' } }, 'bash', { command: 'git status' })).toBe(
+			'allow',
+		)
+	})
+
+	it('denies the command an operator denied', () => {
+		expect(
+			decide({ bash: { 'git push*': 'deny' } }, 'bash', { command: 'git push origin main' }),
+		).toBe('deny')
+	})
+
+	it('does not let one tool_s rule decide another tool_s call', () => {
+		// A rule written under `bash` must not decide an `edit` call whose
+		// arguments happen to contain the same text. The kernel_s pattern rules
+		// carry no tool scope, so this is the CLI_s job and it is easy to lose.
+		expect(
+			decide({ bash: { 'git push*': 'deny' } }, 'edit', { content: 'run git push to deploy' }),
+		).toBe('review')
+	})
+
+	it('asks about a tool nobody wrote a rule for', () => {
+		// The load-bearing case, driven end to end rather than inferred.
+		expect(decide({ read: 'allow' }, 'some_new_bridged_tool', { x: 1 })).toBe('review')
+	})
+
+	it('prefers the specific rule over the catch-all, whatever the config order', () => {
+		const config = { bash: { '*': 'allow', 'git push*': 'deny' } } as const
+		expect(decide(config, 'bash', { command: 'git push --force' })).toBe('deny')
+		expect(decide(config, 'bash', { command: 'ls' })).toBe('allow')
+	})
+})

--- a/packages/cli/src/permissions/__tests__/rules.test.ts
+++ b/packages/cli/src/permissions/__tests__/rules.test.ts
@@ -161,38 +161,92 @@ describe('the rules actually decide a real call', () => {
 			},
 			getRootLogger(),
 		)
-		return gate.evaluate({ toolName: tool, toolInput: input, toolDef: undefined }).decision
+		return gate.evaluate({ toolName: tool, toolInput: input, toolDef: undefined })
 	}
 
 	it('allows the command an operator allowed', () => {
-		expect(decide({ bash: { 'git status*': 'allow' } }, 'bash', { command: 'git status' })).toBe(
-			'allow',
-		)
+		expect(
+			decide({ bash: { 'git status*': 'allow' } }, 'bash', { command: 'git status' }).decision,
+		).toBe('allow')
 	})
 
 	it('denies the command an operator denied', () => {
-		expect(
-			decide({ bash: { 'git push*': 'deny' } }, 'bash', { command: 'git push origin main' }),
-		).toBe('deny')
+		const result = decide({ bash: { 'git push*': 'deny' } }, 'bash', {
+			command: 'git push origin main',
+		})
+
+		expect(result.decision).toBe('deny')
 	})
 
-	it('does not let one tool_s rule decide another tool_s call', () => {
+	it('does not let one tool rule decide another tool call', () => {
 		// A rule written under `bash` must not decide an `edit` call whose
-		// arguments happen to contain the same text. The kernel_s pattern rules
-		// carry no tool scope, so this is the CLI_s job and it is easy to lose.
-		expect(
-			decide({ bash: { 'git push*': 'deny' } }, 'edit', { content: 'run git push to deploy' }),
-		).toBe('review')
+		// arguments happen to contain the same text. The kernel's pattern rules
+		// carry no tool scope, so this is the CLI's job and it is easy to lose.
+		const result = decide({ bash: { 'git push*': 'deny' } }, 'edit', {
+			content: 'run git push to deploy',
+		})
+
+		expect(result.decision).toBe('review')
 	})
 
 	it('asks about a tool nobody wrote a rule for', () => {
 		// The load-bearing case, driven end to end rather than inferred.
-		expect(decide({ read: 'allow' }, 'some_new_bridged_tool', { x: 1 })).toBe('review')
+		expect(decide({ read: 'allow' }, 'some_new_bridged_tool', { x: 1 }).decision).toBe('review')
 	})
 
 	it('prefers the specific rule over the catch-all, whatever the config order', () => {
 		const config = { bash: { '*': 'allow', 'git push*': 'deny' } } as const
-		expect(decide(config, 'bash', { command: 'git push --force' })).toBe('deny')
-		expect(decide(config, 'bash', { command: 'ls' })).toBe('allow')
+		expect(decide(config, 'bash', { command: 'git push --force' }).decision).toBe('deny')
+		expect(decide(config, 'bash', { command: 'ls' }).decision).toBe('allow')
+	})
+})
+
+describe('what a denial actually says to the model', () => {
+	// The decision was never the part that was broken. A model told only
+	// "denied" rewords the command and tries again; a model told WHICH rule
+	// stopped it, and whether a different input could ever pass, can stop and
+	// say so. These assert the sentence, not the verdict.
+	function reasonFor(
+		config: Parameters<typeof compilePermissions>[0],
+		tool: string,
+		input: unknown,
+	) {
+		const { rules } = compilePermissions(config)
+		const gate = new VerificationGate(
+			{
+				enabled: true,
+				rules: [...rules],
+				allowReadOnlyTools: false,
+				denyDangerousPatterns: false,
+				logDecisions: false,
+			},
+			getRootLogger(),
+		)
+		return gate.evaluate({ toolName: tool, toolInput: input, toolDef: undefined }).reason
+	}
+
+	it('a by-name denial says the tool is refused, so a reworded input will not help', () => {
+		const reason = reasonFor({ bash: 'deny' }, 'bash', { command: 'ls' })
+
+		expect(reason).toContain('bash')
+		// The part that stops the retry loop.
+		expect(reason).toContain('a different input will not change it')
+	})
+
+	it('a pattern denial quotes the rule that matched', () => {
+		const reason = reasonFor({ bash: { 'git push*': 'deny' } }, 'bash', {
+			command: 'git push --force',
+		})
+
+		expect(reason).toContain('pattern rule')
+		// The model is shown the rule itself, not the name of its category, so
+		// it can tell which of its options are closed and which are not.
+		expect(reason).toContain('git push')
+	})
+
+	it('an unmatched call says nothing matched, rather than naming a rule', () => {
+		const reason = reasonFor({ read: 'allow' }, 'some_new_tool', {})
+
+		expect(reason).toBe('No matching rule found')
 	})
 })

--- a/packages/cli/src/permissions/rules.ts
+++ b/packages/cli/src/permissions/rules.ts
@@ -1,0 +1,199 @@
+/**
+ * Operator-authored tool permissions, compiled to the kernel's rule vocabulary.
+ *
+ * The kernel already has the engine — `VerificationRule[]` with an
+ * allow/deny/review decision, evaluated first-match-wins. What was missing was
+ * any way for a person to author those rules: the CLI passed `rules: []`, so a
+ * gate with seven rule types ran with none of them and every decision fell back
+ * to "ask a human". This turns a `[permissions]` table into that array.
+ *
+ * The whole surface is pure: config in, rules out. The gate stays the only
+ * thing that decides anything, which is what keeps this testable without a run.
+ */
+
+import type { VerificationRule } from '@namzu/sdk'
+
+/** What the operator wants to happen when a rule matches. */
+export type PermissionEffect = 'allow' | 'ask' | 'deny'
+
+const EFFECTS = new Set<string>(['allow', 'ask', 'deny'])
+
+export function isPermissionEffect(value: unknown): value is PermissionEffect {
+	return typeof value === 'string' && EFFECTS.has(value)
+}
+
+/**
+ * One tool's policy: a single effect for every call, or per-argument patterns.
+ *
+ * `bash = "ask"` and
+ * `bash = { "git status*" = "allow", "*" = "ask" }`
+ * are both meant to be readable by someone who has never seen this file before,
+ * which is the whole point of putting it in config rather than in code.
+ */
+export type ToolPermission = PermissionEffect | Readonly<Record<string, PermissionEffect>>
+
+export type PermissionsConfig = Readonly<Record<string, ToolPermission>>
+
+export interface CompileDiagnostic {
+	readonly tool: string
+	readonly pattern?: string
+	readonly message: string
+}
+
+export interface CompiledPermissions {
+	readonly rules: readonly VerificationRule[]
+	/**
+	 * What was wrong with the config, for the caller to print.
+	 *
+	 * Collected rather than thrown: one unreadable line should cost that line,
+	 * not the other nine rules an operator wrote. But it must be SAID — a
+	 * permission someone believes is in force and which was silently dropped is
+	 * the worst outcome available here, worse than refusing to start.
+	 */
+	readonly diagnostics: readonly CompileDiagnostic[]
+}
+
+/**
+ * Turn a glob-ish pattern into an anchored regex source.
+ *
+ * `*` matches any run of characters, `?` exactly one; everything else is
+ * literal. Backslashes become forward slashes on both sides so one rule works
+ * on every platform — an operator writing `src/*` should not have to write it
+ * twice.
+ *
+ * A pattern ending in `<space>*` also matches the bare command: `git push *`
+ * covers `git push`. Without that, the obvious rule silently misses the exact
+ * invocation it was written to catch, which is the failure this whole file
+ * exists to stop.
+ */
+export function patternToRegExpSource(pattern: string): string {
+	const normalized = pattern.replaceAll('\\', '/')
+	const escaped = normalized
+		.replace(/[.+^${}()|[\]\\]/g, '\\$&')
+		.replace(/\*/g, '.*')
+		.replace(/\?/g, '.')
+	const trailingSpaceStar = escaped.endsWith(' .*') ? `${escaped.slice(0, -3)}( .*)?` : escaped
+	return `^${trailingSpaceStar}$`
+}
+
+/**
+ * A pattern that matches this tool, and only this tool, doing this thing.
+ *
+ * The kernel's `custom_pattern` has no tool scope: `target: 'args'` tests
+ * `JSON.stringify(input)` for ANY tool, so a rule written under `bash` would
+ * also decide an `edit` call whose arguments happened to match. `target:
+ * 'both'` tests `` `${toolName} ${JSON.stringify(input)}` ``, so the tool name
+ * can be pinned by writing it into the pattern — which is what this does.
+ *
+ * The argument half is deliberately unanchored on both sides, because the
+ * operator writes `git push*` while the gate sees
+ * `bash {"command":"git push origin main"}`. An anchored argument pattern would
+ * match nothing at all — a rule that reads like a prohibition and silently
+ * permits everything, which is worse than having no rule.
+ *
+ * The looseness is real and worth naming: a pattern can match text in any
+ * argument field, not only the one the operator had in mind. Narrowing that
+ * needs a rule type that names the argument, which is the kernel's to add.
+ */
+export function toolScopedPattern(tool: string, pattern: string): string {
+	const toolPart = escapeRegExp(tool)
+	const argPart = patternToRegExpSource(pattern).slice(1, -1)
+	return `^${toolPart} .*${argPart}.*$`
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+^${}()|[\]\\?]/g, '\\$&')
+}
+
+/** Whether `input` satisfies `pattern`, with the matching above. */
+export function matchesPattern(input: string, pattern: string): boolean {
+	// Case-insensitive on Windows, where paths and commands are, and
+	// case-sensitive everywhere else, where they are not.
+	const flags = process.platform === 'win32' ? 'si' : 's'
+	return new RegExp(patternToRegExpSource(pattern), flags).test(input.replaceAll('\\', '/'))
+}
+
+/**
+ * Order patterns so the most specific is tried first.
+ *
+ * The kernel evaluates first-match-wins, so `bash = { "*" = "ask", "git push*"
+ * = "deny" }` would otherwise resolve to `ask` and the deny would be dead —
+ * config that reads like a prohibition and is not one. Sorting here means an
+ * operator does not have to know the evaluation order to write what they mean.
+ *
+ * "Specific" is: a bare `*` is always last, then longer literal prefixes before
+ * shorter ones, then alphabetical so the result is stable to read and to test.
+ */
+export function bySpecificity(a: string, b: string): number {
+	if (a === '*' && b !== '*') return 1
+	if (b === '*' && a !== '*') return -1
+	const literal = (p: string): number => {
+		const star = p.search(/[*?]/)
+		return star === -1 ? p.length : star
+	}
+	const diff = literal(b) - literal(a)
+	if (diff !== 0) return diff
+	return a < b ? -1 : a > b ? 1 : 0
+}
+
+/**
+ * Compile a `[permissions]` table into kernel rules.
+ *
+ * `ask` emits nothing. That is not an omission: the gate's fallback for an
+ * unmatched call is already `review`, so the rule that says "ask" and the
+ * absence of any rule have to mean the same thing or the config would be
+ * lying about one of them. It also keeps the emitted array small enough for a
+ * person to read in a log.
+ *
+ * A tool nobody wrote a rule for is therefore asked about, and there is no way
+ * to spell "allow everything by omission" — the only way to widen is to say so.
+ */
+export function compilePermissions(config: PermissionsConfig | undefined): CompiledPermissions {
+	const rules: VerificationRule[] = []
+	const diagnostics: CompileDiagnostic[] = []
+	if (!config) return { rules, diagnostics }
+
+	for (const [tool, permission] of Object.entries(config)) {
+		if (isPermissionEffect(permission)) {
+			if (permission === 'allow') rules.push({ type: 'allow_by_name', toolNames: [tool] })
+			if (permission === 'deny') rules.push({ type: 'deny_by_name', toolNames: [tool] })
+			continue
+		}
+		if (typeof permission !== 'object' || permission === null) {
+			diagnostics.push({
+				tool,
+				message: `expected "allow", "ask", "deny", or a table of patterns; got ${typeof permission}`,
+			})
+			continue
+		}
+		for (const pattern of Object.keys(permission).sort(bySpecificity)) {
+			const effect = permission[pattern]
+			if (!isPermissionEffect(effect)) {
+				diagnostics.push({
+					tool,
+					pattern,
+					message: `expected "allow", "ask" or "deny"; got ${JSON.stringify(effect)}`,
+				})
+				continue
+			}
+			if (effect === 'ask') continue
+			try {
+				new RegExp(patternToRegExpSource(pattern))
+			} catch (err) {
+				diagnostics.push({
+					tool,
+					pattern,
+					message: `pattern is not usable: ${err instanceof Error ? err.message : String(err)}`,
+				})
+				continue
+			}
+			rules.push({
+				type: 'custom_pattern',
+				pattern: toolScopedPattern(tool, pattern),
+				target: 'both',
+				decision: effect,
+			})
+		}
+	}
+	return { rules, diagnostics }
+}

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -41,6 +41,7 @@ import {
 	type ThreadId,
 	type ToolCallSummary,
 	ToolRegistry,
+	type VerificationRule,
 	buildMemoryTools,
 	getBuiltinTools,
 	query,
@@ -255,6 +256,14 @@ export interface AgentSessionOptions {
 	 * having looked in the wrong place.
 	 */
 	readonly cwd?: string
+	/**
+	 * Operator-authored tool rules, already compiled to the kernel's vocabulary.
+	 *
+	 * Absent means an empty rule list, which is what the CLI passed for the
+	 * gate's whole existence: every mutating call fell through to the prompt.
+	 * That stays the behaviour for anyone who writes no config.
+	 */
+	readonly rules?: readonly VerificationRule[]
 }
 
 export async function createAgentSession(
@@ -351,7 +360,7 @@ export async function createAgentSession(
 				if (clawtoolTools.length > 0) r.register(clawtoolTools, 'deferred')
 				return r
 			},
-			verificationGate: VERIFICATION_GATE,
+			verificationGate: gateFor(options.rules),
 			onEvent: (e) => {
 				if (e.type === 'tool_executing') {
 					childSteps.push(`${e.toolName}(${summarizeToolInput(e.input)})`)
@@ -401,6 +410,7 @@ export async function createAgentSession(
 				tools: registry,
 				scope,
 				workingDirectory: cwd,
+				rules: options.rules,
 				approval,
 				taskStore,
 				systemPrompt,
@@ -519,7 +529,21 @@ const VERIFICATION_GATE = {
 	allowReadOnlyTools: true,
 	denyDangerousPatterns: true,
 	logDecisions: false,
-	rules: [],
+	rules: [] as VerificationRule[],
+}
+
+/**
+ * The gate for this session, with the operator's rules in it.
+ *
+ * `rules` was a hardcoded empty array for as long as the gate has existed, so a
+ * kernel with seven rule types ran with none and every mutating call fell
+ * through to the prompt. The two booleans keep their meaning: the
+ * dangerous-pattern denial is the floor and outranks everything, and the
+ * read-only allowance is now consulted AFTER the operator's rules, so
+ * `read = "ask"` is reachable instead of silently unreachable.
+ */
+function gateFor(rules: readonly VerificationRule[] | undefined) {
+	return { ...VERIFICATION_GATE, rules: [...(rules ?? [])] }
 }
 
 // Automatic context compression for long, tool-heavy turns: the structured
@@ -569,6 +593,8 @@ interface RunTurnParams {
 	readonly scope: RunScope
 	/** Directory every filesystem tool in this turn resolves against. */
 	readonly workingDirectory: string
+	/** Operator rules for this run, already compiled. */
+	readonly rules: readonly VerificationRule[] | undefined
 	readonly approval: { all: boolean }
 	readonly taskStore: TaskStore
 	readonly systemPrompt: string | undefined
@@ -584,6 +610,7 @@ async function* runTurn({
 	tools,
 	scope,
 	workingDirectory,
+	rules,
 	approval,
 	taskStore,
 	systemPrompt,


### PR DESCRIPTION
The verification gate has had seven rule types since it was added, and the CLI passed it `rules: []`. So the engine ran with nothing in it and every mutating call fell through to the same prompt — `git status` and a force-push were indistinguishable to the person being asked.

This is the missing half: a `[permissions]` table an operator can author, compiled into the vocabulary the kernel already understands.

```toml
[permissions]
read = "allow"
bash = { "git status*" = "allow", "git push*" = "deny", "*" = "ask" }
```

**What a user experiences differently:** the commands they said were safe stop interrupting them, the ones they said were forbidden stop being offered, and everything else prompts exactly as before.

## The defect class this belongs to

Everything in this branch and the last one is the same failure wearing different clothes: **the run did not fail, it succeeded while quietly not doing what the operator said.**

`--cwd` was parsed and ignored, so the agent searched the wrong tree and reported the user's files missing. A rule ordered behind `allow_read_only` would have been unreachable, so `read = "ask"` would have been accepted and never consulted. A config line that failed to parse and was dropped in silence would leave someone believing a control is in force when it is not. None of these produce an error. That is what makes them worth this much care — a failure announces itself, and these do not.

So: a bad `[permissions]` line is **reported** and the remaining rules still load. Refusing to start would be better than dropping it silently; reporting it and continuing is better than both.

## What happens to a tool nobody wrote a rule for

It is **asked about**, exactly as before this existed.

`ask` deliberately emits no rule at all, because the gate's fallback for an unmatched call is already `review`. If `ask` emitted something, it would have to mean something different from silence — and it does not. There is deliberately no way to spell "allow by omission": widening the default has to be something an operator typed. A clawtool tool bridged in tomorrow prompts.

This is asserted end-to-end against the real gate, not inferred from the compiler's output.

## Precedence

The kernel stops at the first matching rule, so order is meaning. Patterns are sorted most-specific-first at compile time — `{ "*" = "ask", "git push*" = "deny" }` would otherwise read as a prohibition while being none. A trailing `" *"` also matches the bare command, so `git push *` catches `git push`.

Compiling to `target: 'both'` with the tool name pinned into the pattern is not cosmetic: `custom_pattern` carries no tool scope, so a rule written under `bash` would otherwise decide an `edit` call whose arguments happened to match.

## A bug I nearly shipped

The first version of the compiler emitted `custom_pattern` with `target: 'args'`. Two faults, both invisible to every test I had written:

1. No tool scope — a `bash` rule would have decided an `edit` call.
2. `target: 'args'` tests `JSON.stringify(toolInput)`, so an anchored `^git push.*$` can never match `{"command":"git push origin main"}`. **Every pattern rule decided nothing at all.**

It passed every assertion, because I had asserted the *shape* of the emitted rules rather than what they decide. The tests that catch it construct a real `VerificationGate` and evaluate real calls through it.

## Testing

24 tests. The pattern matcher and the specificity ordering are pure and tested as such. Five drive the real gate: the allow, the deny, the cross-tool isolation, the unconfigured tool, and specific-beats-catch-all regardless of config order.

Three assert **the sentence a model actually receives**, not the verdict — a by-name denial says a different input will not help, a pattern denial quotes the rule that matched, an unmatched call names no rule. The decision was never the part that was broken: a model told only "denied" rewords the command and tries again.

Full gates green: typecheck, **340 tests**, `biome check src/` from inside the package, `scripts/audit-external-names.mjs`.

## Peer research

Read at pinned revisions: opencode `4a57013`, Pi `162b188`, Codex `5c44f11`.

opencode's `packages/core/src/permission.ts:80-85` falls back to `ask`, not `allow` — the declarative peer kept safe-by-default, which is the direct answer to the worry that a rules model has to mean allow-by-default. Its `util/wildcard.ts` is the source of the trailing-`" *"` behaviour.

Codex is a mostly-negative result, reported as such. `codex-rs/protocol/src/protocol.rs:917-941` shows `AskForApproval` as a **mode** axis (`UnlessTrusted`, `OnRequest`, `Granular`, `Never`) orthogonal to the rule axis used here; it changes nothing structural. Two things worth noting: `Granular` with a flow set to `false` **auto-rejects** rather than auto-allows — a third independent implementation of absence-never-means-allow — and `Never` returns failures to the model rather than escalating, which is what namzu's headless path already does without naming it.

Pi has only coarse `--tools` / `--exclude-tools` name lists plus a project-trust prompt; nothing to take.

## Reported, not worked around

`custom_pattern` cannot express "this tool, **this argument**". Pinning the tool costs an unanchored argument match, so a pattern can match text in any argument field rather than only the one the operator meant. Narrowing needs a rule type that names the argument — an SDK change, not attempted here.

`describeRule` is not exported from `@namzu/sdk` (`verification/index.ts` re-exports `VerificationGate`, `evaluateRule` and the presets, not it). It did not block this: the gate sets `reason: describeRule(rule)`, so the sentence is reachable through `evaluate().reason` and the tests assert it through the public surface rather than a deep import.

## Deferred deliberately

`--permission-mode` is not in this change. The config table is the load-bearing half, and a flag that overrides a file is a separate decision about precedence between the two. Named so it reads as a choice rather than an omission.

## Depends on

Built on `bf0999d` (#130), which supplies the rule ordering this relies on — operator rules ahead of the read-only allowance. Without it, `read = "ask"` would be silently unreachable, which is precisely the failure described at the top.
