### PR TITLE
fix(cli): run-stream obeys the permissions it was given

### DIFF
--- a/.changeset/run-stream-obeys-the-permissions-it-was-given.md
+++ b/.changeset/run-stream-obeys-the-permissions-it-was-given.md
@@ -1,0 +1,22 @@
+---
+'@namzu/cli': patch
+---
+
+`run-stream` obeys the permission rules and mode it was given, instead of parsing them and running unrestricted
+
+`[permissions]` was compiled for `namzu run` and never for `namzu run-stream`, so
+a host UI ran with an empty rule list whatever the config said. `--permission-mode`
+had the same shape one level smaller: the shared parser accepted it, the command
+started, nothing failed, and the mode did nothing.
+
+Both are the defect the working-directory fix was about, in the change that was
+supposed to be about not making it again: **the run did not fail, it succeeded
+while quietly not doing what the operator said.** It is worse here, because the
+flag that silently does nothing is a SAFETY flag — someone reaches for `strict`
+precisely when they do not trust what the agent might do, and got an unrestricted
+run that looked like it had obeyed.
+
+`run-stream` now compiles the same table, resolves the same mode, and refuses a
+mode it does not recognise rather than proceeding. A rule that cannot be read is
+reported as an in-band error event, which is the only channel a host scanning
+stdout has.

