### PR TITLE
feat(cli): a mode for the calls no rule decided

### DIFF
--- a/.changeset/a-mode-for-the-calls-no-rule-decided.md
+++ b/.changeset/a-mode-for-the-calls-no-rule-decided.md
@@ -1,0 +1,24 @@
+---
+'@namzu/cli': minor
+---
+
+`--permission-mode` decides what happens to the calls no rule covered
+
+The `[permissions]` table says what a tool may do. This says what happens to
+everything it did not cover: `prompt` asks, `auto` approves, `strict` refuses.
+
+`strict` is the one that did not exist. An unattended run could only be `auto`,
+so a CI job either trusted the agent with every tool it might reach for or could
+not use it. Under `strict` nothing runs unless a rule allowed it by name or
+pattern, and the refusal tells the model that asking again will not help — so it
+stops rather than rewording.
+
+`--yolo` and `--dangerously-skip-permissions` now mean `--permission-mode auto`.
+They were accepted and documented as doing nothing, which was true and
+unsatisfying.
+
+**Precedence, stated once:** a mode only governs calls no rule decided, so it can
+never reopen what a rule closed. `--permission-mode auto` cannot run something
+the config says `deny`, and neither can `--yolo`; the dangerous-pattern floor is
+above both. The config file is written once and reviewed; a flag is typed in a
+hurry. A prohibition a flag can lift is not a prohibition.

