### PR TITLE
feat(cli): a conversation can be reopened from a script

### DIFF
--- a/.changeset/a-conversation-can-be-reopened-from-a-script.md
+++ b/.changeset/a-conversation-can-be-reopened-from-a-script.md
@@ -1,0 +1,27 @@
+---
+'@namzu/cli': minor
+---
+
+`namzu run --continue` and `--resume <id>` reopen a previous conversation
+
+The store, the reader and the picker all existed — a conversation you could
+reopen inside the TUI with `/resume` could not be reopened from a script,
+because only the entry point was missing.
+
+`--continue` takes the most recent conversation in the working directory;
+`--resume <id>` takes the one you name.
+
+**Both refuse when the conversation cannot be reopened, and neither ever falls
+back to starting a new one.** Someone who types `--resume` is asking for *that*
+conversation; silently starting a fresh one hands back something
+indistinguishable from what they asked for, and they find out several turns
+later having already acted on it. Resuming with a partial transcript is worse
+still — a half-context is not a degraded context, it is a different context that
+lies about being complete.
+
+The refusal names the cause rather than the outcome, because the causes have
+different fixes: "no previous conversation in /path" points at `--cwd`, which is
+usually the real mistake, while an unknown id says how many others are there.
+
+There is deliberately no way to spell "resume if you can, otherwise start" — run
+with no flag for that.

--- a/docs/cli/headless.md
+++ b/docs/cli/headless.md
@@ -206,3 +206,32 @@ The direction is deliberate. The config file is written once, read by whoever
 reviews the repository, and changed on purpose; a flag is typed in a hurry by
 someone who wants to get on with it. A prohibition a flag can lift is not a
 prohibition.
+
+## Resuming a conversation
+
+```bash
+namzu run --continue "and now the integration tests"
+namzu run --resume ses_abc123 "what did we decide about the cache?"
+```
+
+`--continue` takes the most recent conversation in the working directory;
+`--resume <id>` takes the one you name and no other. `namzu history` lists what
+is there.
+
+**Both refuse when the conversation cannot be reopened, and say why. Neither
+ever falls back to starting a new one.**
+
+That is deliberate, and it is the important part. Someone who types `--resume`
+is asking for *that* conversation. Silently starting a fresh one hands back
+something indistinguishable from what they asked for, and they discover it
+several turns later having already acted on an agent that has no idea what they
+are referring to. Resuming with a partial transcript is worse still: a
+half-context is not a degraded context, it is a different context that lies
+about being complete.
+
+The refusal names the cause, because the causes have different fixes — "no
+previous conversation in /path" points at `--cwd`, which is usually the real
+mistake, while a bad id lists how many other conversations are there.
+
+There is no way to spell "resume if you can, otherwise start". Run the command
+with no flag if that is what you want.

