### PR TITLE
feat(sdk): a rule can name its argument, and a compaction reports both outcomes

### DIFF
--- a/.changeset/a-compaction-that-sheds-nothing-says-so.md
+++ b/.changeset/a-compaction-that-sheds-nothing-says-so.md
@@ -1,0 +1,42 @@
+---
+'@namzu/sdk': minor
+---
+
+A compaction pass now reports both of its outcomes.
+
+Two gaps, in opposite directions, in the same function.
+
+**A compaction that sheds nothing was invisible to everyone.** All three decline
+paths — the reducer throws, it returns no fewer messages than it was given, or
+its result splits a `tool_use` from its `tool_result` and is refused wholesale —
+reached a log line and stopped there. A host that silences its logger, which
+every command-line entry point does, made a failed compaction invisible to the
+user, to the host *and* to the model at once. The run then continued at full
+context toward a provider rejection several turns later that named none of this.
+A shed that did not happen is exactly as consequential as one that did, and only
+one of them was on the wire.
+
+New `compaction_failed` event (wire: `compaction.failed`) carrying `cause`
+(`reducer_threw` | `shed_nothing` | `split_tool_pair`), the unchanged message
+count, and the reducer's error where there was one. The cause is on the event
+because the three want different responses: one may succeed next pass, one will
+decline identically every time, and one is a reducer bug that `findSafeTrimIndex`
+exists to prevent.
+
+**And a compaction that succeeded was invisible on the path most hosts take.**
+`compaction_completed` was emitted only from the structured working-state path.
+The reducer path — taken by any host-supplied `contextReducer` and by
+`strategy: 'sliding-window'` — emitted nothing at all, so the event whose own
+documentation says it exists because "a host could not show the user that context
+was dropped" never reached the hosts most likely to need it. It is emitted from
+both paths now.
+
+That second one was found by a test written for the first: asserting that a
+successful compaction does *not* report a failure is what showed it reported
+nothing.
+
+**If you switch exhaustively over `RunEvent`, you need a case for
+`compaction_failed`.** Nothing else changes: no existing event's shape moved, and
+a host that ignores unknown events is unaffected. The A2A bridge deliberately
+does not forward either compaction event — a peer models a task lifecycle and
+cannot act on how this runtime manages its own context.

--- a/.changeset/a-rule-can-name-a-tool-and-an-argument.md
+++ b/.changeset/a-rule-can-name-a-tool-and-an-argument.md
@@ -1,0 +1,34 @@
+---
+'@namzu/sdk': minor
+---
+
+A verification rule can name one tool and one argument.
+
+Every pattern rule an operator could write was one of two wrong things.
+
+`custom_pattern` carries no tool scope, so a rule written about `bash` decided
+`edit` calls as well — `target: 'both'` prefixes the tool name to the subject
+rather than requiring it, which is not a scope. And `target: 'args'` tests
+`JSON.stringify(toolInput)`, so the subject is the JSON *text* of the whole
+argument object: the natural, anchored thing to write, `^git push`, is tested
+against `{"command":"git push origin main"}` and can never match. The rule then
+decides nothing, silently. Pinning the tool cost the anchor; anchoring cost the
+tool scope.
+
+New `argument_pattern` rule — `toolNames`, `argument`, `pattern`, `decision` —
+whose subject is the named argument's own value, so an anchored pattern means
+what it looks like it means. The refusal names the argument as well as the
+pattern, which is what tells a model whether a different value could get through.
+
+It deliberately decides nothing in three cases: the tool was not called, the
+argument is absent, or the argument holds an object or an array. No string a
+pattern could match says anything true about a structured value, and serialising
+one to try would put this rule back where `custom_pattern` already is. To refuse
+a tool over the *shape* of its input, deny it by name. Numbers and booleans are
+matched rather than skipped — they render unambiguously, and a rule about a
+numeric argument is a reasonable thing to write.
+
+`custom_pattern` is unchanged and not deprecated: matching anywhere in the
+serialised input without caring where is a real use, and it is now documented as
+being that rather than reading as something it never was. The trap was the name,
+not the behaviour.

--- a/packages/sdk/src/bridge/a2a/mapper.ts
+++ b/packages/sdk/src/bridge/a2a/mapper.ts
@@ -188,6 +188,10 @@ const MAPPING: {
 	// Context management is kernel-internal bookkeeping; A2A peers model a
 	// task lifecycle, not the host runtime's memory strategy.
 	compaction_completed: null,
+	// Compaction, succeeded or declined, is a property of how this runtime
+	// manages its own context. A peer models a task lifecycle and cannot act on
+	// either outcome.
+	compaction_failed: null,
 	// A refusal is the run's own policy decision; the peer sees it in the
 	// terminal task state, not as a separate signal.
 	guardrail_triggered: null,

--- a/packages/sdk/src/bridge/sse/mapper.ts
+++ b/packages/sdk/src/bridge/sse/mapper.ts
@@ -92,6 +92,21 @@ const MAPPING: {
 		}),
 	},
 
