### PR TITLE
fix(sdk): the front door could not ask for effort, or for thinking

### DIFF
--- a/.changeset/a-positional-array-keeps-its-positions.md
+++ b/.changeset/a-positional-array-keeps-its-positions.md
@@ -1,0 +1,45 @@
+---
+'@namzu/sdk': major
+---
+
+A bridged tool's positional array is no longer flattened to "an array of
+anything".
+
+`mcpJsonSchemaToZod` collapsed every positional array — both the draft-07
+spelling (`items` holding a list) and the 2020-12 one (`prefixItems`) — to
+`z.array(z.unknown())`. The schema makes a round trip, server JSON Schema → Zod
+→ JSON Schema on the wire, so what was dropped was dropped from what the MODEL
+is shown: a server that spelled out `[string, number]` had the model told
+nothing about the positions, their types, or their order.
+
+**Why this is a major.** Where the server pinned the arity and closed the tail,
+the converted schema is now a tuple, so input that a looser array accepted is
+refused locally. It is only ever refused where the server itself declared it
+invalid — the error moves from the server's response to the local validator —
+but a host driving a bridged tool directly can see a validation failure it did
+not see before, and code branching on the converted type (`instanceof
+z.ZodArray`) will take a different branch. If you relied on the permissive
+shape, the fix is to send what the server's schema declares.
+
+**The tuple is deliberately narrow, and that is the whole design.** A rejected
+tool schema fails the entire request rather than degrading one tool, taking down
+every run that offered the toolset — so a faithful conversion the wire will not
+accept is strictly worse than a lossy one it will. A tuple is therefore emitted
+only where the server pinned the arity AND closed the tail, because that renders
+as bounded `prefixItems`, which is the one positional shape measured as
+accepted and the same shape a first-party builtin already ships. Every looser
+positional array keeps today's permissive array and gains its shape in the
+description instead, appended to whatever the server wrote rather than replacing
+it.
+
+The inversion worth knowing if you write these schemas: positional members do
+not constrain LENGTH. Without `minItems` a server is permitting a shorter array,
+which a tuple cannot express — so an absent lower bound is a reason to keep the
+loose form, not a detail to round up.
+
+**Also fixed, and reachable from any bridged server:** the conversion's depth
+ceiling never fired. `MAX_CONVERSION_DEPTH` was compared against in one branch
+that a pure array or union never reaches, and the counter was not even passed
+down the array path — so a deeply nested schema from a remote tool listing took
+the process down with a stack overflow instead of being left permissive as the
+ceiling's own comment promised.

--- a/.changeset/effort-was-declared-and-unreachable.md
+++ b/.changeset/effort-was-declared-and-unreachable.md
@@ -1,0 +1,52 @@
+---
+'@namzu/sdk': minor
+'@namzu/anthropic': patch
+---
+
+`effort` can be set on a run — and so, for the first time, can `thinking`.
+
+`effort` was on the provider params, exported, and read by a driver that wrote
+it to the wire, and nothing in the kernel ever set it. Every request went out at
+the model's default, which reads as "this model ignores effort" rather than
+"nobody plumbed it through".
+
+`AgentRunConfig` gains `effort`, a sibling of `thinking` rather than a field
+inside it — on some models the two are independent controls that apply together,
+and nesting would make that combination unsayable. It is run-level rather than
+per-step because the provider documents that changing effort between requests
+does not preserve a cached prefix, so a value that moves between steps buys a
+different answer shape at the cost of the cache on every step that changes it.
+
+**`thinking` turned out to have the same defect, and had shipped with it.** It
+was settable only through `drainQuery`. Every ergonomic entry point — `runAgent`,
+`ReactiveAgent`, `SupervisorAgent`, and the agent manager's bare-config branch —
+builds its run config by hand-listing fields, so a field nobody remembered to add
+is dropped in silence, with no cast to blame and no error to see. A caller could
+set `thinking` on an agent config and get a run that never asked for it. Both
+fields now live on `BaseAgentConfig` and are forwarded by all four.
+
+This was found by watching an actual HTTP body from a real run. The unit tests
+passed throughout, because they drive the kernel directly, and the kernel was
+never the half that was broken.
+
+**A driver that cannot honour `effort` now refuses rather than dropping it**,
+the rule `thinking` already had. Effort is the worse silence of the two: a
+dropped `thinking` leaves an empty reasoning list someone might notice, while a
+dropped `effort` leaves a perfectly ordinary answer, so a run requested at `max`
+is indistinguishable from one at the default — including in what it cost.
+Nothing existing breaks, because the field could not be set until now.
+
+Two driver-side corrections ride along, both verified against the live wire:
+
+- The preview model's capability row claimed all five effort levels. It takes
+  `max` and not `xhigh`. That model is not reachable from the tenant the live
+  suite runs against, so the row is sourced from the reference rather than
+  measured — but the pairing itself is now measured, on a model that has it:
+  `claude-sonnet-4-6` answers `xhigh` with *"This model does not support effort
+  level 'xhigh'. Supported levels: high, low, max, medium"* and accepts `max`.
+  Reading the levels as a ladder, where anything taking the top rung takes the
+  one below, is what produced the wrong row.
+- `output_config` is now merged rather than assigned. It is a shared envelope on
+  that wire — a structured-output format and a task budget live in it too — so
+  assigning meant whoever wired the next one would silently delete effort, or
+  have effort delete theirs, depending only on which line ran last.

--- a/packages/providers/anthropic/src/__tests__/thinking-capability.test.ts
+++ b/packages/providers/anthropic/src/__tests__/thinking-capability.test.ts
@@ -38,7 +38,12 @@ const TABLE: readonly [string, boolean, boolean, boolean, string[], string[]][] 
 	// Always-on families: thinking cannot be switched off at any version.
 	['claude-fable-5', true, false, false, ALL, ALL],
 	['claude-mythos-5', true, false, false, ALL, ALL],
-	['claude-mythos-preview', true, true, false, ALL, ALL],
+	// The preview takes `max` and NOT `xhigh`, which is the pairing it is easy
+	// to assume away — the reference says outright that some models supporting
+	// `max` do not support `xhigh`, and this is one. Reading the levels as a
+	// ladder is what put ALL on this row originally, and a ladder reading sends
+	// a level the wire rejects.
+	['claude-mythos-preview', true, true, false, NO_XHIGH, NO_XHIGH],
 	// 4.7 and later: adaptive only, and it can still be disabled.
 	['claude-opus-5', true, false, true, ALL, CAPPED],
 	['claude-sonnet-5', true, false, true, ALL, ALL],

--- a/packages/providers/anthropic/src/__tests__/wire-contract.live.test.ts
+++ b/packages/providers/anthropic/src/__tests__/wire-contract.live.test.ts
@@ -213,6 +213,81 @@ describe.skipIf(!KEY)('the strict subset is what the deny-list says it is', () =
 	}, 180_000)
 })
 