--- a/packages/cli/src/commands/__tests__/resume.test.ts
+++ b/packages/cli/src/commands/__tests__/resume.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Resuming a conversation, and — mostly — refusing to.
+ *
+ * The rule under test: when the named conversation cannot be resumed, this
+ * REFUSES and names the cause. It never falls back to a fresh session, and it
+ * never resumes with a partial history.
+ *
+ * Both fallbacks would be invisible from outside. The user asked for a specific
+ * conversation, would get something that looks like one, and would find out
+ * several turns later having already acted on it. A half-context is the worse
+ * of the two: it is not a degraded context, it is a different context that lies
+ * about being complete.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+
+import type { CliSessions } from '../../integrations/sessions/store.js'
+import { listRecent, loadConversation } from '../../integrations/sessions/store.js'
+import { resolveResume } from '../resume.js'
+
+vi.mock('../../integrations/sessions/store.js', () => ({
+	listRecent: vi.fn(),
+	loadConversation: vi.fn(),
+}))
+
+const sessions = {} as CliSessions
+const CWD = '/projects/foo'
+
+function recent(...ids: string[]) {
+	vi.mocked(listRecent).mockResolvedValue(
+		ids.map((id, i) => ({
+			id: id as never,
+			title: id,
+			updatedAt: `2026-08-0${i + 1}T00:00:00Z`,
+			count: 2,
+		})),
+	)
+}
+
+describe('asking for nothing', () => {
+	it('is a fresh run, not an error', async () => {
+		const out = await resolveResume(sessions, { continueLast: false, sessionId: null }, CWD)
+
+		expect(out.kind).toBe('fresh')
+	})
+})
+
+describe('--continue', () => {
+	it('takes the most recent conversation', async () => {
+		recent('ses_new', 'ses_old')
+		vi.mocked(loadConversation).mockResolvedValue([
+			{ role: 'user', content: 'hi', timestamp: 0 },
+		] as never)
+
+		const out = await resolveResume(sessions, { continueLast: true, sessionId: null }, CWD)
+
+		expect(out).toMatchObject({ kind: 'resumed', sessionId: 'ses_new' })
+	})
+
+	it('refuses with its OWN sentence when there is nothing here', async () => {
+		// Not "cannot resume" — the cause is different and so is the fix. Someone
+		// with no conversation here is usually standing in the wrong directory,
+		// so the message has to point at --cwd rather than at a broken store.
+		recent()
+
+		const out = await resolveResume(sessions, { continueLast: true, sessionId: null }, CWD)
+
+		expect(out.kind).toBe('error')
+		expect(out).toMatchObject({ message: expect.stringContaining('no previous conversation') })
+		expect(out).toMatchObject({ message: expect.stringContaining(CWD) })
+		expect(out).toMatchObject({ message: expect.stringContaining('--cwd') })
+	})
+})
+
+describe('--resume <id>', () => {
+	it('takes the conversation it was given, not the most recent', async () => {
+		recent('ses_new', 'ses_wanted')
+		vi.mocked(loadConversation).mockResolvedValue([
+			{ role: 'user', content: 'hi', timestamp: 0 },
+		] as never)
+
+		const out = await resolveResume(sessions, { continueLast: false, sessionId: 'ses_wanted' }, CWD)
+
+		expect(out).toMatchObject({ kind: 'resumed', sessionId: 'ses_wanted' })
+	})
+
+	it('refuses an id that is not here, and says how many are', async () => {
+		// THE case. Starting fresh would hand back something indistinguishable
+		// from what was asked for.
+		recent('ses_a', 'ses_b')
+
+		const out = await resolveResume(sessions, { continueLast: false, sessionId: 'ses_gone' }, CWD)
+
+		expect(out.kind).toBe('error')
+		expect(out).toMatchObject({ message: expect.stringContaining('ses_gone') })
+		expect(out).toMatchObject({ message: expect.stringContaining('2 others') })
+	})
+
+	it('points at --cwd when the directory has nothing at all', async () => {
+		recent()
+
+		const out = await resolveResume(sessions, { continueLast: false, sessionId: 'ses_gone' }, CWD)
+
+		expect(out).toMatchObject({ message: expect.stringContaining('--cwd') })
+	})
+
+	it('refuses rather than resuming with a partial history', async () => {
+		// The half-context case. Carrying on with an empty transcript would look
+		// exactly like a resumed session to the user and to the model.
+		recent('ses_a')
+		vi.mocked(loadConversation).mockRejectedValue(new Error('transcript is corrupt'))
+
+		const out = await resolveResume(sessions, { continueLast: false, sessionId: 'ses_a' }, CWD)
+
+		expect(out.kind).toBe('error')
+		expect(out).toMatchObject({ message: expect.stringContaining('transcript is corrupt') })
+	})
+
+	it('refuses an empty transcript rather than calling it resumed', async () => {
+		recent('ses_a')
+		vi.mocked(loadConversation).mockResolvedValue([])
+
+		const out = await resolveResume(sessions, { continueLast: false, sessionId: 'ses_a' }, CWD)
+
+		expect(out.kind).toBe('error')
+		expect(out).toMatchObject({ message: expect.stringContaining('no messages') })
+	})
+})
+
+describe('the two flags together', () => {
+	it('refuses, because they name different conversations', async () => {
+		const out = await resolveResume(sessions, { continueLast: true, sessionId: 'ses_a' }, CWD)
+
+		expect(out.kind).toBe('error')
+		expect(out).toMatchObject({ message: expect.stringContaining('Pass one') })
+	})
+})
+
+describe('no store at all', () => {
+	it('refuses instead of quietly starting fresh', async () => {
+		const out = await resolveResume(null, { continueLast: true, sessionId: null }, CWD)
+
+		expect(out.kind).toBe('error')
+		expect(out).toMatchObject({ message: expect.stringContaining('nothing to resume') })
+	})
+
+	it('still runs fresh when nothing was asked for', async () => {
+		const out = await resolveResume(null, { continueLast: false, sessionId: null }, CWD)
+
+		expect(out.kind).toBe('fresh')
+	})
+})

