### PR TITLE
feat(cli)!: --instance is removed, because it never did anything

### DIFF
--- a/.changeset/instance-was-a-lie-in-the-surface.md
+++ b/.changeset/instance-was-a-lie-in-the-surface.md
@@ -1,0 +1,31 @@
+---
+'@namzu/cli': minor
+---
+
+`--instance` is removed, because it never did anything
+
+`run` and `run-stream` parsed `--instance <name>` into a field that nothing in
+the repository read. Its own comment said it chose "which namzu persona
+answers"; no persona selection exists. A host that passed it got the behaviour
+it asked for exactly never, and was told exactly nothing.
+
+That is worse than an absent flag. An absent flag reports itself the moment you
+use it. A flag that parses and is discarded reports nothing until someone
+notices the behaviour they asked for never happened — which for a persona
+selector could be a long time, or never.
+
+**What breaks:** `namzu run --instance x "…"` and `namzu run-stream --instance x
+"…"` now fail with `unknown option(s): --instance` — exit 64 for `run`, an
+in-band error event for `run-stream`. Remove the flag from the invocation;
+nothing else changes, because nothing else ever depended on it.
+
+**Why no deprecation window.** SemVer's guidance is to precede a removal with a
+release that warns, so working code has a version where it still compiles. That
+exists to protect code that WORKS. There is no working code to protect here: the
+flag had no producer, no reader and no runtime effect, and the repository's
+release rule says such a declaration may be removed outright provided the
+changeset says so. This one says so.
+
+It was not wired instead, because wiring it would mean inventing persona
+selection to justify a flag that was already there — which is how dead
+configuration gets written rather than removed.

--- a/packages/cli/src/commands/__tests__/run-flags.test.ts
+++ b/packages/cli/src/commands/__tests__/run-flags.test.ts
@@ -215,3 +215,17 @@ describe('the pipe reaches the model, not just the composer', () => {
 		})
 	})
 })
+
+describe('a flag that was never read is refused, not swallowed', () => {
+	// `--instance` was parsed into a field nothing anywhere in the repo read.
+	// A host passing it got the persona selection it asked for exactly never,
+	// and was told exactly nothing — which is worse than an absent flag,
+	// because an absent flag says so immediately.
+	it('refuses --instance now that it means nothing', async () => {
+		const { code, errors } = await run(['--instance', 'namzu-2', 'hello'])
+
+		expect(code).toBe(EXIT_USAGE)
+		expect(errors.join('')).toContain('--instance')
+		expect(seen.prompt).toBeNull()
+	})
+})

--- a/packages/cli/src/commands/run-flags.ts
+++ b/packages/cli/src/commands/run-flags.ts
@@ -26,7 +26,6 @@ export interface RunFlags {
 	session: string | null
 	model: string | null
 	provider: string | null
-	instance: string | null
 	/** Where the agent works: filesystem tools, sub-agents, session store, skills. */
 	cwd: string | null
 	/** How calls no `[permissions]` rule decided are resolved: prompt/auto/strict. */
@@ -55,7 +54,6 @@ export function parseRunFlags(rawArgs: readonly string[]): RunFlags {
 		session: null,
 		model: null,
 		provider: null,
-		instance: null,
 		cwd: null,
 		permissionMode: null,
 		skipPermissions: false,
@@ -151,17 +149,6 @@ export function parseRunFlags(rawArgs: readonly string[]): RunFlags {
 				'provider',
 				trimmed((v) => {
 					out.provider = v
-				}),
-				idx,
-			)
-		)
-			continue
-		if (
-			take(
-				a,
-				'instance',
-				trimmed((v) => {
-					out.instance = v
 				}),
 				idx,
 			)


### PR DESCRIPTION
`run` and `run-stream` parsed `--instance <name>` into a field that **nothing in the repository read**. Its own comment said it chose "which namzu persona answers"; no persona selection exists. A host that passed it got the behaviour it asked for exactly never, and was told exactly nothing.

## Why removing beats leaving it

A flag that parses and is discarded is **worse than an absent flag**. An absent flag reports itself the moment you use it. An inert one reports nothing until someone notices the behaviour they asked for never happened — which for a persona selector could be a long time, or never.

It is the same defect as a `--cwd` that parsed and never reached the agent (#127), with the failure moved out of the run and into the operator's model of what the run does.

## Why removing beats wiring

Wiring it would mean inventing persona selection to justify a flag that was already there. That is how dead configuration gets written instead of removed — the same reasoning that kept me from building a CLI surface for `effort` just to justify fixing a hand-listed run config.

## What breaks

`namzu run --instance x "…"` and `namzu run-stream --instance x "…"` now fail with `unknown option(s): --instance` — exit 64 for `run`, an in-band error event for `run-stream`. Remove the flag from the invocation; nothing else changes, because nothing else ever depended on it.

**No deprecation window.** SemVer's guidance is to precede a removal with a release that warns, so working code has a version where it still compiles. That exists to protect code that *works*, and there is none here: no producer, no reader, no runtime effect. The repository's release rule permits an outright removal provided the changeset says so, and it does.

## Verified before acting

Re-grepped the package: set in four places in `run-flags.ts`, read in none. The other `instance` hits are clawtool peer-agent identifiers, an unrelated concept.

One test asserts the flag is now refused rather than swallowed. 367 tests, typecheck, biome from inside the package, external-name audit — all green.