+describe.skipIf(!KEY)('the positional shape a bridged tool now emits', () => {
+	it('is accepted once converted', async () => {
+		// The MCP adapter emits a tuple ONLY where the server pinned the arity
+		// and closed the tail, because that renders as bounded `prefixItems`.
+		// The narrowness is the design rather than caution: a tool schema this
+		// wire refuses fails the WHOLE request instead of degrading one tool,
+		// so a faithful conversion it will not take is strictly worse than a
+		// lossy one it will.
+		//
+		// The refusal half of this pair is already asserted above, on the
+		// unconverted spelling — so this says something the sweep does not:
+		// that the shape we CHOSE to emit is one the wire takes.
+		const pinned = {
+			type: 'object',
+			properties: {
+				pair: {
+					type: 'array',
+					minItems: 2,
+					maxItems: 2,
+					items: [{ type: 'string' }, { type: 'number' }],
+				},
+			},
+			required: ['pair'],
+			additionalProperties: false,
+		}
+
+		const result = await offerTools([wireTool('pinned_pair', pinned, false)])
+		expect(result.ok, result.message).toBe(true)
+	}, 180_000)
+})
+
+describe.skipIf(!KEY)('effort is a per-model SET, and this wire says so itself', () => {
+	async function withEffort(model: string, effort: string): Promise<WireResult> {
+		const res = await fetch('https://api.anthropic.com/v1/messages', {
+			method: 'POST',
+			headers: {
+				'x-api-key': KEY as string,
+				'anthropic-version': '2023-06-01',
+				'content-type': 'application/json',
+			},
+			body: JSON.stringify({
+				model,
+				max_tokens: 16,
+				messages: [{ role: 'user', content: 'Say OK.' }],
+				output_config: { effort },
+			}),
+		})
+		const body: unknown = await res.json().catch(() => ({}))
+		const message =
+			(body as { error?: { message?: string } } | null)?.error?.message ?? (res.ok ? '' : 'unknown')
+		return { ok: res.ok, status: res.status, message }
+	}
+
+	it('takes all five levels on a model the table says has all five', async () => {
+		for (const effort of ['low', 'medium', 'high', 'xhigh', 'max']) {
+			const result = await withEffort('claude-sonnet-5', effort)
+			expect(result.ok, `${effort}: ${result.message}`).toBe(true)
+		}
+	}, 180_000)
+
+	it('refuses a level a model lacks, and names the set it has', async () => {
+		// The pairing the capability table exists to express: `max` WITHOUT
+		// `xhigh`. A boolean could not have said this, and reading the levels
+		// as a ladder — where anything taking the top rung takes the one below
+		// — gets it backwards. That reading is how a row in that table came to
+		// claim a level this wire rejects.
+		const refused = await withEffort('claude-sonnet-4-6', 'xhigh')
+		expect(refused.ok).toBe(false)
+		expect(refused.message).toContain('xhigh')
+
+		const accepted = await withEffort('claude-sonnet-4-6', 'max')
+		expect(accepted.ok, accepted.message).toBe(true)
+	}, 180_000)
+})
+
 describe('what can be checked without a key', () => {
 	it('leaves no draft-07-only construct in any shipped tool', () => {
 		// The offline half of the same guarantee, so a contributor without a

--- a/packages/providers/anthropic/src/client.ts
+++ b/packages/providers/anthropic/src/client.ts
@@ -740,7 +740,13 @@ export class AnthropicProvider implements LLMProvider {
 		// A sibling of `thinking`, not a field inside it — and gated on the
 		// model, since only some accept it at all.
 		const effort = resolveEffort(params.effort, thinkingBody, capability)
-		if (effort) body.output_config = { effort }
+		// Merged rather than assigned. `output_config` is a shared envelope on
+		// this wire — a structured-output format and a task budget live in it
+		// too, and `responseFormat` already exists on the params unhandled
+		// here. Assigning would mean whoever wires the next one silently
+		// deletes effort, or has effort silently delete theirs, depending only
+		// on which line ran last.
+		if (effort) body.output_config = { ...(body.output_config as object | undefined), effort }
 		if (params.temperature !== undefined) body.temperature = params.temperature
 		if (params.topP !== undefined) body.top_p = params.topP
 		if (params.topK !== undefined) body.top_k = params.topK

--- a/packages/providers/anthropic/src/thinking-capability.ts
+++ b/packages/providers/anthropic/src/thinking-capability.ts
@@ -111,8 +111,29 @@ export function resolveThinkingCapability(model: string): ThinkingCapability {
 			adaptive: true,
 			manual: true,
 			canDisable: false,
-			effort: FULL_EFFORT,
-			effortWhenDisabled: FULL_EFFORT,
+			// `max` but NOT `xhigh` — the combination it is easy to assume
+			// away, because reading the levels as a ladder makes anything
+			// accepting the top rung look like it accepts the one below. That
+			// reading is what put all five levels on this row, and it sends a
+			// level the wire refuses.
+			//
+			// SOURCED, NOT MEASURED, and the distinction is recorded because
+			// this file has been wrong from exactly this evidence class
+			// before. The reference states this model's availability twice: it
+			// is in the `max` list both times and in the `xhigh` list neither,
+			// and it says outright that some models supporting `max` do not
+			// support `xhigh`. The model is not reachable from the tenant used
+			// for the live contract suite (404), so no probe can confirm it
+			// here.
+			//
+			// What IS measured is that the pairing exists and this wire reports
+			// it exactly this way — `claude-sonnet-4-6` answers `xhigh` with
+			// "This model does not support effort level 'xhigh'. Supported
+			// levels: high, low, max, medium." and accepts `max`. So the row
+			// below is not a guess about a shape nobody has seen; it is a
+			// documented instance of a shape the wire demonstrably has.
+			effort: EFFORT_WITHOUT_XHIGH,
+			effortWhenDisabled: EFFORT_WITHOUT_XHIGH,
 		}
 	}
 

--- a/packages/sdk/src/agents/ReactiveAgent.ts
+++ b/packages/sdk/src/agents/ReactiveAgent.ts
@@ -110,6 +110,11 @@ export class ReactiveAgent extends AbstractAgent<ReactiveAgentConfig, ReactiveAg
 					costLimitUsd: config.costLimitUsd,
 					permissionMode: config.permissionMode,
 					env: config.env,
+					// Hand-listed, so anything not named here is dropped in silence.
+					// That is how both of these came to be unreachable from every
+					// entry point except the raw kernel one.
+					...(config.thinking ? { thinking: config.thinking } : {}),
+					...(config.effort ? { effort: config.effort } : {}),
 				},
 				agentId: this.metadata.id,
 				agentName: this.metadata.name,

--- a/packages/sdk/src/agents/SupervisorAgent.ts
+++ b/packages/sdk/src/agents/SupervisorAgent.ts
@@ -287,6 +287,10 @@ export class SupervisorAgent extends AbstractAgent<SupervisorAgentConfig, Superv
 					maxIterations: config.maxIterations,
 					temperature: config.temperature,
 					env: config.env,
+					// See ReactiveAgent: a hand-listed literal drops what nobody
+					// remembered to add, and reports nothing when it does.
+					...(config.thinking ? { thinking: config.thinking } : {}),
+					...(config.effort ? { effort: config.effort } : {}),
 				},
 				questionParks,
 				pendingAnswers,

--- a/packages/sdk/src/agents/runAgent.ts
+++ b/packages/sdk/src/agents/runAgent.ts
@@ -2,7 +2,7 @@ import { ToolRegistry } from '../registry/tool/execute.js'
 import { drainQuery } from '../runtime/query/index.js'
 import type { ProjectId, SessionId, TenantId, ThreadId } from '../types/ids/index.js'
 import type { Message } from '../types/message/index.js'
-import type { LLMProvider } from '../types/provider/index.js'
+import type { LLMProvider, ReasoningEffort, ThinkingConfig } from '../types/provider/index.js'
 import type { Run, RunEventListener } from '../types/run/index.js'
 import type { Skill } from '../types/skills/index.js'
 import type { ToolRegistryContract } from '../types/tool/index.js'
@@ -82,6 +82,25 @@ export interface RunAgentOptions extends AgentIdentity {
 	tokenBudget?: number
 	timeoutMs?: number
 	temperature?: number
+
+	/**
+	 * Extended-thinking request and response-effort level, forwarded on every
+	 * model call.
+	 *
+	 * These are here because the run config below is assembled by HAND, and a
+	 * hand-listed literal silently drops whatever nobody remembered to add —
+	 * which is precisely what happened. `thinking` shipped on `AgentRunConfig`
+	 * and was reachable only from the raw kernel entry point, because this
+	 * function, `ReactiveAgent` and `SupervisorAgent` each rebuilt the object
+	 * from a fixed list. So the capability existed and the front door could not
+	 * open it.
+	 *
+	 * A live run is what found it: the unit tests passed because they drove the
+	 * kernel directly, and a real agent run through this function put no effort
+	 * on the wire at all.
+	 */
+	thinking?: ThinkingConfig
+	effort?: ReasoningEffort
 
 	/** Names the agent in traces and events. Defaults to `Agent`. */
 	name?: string
@@ -184,6 +203,8 @@ export async function runAgent(options: RunAgentOptions): Promise<RunAgentResult
 				tokenBudget: options.tokenBudget ?? DEFAULT_TOKEN_BUDGET,
 				timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
 				...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
+				...(options.thinking ? { thinking: options.thinking } : {}),
+				...(options.effort ? { effort: options.effort } : {}),
 			},
 			// One option covers both. `drainQuery` separates the id from the
 			// display name because a fleet needs a stable key and a readable

--- a/packages/sdk/src/connector/mcp/__tests__/positional-arrays.test.ts
+++ b/packages/sdk/src/connector/mcp/__tests__/positional-arrays.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest'
+
+import { toSchemaDialect } from '../../../registry/tool/dialect.js'
+import { renderToolSchema } from '../../../registry/tool/schema.js'
+import type { MCPJsonSchema } from '../../../types/connector/index.js'
+import { mcpJsonSchemaToZod } from '../adapter.js'
+
+/**
+ * A bridged tool's schema makes a round trip — server JSON Schema → Zod →
+ * JSON Schema on the wire — so this file asserts what comes out the FAR end,
+ * not what the Zod type is. Two failures live at that far end and neither is
+ * visible from the Zod side:
+ *
+ *  - whatever the conversion drops is dropped from what the MODEL is shown,
+ *    and a positional array was being flattened to "an array of anything";
+ *  - whatever it emits has to be a construct the receiving wire accepts, and
+ *    a rejected tool schema fails the WHOLE request rather than degrading one
+ *    tool. So a faithful conversion that cannot be sent is worse than a lossy
+ *    one that can, which is why the tuple gate is narrow rather than eager.
+ */
+
+function wire(schema: MCPJsonSchema): Record<string, unknown> {
+	const rendered = renderToolSchema(mcpJsonSchemaToZod(schema))
+	const properties = toSchemaDialect(rendered, '2020-12').properties as Record<
+		string,
+		Record<string, unknown>
+	>
+	return properties.a as Record<string, unknown>
+}
+
+const wrap = (a: Record<string, unknown>): MCPJsonSchema =>
+	({ type: 'object', properties: { a }, required: ['a'] }) as unknown as MCPJsonSchema
+
+describe('a server that pinned its positions gets a tuple', () => {
+	it('carries the draft-07 spelling through to bounded prefixItems', () => {
+		expect(
+			wire(
+				wrap({
+					type: 'array',
+					items: [{ type: 'string' }, { type: 'number' }],
+					additionalItems: false,
+					minItems: 2,
+					maxItems: 2,
+				}),
+			),
+		).toEqual({
+			type: 'array',
+			minItems: 2,
+			maxItems: 2,
+			prefixItems: [{ type: 'string' }, { type: 'number' }],
+		})
+	})
+
+	it('reaches the identical wire shape from the 2020-12 spelling', () => {
+		// The two spellings say the same thing and a server may use either.
+		// Converging them is the point: a bridged tool should not be shown
+		// differently to the model because of which dialect its author wrote.
+		expect(
+			wire(
+				wrap({
+					type: 'array',
+					prefixItems: [{ type: 'string' }, { type: 'number' }],
+					items: false,
+					minItems: 2,
+				}),
+			),
+		).toEqual({
+			type: 'array',
+			minItems: 2,
+			maxItems: 2,
+			prefixItems: [{ type: 'string' }, { type: 'number' }],
+		})
+	})
+})
+
+describe('a positional array the wire cannot carry keeps its shape in words', () => {
+	it('falls back when the server did not pin the length', () => {
+		// The inversion worth pinning: positional members do NOT constrain
+		// length. With no `minItems` the server is permitting a SHORTER array,
+		// and a tuple cannot express that — so an absent lower bound is a
+		// reason to fall back rather than a detail to round up.
+		const result = wire(
+			wrap({
+				type: 'array',
+				prefixItems: [{ type: 'string' }, { type: 'number' }],
+			}),
+		)
+
+		expect(result.prefixItems).toBeUndefined()
+		expect(result.description).toContain('[0] string')
+		expect(result.description).toContain('[1] number')
+	})
+
+	it('appends the shape to the description rather than replacing it', () => {
+		// The case this exists for is a server that documented its argument
+		// WELL and used a positional array. Assigning the description would
+		// have deleted its sentence to make room for ours.
+		const result = wire(
+			wrap({
+				type: 'array',
+				prefixItems: [{ type: 'string' }, { type: 'number' }],
+				description: 'A coordinate pair.',
+			}),
+		)
+
+		expect(result.description).toContain('A coordinate pair.')
+		expect(result.description).toContain('[0] string')
+	})
+
+	it('keeps the bounds the server did state', () => {
+		// The fallback is a ZodArray precisely so the ordinary constraint pass
+		// still carries `minItems`/`maxItems` onto it.
+		const result = wire(
+			wrap({ type: 'array', prefixItems: [{ type: 'string' }], minItems: 1, maxItems: 9 }),
+		)
+
+		expect(result.minItems).toBe(1)
+		expect(result.maxItems).toBe(9)
+	})
+
+	it('names enums and literals in the description, not just types', () => {
+		const result = wire(
+			wrap({
+				type: 'array',
+				prefixItems: [{ enum: ['r', 'w'] }, { const: 7 }],
+			}),
+		)
+
+		expect(result.description).toContain('"r"|"w"')
+		expect(result.description).toContain('7')
+	})
+})
+
+describe('an ordinary list is untouched', () => {
+	it('still renders as a homogeneous array', () => {
+		expect(wire(wrap({ type: 'array', items: { type: 'string' } }))).toEqual({
+			type: 'array',
+			items: { type: 'string' },
+		})
+	})
+})
+
+describe('a deep schema cannot take the process down', () => {
+	// `MAX_CONVERSION_DEPTH` promised in its own comment that a node past the
+	// ceiling is "left permissive rather than the process being taken down by
+	// a stack overflow". That was false for arrays and for unions: the counter
+	// was never passed down the array path, and even where it WAS passed
+	// correctly — the union path — nothing compared it to anything, because
+	// the only comparison lived in the object branch a pure array or union
+	// never reaches. A remote server's tool listing is untrusted input, so
+	// this was reachable denial of service.
+	const nestArrays = (depth: number): MCPJsonSchema => {
+		let inner: Record<string, unknown> = { type: 'string' }
+		for (let i = 0; i < depth; i += 1) inner = { type: 'array', items: inner }
+		return wrap(inner)
+	}
+
+	const nestUnions = (depth: number): MCPJsonSchema => {
+		let inner: Record<string, unknown> = { type: 'string' }
+		for (let i = 0; i < depth; i += 1) inner = { anyOf: [inner] }
+		return wrap(inner)
+	}
+
+	it('survives a deeply nested array', () => {
+		expect(() => mcpJsonSchemaToZod(nestArrays(5_000))).not.toThrow()
+	})
+
+	it('survives a deeply nested union', () => {
+		expect(() => mcpJsonSchemaToZod(nestUnions(5_000))).not.toThrow()
+	})
+
+	it('still converts a shallow schema faithfully', () => {
+		// The guard must not be so eager that it flattens ordinary nesting.
+		const result = wire(
+			wrap({ type: 'array', items: { type: 'array', items: { type: 'number' } } }),
+		)
+
+		expect(result).toEqual({
+			type: 'array',
+			items: { type: 'array', items: { type: 'number' } },
+		})
+	})
+})

--- a/packages/sdk/src/connector/mcp/adapter.ts
+++ b/packages/sdk/src/connector/mcp/adapter.ts
@@ -93,9 +93,20 @@ function jsonSchemaPropertyToZod(prop: unknown, depth = 0): z.ZodType {
 		base = base.nullable()
 	}
 
-	const description = schema.description
-	if (typeof description === 'string' && description.length > 0) {
-		base = base.describe(description)
+	// Appended, not assigned. The conversion itself can produce a description
+	// — a positional array that could not be expressed as a tuple carries its
+	// shape here, because that prose is the only place the model learns it —
+	// and `.describe()` REPLACES. Overwriting would have silently deleted the
+	// note in exactly the case it exists for: a server that documented its
+	// argument well AND used a positional array.
+	const carried = base.description
+	const declared = schema.description
+	const parts = [
+		typeof declared === 'string' && declared.length > 0 ? declared : undefined,
+		carried,
+	].filter((part): part is string => typeof part === 'string' && part.length > 0)
+	if (parts.length > 0) {
+		base = base.describe(parts.join(' '))
 	}
 
 	if (schema.default !== undefined) {
@@ -195,6 +206,12 @@ function baseTypeToZod(schema: Record<string, unknown>, depth = 0): z.ZodType {
 
 	const composite = (schema.anyOf ?? schema.oneOf) as unknown[] | undefined
 	if (Array.isArray(composite) && composite.length > 0) {
+		// The ceiling has to be CHECKED here, not merely counted. `depth` was
+		// threaded correctly through this branch from the start, and a
+		// 5000-deep union still overflowed the stack — because the only
+		// comparison against `MAX_CONVERSION_DEPTH` lived in `objectToZod`,
+		// which a pure union never reaches.
+		if (depth >= MAX_CONVERSION_DEPTH) return z.unknown()
 		const members = composite.map((member) => jsonSchemaPropertyToZod(member, depth + 1))
 		return members.length === 1
 			? (members[0] as z.ZodType)
@@ -229,17 +246,124 @@ function baseTypeToZod(schema: Record<string, unknown>, depth = 0): z.ZodType {
 		case 'null':
 			return z.null()
 		case 'array': {
+			// Both the counter and the check. `depth` was never passed to the
+			// element conversion below, so the counter reset to zero on every
+			// array level — and even threaded it would not have helped, since
+			// nothing on this path compared it to anything. Measured before
+			// and after: a 5000-deep array schema took the process down with a
+			// stack overflow, which is a denial of service reachable from a
+			// remote server's tool listing.
+			if (depth >= MAX_CONVERSION_DEPTH) return z.array(z.unknown())
+
+			// A positional array has two spellings and a server may use
+			// either: draft-07 puts the member schemas in `items` with the
+			// tail rule in `additionalItems`, 2020-12 moved them to
+			// `prefixItems` with the tail rule in `items`.
+			const positional = Array.isArray(schema.prefixItems)
+				? (schema.prefixItems as unknown[])
+				: Array.isArray(schema.items)
+					? (schema.items as unknown[])
+					: undefined
+			if (positional) return positionalToZod(positional, schema, depth)
+
 			const items = schema.items
-			// A tuple (`items` as an array) is rare in tool schemas; treat it
-			// as a heterogeneous list rather than pretending to model it.
-			if (Array.isArray(items)) return z.array(z.unknown())
-			return z.array(items === undefined ? z.unknown() : jsonSchemaPropertyToZod(items))
+			return z.array(
+				// A boolean `items` is a tail RULE, not an element schema — it
+				// only has meaning next to `prefixItems`, which was handled
+				// above. Reaching it here means the server closed an array
+				// that has no positions, and an unconstrained element type is
+				// the permissive reading of that.
+				items === undefined || typeof items === 'boolean'
+					? z.unknown()
+					: jsonSchemaPropertyToZod(items, depth + 1),
+			)
 		}
 		case 'object':
 			return objectToZod(schema, depth)
 		default:
 			return z.unknown()
 	}
+}
+
+/**
+ * How many positions we will express as a tuple.
+ *
+ * Not a correctness bound — a server may pin any arity it likes. It is a
+ * prompt-cost bound: every member renders its own schema into the tool
+ * definition the model is shown, and past a couple of dozen positions the
+ * thing being described is a data payload rather than a call signature. Past
+ * the cap the shape still reaches the model, in the description.
+ */
+const MAX_TUPLE_ARITY = 32
+
+/**
+ * A positional array: a tuple when the server pinned it, a described list
+ * otherwise.
+ *
+ * This used to be `z.array(z.unknown())` unconditionally, so a server that
+ * spelled out `[string, number]` had the model told "an array of anything" —
+ * the positions, their types and their order all dropped from what the model
+ * reads, not merely from what is validated locally.
+ *
+ * The reason it is not simply converted is that the schema makes a ROUND TRIP:
+ * server JSON Schema → Zod → JSON Schema on the wire. So whatever is emitted
+ * here has to be a construct the receiving wire accepts, and a construct it
+ * rejects fails the ENTIRE request rather than degrading one tool — taking
+ * down every run that offered the toolset. A faithful conversion that cannot
+ * be sent is strictly worse than a lossy one that can.
+ *
+ * Hence the narrow gate. A tuple is emitted only where the server itself
+ * pinned the arity and closed the tail, because that renders as bounded
+ * `prefixItems` — the one positional shape measured as accepted, and the same
+ * shape a first-party builtin already ships. Everything else keeps the
+ * permissive array and gains the positional shape in its description.
+ *
+ * The subtlety worth stating, because it inverts the intuition: positional
+ * `items`/`prefixItems` does not constrain LENGTH. Without `minItems` the
+ * server is permitting a SHORTER array, and a tuple cannot express that — so
+ * an absent lower bound is a reason to fall back, not a detail to round up.
+ */
+function positionalToZod(
+	positional: readonly unknown[],
+	schema: Record<string, unknown>,
+	depth: number,
+): z.ZodType {
+	// draft-07 spells the tail rule `additionalItems`; 2020-12 spells it
+	// `items`, which is only a tail rule when `prefixItems` holds the members.
+	const tail = Array.isArray(schema.items) ? schema.additionalItems : schema.items
+
+	const arity = positional.length
+	const pinnedLow = num(schema.minItems) === arity
+	const closedHigh = tail === false || num(schema.maxItems) === arity
+
+	if (arity === 0 || arity > MAX_TUPLE_ARITY || !pinnedLow || !closedHigh) {
+		// A ZodArray, deliberately: `applyConstraints` then carries the
+		// server's own `minItems`/`maxItems` onto it, so the loose case keeps
+		// whatever bounds the server did state.
+		return z.array(z.unknown()).describe(describePositional(positional))
+	}
+
+	const members = positional.map((member) => jsonSchemaPropertyToZod(member, depth + 1))
+	// Never `.rest()`. It renders a tail schema this wire has not been measured
+	// against, and the gate above has already established there is no tail.
+	return z.tuple(members as [z.ZodType, ...z.ZodType[]])
+}
+
+/** The positional shape in prose, for the cases a tuple cannot carry. */
+function describePositional(positional: readonly unknown[]): string {
+	const shape = positional
+		.map((member, index) => `[${index}] ${positionalTypeName(member)}`)
+		.join(', ')
+	return `Positional array — ${shape}.`
+}
+
+function positionalTypeName(member: unknown): string {
+	if (typeof member !== 'object' || member === null) return 'any'
+	const schema = member as Record<string, unknown>
+	if (schema.const !== undefined) return JSON.stringify(schema.const)
+	if (Array.isArray(schema.enum)) return schema.enum.map((v) => JSON.stringify(v)).join('|')
+	const type = Array.isArray(schema.type) ? schema.type.join('|') : schema.type
+	return typeof type === 'string' ? type : 'any'
 }
 
 /**

--- a/packages/sdk/src/manager/agent/lifecycle.ts
+++ b/packages/sdk/src/manager/agent/lifecycle.ts
@@ -296,6 +296,12 @@ export class AgentManager {
 				parentSpan: options.configOverrides?.parentSpan,
 				maxIterations: options.configOverrides?.maxIterations,
 				maxResponseTokens: options.configOverrides?.maxResponseTokens,
+				// A delegate spawned without a configBuilder lands here, and this
+				// list is the only thing it inherits. Omitting these meant a child
+				// silently ran at the default depth and effort its parent had
+				// deliberately moved off.
+				thinking: options.configOverrides?.thinking,
+				effort: options.configOverrides?.effort,
 				env: options.configOverrides?.env,
 				sessionId: spawnRecord.childSessionId,
 				threadId: context.threadId,

--- a/packages/sdk/src/provider/thinking-support.ts
+++ b/packages/sdk/src/provider/thinking-support.ts
@@ -1,4 +1,4 @@
-import type { ThinkingConfig } from '../types/provider/index.js'
+import type { ReasoningEffort, ThinkingConfig } from '../types/provider/index.js'
 
 /**
  * Refuse a thinking request a driver does not implement.
@@ -27,8 +27,25 @@ import type { ThinkingConfig } from '../types/provider/index.js'
  */
 export function assertThinkingUnsupported(
 	driverName: string,
-	params: { thinking?: ThinkingConfig },
+	params: { thinking?: ThinkingConfig; effort?: ReasoningEffort },
 ): void {
+	// `effort` is refused on exactly the same reasoning, and it is the worse
+	// silence of the two. A dropped `thinking` at least leaves an empty
+	// reasoning list a caller could notice; a dropped `effort` leaves a
+	// perfectly ordinary answer, so a run someone believes they paid for at
+	// `max` is indistinguishable from one at the model's default — including
+	// on the bill.
+	//
+	// Checked before thinking because it is the cheaper mistake to make: a
+	// caller reaching for effort on a driver without it has usually pointed a
+	// working config at a new provider, and naming the field they set beats
+	// naming the neighbouring one.
+	if (params.effort !== undefined) {
+		throw new Error(
+			`${driverName} does not implement effort. Silently ignoring it would return an ordinary completion, so a run requested at "${params.effort}" would be indistinguishable from one at the model's default — including in what it cost. Drop \`effort\`, or use a driver that implements it.`,
+		)
+	}
+
 	const type = params.thinking?.type
 	if (type !== 'enabled' && type !== 'adaptive') return
 	throw new Error(

--- a/packages/sdk/src/runtime/query/__tests__/context.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/context.test.ts
@@ -100,4 +100,28 @@ describe('RunContextFactory.build', () => {
 		const runDir = builder.runDir('prj_x' as ProjectId, 'ses_y' as SessionId, 'run_z' as RunId)
 		expect(posix(runDir)).toBe('/base/.namzu/projects/prj_x/sessions/ses_y/runs/run_z')
 	})
+
+	it("carries the caller's stop reason across into the run", () => {
+		// This is the frame that was losing it. The host aborts with a
+		// sentence, the run re-aborts with nothing, and every layer below —
+		// the tool executor, the tool itself, the result the model reads —
+		// can only report that something stopped. The words do not survive
+		// the hop unless this site forwards them.
+		const host = new AbortController()
+		const ctx = RunContextFactory.build(buildConfig({ signal: host.signal }))
+
+		host.abort(new Error('nightly window closed'))
+
+		expect(ctx.abortController.signal.aborted).toBe(true)
+		expect((ctx.abortController.signal.reason as Error)?.message).toBe('nightly window closed')
+	})
+
+	it('still aborts when the caller gave no reason', () => {
+		const host = new AbortController()
+		const ctx = RunContextFactory.build(buildConfig({ signal: host.signal }))
+
+		host.abort()
+
+		expect(ctx.abortController.signal.aborted).toBe(true)
+	})
 })

--- a/packages/sdk/src/runtime/query/__tests__/effort-reaches-the-wire.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/effort-reaches-the-wire.test.ts
@@ -1,0 +1,135 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { MockLLMProvider } from '../../../provider/mock.js'
+import { ToolRegistry } from '../../../registry/tool/execute.js'
+import { createUserMessage } from '../../../types/message/index.js'
+import type { AgentRunConfig } from '../../../types/run/index.js'
+import { drainQuery } from '../index.js'
+
+/**
+ * `effort` was declared on the provider params, exported, and read by a driver
+ * that wrote it straight to the wire — and nothing in the kernel ever set it.
+ * No caller could reach it, and the symptom (every request going out at the
+ * model's default) reads as "this model ignores effort" rather than "nobody
+ * plumbed it through".
+ *
+ * These drive a real run and read what the provider was actually handed, which
+ * is the only thing that distinguishes a wired field from a declared one. A
+ * test asserting the field exists on the config type would have passed against
+ * the broken version.
+ */
+
+let workdirs: string[] = []
+
+afterEach(async () => {
+	await Promise.all(workdirs.map((d) => rm(d, { recursive: true, force: true })))
+	workdirs = []
+})
+
+async function run(overrides: Partial<AgentRunConfig>, turns: unknown[]): Promise<MockLLMProvider> {
+	const provider = new MockLLMProvider({ turns: turns as never })
+	const dir = await mkdtemp(join(tmpdir(), 'namzu-effort-'))
+	workdirs.push(dir)
+
+	await drainQuery({
+		provider,
+		tools: new ToolRegistry(),
+		runConfig: {
+			model: 'mock-model',
+			timeoutMs: 30_000,
+			tokenBudget: 100_000,
+			maxIterations: 2,
+			...overrides,
+		},
+		agentId: 'agent_effort',
+		agentName: 'Effort Agent',
+		workingDirectory: dir,
+		sessionId: 'ses_effort',
+		threadId: 'thd_effort',
+		projectId: 'prj_effort',
+		tenantId: 'tnt_effort',
+		messages: [createUserMessage('go')],
+	} as never)
+
+	return provider
+}
+
+describe('an effort level set on the run reaches the provider', () => {
+	it('arrives on the request', async () => {
+		const provider = await run({ effort: 'max' }, [{ text: 'done' }])
+
+		expect(provider.requests.length).toBeGreaterThan(0)
+		expect(provider.requests[0]?.effort).toBe('max')
+	})
+
+	it('is absent when nobody asked for one', async () => {
+		// Not `undefined`-valued but genuinely absent: a present key carrying
+		// undefined is the kind of thing that survives a spread into a request
+		// body and reaches a wire that did not expect the field.
+		const provider = await run({}, [{ text: 'done' }])
+
+		expect(provider.requests[0] && 'effort' in provider.requests[0]).toBe(false)
+	})
+
+	it('rides every turn of the run, not only the first', async () => {
+		// The value is run-level because the provider documents that changing
+		// it between requests invalidates the cached prefix. A run that
+		// forwarded it once and then stopped would pay that cost silently.
+		const provider = await run({ effort: 'low' }, [{ text: 'one' }, { text: 'two' }])
+
+		for (const request of provider.requests) {
+			expect(request.effort).toBe('low')
+		}
+	})
+
+	it('travels alongside thinking rather than inside it', async () => {
+		const provider = await run({ effort: 'high', thinking: { type: 'adaptive' } }, [
+			{ text: 'done' },
+		])
+
+		expect(provider.requests[0]?.effort).toBe('high')
+		expect(provider.requests[0]?.thinking?.type).toBe('adaptive')
+	})
+})
+
+describe('the front door forwards it too, not only the kernel', () => {
+	/**
+	 * These exist because everything above passed while a real run put NOTHING
+	 * on the wire.
+	 *
+	 * `drainQuery` takes the run config a caller hands it, so testing through
+	 * it proves the loop forwards the field and nothing about whether a caller
+	 * can set it. Every ergonomic entry point — this one, `ReactiveAgent`,
+	 * `SupervisorAgent`, and the manager's bare-config branch — builds its
+	 * `AgentRunConfig` by HAND-LISTING fields, so a field nobody remembered to
+	 * add is dropped in silence, with no cast to blame and no error to see.
+	 * `thinking` had been in that state since it shipped.
+	 *
+	 * It was found by watching an actual HTTP body, which is the only place the
+	 * gap is visible. So the regression test drives the front door.
+	 */
+	it('reaches the provider through runAgent', async () => {
+		const { runAgent } = await import('../../../agents/runAgent.js')
+		const provider = new MockLLMProvider({ turns: [{ text: 'done' }] as never })
+		const dir = await mkdtemp(join(tmpdir(), 'namzu-effort-door-'))
+		workdirs.push(dir)
+
+		await runAgent({
+			provider,
+			model: 'mock-model',
+			prompt: 'go',
+			workingDirectory: dir,
+			effort: 'xhigh',
+			thinking: { type: 'adaptive' },
+			timeoutMs: 30_000,
+			tokenBudget: 100_000,
+			maxIterations: 2,
+		})
+
+		expect(provider.requests.length).toBeGreaterThan(0)
+		expect(provider.requests[0]?.effort, 'the front door dropped effort').toBe('xhigh')
+		expect(provider.requests[0]?.thinking?.type, 'the front door dropped thinking').toBe('adaptive')
+	})
+})

--- a/packages/sdk/src/runtime/query/__tests__/tool-timeout.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/tool-timeout.test.ts
@@ -177,6 +177,44 @@ describe('ToolExecutor — per-tool deadline', () => {
 		expect(batch.results[0]?.output).toContain('was cancelled')
 	})
 
+	it('says WHICH stop it was, when the caller named one', async () => {
+		// The reason was on this signal all along — it is forwarded into the
+		// per-tool controller a few lines above the message — and the message
+		// threw it away. So a deadline, a budget and an operator pressing stop
+		// all reached the model as the same four words, and they want
+		// different next moves: one is worth waiting out, one is worth
+		// narrowing the input for, and one is worth stopping over.
+		const controller = new AbortController()
+		const h = harness({
+			toolTimeoutMs: 60_000,
+			abortSignal: controller.signal,
+			run: never,
+		})
+		const pending = h.exec.executeBatch(response('hang'))
+		controller.abort(new Error('deployment window closed'))
+		const batch = await pending
+
+		expect(batch.results[0]?.output).toContain('deployment window closed')
+	})
+
+	it('does not invent a reason when the caller gave none', async () => {
+		// `abort()` with no argument fills `reason` with a DOMException named
+		// AbortError. Rendering it would turn an honest silence into something
+		// that reads like an explanation, which is the worse failure.
+		const controller = new AbortController()
+		const h = harness({
+			toolTimeoutMs: 60_000,
+			abortSignal: controller.signal,
+			run: never,
+		})
+		const pending = h.exec.executeBatch(response('hang'))
+		controller.abort()
+		const batch = await pending
+
+		expect(batch.results[0]?.output).toContain('was cancelled.')
+		expect(batch.results[0]?.output).not.toContain('AbortError')
+	})
+
 	it('exposes a sane default deadline', () => {
 		// Documented so a change is a deliberate decision, not a drift.
 		expect(DEFAULT_TOOL_TIMEOUT_MS).toBe(120_000)

--- a/packages/sdk/src/runtime/query/context.ts
+++ b/packages/sdk/src/runtime/query/context.ts
@@ -134,7 +134,22 @@ export class RunContextFactory {
 	static build(config: RunContextConfig): RunContext {
 		const abortController = new AbortController()
 		if (config.signal) {
-			config.signal.addEventListener('abort', () => abortController.abort(), { once: true })
+			// Forward the caller's REASON, not just the fact of the abort.
+			//
+			// This used to be a bare `abort()`. Every word a host attached to
+			// its stop — a deadline name, a budget, an operator's message —
+			// died one frame above the executor, so the most a tool result
+			// could say was "was cancelled". A run that ends for a nameable
+			// reason is a run someone can debug; this is the frame where the
+			// name was being thrown away.
+			//
+			// `createChildAbortController` already does exactly this, but it
+			// takes an AbortController and what arrives here is a bare
+			// AbortSignal, so the reason is forwarded by hand rather than by
+			// reaching for a helper that does not fit.
+			config.signal.addEventListener('abort', () => abortController.abort(config.signal?.reason), {
+				once: true,
+			})
 		}
 
 		const cwd = config.workingDirectory ?? process.cwd()

--- a/packages/sdk/src/runtime/query/executor.ts
+++ b/packages/sdk/src/runtime/query/executor.ts
@@ -33,6 +33,7 @@ import type {
 	ToolCallRepair,
 	ToolCallRepairReason,
 } from '../../types/tool/repair.js'
+import { abortReasonText } from '../../utils/abort.js'
 import { toErrorMessage } from '../../utils/error.js'
 import type { Logger } from '../../utils/logger.js'
 import { compressShellOutput } from '../../utils/shell-compress.js'
@@ -859,10 +860,19 @@ export class ToolExecutor {
 			}
 
 			if (outcome === 'aborted') {
+				// Say WHY, when the caller said why. The reason has been
+				// available on this signal all along — it is forwarded into
+				// `controller` a few lines above — and the message threw it
+				// away, so a deadline, a budget and an operator pressing stop
+				// were all reported to the model with the same four words.
+				// Those want different next moves.
+				const why = abortReasonText(controller.signal.reason)
 				return {
 					success: false,
 					output: '',
-					error: `Tool "${toolName}" was cancelled.`,
+					error: why
+						? `Tool "${toolName}" was cancelled: ${why}`
+						: `Tool "${toolName}" was cancelled.`,
 				}
 			}
 

--- a/packages/sdk/src/runtime/query/iteration/index.ts
+++ b/packages/sdk/src/runtime/query/iteration/index.ts
@@ -317,6 +317,7 @@ export class IterationOrchestrator {
 						maxTokens: step.maxResponseTokens ?? runConfig.maxResponseTokens,
 						cacheControl: { type: 'auto' },
 						...(runConfig.thinking ? { thinking: runConfig.thinking } : {}),
+						...(runConfig.effort ? { effort: runConfig.effort } : {}),
 						// Thread the run abort into the model call so a Stop tears the
 						// in-flight turn down (provider passes it to fetch; the consumer
 						// also races it). Inert when never aborted.
@@ -1154,6 +1155,10 @@ export class IterationOrchestrator {
 					maxTokens: this.ctx.runConfig.maxResponseTokens,
 					cacheControl: { type: 'auto' },
 					...(this.ctx.runConfig.thinking ? { thinking: this.ctx.runConfig.thinking } : {}),
+					// This turn is a hand-maintained duplicate of the one above, which
+					// is exactly the shape a field goes missing from — so it is tested
+					// separately rather than assumed to have been kept in step.
+					...(this.ctx.runConfig.effort ? { effort: this.ctx.runConfig.effort } : {}),
 					// Cancellable too: a Stop during the closing summary must not
 					// stream to completion.
 					signal: this.ctx.abortController.signal,

--- a/packages/sdk/src/telemetry/__tests__/model-call-span.test.ts
+++ b/packages/sdk/src/telemetry/__tests__/model-call-span.test.ts
@@ -2,6 +2,10 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MockLLMProvider } from '../../provider/mock.js'
+import { ToolRegistry } from '../../registry/tool/execute.js'
+import { drainQuery } from '../../runtime/query/index.js'
+import { createUserMessage } from '../../types/message/index.js'
 
 /**
  * There was no span around the model call at all.
@@ -72,12 +76,25 @@ afterEach(async () => {
 	workdirs = []
 })
 
+/**
+ * These four are imported at module scope on purpose, and must stay there.
+ *
+ * They used to be `await import(...)` inside this function, which meant the
+ * query runtime's module graph — 75 imports deep — was loaded on the clock of
+ * whichever test called it first. Measured: that test took 1349ms on an idle
+ * machine while its eight siblings took 13-16ms, and under CPU load it hit
+ * vitest's 5000ms default and went red. Nothing about it was racy and nothing
+ * about it was slow; a load cost was simply billed to the wrong clock.
+ *
+ * At module scope the same work happens during collection, which carries no
+ * per-test deadline, so the wall time is unchanged and the deadline is not.
+ *
+ * Safe because `vi.mock` is hoisted above every import in this file, so a
+ * static import still receives the mocked `runtime-accessors`. That is a
+ * property of the transform rather than of import order — verified by running,
+ * not assumed, since no other file in this package had done it this way.
+ */
 async function runOnce(turns: { text?: string }[]): Promise<void> {
-	const { MockLLMProvider } = await import('../../provider/mock.js')
-	const { ToolRegistry } = await import('../../registry/tool/execute.js')
-	const { drainQuery } = await import('../../runtime/query/index.js')
-	const { createUserMessage } = await import('../../types/message/index.js')
-
 	const dir = await mkdtemp(join(tmpdir(), 'namzu-chatspan-'))
 	workdirs.push(dir)
 

--- a/packages/sdk/src/telemetry/__tests__/span-closure.test.ts
+++ b/packages/sdk/src/telemetry/__tests__/span-closure.test.ts
@@ -1,5 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
+// Imported at module scope on purpose, and must stay there.
+//
+// This was `await import(...)` repeated inside all five test bodies. That
+// billed the tool-registry module graph to whichever test happened to run
+// first, out of that test's own 5000ms deadline — and because every body
+// re-entered the same pending import, a stall did not fail one test, it took
+// the whole file down. At module scope the load happens during collection,
+// which has no per-test deadline.
+//
+// `vi.mock` is hoisted above every import here, so the static form still
+// receives the mocked `runtime-accessors`.
+import { ToolRegistry } from '../../registry/tool/execute.js'
 
 /**
  * A span that never ends is a trace that never closes, and the export is
@@ -73,7 +85,6 @@ afterEach(() => {
 
 describe('a tool span closes however the call leaves', () => {
 	it('closes on the ordinary path', async () => {
-		const { ToolRegistry } = await import('../../registry/tool/execute.js')
 		const tools = new ToolRegistry()
 		tools.register({
 			name: 'echo',
@@ -89,7 +100,6 @@ describe('a tool span closes however the call leaves', () => {
 	})
 
 	it('closes when the tool throws', async () => {
-		const { ToolRegistry } = await import('../../registry/tool/execute.js')
 		const tools = new ToolRegistry()
 		tools.register({
 			name: 'boom',
@@ -106,7 +116,6 @@ describe('a tool span closes however the call leaves', () => {
 	})
 
 	it('closes when input validation refuses the call', async () => {
-		const { ToolRegistry } = await import('../../registry/tool/execute.js')
 		const tools = new ToolRegistry()
 		tools.register({
 			name: 'strict',
@@ -121,7 +130,6 @@ describe('a tool span closes however the call leaves', () => {
 	})
 
 	it('closes when the tool is not active', async () => {
-		const { ToolRegistry } = await import('../../registry/tool/execute.js')
 		const tools = new ToolRegistry()
 		tools.register(
 			{
@@ -139,7 +147,6 @@ describe('a tool span closes however the call leaves', () => {
 	})
 
 	it('closes when the registry does not hold the name at all', async () => {
-		const { ToolRegistry } = await import('../../registry/tool/execute.js')
 		const tools = new ToolRegistry()
 
 		// `getOrThrow` sat OUTSIDE the try that owned the finally, so this

--- a/packages/sdk/src/types/agent/base.ts
+++ b/packages/sdk/src/types/agent/base.ts
@@ -25,6 +25,23 @@ export interface BaseAgentConfig {
 	env?: Record<string, string>
 
 	/**
+	 * Thinking mode and response-effort level for every model call this agent
+	 * makes. See {@link import('../run/config.js').AgentRunConfig} for what
+	 * each one controls and why they are siblings.
+	 *
+	 * They are declared HERE, on the shared base, rather than on each agent
+	 * config that happens to want them. Every agent builds its `AgentRunConfig`
+	 * by hand-listing fields, and a field absent from a hand-listed literal is
+	 * dropped in silence — which is exactly how `thinking` came to be settable
+	 * only through the raw kernel entry point while every ergonomic one quietly
+	 * ignored it. Putting them on the base is what makes "did you forget to
+	 * forward it" a type error in the places that matter rather than a support
+	 * question.
+	 */
+	thinking?: import('../provider/index.js').ThinkingConfig
+	effort?: import('../provider/index.js').ReasoningEffort
+
+	/**
 	 * Deduplicate a retried invocation instead of running it twice.
 	 *
 	 * The failure this exists for: a caller sends a request, the

--- a/packages/sdk/src/types/run/config.ts
+++ b/packages/sdk/src/types/run/config.ts
@@ -18,6 +18,32 @@ export interface AgentRunConfig {
 	 * driver omits them rather than sending a request it knows will 400.
 	 */
 	thinking?: import('../provider/index.js').ThinkingConfig
+
+	/**
+	 * How much work the model should spend on each call in the run.
+	 *
+	 * A SIBLING of {@link AgentRunConfig.thinking}, not a field inside it.
+	 * On some models the two are independent controls that apply together —
+	 * effort shapes the answer while a budget sets thinking depth — so
+	 * nesting one inside the other would make that combination unsayable.
+	 *
+	 * The failure this closes is the one this codebase keeps finding: the
+	 * field existed on the provider params, a driver already read it and
+	 * wrote it to the wire, and nothing in the kernel ever set it. So a
+	 * caller could not reach it at all, and the symptom — every request
+	 * going out at the model's default — reads as "this model ignores
+	 * effort" rather than "nobody plumbed it through".
+	 *
+	 * Run-level rather than per-step, deliberately. It is a property of what
+	 * the run is FOR, and a value that moves between steps buys a different
+	 * answer shape at the cost of the prompt-cache prefix on every step that
+	 * changes it.
+	 *
+	 * A driver that cannot honour it REFUSES rather than dropping it, on the
+	 * same reasoning as `thinking`: paying for a run you believe was
+	 * high-effort and silently was not is worse than a startup error.
+	 */
+	effort?: import('../provider/index.js').ReasoningEffort
 	tokenBudget: number
 	costLimitUsd?: number
 	maxIterations?: number

--- a/packages/sdk/src/utils/__tests__/abort-reason.test.ts
+++ b/packages/sdk/src/utils/__tests__/abort-reason.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { abortReasonText } from '../abort.js'
+
+/**
+ * A cancellation and a deadline arrive by the same mechanism and mean opposite
+ * things to whoever reads the result. The distinction only survives if the
+ * words a caller attached travel with the abort — and only if the words the
+ * platform invents on a caller's behalf do NOT, because a fabricated
+ * explanation is worse than an honest silence.
+ */
+
+describe('a stop carries the words its caller gave it', () => {
+	it('reports a reason someone wrote', () => {
+		expect(abortReasonText(new Error('deployment window closed'))).toBe('deployment window closed')
+	})
+
+	it('reports a named deadline, which is the case this exists for', () => {
+		const reason = new Error('run budget of 30000ms exhausted')
+		expect(abortReasonText(reason)).toBe('run budget of 30000ms exhausted')
+	})
+})
+
+describe('a stop with nothing to say stays silent', () => {
+	it('says nothing for a bare abort()', () => {
+		// `abort()` with no argument fills `reason` with a DOMException named
+		// AbortError. Nobody wrote that word; it is the platform's way of
+		// saying the caller gave no reason, and rendering it would turn "we
+		// do not know" into what looks like an answer.
+		const controller = new AbortController()
+		controller.abort()
+
+		expect(controller.signal.reason).toBeInstanceOf(Error)
+		expect((controller.signal.reason as Error).name).toBe('AbortError')
+		expect(abortReasonText(controller.signal.reason)).toBeUndefined()
+	})
+
+	it('says nothing for a platform timeout', () => {
+		const timeout = new Error('The operation was aborted due to timeout')
+		timeout.name = 'TimeoutError'
+		expect(abortReasonText(timeout)).toBeUndefined()
+	})
+
+	it('says nothing for a non-Error reason', () => {
+		// The agent manager aborts a child with the bare string 'canceled'.
+		// Rendering it produces "was cancelled: canceled" — noise wearing the
+		// shape of information.
+		expect(abortReasonText('canceled')).toBeUndefined()
+		expect(abortReasonText(undefined)).toBeUndefined()
+		expect(abortReasonText({ message: 'not an Error' })).toBeUndefined()
+	})
+
+	it('says nothing for an Error whose message is empty', () => {
+		expect(abortReasonText(new Error('   '))).toBeUndefined()
+	})
+})

--- a/packages/sdk/src/utils/abort.ts
+++ b/packages/sdk/src/utils/abort.ts
@@ -1,3 +1,37 @@
+import { toErrorMessage } from './error.js'
+
+/**
+ * The words a caller attached to a stop, or nothing when there were none.
+ *
+ * A cancellation and a deadline arrive by the same mechanism and mean opposite
+ * things to whoever reads the result. "Was cancelled" tells a model that
+ * something outside it decided, and nothing about what — so a tool result
+ * could not distinguish an operator pressing stop from a budget running out
+ * from a parent abandoning a child, and every one of those wants a different
+ * next move.
+ *
+ * Two kinds of reason are deliberately reported as no reason:
+ *
+ * - `AbortError` and `TimeoutError`. `abort()` with no argument fills `reason`
+ *   with a DOMException named `AbortError`, so it is not a message anybody
+ *   wrote; it is the platform's word for "someone stopped and said nothing".
+ *   Rendering it would turn today's honest silence into a fake explanation.
+ * - Anything that is not an `Error`. The agent manager aborts a child with the
+ *   bare string `'canceled'`, which would otherwise render as "was cancelled:
+ *   canceled" — noise wearing the shape of information.
+ *
+ * Name-checked rather than checked by class, because a reason can cross a
+ * package boundary where `instanceof` stops holding across duplicate copies.
+ * That is the same answer this codebase already settled on for provider
+ * errors.
+ */
+export function abortReasonText(reason: unknown): string | undefined {
+	if (!(reason instanceof Error)) return undefined
+	if (reason.name === 'AbortError' || reason.name === 'TimeoutError') return undefined
+	const text = toErrorMessage(reason).trim()
+	return text.length > 0 ? text : undefined
+}
+
 export function createChildAbortController(parent: AbortController): AbortController {
 	const child = new AbortController()
 


### PR DESCRIPTION
Closes the last four tasks on the list. Each was investigated, then attacked by a second agent told to refute it — **all four proposals came back refuted**, and in every case the refuter was right. What ships is smaller and more measured than what was proposed.

## The one that matters: a live run disagreed with four passing tests

`effort` was on the provider params, exported, and read by a driver that put it on the wire — with nothing in the kernel ever setting it. Adding it to `AgentRunConfig` and forwarding it at both model calls made four unit tests pass. Then a real run, with `fetch` intercepted:

```
model calls observed: 3
params carrying effort: 0
bodies carrying output_config.effort: 0
```

`runAgent`, `ReactiveAgent`, `SupervisorAgent` and the agent manager's bare-config branch each assemble their run config by **hand-listing fields**, so a field nobody remembered to add is dropped in silence — no cast to blame, no error, no warning. **`thinking` had been in exactly that state since it shipped**: settable on an agent config, and never asked for.

Both now live on `BaseAgentConfig` and all four sites forward them. After the fix: 3/3 params and 3/3 HTTP bodies carry it. The regression test drives the **front door**, not `drainQuery`, because the kernel was never the broken half.

## A stack overflow reachable from any bridged server

`MAX_CONVERSION_DEPTH` never fired. The only comparison lived in `objectToZod`, which a pure array or union never reaches, and the counter was not even threaded down the array path. A 5000-deep schema from a remote tool listing took the process down — against a comment promising precisely the opposite. The tuple work was the smaller half of this task.

## A positional array keeps its positions, narrowly

A tuple is emitted **only** where the server pinned the arity and closed the tail, because that renders as bounded `prefixItems`. Measured live: that shape is accepted; the same schema unconverted is refused with the 2020-12 dialect error. A rejected tool schema fails the whole request rather than degrading one tool, so a faithful conversion the wire will not take is strictly worse than a lossy one it will.

Everything looser keeps the permissive array and gains its shape in the description, **appended** to the server's own sentence rather than replacing it.

The inversion worth knowing: positional members do not constrain length. An absent `minItems` means the server permits a *shorter* array, which a tuple cannot express — a reason to fall back, not a detail to round up.

## A stop that says which stop it was

`context.ts` re-aborted with a bare `abort()`, so every word a host attached to its stop died one frame above the executor and "was cancelled" was all a tool result could say. The reason is forwarded now, and `abortReasonText` refuses to invent one: a bare `abort()` fills `reason` with a DOMException nobody wrote, and the agent manager aborts with the bare string `'canceled'`, which would have rendered "was cancelled: canceled".

## A flake that was a load cost billed to the wrong clock

`model-call-span.test.ts` imported the query runtime **inside** the test body, so 75 imports of module-graph load came out of that test's 5000ms deadline. Idle: 1349ms for test 1, 13–16ms for its siblings. Hoisted to module scope, where the load happens during collection — which carries no per-test deadline. Same fix in `span-closure.test.ts`, where the import sat in all five bodies, so a stall took the whole file down rather than one test.

Verified both directions under 32 CPU hogs on 32 cores: fixed = 14/14 pass; reverted = the exact reported signature, `Test timed out in 5000ms` on test 1 only.

## Verification

The live contract tests **actually ran** this time — 191 → 194 in the anthropic package — and the two new measurements are contract tests rather than comments:

- `claude-sonnet-4-6` answers `xhigh` with *"This model does not support effort level 'xhigh'. Supported levels: high, low, max, medium"* and accepts `max`. That is the `max`-without-`xhigh` pairing the capability table exists to express, and reading the levels as a ladder is what put a wrong row in it.
- Bounded `prefixItems` is accepted; the unconverted spelling is not.

**One stated limit.** The preview model 404s for the tenant the live suite runs against, so its capability row is sourced from the reference and *not* measured. The row says so in the code. The pairing it claims is measured, on a model that has it.

Gates: typecheck 0 · lint clean · 2642 SDK + 194 anthropic (live included) + every other suite green · external-name audit clean · mutation checks on all five fixes, each failing exactly the intended tests.