+	// Carried for the same reason its sibling is: a host that can show a user
+	// context was dropped must also be able to show them it was not, because a
+	// run continuing at full context is the state that ends in an opaque
+	// provider rejection later.
+	compaction_failed: {
+		wire: 'compaction.failed',
+		transform: (e, runId) => ({
+			run_id: runId,
+			iteration: e.iteration,
+			cause: e.cause,
+			messages: e.messages,
+			...(e.error !== undefined ? { error: e.error } : {}),
+		}),
+	},
+
 	tool_executing: {
 		wire: 'tool.executing',
 		transform: (e, runId) => ({

--- a/packages/sdk/src/contracts/api.ts
+++ b/packages/sdk/src/contracts/api.ts
@@ -155,6 +155,7 @@ export type StreamEventType =
 	 * transcript needs to know its middle was dropped, not infer it.
 	 */
 	| 'compaction.completed'
+	| 'compaction.failed'
 	/** A guardrail refused or corrected the run. */
 	| 'guardrail.triggered'
 	/**

--- a/packages/sdk/src/run/reporter.ts
+++ b/packages/sdk/src/run/reporter.ts
@@ -270,6 +270,18 @@ export function createRunReporter(parentLogger?: Logger): RunReporter {
 				})
 				break
 
+			case 'compaction_failed':
+				// warn rather than info: the run is now continuing at a context
+				// size it had already decided was too large.
+				log.warn('Context compaction shed nothing', {
+					runId: event.runId,
+					iteration: event.iteration,
+					cause: event.cause,
+					messages: event.messages,
+					...(event.error !== undefined ? { error: event.error } : {}),
+				})
+				break
+
 			case 'capability_warning':
 				log.warn('Provider capability mismatch', {
 					runId: event.runId,

--- a/packages/sdk/src/runtime/query/iteration/phases/__tests__/compaction-declined.test.ts
+++ b/packages/sdk/src/runtime/query/iteration/phases/__tests__/compaction-declined.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ContextReduction } from '../../../../../compaction/reducer.js'
+import type { Message } from '../../../../../types/message/index.js'
+import type { RunEvent } from '../../../../../types/run/index.js'
+import { getRootLogger } from '../../../../../utils/logger.js'
+import { runCompactionCheck } from '../compaction.js'
+import type { IterationContext } from '../context.js'
+
+/**
+ * A shed that did not happen is exactly as consequential as one that did, and
+ * only one of them was on the wire.
+ *
+ * All three decline paths reached a log line and stopped there. Every
+ * command-line entry point silences the logger, so the outcome was invisible to
+ * the user, to the host AND to the model at once — and the run carried on at
+ * full context toward a provider rejection several turns later that named none
+ * of this.
+ *
+ * Each path is driven separately rather than one being tested and the rest
+ * assumed. "The other branches presumably do the same" is the reasoning that
+ * put the gap here.
+ */
+
+const user = (content: string): Message => ({ role: 'user', content, timestamp: 1 })
+
+function context(reducer: IterationContext['contextReducer']): {
+	ctx: IterationContext
+	events: RunEvent[]
+	messages: Message[]
+} {
+	const events: RunEvent[] = []
+	// Enough messages that the trigger fires against the tiny window below.
+	const messages: Message[] = Array.from({ length: 12 }, (_, i) => user(`m${i} ${'x'.repeat(400)}`))
+
+	const ctx = {
+		runMgr: { id: 'run_dec', messages, currentIteration: 3 },
+		runConfig: { model: 'mock-model' },
+		compactionConfig: {
+			strategy: 'custom',
+			triggerThreshold: 0.1,
+			contextWindowTokens: 100,
+			keepRecentMessages: 2,
+		},
+		contextReducer: reducer,
+		log: getRootLogger(),
+		emitEvent: async (event: RunEvent) => {
+			events.push(event)
+		},
+	} as unknown as IterationContext
+
+	return { ctx, events, messages }
+}
+
+const failure = (
+	events: RunEvent[],
+): Extract<RunEvent, { type: 'compaction_failed' }> | undefined =>
+	events.find((e): e is Extract<RunEvent, { type: 'compaction_failed' }> => {
+		return e.type === 'compaction_failed'
+	})
+
+describe('a compaction that sheds nothing says so', () => {
+	it('reports a reducer that threw, and carries its message', async () => {
+		const { ctx, events, messages } = context(() => {
+			throw new Error('summariser call failed')
+		})
+		const before = messages.length
+
+		await runCompactionCheck(ctx)
+
+		const event = failure(events)
+		expect(event, 'the throw was swallowed into a log line').toBeDefined()
+		expect(event?.cause).toBe('reducer_threw')
+		expect(event?.error).toContain('summariser call failed')
+		expect(event?.messages).toBe(before)
+		expect(messages.length, 'the history must be untouched').toBe(before)
+	})
+
+	it('reports a reducer that shed nothing', async () => {
+		// Distinct from the others in what it means: every later pass will
+		// decline identically, so a host seeing this repeatedly knows the
+		// reducer's floor disagrees with the trigger rather than that something
+		// intermittent is happening.
+		const { ctx, events, messages } = context((reduction: ContextReduction) => [
+			...reduction.messages,
+		])
+		const before = messages.length
+
+		await runCompactionCheck(ctx)
+
+		expect(failure(events)?.cause).toBe('shed_nothing')
+		expect(messages.length).toBe(before)
+	})
+
+	it('reports a result refused for splitting a tool pair', async () => {
+		const { ctx, events, messages } = context(() => [
+			{
+				role: 'assistant',
+				content: null,
+				timestamp: 1,
+				toolCalls: [
+					{ id: 'call_1', type: 'function', function: { name: 'echo', arguments: '{}' } },
+				],
+			} as Message,
+		])
+		const before = messages.length
+
+		await runCompactionCheck(ctx)
+
+		expect(failure(events)?.cause).toBe('split_tool_pair')
+		expect(messages.length, 'a refused result must not be half-applied').toBe(before)
+	})
+
+	it('says nothing when the reducer actually sheds', async () => {
+		// The event must not fire on success, or a host cannot tell the two
+		// apart and the signal is worth nothing.
+		const { ctx, events } = context((reduction: ContextReduction) => reduction.messages.slice(-2))
+
+		await runCompactionCheck(ctx)
+
+		expect(failure(events)).toBeUndefined()
+		expect(events.some((e) => e.type === 'compaction_completed')).toBe(true)
+	})
+})

--- a/packages/sdk/src/runtime/query/iteration/phases/compaction.ts
+++ b/packages/sdk/src/runtime/query/iteration/phases/compaction.ts
@@ -221,10 +221,42 @@ function totalChars(messages: readonly { content: unknown }[]): number {
  * invariant is written on {@link ContextReducer}; enforcing it where it is
  * violated is what makes it true rather than aspirational.
  */
+/**
+ * Put a compaction that shed nothing on the wire.
+ *
+ * All three decline paths reached a log line and stopped there. Every
+ * command-line entry point silences the logger, so the outcome was invisible
+ * to the user, to the host and to the model at once — and the run carried on
+ * at full context toward a provider rejection several turns later that named
+ * none of this. A shed that did not happen is as consequential as one that
+ * did, and only one of them was observable.
+ *
+ * The history is untouched on every path, so this reports rather than repairs.
+ */
+async function declined(
+	ctx: IterationContext,
+	cause: 'reducer_threw' | 'shed_nothing' | 'split_tool_pair',
+	messages: number,
+	error?: string,
+): Promise<void> {
+	await ctx.emitEvent?.({
+		type: 'compaction_failed',
+		runId: ctx.runMgr.id,
+		iteration: ctx.runMgr.currentIteration,
+		cause,
+		messages,
+		...(error !== undefined ? { error } : {}),
+	})
+}
+
 async function applyReducer(
 	ctx: IterationContext,
 	reducer: ContextReducer,
 	reduction: ContextReduction,
+	measurement: {
+		measuredBy: 'provider' | 'estimate'
+		windowSource: 'config' | 'model-table' | 'default'
+	},
 ): Promise<void> {
 	const messages = ctx.runMgr.messages
 	const before = messages.length
@@ -234,11 +266,13 @@ async function applyReducer(
 	try {
 		next = await reducer(reduction)
 	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
 		ctx.log.warn('Context reducer threw — keeping the full history', {
 			runId: ctx.runMgr.id,
 			reason: reduction.reason,
-			error: error instanceof Error ? error.message : String(error),
+			error: message,
 		})
+		await declined(ctx, 'reducer_threw', before, message)
 		return
 	}
 
@@ -248,6 +282,7 @@ async function applyReducer(
 			reason: reduction.reason,
 			messages: before,
 		})
+		await declined(ctx, 'shed_nothing', before)
 		return
 	}
 
@@ -257,6 +292,7 @@ async function applyReducer(
 			reason: reduction.reason,
 			hint: 'use findSafeTrimIndex to move a cut off a tool_use/tool_result boundary',
 		})
+		await declined(ctx, 'split_tool_pair', before)
 		return
 	}
 
@@ -274,6 +310,28 @@ async function applyReducer(
 		oldMessageCount: before,
 		newMessageCount: messages.length,
 		charsShed: beforeChars - totalChars(messages),
+	})
+
+	// This path emitted NOTHING on success, and it is the path a host-supplied
+	// reducer and `strategy: 'sliding-window'` both take. So the event whose own
+	// docstring says it exists because "a host could not show the user that
+	// context was dropped" was never reaching the hosts most likely to need it —
+	// the same mechanism-exists-and-one-site-does-not-use-it shape as the
+	// silence on the decline paths above, in the opposite direction.
+	//
+	// Found by a test written for the decline paths asserting that success does
+	// NOT report a failure, which is the only reason anybody looked here.
+	await ctx.emitEvent?.({
+		type: 'compaction_completed',
+		runId: ctx.runMgr.id,
+		iteration: ctx.runMgr.currentIteration,
+		messagesBefore: before,
+		messagesAfter: messages.length,
+		tokensBefore: reduction.estimatedTokens,
+		tokensAfter: estimateMessageTokens(messages),
+		measuredBy: measurement.measuredBy,
+		contextWindowTokens: reduction.contextWindowTokens,
+		windowSource: measurement.windowSource,
 	})
 }
 