--- a/packages/cli/src/commands/resume.ts
+++ b/packages/cli/src/commands/resume.ts
@@ -1,0 +1,140 @@
+/**
+ * Picking up a previous conversation from the command line.
+ *
+ * The store, the reader and the picker all existed; only the entry point was
+ * missing, so a conversation you could resume inside the TUI could not be
+ * resumed from a script.
+ *
+ * ## What happens when it cannot be done
+ *
+ * **It refuses, and names the cause. It never falls back to a new session.**
+ *
+ * Someone who types `--resume <id>` is asking for THAT conversation. The three
+ * available answers are not equally good:
+ *
+ * - *Start fresh* is the worst. They asked for a specific thing, got a
+ *   different thing that is indistinguishable from outside, and nothing
+ *   failed — they find out several turns later, having already acted on an
+ *   agent that has no idea what they are referring to.
+ * - *Resume with whatever survived* is worse still. The agent gets a partial
+ *   history and neither it nor the user knows which part is missing, so it acts
+ *   confidently on a hole. A half-context is not a degraded context; it is a
+ *   different context that lies about being complete.
+ * - *Refuse* costs one command and loses nothing.
+ *
+ * The message names the CAUSE rather than the outcome, because the causes have
+ * different next moves — a conversation belonging to another directory is
+ * fixed with `--cwd`, and an empty store is not fixed at all. "Cannot resume"
+ * alone sends someone hunting through a store that is fine.
+ *
+ * There is deliberately no way to spell "resume if you can, otherwise start".
+ * If that is what you want, run the command with no flag. The absence of a
+ * thing must not be spellable as a silent widening of it.
+ */
+
+import type { Message } from '@namzu/sdk'
+
+import {
+	type CliSessions,
+	type RecentConversation,
+	listRecent,
+	loadConversation,
+} from '../integrations/sessions/store.js'
+
+export interface ResumeRequest {
+	/** `--continue`: the most recent conversation in this directory. */
+	readonly continueLast: boolean
+	/** `--resume <id>`: this conversation, and no other. */
+	readonly sessionId: string | null
+}
+
+export type ResumeOutcome =
+	| { readonly kind: 'fresh' }
+	| { readonly kind: 'resumed'; readonly sessionId: string; readonly messages: readonly Message[] }
+	| { readonly kind: 'error'; readonly message: string }
+
+/**
+ * Resolve what a `--continue` / `--resume` asked for.
+ *
+ * `cwd` is carried only so a refusal can name the directory it looked in — the
+ * most common cause of "no previous session" is standing in the wrong one, and
+ * a message that does not say where it looked cannot tell you that.
+ */
+export async function resolveResume(
+	sessions: CliSessions | null,
+	request: ResumeRequest,
+	cwd: string,
+): Promise<ResumeOutcome> {
+	if (!request.continueLast && !request.sessionId) return { kind: 'fresh' }
+	if (request.continueLast && request.sessionId) {
+		return {
+			kind: 'error',
+			message:
+				'--continue and --resume ask for different conversations: --continue takes the most recent, --resume takes the one you named. Pass one.',
+		}
+	}
+	if (!sessions) {
+		return {
+			kind: 'error',
+			message: `no conversation store in ${cwd} — it could not be opened, so there is nothing to resume`,
+		}
+	}
+
+	const recent = await listRecent(sessions, 50)
+
+	if (request.continueLast) {
+		const latest = recent[0]
+		if (!latest) {
+			// Its own sentence, because the cause is different from a bad id and
+			// so is the fix. Someone with no session here is usually standing in
+			// the wrong directory, and `--cwd` is the next thing to try.
+			return {
+				kind: 'error',
+				message: `no previous conversation in ${cwd} — run without --continue to start one, or pass --cwd if you meant a different directory`,
+			}
+		}
+		return await load(sessions, latest)
+	}
+
+	const wanted = request.sessionId as string
+	const match = recent.find((c) => c.id === wanted)
+	if (!match) {
+		const known = recent.length
+		return {
+			kind: 'error',
+			message:
+				known === 0
+					? `no conversation "${wanted}" in ${cwd}, and no others either — pass --cwd if you meant a different directory`
+					: `no conversation "${wanted}" in ${cwd}. ${known} other${known === 1 ? '' : 's'} here; \`namzu history\` lists them`,
+		}
+	}
+	return await load(sessions, match)
+}
+
+async function load(
+	sessions: CliSessions,
+	conversation: RecentConversation,
+): Promise<ResumeOutcome> {
+	let messages: readonly Message[]
+	try {
+		messages = await loadConversation(sessions, conversation.id)
+	} catch (err) {
+		// Reading the transcript failed after the conversation was found. NOT
+		// recoverable by carrying on with an empty history: that is the
+		// half-context case, and it would look to the user exactly like a
+		// session that had been resumed.
+		return {
+			kind: 'error',
+			message: `conversation "${conversation.id}" could not be read: ${
+				err instanceof Error ? err.message : String(err)
+			}`,
+		}
+	}
+	if (messages.length === 0) {
+		return {
+			kind: 'error',
+			message: `conversation "${conversation.id}" has no messages to resume — its transcript is empty`,
+		}
+	}
+	return { kind: 'resumed', sessionId: conversation.id, messages }
+}