--- a/packages/cli/src/commands/__tests__/run-stream-flags.test.ts
+++ b/packages/cli/src/commands/__tests__/run-stream-flags.test.ts
@@ -21,7 +21,9 @@ vi.mock('../../integrations/sessions/store.js', () => ({
 // Stubbed so a turn can be driven to completion without a credential, and so
 // the directory the SESSION is created in is observable. What the session then
 // does with that directory is asserted in `src/tui/__tests__/`.
-const sessionOptions: Array<{ cwd?: string } | undefined> = []
+const sessionOptions: Array<
+	{ cwd?: string; rules?: unknown[]; permissionMode?: string } | undefined
+> = []
 vi.mock('../../tui/agent.js', () => ({
 	probeAgentSession: vi.fn(async () => ({
 		preferences: { version: 2, provider: 'anthropic', subagents: { active: [] } },
@@ -29,7 +31,11 @@ vi.mock('../../tui/agent.js', () => ({
 		detected: [],
 	})),
 	createAgentSession: vi.fn(
-		async (_prefs: unknown, _detected: unknown, opts?: { cwd?: string }) => {
+		async (
+			_prefs: unknown,
+			_detected: unknown,
+			opts?: { cwd?: string; rules?: unknown[]; permissionMode?: string },
+		) => {
 			sessionOptions.push(opts)
 			return {
 				hasProvider: true,
@@ -57,7 +63,7 @@ vi.mock('../../tui/agent.js', () => ({
  * actually honouring the flag that was advertised.
  */
 
-const ctx = {} as unknown as CommandContext
+const ctx = { config: {} } as unknown as CommandContext
 
 function capture(): { lines: string[]; restore: () => void } {
 	const lines: string[] = []
@@ -131,7 +137,7 @@ describe('run-stream works in the directory it was pointed at', () => {
 			rmSync(elsewhere, { recursive: true, force: true })
 		}
 
-		expect(sessionOptions).toEqual([{ cwd: elsewhere }])
+		expect(sessionOptions[0]?.cwd).toBe(elsewhere)
 	})
 
 	it('refuses a --cwd that is not there instead of quietly using this one', async () => {
@@ -261,5 +267,68 @@ describe('history reads the directory it was pointed at', () => {
 		}
 
 		expect(openSessions).toHaveBeenCalledWith(process.cwd())
+	})
+})
+
+describe('run-stream honours the permission surface, not just parses it', () => {
+	// It accepted `--permission-mode` and never used it, and it never compiled
+	// the `[permissions]` table at all — so an operator who wrote rules, or who
+	// typed `--permission-mode strict` precisely because they did not trust the
+	// run, got an unrestricted one that looked like it had obeyed. A safety
+	// control that parses and does nothing is worse than one that is missing,
+	// because the absence is visible and the silence is not.
+	const withConfig = {
+		config: { permissions: { bash: 'deny' } },
+	} as unknown as CommandContext
+
+	async function runWith(rawArgs: string[], context = withConfig): Promise<string[]> {
+		const { lines, restore } = capture()
+		try {
+			await runStreamCommand.handler({ rawArgs, ctx: context } as never)
+		} finally {
+			restore()
+		}
+		return lines
+	}
+
+	it('compiles the operator table into the session', async () => {
+		await runWith(['--session', 'k', 'hello'])
+
+		expect(sessionOptions[0]?.rules).toEqual([{ type: 'deny_by_name', toolNames: ['bash'] }])
+	})
+
+	it('passes --permission-mode through instead of ignoring it', async () => {
+		await runWith(['--session', 'k', '--permission-mode', 'strict', 'hello'])
+
+		expect(sessionOptions[0]?.permissionMode).toBe('strict')
+	})
+
+	it('refuses a mode it does not know rather than running unrestricted', async () => {
+		const lines = await runWith(['--session', 'k', '--permission-mode', 'yolo', 'hello'])
+
+		expect(lines.join('')).toContain('--permission-mode must be one of')
+		expect(sessionOptions).toEqual([])
+	})
+
+	it('defaults to auto when nothing was asked for, and says so by acting on it', async () => {
+		await runWith(['--session', 'k', 'hello'])
+
+		expect(sessionOptions[0]?.permissionMode).toBe('auto')
+	})
+
+	it('reports an unreadable rule in band, where a host can see it', async () => {
+		const bad = {
+			config: { permissions: { bash: { 'git push*': 'maybe' } } },
+		} as unknown as CommandContext
+
+		const lines = await runWith(['--session', 'k', 'hello'], bad)
+
+		// Parsed, not substring-matched: the line is JSON, so the quotes around
+		// the pattern are escaped in the raw text and a naive contains() would
+		// pass or fail for reasons unrelated to what the host actually reads.
+		const messages = lines
+			.map((l) => JSON.parse(l) as { message?: string })
+			.map((e) => e.message ?? '')
+		expect(messages.some((m) => m.includes('permissions.bash."git push*"'))).toBe(true)
 	})
 })

--- a/packages/cli/src/commands/run-stream.ts
+++ b/packages/cli/src/commands/run-stream.ts
@@ -29,6 +29,8 @@ import {
 	openSessions,
 	resolveConversation,
 } from '../integrations/sessions/store.js'
+import { resolvePermissionMode } from '../permissions/mode.js'
+import { compilePermissions } from '../permissions/rules.js'
 import {
 	loadSkillsContext,
 	parseRunFlags,
@@ -84,10 +86,13 @@ export const runStreamCommand: CommandDef = {
 		'event. Built for a host UI that renders progress rather than waiting',
 		'for a final string.',
 		'',
+		'Takes the same options as `namzu run`, including --permission-mode and',
+		'the [permissions] table from the config file.',
+		'',
 		'Needs a provider. Set a credential in the environment, or run namzu',
 		'once to pick one interactively.',
 	].join('\n'),
-	handler: async ({ rawArgs }) => {
+	handler: async ({ ctx, rawArgs }) => {
 		const write = (o: unknown): void => {
 			process.stdout.write(`${JSON.stringify(o)}\n`)
 		}
@@ -139,10 +144,35 @@ export const runStreamCommand: CommandDef = {
 		if (flags.provider) prefs = { ...prefs, provider: flags.provider as ProviderId }
 		if (flags.model) prefs = { ...prefs, model: flags.model }
 
-		// The resolved `--cwd` is what the agent's tools resolve against, not
-		// just where the session store lives — a run told to work in another
-		// checkout has to glob, read and edit files there.
-		const session = await createAgentSession(prefs, probe.detected, { cwd })
+		// The operator's rules and mode reach this command too. They did not:
+		// `[permissions]` was compiled for `run` and never for `run-stream`, so a
+		// host UI ran with an empty rule list whatever the config said — the same
+		// shape as a flag that parses and does nothing, one level larger, and
+		// silent in exactly the same way.
+		const modeResult = resolvePermissionMode({
+			flag: flags.permissionMode,
+			skipPermissions: flags.skipPermissions,
+			interactive: false,
+		})
+		if ('error' in modeResult) return fail(modeResult.error)
+
+		const permissions = compilePermissions(ctx.config.permissions)
+		for (const d of permissions.diagnostics) {
+			const where = d.pattern ? `permissions.${d.tool}."${d.pattern}"` : `permissions.${d.tool}`
+			// In band, because a host line-scanning stdout has no other channel —
+			// and a permission the operator believes is in force must never be
+			// dropped without saying so.
+			write({ kind: 'error', message: `${where}: ${d.message}` })
+		}
+
+		// The resolved `--cwd` is what the agent's tools resolve against, not just
+		// where the session store lives — a run told to work in another checkout
+		// has to glob, read and edit files there.
+		const session = await createAgentSession(prefs, probe.detected, {
+			cwd,
+			rules: permissions.rules,
+			permissionMode: modeResult.mode,
+		})
 		if (!session.hasProvider) return fail(session.errorHint ?? 'agent is not ready')
 
 		// --skills <a,b,c>: load the named skills' bodies and inject them as the


### PR DESCRIPTION
`[permissions]` was compiled for `namzu run` and never for `namzu run-stream`, so a host UI ran with an empty rule list whatever the config said. `--permission-mode` had the same shape one level smaller: the shared parser accepted it, the command started, nothing failed, and the mode did nothing.

Both are the defect the `--cwd` fix (#127) was about, appearing in the work that was supposed to be about not making it again:

> **The run did not fail — it succeeded while quietly not doing what the operator said.**

It is worse here than it was there, because the flag that silently does nothing is a **safety** flag. Someone reaches for `--permission-mode strict` precisely when they do not trust what the agent might do, and got an unrestricted run that looked like it had obeyed.

## Why wiring rather than refusing

The smaller move was to refuse the flag on `run-stream` and say why. Going in to do that found something larger: **`run-stream` never compiled the `[permissions]` table either**, so the whole operator surface has been inert there since #131. Refusing the flag would have fixed the visible symptom and left the bigger silent one, so this wires it properly — about fifteen lines.

## What changed

`run-stream` compiles the same table, resolves the same mode, and refuses a mode it does not recognise instead of proceeding. A rule that cannot be read is reported as an in-band `{"kind":"error"}` event, because a host scanning stdout has no other channel and a permission someone believes is in force must not be dropped in silence.

## Testing

Five tests: the table reaches the session, the mode reaches it, an unknown mode is refused before the session is built, the default resolves to `auto`, and an unreadable rule is reported where a host can see it.

Mutation-checked — removing the two lines that pass `rules` and `permissionMode` fails exactly the three tests that assert they arrive.

Two of my own assertions were wrong on the first pass and are worth noting, since both would have passed for the wrong reason: a stale `toEqual` against the whole options object, and a substring match against JSON where the quotes are escaped. The second is now asserted against the parsed message rather than the raw line.

356 tests, typecheck, biome from inside the package, external-name audit — all green.