@@ -313,14 +371,19 @@ export async function runCompactionCheck(
 		ctx.contextReducer ??
 		(config.strategy === 'sliding-window' ? createSlidingWindowReducer() : undefined)
 	if (reducer) {
-		await applyReducer(ctx, reducer, {
-			messages: ctx.runMgr.messages,
-			reason: options?.force ? 'overflow' : 'threshold',
-			estimatedTokens,
-			contextWindowTokens: budget,
-			model: ctx.runConfig.model,
-			keepRecentMessages: config.keepRecentMessages,
-		})
+		await applyReducer(
+			ctx,
+			reducer,
+			{
+				messages: ctx.runMgr.messages,
+				reason: options?.force ? 'overflow' : 'threshold',
+				estimatedTokens,
+				contextWindowTokens: budget,
+				model: ctx.runConfig.model,
+				keepRecentMessages: config.keepRecentMessages,
+			},
+			{ measuredBy: measured.source, windowSource: window.source },
+		)
 		return
 	}
 

--- a/packages/sdk/src/types/run/events.ts
+++ b/packages/sdk/src/types/run/events.ts
@@ -85,6 +85,48 @@ type CoreRunEvent =
 			 */
 			reachedResetThreshold?: boolean
 	  }
+	/**
+	 * A compaction pass ran and shed nothing, so the history is unchanged.
+	 *
+	 * A shed that did not happen is exactly as consequential as one that did,
+	 * and until this existed only one of them was on the wire. The three
+	 * decline paths all reached a log line — and a host that silences its
+	 * logger, which every command-line entry point does, made a failed
+	 * compaction invisible to the user, to the host AND to the model. The run
+	 * then continued at full context toward a provider rejection several turns
+	 * later that named none of this.
+	 *
+	 * The history is guaranteed untouched on every one of these: the reducer's
+	 * result is installed whole or not at all, so there is no partial state to
+	 * reason about. That is the property that makes reporting sufficient and a
+	 * repair unnecessary.
+	 */
+	| {
+			type: 'compaction_failed'
+			runId: RunId
+			iteration: number
+			/**
+			 * Which decline path was taken. These want different responses, so
+			 * a single "it failed" would put the reader back where the silence
+			 * did:
+			 *
+			 * - `reducer_threw` — the reducer raised. Usually a bug or a failed
+			 *   model call inside a summarising reducer; the next pass may work.
+			 * - `shed_nothing` — it returned no fewer messages than it was
+			 *   given. The history is already at its floor, or the reducer's
+			 *   own threshold disagrees with the trigger's, and every later
+			 *   pass will decline identically.
+			 * - `split_tool_pair` — its result separated a `tool_use` from its
+			 *   `tool_result`, so it was refused wholesale rather than sent to
+			 *   a provider that rejects the pairing. A reducer bug, and one
+			 *   `findSafeTrimIndex` exists to prevent.
+			 */
+			cause: 'reducer_threw' | 'shed_nothing' | 'split_tool_pair'
+			/** Unchanged, and stated so a reader need not infer it. */
+			messages: number
+			/** Present only for `reducer_threw`. */
+			error?: string
+	  }
 	| {
 			type: 'tool_executing'
 			runId: RunId

--- a/packages/sdk/src/types/verification/index.ts
+++ b/packages/sdk/src/types/verification/index.ts
@@ -16,9 +16,60 @@ export type VerificationRule =
 	| { type: 'allow_by_name'; toolNames: string[] }
 	| { type: 'deny_by_name'; toolNames: string[] }
 	| {
+			/**
+			 * Match a regular expression against the tool's NAME, the
+			 * serialised arguments, or both concatenated.
+			 *
+			 * Read `target: 'args'` carefully before writing one: it tests
+			 * `JSON.stringify(toolInput)`, so the subject is the JSON TEXT of
+			 * the whole argument object — `{"command":"git push origin main"}`
+			 * — and not any single argument. The name suggests otherwise, and
+			 * that is what makes it a trap: an anchored pattern like
+			 * `^git push.*$` is a natural thing to write and can never match,
+			 * so the rule silently decides nothing. `'both'` PREFIXES the tool
+			 * name to that text rather than requiring it, so it is not a scope
+			 * either — a rule written with `bash` in mind still sees every
+			 * other tool's arguments.
+			 *
+			 * When you mean "this tool, this argument", use
+			 * {@link VerificationRule} `argument_pattern` instead. This one
+			 * stays for the case it is actually good at: matching anywhere in
+			 * the serialised input without caring where.
+			 */
 			type: 'custom_pattern'
 			pattern: string
 			target: 'name' | 'args' | 'both'
+			decision: 'allow' | 'deny'
+	  }
+	| {
+			/**
+			 * Match a regular expression against ONE named argument of ONE
+			 * named set of tools.
+			 *
+			 * This exists because `custom_pattern` could express neither half.
+			 * It carries no tool scope, so a rule an operator wrote about
+			 * `bash` decided `edit` calls too; and its argument target tests
+			 * the serialised object, so pinning the tool cost the ability to
+			 * anchor and anchoring cost the tool scope. Every pattern rule was
+			 * therefore one of those two wrong things.
+			 *
+			 * The subject here is the argument's own VALUE, so `^git push`
+			 * means what it looks like it means.
+			 *
+			 * A rule whose tool is not called, or whose argument is absent,
+			 * decides nothing — the rule's precondition simply is not met. So
+			 * does one whose argument holds an object or an array: a pattern
+			 * cannot say anything true about a structured value, and pretending
+			 * otherwise by matching its serialisation would reintroduce exactly
+			 * the confusion this rule was added to remove. If you need to
+			 * refuse a tool over the SHAPE of its input rather than a string in
+			 * it, deny it by name.
+			 */
+			type: 'argument_pattern'
+			toolNames: string[]
+			/** The argument key, at the top level of the tool's input. */
+			argument: string
+			pattern: string
 			decision: 'allow' | 'deny'
 	  }
 	| { type: 'allow_by_tier'; tiers: string[] }
@@ -43,6 +94,15 @@ const CustomPatternSchema = z.object({
 	target: z.enum(['name', 'args', 'both']),
 	decision: z.enum(['allow', 'deny']),
 })
+const ArgumentPatternSchema = z.object({
+	type: z.literal('argument_pattern'),
+	toolNames: z.array(z.string()).min(1),
+	// A rule that names no argument would silently apply to none, which is the
+	// fail-open shape this rule type exists to remove.
+	argument: z.string().min(1),
+	pattern: z.string().max(MAX_CUSTOM_PATTERN_LENGTH),
+	decision: z.enum(['allow', 'deny']),
+})
 const AllowByTierSchema = z.object({
 	type: z.literal('allow_by_tier'),
 	tiers: z.array(z.string()),
@@ -55,6 +115,7 @@ export const VerificationRuleSchema = z.discriminatedUnion('type', [
 	AllowByNameSchema,
 	DenyByNameSchema,
 	CustomPatternSchema,
+	ArgumentPatternSchema,
 	AllowByTierSchema,
 ])
 

--- a/packages/sdk/src/verification/__tests__/argument-pattern.test.ts
+++ b/packages/sdk/src/verification/__tests__/argument-pattern.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ToolDefinition } from '../../types/tool/index.js'
+import type { VerificationGateConfig, VerificationRule } from '../../types/verification/index.js'
+import { getRootLogger } from '../../utils/logger.js'
+import { VerificationGate } from '../gate.js'
+
+/**
+ * Every pattern rule an operator could write was one of two wrong things.
+ *
+ * `custom_pattern` carries no tool scope, so a rule written about `bash`
+ * decided `edit` calls as well. And `target: 'args'` tests
+ * `JSON.stringify(toolInput)`, so the subject is the JSON TEXT of the whole
+ * argument object — meaning the natural, anchored thing to write
+ * (`^git push.*$`) can never match, and the rule silently decides nothing.
+ * Pinning the tool cost the anchor; anchoring cost the tool scope.
+ */
+
+function gate(rules: VerificationGateConfig['rules']): VerificationGate {
+	return new VerificationGate(
+		{
+			enabled: true,
+			rules,
+			allowReadOnlyTools: false,
+			denyDangerousPatterns: false,
+			logDecisions: false,
+		} as VerificationGateConfig,
+		getRootLogger(),
+	)
+}
+
+/** Only the fields the gate reads. */
+function toolDef(name: string): ToolDefinition {
+	return { name, isReadOnly: () => false } as unknown as ToolDefinition
+}
+
+const PUSH_RULE: VerificationRule = {
+	type: 'argument_pattern',
+	toolNames: ['bash'],
+	argument: 'command',
+	pattern: '^git push',
+	decision: 'deny',
+}
+
+function evaluate(
+	rules: VerificationGateConfig['rules'],
+	toolName: string,
+	toolInput: unknown,
+): ReturnType<VerificationGate['evaluate']> {
+	return gate(rules).evaluate({ toolName, toolInput, toolDef: toolDef(toolName) })
+}
+
+describe('a rule can name one tool and one argument at once', () => {
+	it('denies the call it was written about', () => {
+		const result = evaluate([PUSH_RULE], 'bash', { command: 'git push origin main' })
+		expect(result.decision).toBe('deny')
+	})
+
+	it('anchors against the value, which is what the old rule could not do', () => {
+		// The whole defect in one assertion: this same pattern under
+		// `custom_pattern` with `target: 'args'` is tested against
+		// `{"command":"git push origin main"}`, where `^git push` cannot match
+		// because the string does not start there.
+		const viaOldRule = evaluate(
+			[{ type: 'custom_pattern', pattern: '^git push', target: 'args', decision: 'deny' }],
+			'bash',
+			{ command: 'git push origin main' },
+		)
+		expect(viaOldRule.decision, 'the old rule silently decided nothing').not.toBe('deny')
+
+		expect(evaluate([PUSH_RULE], 'bash', { command: 'git push origin main' }).decision).toBe('deny')
+	})
+
+	it('leaves a different tool alone', () => {
+		// The other half: a rule about `bash` used to decide `edit` too,
+		// because the pattern was matched against a serialisation that has no
+		// idea which tool produced it.
+		const result = evaluate([PUSH_RULE], 'edit', { command: 'git push origin main' })
+		expect(result.decision).not.toBe('deny')
+	})
+
+	it('leaves a different argument alone', () => {
+		const result = evaluate([PUSH_RULE], 'bash', { description: 'git push origin main' })
+		expect(result.decision).not.toBe('deny')
+	})
+
+	it('says which argument decided, so a model knows whether to reword', () => {
+		const result = evaluate([PUSH_RULE], 'bash', { command: 'git push origin main' })
+
+		expect(result.reason).toContain('command')
+		expect(result.reason).toContain('^git push')
+		expect(result.reason).toContain('bash')
+	})
+})
+
+describe('what it deliberately does not decide', () => {
+	it('decides nothing when the argument is absent', () => {
+		const result = evaluate([PUSH_RULE], 'bash', {})
+		expect(result.decision).not.toBe('deny')
+	})
+
+	it('decides nothing about a structured argument', () => {
+		// No string a pattern could match says anything true about an object,
+		// and serialising it to try would put this rule back where
+		// `custom_pattern` already is. An operator who needs to refuse a tool
+		// over the SHAPE of its input wants deny_by_name.
+		const rule: VerificationRule = { ...PUSH_RULE, argument: 'env', pattern: 'PROD' }
+		const result = evaluate([rule], 'bash', { env: { NODE_ENV: 'PROD' } })
+
+		expect(result.decision).not.toBe('deny')
+	})
+
+	it('reads a number or a boolean rather than skipping it', () => {
+		// These render unambiguously, so skipping them would be a fail-open
+		// with no upside: a rule about a numeric argument is a rule someone
+		// can reasonably write.
+		const rule: VerificationRule = {
+			type: 'argument_pattern',
+			toolNames: ['sleep'],
+			argument: 'seconds',
+			pattern: '^[0-9]{4,}$',
+			decision: 'deny',
+		}
+
+		expect(evaluate([rule], 'sleep', { seconds: 86400 }).decision).toBe('deny')
+		expect(evaluate([rule], 'sleep', { seconds: 5 }).decision).not.toBe('deny')
+	})
+})
+
+describe('a rule that cannot be compiled decides nothing at all', () => {
+	it('does not widen into a rule about the whole tool', () => {
+		// The failure this forbids: a typo'd regex turning "deny bash when its
+		// command matches X" into "deny bash" — a far larger authorization than
+		// anybody wrote, granted by a mistake nobody would notice.
+		//
+		// What actually secures it is the missing-pattern check at the top of
+		// `evaluateRule`, which returns before the tool name is consulted. The
+		// gate's construction order (compile first, only then record the names)
+		// is defence in depth and NOT the mechanism: reversing those two lines
+		// fails nothing, which was measured rather than assumed. So this test
+		// pins the OUTCOME and the comment in the gate says which line to keep.
+		const broken: VerificationRule = { ...PUSH_RULE, pattern: '([unclosed' }
+		const result = evaluate([broken], 'bash', { command: 'ls' })
+
+		expect(result.decision).not.toBe('deny')
+	})
+
+	it('is secured by the pattern check, not by the construction order', () => {
+		// The honest version of the mutation: remove the check that actually
+		// holds and this fails. A rule whose pattern never compiled has no
+		// pattern to test, so it must decide nothing even for a tool it names.
+		const broken: VerificationRule = { ...PUSH_RULE, pattern: '([unclosed' }
+
+		expect(evaluate([broken], 'bash', { command: 'git push origin main' }).decision).not.toBe(
+			'deny',
+		)
+	})
+})

--- a/packages/sdk/src/verification/gate.ts
+++ b/packages/sdk/src/verification/gate.ts
@@ -44,6 +44,14 @@ export function describeRule(rule: VerificationRule): string {
 			return `allowed by category (${rule.categories.join(', ')})`
 		case 'allow_by_tier':
 			return `allowed by tier (${rule.tiers.join(', ')})`
+		case 'argument_pattern': {
+			// Names the argument, not just the pattern. That is what tells a
+			// model whether a different value could get through — which is the
+			// difference between rewording once and rewording forever.
+			const verb = rule.decision === 'deny' ? 'denied' : 'allowed'
+			return `${verb} because the \`${rule.argument}\` argument matched ${rule.pattern} (this rule applies to ${rule.toolNames.join(', ')})`
+		}
+
 		case 'custom_pattern': {
 			const where = rule.target === 'both' ? 'name or arguments' : rule.target
 			const verb = rule.decision === 'deny' ? 'denied' : 'allowed'
@@ -119,6 +127,43 @@ export class VerificationGate {
 					this.compiledPatterns.set(i, new RegExp(rule.pattern))
 				} catch (err) {
 					this.log.warn('Invalid custom pattern regex, skipping', {
+						index: i,
+						pattern: rule.pattern,
+						error: err instanceof Error ? err.message : String(err),
+					})
+				}
+			}
+
+			if (rule.type === 'argument_pattern') {
+				// Needs BOTH, because it is the rule that names both.
+				//
+				// The name set is recorded only after the pattern compiles, so
+				// a rule with a typo'd regex leaves neither half behind. That
+				// ordering is defence in depth and NOT what makes the guarantee
+				// — `evaluateRule` returns null on a missing compiled pattern
+				// before it ever looks at the name set, so reversing these two
+				// lines changes no behaviour. Measured: reversing them fails no
+				// test, and the test that looks like it covers this is really
+				// covering the check in `evaluateRule`.
+				//
+				// Written down because the alternative is someone later reading
+				// the order as load-bearing and preserving it for the wrong
+				// reason, or removing the real check believing this one covers
+				// it.
+				if (rule.pattern.length > MAX_CUSTOM_PATTERN_LENGTH) {
+					this.log.warn('Argument pattern exceeds max length, skipping', {
+						index: i,
+						length: rule.pattern.length,
+						maxLength: MAX_CUSTOM_PATTERN_LENGTH,
+					})
+					continue
+				}
+				try {
+					const compiled = new RegExp(rule.pattern)
+					this.compiledPatterns.set(i, compiled)
+					this.nameSets.set(i, new Set(rule.toolNames))
+				} catch (err) {
+					this.log.warn('Invalid argument pattern regex, skipping', {
 						index: i,
 						pattern: rule.pattern,
 						error: err instanceof Error ? err.message : String(err),

--- a/packages/sdk/src/verification/rules.ts
+++ b/packages/sdk/src/verification/rules.ts
@@ -63,6 +63,34 @@ export function evaluateRule(
 			return compiledPattern.test(target) ? rule.decision : null
 		}
 
+		case 'argument_pattern': {
+			if (!compiledPattern) return null
+			if (!nameSet?.has(toolName)) return null
+
+			if (typeof toolInput !== 'object' || toolInput === null) return null
+			const value = (toolInput as Record<string, unknown>)[rule.argument]
+
+			// The subject is the argument's own value, which is the whole point
+			// — `^git push` here means what a reader expects, where the same
+			// pattern against the serialised object could never match.
+			//
+			// Numbers and booleans are rendered rather than skipped, because
+			// `String(4000)` is unambiguous and anchorable. Objects and arrays
+			// are NOT: no string a pattern could match says anything true about
+			// a structured value, and serialising one would put us back where
+			// `custom_pattern` already is. A rule about the shape of an input
+			// is a rule about the tool, and `deny_by_name` is where it belongs.
+			const subject =
+				typeof value === 'string'
+					? value
+					: typeof value === 'number' || typeof value === 'boolean'
+						? String(value)
+						: undefined
+			if (subject === undefined) return null
+
+			return compiledPattern.test(subject) ? rule.decision : null
+		}
+
 		case 'allow_by_tier': {
 			if (toolDef?.tier && rule.tiers.includes(toolDef.tier)) {
 				return 'allow'


### PR DESCRIPTION
Two reports from the agent building the command-line permission surface. It hit both, reported both, and worked around neither — which is why the second one turned out to be twice its stated size.

## A pattern rule could name a tool, or anchor an argument, never both

`custom_pattern` carries no tool scope, so a rule written about `bash` decided `edit` calls as well — `target: 'both'` *prefixes* the tool name to the subject rather than requiring it, which is not a scope. And `target: 'args'` tests `JSON.stringify(toolInput)`, so the natural anchored pattern is matched against the JSON text:

```
rule:    ^git push
subject: {"command":"git push origin main"}   ← can never match
```

Pinning the tool cost the anchor; anchoring cost the tool scope. So every pattern rule an operator could write was one of those two wrong things, and the failure mode was silence: the rule simply decided nothing.

`argument_pattern` names both, and its subject is the argument's own value. One test asserts the whole defect in one place — the same pattern under the old rule and the new one, against the same call.

It deliberately decides **nothing** for an object or array argument. No string a pattern could match says anything true about a structured value, and serialising one to try would put the rule back where `custom_pattern` already is. To refuse a tool over the *shape* of its input, deny it by name. Numbers and booleans are matched rather than skipped — they render unambiguously, and skipping would be a fail-open with no upside.

**A mutation that did not catch, and the honest response was to change the comment.** I wrote the gate to compile the regex before recording the tool names, and claimed in the comment that this ordering is what stops a typo'd regex widening *"deny bash when its command matches X"* into *"deny bash"*. Reversing the two lines fails no test. The real protection is the missing-pattern check at the top of `evaluateRule`, which returns before the name set is consulted — so my test was passing for a reason other than the one it named. The comment now says the ordering is defence in depth and **not** the mechanism, with the measurement stated, and a second test targets the check that actually holds.

## A compaction that shed nothing was invisible to everyone

All three decline paths in `applyReducer` — the reducer throws, it sheds nothing, its result splits a `tool_use`/`tool_result` pair and is refused wholesale — reached `ctx.log.warn` and stopped. Every command-line entry point sets the logger to silent, so a failed compaction was invisible to the user, to the host **and** to the model at once. The run then continued at full context toward a provider rejection several turns later that named none of this.

New `compaction_failed` event carrying *which* decline path was taken, because the three want different responses: one may succeed next pass, one will decline identically forever, and one is a reducer bug that `findSafeTrimIndex` exists to prevent.

## The test written for that found the larger half

The case asserting a *successful* compaction does not report a failure went red. `applyReducer` emits nothing at all on success — `compaction_completed` was only ever emitted from the structured working-state path.

So the event whose own docstring says it exists because *"a host could not show the user that context was dropped"* never reached a host using its own `contextReducer` or `strategy: 'sliding-window'`: the two paths most likely to be in use, and the hosts the event exists for. It is emitted from both paths now.

That is the known defect class with a passing test suite: not a declaration nothing drives, but a declaration driven from only one of its sites.

## Notes

The type system did the work on the surfaces — adding the event failed compilation in the A2A mapper, the SSE mapper and the run reporter. An exhaustive map behaving exactly as intended. A2A deliberately forwards neither compaction event: a peer models a task lifecycle and cannot act on how this runtime manages its own context.

Bump precedent checked rather than assumed — `capability_warning` was added as an additive `RunEvent` variant in 1.2.0, a minor. Followed, and the changeset says what that precedent did not: a host switching exhaustively over `RunEvent` needs a new case.

Gates: typecheck 0 · lint clean · 2657 SDK tests + every other package (live contract tests included) · external-name audit clean · surface 523/1211. Mutations: tool scope removed → 1 fails; structured value serialised → 1 fails; each of the three decline emits removed → exactly 1 each; the success emit removed → 1.