--- a/docs/cli/headless.md
+++ b/docs/cli/headless.md
@@ -171,3 +171,38 @@ both printing `[]` rather than failing:
 namzu skills-json --cwd <path>     # [{name, description, source}]
 namzu providers-json               # [{provider, label, detected, default, models}]
 ```
+
+## Permission modes
+
+The `[permissions]` table says what a tool may do. `--permission-mode` says what
+happens to everything it did not cover.
+
+| Mode | An undecided call is | Default when |
+| --- | --- | --- |
+| `prompt` | asked about | a terminal is attached |
+| `auto` | approved | there is no terminal — every headless run, historically |
+| `strict` | refused | never; you ask for it |
+
+```bash
+namzu run --permission-mode strict "run the test suite"
+```
+
+`strict` is the mode for an unattended run: nothing executes unless a rule
+allowed it by name or pattern, and the model is told that asking again will not
+help. Before it existed an unattended run could only be `auto`, so a CI job
+either trusted the agent with everything or could not use it at all.
+
+`--yolo` and `--dangerously-skip-permissions` mean `--permission-mode auto`.
+
+### Precedence between the flag and the file
+
+**A mode only governs calls no rule decided, so it can never reopen what a rule
+closed.** A rule that denied a call already stopped it and a rule that allowed
+one never asked, so neither reaches the mode. `--permission-mode auto` cannot
+run something the config says `deny`, and neither can `--yolo`. The
+dangerous-pattern floor sits above both.
+
+The direction is deliberate. The config file is written once, read by whoever
+reviews the repository, and changed on purpose; a flag is typed in a hurry by
+someone who wants to get on with it. A prohibition a flag can lift is not a
+prohibition.

--- a/packages/cli/src/commands/run-flags.ts
+++ b/packages/cli/src/commands/run-flags.ts
@@ -29,6 +29,10 @@ export interface RunFlags {
 	instance: string | null
 	/** Where the agent works: filesystem tools, sub-agents, session store, skills. */
 	cwd: string | null
+	/** How calls no `[permissions]` rule decided are resolved: prompt/auto/strict. */
+	permissionMode: string | null
+	/** --yolo / --dangerously-skip-permissions was given. */
+	skipPermissions: boolean
 	skills: string[]
 	/**
 	 * `--flags` this parser does not know.
@@ -49,6 +53,8 @@ export function parseRunFlags(rawArgs: readonly string[]): RunFlags {
 		provider: null,
 		instance: null,
 		cwd: null,
+		permissionMode: null,
+		skipPermissions: false,
 		skills: [],
 		unknown: [],
 		rest: [],
@@ -80,6 +86,17 @@ export function parseRunFlags(rawArgs: readonly string[]): RunFlags {
 				'cwd',
 				trimmed((v) => {
 					out.cwd = v
+				}),
+				idx,
+			)
+		)
+			continue
+		if (
+			take(
+				a,
+				'permission-mode',
+				trimmed((v) => {
+					out.permissionMode = v
 				}),
 				idx,
 			)
@@ -143,11 +160,16 @@ export function parseRunFlags(rawArgs: readonly string[]): RunFlags {
 			)
 		)
 			continue
-		// Accepted and ignored: the headless commands never prompt for tool
-		// approval, so there is nothing for a bypass flag to bypass. Refusing it
-		// would break `namzu --yolo run …`, which reads as reasonable and is
-		// already how the interactive launch is spelled.
-		if (a === '--yolo' || a === '--dangerously-skip-permissions') continue
+		// Was accepted and ignored, because a headless run never prompted and so
+		// had nothing to bypass. Now that an operator can write rules, it means
+		// something: `auto` for the calls no rule decided. It still cannot reopen
+		// a `deny` or the dangerous-pattern floor, so it promises more than it
+		// delivers — deliberately, since a flag with this name should read as
+		// more dangerous than it is rather than less.
+		if (a === '--yolo' || a === '--dangerously-skip-permissions') {
+			out.skipPermissions = true
+			continue
+		}
 		if (a.startsWith('--')) {
 			out.unknown.push(a.split('=')[0])
 			continue

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -21,6 +21,7 @@ import type { StopReason } from '@namzu/sdk'
 
 import { EXIT_USAGE } from '../exit-codes.js'
 import type { DetectedProvider, Preferences, ProviderId } from '../integrations/providers/index.js'
+import { resolvePermissionMode } from '../permissions/mode.js'
 import { compilePermissions } from '../permissions/rules.js'
 import {
 	loadSkillsContext,
@@ -122,11 +123,15 @@ export const runCommand: CommandDef = {
 		'  --provider <id>       Provider to answer with',
 		'  --model <id>          Model to answer with',
 		'  --skills <a,b,c>      Load these skills as context for the turn',
+		'  --permission-mode <m> prompt | auto | strict — what happens to a call',
+		'                        no [permissions] rule decided (default: auto)',
 		'  --                    End of options; the rest is the prompt verbatim',
 		'',
-		'Tools run without asking, because there is nobody to ask — the safety',
-		'gate still refuses catastrophic commands. `--yolo` is accepted and does',
-		'nothing here for the same reason.',
+		'By default tools run without asking, because there is nobody to ask, and',
+		'the safety gate still refuses catastrophic commands. Use --permission-mode',
+		'strict for an unattended run that must refuse anything no rule allowed.',
+		'',
+		'A mode only decides calls no rule decided: it can never reopen a deny.',
 		'',
 		'Needs a provider. Set a credential in the environment, or run namzu',
 		'once to pick one interactively.',
@@ -180,6 +185,18 @@ export const runCommand: CommandDef = {
 		// A permission the operator wrote and which was silently dropped is the
 		// worst outcome available here: they believe a control is in force and it
 		// is not. So a bad line is reported and the rest still load.
+		const modeResult = resolvePermissionMode({
+			flag: flags.permissionMode,
+			skipPermissions: flags.skipPermissions,
+			// A headless run has nobody to ask, so `prompt` here would silently
+			// become `auto`. Resolving it as `auto` says so instead.
+			interactive: false,
+		})
+		if ('error' in modeResult) {
+			ctx.formatter.error({ message: modeResult.error })
+			return EXIT_USAGE
+		}
+
 		const permissions = compilePermissions(ctx.config.permissions)
 		for (const d of permissions.diagnostics) {
 			const where = d.pattern ? `permissions.${d.tool}."${d.pattern}"` : `permissions.${d.tool}`
@@ -189,6 +206,7 @@ export const runCommand: CommandDef = {
 		const session = await createAgentSession(prefs, probe.detected, {
 			cwd: resolved.cwd,
 			rules: permissions.rules,
+			permissionMode: modeResult.mode,
 		})
 		if (!session.hasProvider) {
 			ctx.formatter.error({ message: session.errorHint ?? 'agent is not ready' })

--- a/packages/cli/src/permissions/__tests__/mode.test.ts
+++ b/packages/cli/src/permissions/__tests__/mode.test.ts
@@ -1,0 +1,149 @@
+/**
+ * The mode, and its precedence against the config file.
+ *
+ * The rule being protected is one sentence: a mode governs only the calls no
+ * rule decided, so it can never reopen what a rule closed. The tests that
+ * matter are the ones that would catch a future change making
+ * `--permission-mode auto` able to run something the operator wrote `deny` for.
+ */
+
+import { VerificationGate, configureLogger, getRootLogger } from '@namzu/sdk'
+import { describe, expect, it } from 'vitest'
+
+import { makeResumeHandler } from '../../tui/agent.js'
+import { PERMISSION_MODES, isPermissionMode, resolvePermissionMode } from '../mode.js'
+import { compilePermissions } from '../rules.js'
+
+configureLogger({ level: 'silent' })
+
+describe('resolving the mode from flag, alias and terminal', () => {
+	it('takes an explicit flag over everything else', () => {
+		expect(resolvePermissionMode({ flag: 'strict', interactive: true })).toEqual({ mode: 'strict' })
+		expect(
+			resolvePermissionMode({ flag: 'prompt', skipPermissions: true, interactive: false }),
+		).toEqual({ mode: 'prompt' })
+	})
+
+	it('refuses a mode it does not know, and names the ones it does', () => {
+		const result = resolvePermissionMode({ flag: 'yolo', interactive: false })
+
+		expect('error' in result && result.error).toContain('prompt, auto, strict')
+	})
+
+	it('maps the bypass aliases to auto', () => {
+		expect(resolvePermissionMode({ skipPermissions: true, interactive: true })).toEqual({
+			mode: 'auto',
+		})
+	})
+
+	it('asks when there is someone to ask, and does not when there is not', () => {
+		// `prompt` without a terminal would silently become `auto` anyway;
+		// resolving it as `auto` makes the resolved mode honest in a log.
+		expect(resolvePermissionMode({ interactive: true })).toEqual({ mode: 'prompt' })
+		expect(resolvePermissionMode({ interactive: false })).toEqual({ mode: 'auto' })
+	})
+
+	it('exposes exactly the modes it accepts', () => {
+		expect(PERMISSION_MODES.every(isPermissionMode)).toBe(true)
+		expect(isPermissionMode('trusted')).toBe(false)
+	})
+})
+
+describe('a mode decides only what no rule decided', () => {
+	function gate(config: Parameters<typeof compilePermissions>[0]) {
+		const { rules } = compilePermissions(config)
+		return new VerificationGate(
+			{
+				enabled: true,
+				rules: [...rules],
+				allowReadOnlyTools: false,
+				denyDangerousPatterns: false,
+				logDecisions: false,
+			},
+			getRootLogger(),
+		)
+	}
+
+	it('a denied call never reaches the mode at all', async () => {
+		// THE precedence test. `deny` is settled by the gate, so no mode — not
+		// even the one spelled --yolo — is ever consulted about it. If this ever
+		// fails, a flag has become able to lift a prohibition someone wrote down.
+		const decision = gate({ bash: 'deny' }).evaluate({
+			toolName: 'bash',
+			toolInput: { command: 'rm -rf /tmp/x' },
+			toolDef: undefined,
+		})
+
+		expect(decision.decision).toBe('deny')
+	})
+
+	it('an allowed call never reaches the mode either', () => {
+		const decision = gate({ bash: { 'git status*': 'allow' } }).evaluate({
+			toolName: 'bash',
+			toolInput: { command: 'git status' },
+			toolDef: undefined,
+		})
+
+		expect(decision.decision).toBe('allow')
+	})
+})
+
+describe('what each mode does with an undecided call', () => {
+	const destructive = [
+		{ id: '1', name: 'write', input: { path: 'a.txt' }, isDestructive: true },
+	] as never
+
+	it('auto approves it', async () => {
+		const handler = makeResumeHandler({ all: false }, undefined, 'auto')
+
+		const decision = await handler({ type: 'tool_review', toolCalls: destructive } as never)
+
+		expect(decision).toEqual({ action: 'approve_tools' })
+	})
+
+	it('strict refuses it, and says asking again will not help', async () => {
+		// The mode that did not exist: an unattended run could only be `auto`, so
+		// a CI job either trusted the agent with everything or could not use it.
+		const handler = makeResumeHandler({ all: false }, undefined, 'strict')
+
+		const decision = (await handler({
+			type: 'tool_review',
+			toolCalls: destructive,
+		} as never)) as { action: string; feedback: string }
+
+		expect(decision.action).toBe('reject_tools')
+		expect(decision.feedback).toContain('Asking again will not change it')
+	})
+
+	it('prompt asks the human, and honours the answer', async () => {
+		let asked = false
+		const handler = makeResumeHandler(
+			{ all: false },
+			async () => {
+				asked = true
+				return { kind: 'reject', feedback: 'not that one' }
+			},
+			'prompt',
+		)
+
+		const decision = (await handler({
+			type: 'tool_review',
+			toolCalls: destructive,
+		} as never)) as { action: string; feedback: string }
+
+		expect(asked).toBe(true)
+		expect(decision.action).toBe('reject_tools')
+		expect(decision.feedback).toBe('not that one')
+	})
+
+	it('read-only batches run under every mode, including strict', async () => {
+		// `strict` refuses what needs asking, and a read never needed asking.
+		// Refusing reads would make the mode unusable rather than strict.
+		const readOnly = [{ id: '1', name: 'read', input: {}, isDestructive: false }] as never
+		const handler = makeResumeHandler({ all: false }, undefined, 'strict')
+
+		expect(await handler({ type: 'tool_review', toolCalls: readOnly } as never)).toEqual({
+			action: 'approve_tools',
+		})
+	})
+})

--- a/packages/cli/src/permissions/mode.ts
+++ b/packages/cli/src/permissions/mode.ts
@@ -1,0 +1,77 @@
+/**
+ * How a run resolves the calls no rule decided.
+ *
+ * The `[permissions]` table says what a tool may do. This says what happens to
+ * everything it did not cover. The two axes are separate on purpose: a rule is
+ * a durable statement an operator reviewed, and a mode is a property of ONE
+ * invocation — the difference between "we never force-push" and "this run is
+ * unattended".
+ *
+ * ## Precedence between a flag and the config file
+ *
+ * A mode only governs calls the gate routed to REVIEW. A rule that denied a
+ * call already stopped it, and a rule that allowed one never asked, so neither
+ * reaches the mode at all. **A mode can therefore never reopen what a rule
+ * closed, and `--permission-mode` cannot widen a `deny`.**
+ *
+ * That direction is deliberate. The config file is written once, read by
+ * whoever reviews the repository, and changed on purpose; a flag is typed in a
+ * hurry by someone who wants to get on with it. Letting the hurried thing
+ * overrule the considered one would make every `deny` in the file advisory, and
+ * a prohibition that a flag can lift is not a prohibition. The dangerous-pattern
+ * floor sits above both and no mode reaches it either.
+ */
+export type PermissionMode =
+	/** Ask a human. The default when a terminal is attached. */
+	| 'prompt'
+	/**
+	 * Approve it. The default with no terminal, and what every headless run has
+	 * always done — named here rather than left implicit.
+	 */
+	| 'auto'
+	/**
+	 * Refuse it. Nothing runs unless a rule allowed it by name or pattern.
+	 *
+	 * The mode that did not exist before: an unattended run could previously
+	 * only be `auto`, so a CI job either trusted the agent with everything or
+	 * could not use it. This makes the allowlist the whole permission surface,
+	 * which is the only form an unattended run can actually be reasoned about.
+	 */
+	| 'strict'
+
+export const PERMISSION_MODES: readonly PermissionMode[] = ['prompt', 'auto', 'strict']
+
+export function isPermissionMode(value: unknown): value is PermissionMode {
+	return typeof value === 'string' && (PERMISSION_MODES as readonly string[]).includes(value)
+}
+
+/**
+ * The mode for a run, from the flag, the bypass alias, and whether anyone is
+ * there to answer.
+ *
+ * `--yolo` / `--dangerously-skip-permissions` map to `auto`. They were accepted
+ * and documented as doing nothing, which was true and unsatisfying; now they
+ * say the same thing the mode vocabulary says, and in the TUI they do what
+ * their name has always implied. Neither reaches a `deny` rule or the
+ * dangerous-pattern floor, so the name still overstates what it can do —
+ * deliberately, because it should read as more dangerous than it is rather than
+ * less.
+ */
+export function resolvePermissionMode(opts: {
+	readonly flag?: string | null
+	readonly skipPermissions?: boolean
+	readonly interactive: boolean
+}): { mode: PermissionMode } | { error: string } {
+	if (opts.flag != null && opts.flag !== '') {
+		if (!isPermissionMode(opts.flag)) {
+			return {
+				error: `--permission-mode must be one of: ${PERMISSION_MODES.join(', ')} (got "${opts.flag}")`,
+			}
+		}
+		return { mode: opts.flag }
+	}
+	if (opts.skipPermissions) return { mode: 'auto' }
+	// No terminal means nobody to ask, so `prompt` would silently become `auto`
+	// anyway. Saying so here keeps the resolved mode honest in a log.
+	return { mode: opts.interactive ? 'prompt' : 'auto' }
+}

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -63,6 +63,7 @@ import {
 } from '../integrations/providers/index.js'
 import { createSubagentRuntime } from '../integrations/subagents/runtime.js'
 import { composeMemoryPrompt, readMemory } from '../memory/store.js'
+import type { PermissionMode } from '../permissions/mode.js'
 
 export type AgentEvent =
 	| { readonly kind: 'delta'; readonly text: string }
@@ -264,6 +265,8 @@ export interface AgentSessionOptions {
 	 * That stays the behaviour for anyone who writes no config.
 	 */
 	readonly rules?: readonly VerificationRule[]
+	/** How calls no rule decided are resolved. Defaults to prompt/auto by TTY. */
+	readonly permissionMode?: PermissionMode
 }
 
 export async function createAgentSession(
@@ -411,6 +414,7 @@ export async function createAgentSession(
 				scope,
 				workingDirectory: cwd,
 				rules: options.rules,
+				permissionMode: options.permissionMode,
 				approval,
 				taskStore,
 				systemPrompt,
@@ -595,6 +599,7 @@ interface RunTurnParams {
 	readonly workingDirectory: string
 	/** Operator rules for this run, already compiled. */
 	readonly rules: readonly VerificationRule[] | undefined
+	readonly permissionMode: PermissionMode | undefined
 	readonly approval: { all: boolean }
 	readonly taskStore: TaskStore
 	readonly systemPrompt: string | undefined
@@ -611,6 +616,7 @@ async function* runTurn({
 	scope,
 	workingDirectory,
 	rules,
+	permissionMode,
 	approval,
 	taskStore,
 	systemPrompt,
@@ -645,7 +651,7 @@ async function* runTurn({
 			...(systemPrompt ? { systemPrompt } : {}),
 			messages: [...messages],
 			workingDirectory,
-			resumeHandler: makeResumeHandler(approval, opts?.onPermission),
+			resumeHandler: makeResumeHandler(approval, opts?.onPermission, permissionMode),
 			signal,
 			...scope,
 		})
@@ -691,12 +697,28 @@ async function* runTurn({
 export function makeResumeHandler(
 	approval: { all: boolean },
 	onPermission: PermissionFn | undefined,
+	mode: PermissionMode = onPermission ? 'prompt' : 'auto',
 ): ResumeHandler {
 	return async (request): Promise<HITLResumeDecision> => {
 		if (request.type !== 'tool_review') {
 			return request.type === 'plan_approval' ? { action: 'approve_plan' } : { action: 'continue' }
 		}
-		if (!onPermission || approval.all || !batchNeedsPrompt(request.toolCalls)) {
+		// Only calls the gate routed to REVIEW arrive here — a rule that denied
+		// one already stopped it, and a rule that allowed one never asked. So the
+		// mode decides what happens to the undecided, and cannot reopen anything
+		// a rule closed. That is the whole precedence story between a flag and a
+		// config file, and it is one sentence on purpose.
+		if (!batchNeedsPrompt(request.toolCalls)) {
+			return { action: 'approve_tools' }
+		}
+		if (mode === 'strict') {
+			return {
+				action: 'reject_tools',
+				feedback:
+					'Refused: this run only permits tools an explicit rule allows, and no rule covers this call. Asking again will not change it — either the operator adds a rule, or this has to be done another way.',
+			}
+		}
+		if (mode === 'auto' || !onPermission || approval.all) {
 			return { action: 'approve_tools' }
 		}
 		const decision = await onPermission({


### PR DESCRIPTION
The `[permissions]` table (#131) says what a tool may do. This says what happens to everything it did not cover.

| Mode | An undecided call is | Default when |
| --- | --- | --- |
| `prompt` | asked about | a terminal is attached |
| `auto` | approved | there is no terminal — every headless run, historically |
| `strict` | refused | never; you ask for it |

```bash
namzu run --permission-mode strict "run the test suite"
```

**`strict` is the one that did not exist.** An unattended run could only be `auto`, so a CI job either trusted the agent with every tool it might reach for or could not use it at all. Under `strict` nothing runs unless a rule allowed it by name or pattern, and the refusal tells the model that asking again will not help — so it stops rather than rewording and trying the same thing.

`--yolo` and `--dangerously-skip-permissions` now mean `--permission-mode auto`. They were accepted and documented as doing nothing, which was true and unsatisfying.

## Precedence between the flag and the file

**A mode governs only the calls no rule decided, so it can never reopen what a rule closed.**

This is not a guard bolted on: a denied call is settled by the gate and never reaches the resume handler where a mode lives, and an allowed call never asked. The property falls out of the existing control flow. `--permission-mode auto` cannot run something the config says `deny`, and neither can `--yolo`; the dangerous-pattern floor is above both.

The direction is the deliberate part. The config file is written once, read by whoever reviews the repository, and changed on purpose; a flag is typed in a hurry by someone who wants to get on with it. A prohibition a flag can lift is not a prohibition.

## Testing

35 permission tests, 351 in the package. The load-bearing one asserts that a `deny` never reaches the mode at all — **if that test ever fails, a flag has become able to lift a prohibition someone wrote down.** Also asserted: read-only batches still run under `strict`, or the mode would be unusable rather than strict.

## Vocabulary

The three modes come from the approval-mode axis in Codex (`codex-rs/protocol/src/protocol.rs:917-941`, read at `5c44f11`), which is orthogonal to the rule axis #131 implemented — that tool has both, and so now does this one.

## Deferred

`--permission-mode` is on `run` only. `run-stream` shares the parser so it accepts the flag, but its host-UI path resolves permissions differently and was left alone rather than half-wired. Named so it reads as a choice.