--- a/packages/cli/src/commands/run-flags.ts
+++ b/packages/cli/src/commands/run-flags.ts
@@ -33,6 +33,10 @@ export interface RunFlags {
 	permissionMode: string | null
 	/** --yolo / --dangerously-skip-permissions was given. */
 	skipPermissions: boolean
+	/** --continue: pick up the most recent conversation here. */
+	continueLast: boolean
+	/** --resume <id>: pick up this conversation and no other. */
+	resume: string | null
 	skills: string[]
 	/**
 	 * `--flags` this parser does not know.
@@ -55,6 +59,8 @@ export function parseRunFlags(rawArgs: readonly string[]): RunFlags {
 		cwd: null,
 		permissionMode: null,
 		skipPermissions: false,
+		continueLast: false,
+		resume: null,
 		skills: [],
 		unknown: [],
 		rest: [],
@@ -97,6 +103,21 @@ export function parseRunFlags(rawArgs: readonly string[]): RunFlags {
 				'permission-mode',
 				trimmed((v) => {
 					out.permissionMode = v
+				}),
+				idx,
+			)
+		)
+			continue
+		if (a === '--continue' || a === '-c') {
+			out.continueLast = true
+			continue
+		}
+		if (
+			take(
+				a,
+				'resume',
+				trimmed((v) => {
+					out.resume = v
 				}),
 				idx,
 			)

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -17,12 +17,14 @@
  */
 
 import { configureLogger } from '@namzu/sdk'
-import type { StopReason } from '@namzu/sdk'
+import type { Message, StopReason } from '@namzu/sdk'
 
 import { EXIT_USAGE } from '../exit-codes.js'
 import type { DetectedProvider, Preferences, ProviderId } from '../integrations/providers/index.js'
+import { openSessions } from '../integrations/sessions/store.js'
 import { resolvePermissionMode } from '../permissions/mode.js'
 import { compilePermissions } from '../permissions/rules.js'
+import { resolveResume } from './resume.js'
 import {
 	loadSkillsContext,
 	parseRunFlags,
@@ -123,6 +125,8 @@ export const runCommand: CommandDef = {
 		'  --provider <id>       Provider to answer with',
 		'  --model <id>          Model to answer with',
 		'  --skills <a,b,c>      Load these skills as context for the turn',
+		'  --continue, -c        Resume the most recent conversation here',
+		'  --resume <id>         Resume that conversation, and no other',
 		'  --permission-mode <m> prompt | auto | strict — what happens to a call',
 		'                        no [permissions] rule decided (default: auto)',
 		'  --                    End of options; the rest is the prompt verbatim',
@@ -132,6 +136,10 @@ export const runCommand: CommandDef = {
 		'strict for an unattended run that must refuse anything no rule allowed.',
 		'',
 		'A mode only decides calls no rule decided: it can never reopen a deny.',
+		'',
+		'--continue and --resume refuse when the conversation cannot be reopened,',
+		'and say why. Neither ever falls back to starting a new one: run with no',
+		'flag if that is what you want.',
 		'',
 		'Needs a provider. Set a credential in the environment, or run namzu',
 		'once to pick one interactively.',
@@ -218,11 +226,39 @@ export const runCommand: CommandDef = {
 
 		const extraSystem = await loadSkillsContext(resolved.cwd, flags.skills)
 
+		// A conversation the TUI could reopen could not be reopened from a
+		// script: the store, the reader and the picker all existed and only the
+		// entry point was missing.
+		let sessions: Awaited<ReturnType<typeof openSessions>> | null = null
+		if (flags.continueLast || flags.resume) {
+			try {
+				sessions = await openSessions(resolved.cwd)
+			} catch {
+				sessions = null // reported by resolveResume, which knows what was asked for
+			}
+		}
+		const resume = await resolveResume(
+			sessions,
+			{ continueLast: flags.continueLast, sessionId: flags.resume },
+			resolved.cwd,
+		)
+		if (resume.kind === 'error') {
+			// Refused, never silently started fresh. Someone who asked for a
+			// specific conversation and got a new one that looks the same finds
+			// out several turns later, having already acted on it.
+			ctx.formatter.error({ message: resume.message })
+			return EXIT_USAGE
+		}
+		const prior: readonly Message[] = resume.kind === 'resumed' ? resume.messages : []
+		if (resume.kind === 'resumed') {
+			ctx.formatter.info(`resuming ${resume.sessionId} · ${prior.length} messages`)
+		}
+
 		let text = ''
 		let failed: string | null = null
 		let stopReason: StopReason | undefined
 		for await (const event of session.send(
-			[{ role: 'user', content: prompt, timestamp: Date.now() }],
+			[...prior, { role: 'user', content: prompt, timestamp: Date.now() }],
 			extraSystem ? { extraSystem } : undefined,
 		)) {
 			if (event.kind === 'delta') text += event.text


### PR DESCRIPTION
The store, the reader and the picker all existed. A conversation you could reopen inside the TUI with `/resume` could not be reopened from a script, because only the entry point was missing.

```bash
namzu run --continue "and now the integration tests"
namzu run --resume ses_abc123 "what did we decide about the cache?"
```

`--continue` takes the most recent conversation in the working directory; `--resume <id>` takes the one you name and no other.

## The load-bearing decision: it refuses, and never falls back

**When the conversation cannot be reopened, this refuses and names the cause. It never starts a fresh session instead, and never resumes with a partial transcript.**

The three available answers are not equally good:

- **Start fresh** is the worst. They asked for a specific conversation, got a different thing that is indistinguishable from outside, and nothing failed — they find out several turns later, having already acted on an agent that has no idea what they are referring to.
- **Resume with whatever survived** is worse still. The agent gets a partial history and neither it nor the user knows which part is missing, so it acts confidently on a hole. *A half-context is not a degraded context; it is a different context that lies about being complete.*
- **Refuse** costs one command and loses nothing.

This is the same defect class as `--cwd` and the inert permission flag: the run does not fail, it succeeds while quietly not doing what the operator said.

## The refusal names the cause, not the outcome

Because the causes have different next moves. `--continue` with nothing to continue gets its own sentence — "no previous conversation in `<dir>`" — which points at `--cwd`, usually the real mistake. "Cannot resume" would send someone hunting through a store that is fine. An unknown id instead says how many other conversations are there, and that `namzu history` lists them.

Same discipline as a rule denial quoting the rule: a refusal is only useful if it tells you where to look next.

## Deliberately un-spellable

There is no way to express "resume if you can, otherwise start". Run with no flag for that. It is the same shape as `ask` emitting no rule — the absence of a thing must not be spellable as a silent widening of it. If that behaviour is ever wanted it should be its own explicitly named flag, never a fallback path inside `--resume`.

## Testing

11 tests on the resolver, every one a refusal path except two. The two that matter most are the ones that would otherwise be indistinguishable from success: a transcript that fails to load, and a conversation whose transcript is empty. Both refuse rather than continuing with nothing.

367 tests in the package, typecheck, biome from inside the package, external-name audit — all green.

## A negative result on the run-config tip

Checked whether the CLI drops run-config fields the way `runAgent` did. `tui/agent.ts` does hand-list six of `AgentRunConfig`'s fields — but the CLI exposes no `thinking`, `effort` or `temperature` anywhere a user can set, so nothing is being dropped. The surface is narrow, not lossy.

The latent version is real and worth recording: the hand-list means a field added to `AgentRunConfig` later is invisible here with no signal. Not fixed speculatively, because there is no user-facing surface to connect it to yet.
