### PR TITLE
feat(cli): a compaction says so, instead of discarding context in silence

### DIFF
--- a/.changeset/a-compaction-says-so.md
+++ b/.changeset/a-compaction-says-so.md
@@ -1,0 +1,43 @@
+---
+'@namzu/cli': minor
+---
+
+a compaction says so, instead of discarding context in silence
+
+Compaction deletes messages irrecoverably at 70% of the context window. The
+kernel measures the loss and puts both outcomes on the wire specifically so a
+host can show it; this one dropped them at `default: return null`, one function
+from the screen. So the first time anyone learned compaction existed was when
+the agent had forgotten something they were relying on — which reads as the
+model being stupid rather than the harness discarding context.
+
+Everything else fixed recently was *the run quietly not doing what the operator
+said*. This is the same class with the opposite sign: *the run quietly doing
+something they did not ask for*.
+
+A compaction now appears in the transcript, on stderr for `namzu run`, and as an
+NDJSON event for a host:
+
+```
+⌫ context compacted — 42 messages replaced by 9, ~120k → ~38k tokens
+```
+
+**Only what is checkable.** Compaction summarises, so it cannot enumerate what
+was lost — the loss is fidelity, not a set of removable items, and "removed the
+file contents from turns 3-8" is a claim that cannot be substantiated and is
+worse than silence the first time it is subtly wrong. An estimated token count
+says it is estimated, because quoting an estimate as a measurement is that same
+lie in miniature.
+
+**A compaction that declines says which of three things happened**, because they
+want different responses and "compaction failed" would put the reader back where
+the silence did: a reducer that threw may work next pass and carries its own
+error; a reducer that shed nothing is reporting a fact, not an error, and will
+answer identically every time; a reducer that split a tool call from its result
+is a bug with no user action at all. Every case states that the history is
+unchanged, which the kernel guarantees by installing a reduction whole or not at
+all.
+
+The notice goes in the transcript rather than a status indicator, because an
+indicator is present while nothing is happening and gone afterwards — someone
+reading back could not tell whether the gap they were looking at was compacted.

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -264,6 +264,9 @@ export const runCommand: CommandDef = {
 			if (event.kind === 'delta') text += event.text
 			else if (event.kind === 'tool-start')
 				ctx.formatter.info(`⏺ ${event.toolName} ${event.summary}`)
+			// stderr, like every other status line, so it reaches a person
+			// watching without contaminating the answer a caller piped.
+			else if (event.kind === 'context') ctx.formatter.info(event.text)
 			else if (event.kind === 'error') failed = event.message
 			else if (event.kind === 'done') stopReason = event.stopReason
 		}

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -429,6 +429,14 @@ export function App({ ctx }: AppProps) {
 				case 'task':
 					pushMessage('tool', event.subject, false, event.status === 'completed' ? '☑' : '☐')
 					break
+				case 'context':
+					// Into the TRANSCRIPT, not a status line. A status indicator is
+					// present while nothing is happening and gone afterwards, so
+					// someone reading back could not tell whether the gap they are
+					// looking at was compacted. The event is a fact about the
+					// conversation and belongs in its record.
+					pushMessage('system', event.text, false, event.shed ? '⌫' : '⌦')
+					break
 				case 'done':
 					closeAssistant()
 					break

--- a/packages/cli/src/tui/__tests__/to-agent-event.test.ts
+++ b/packages/cli/src/tui/__tests__/to-agent-event.test.ts
@@ -59,3 +59,105 @@ describe('toAgentEvent carries the stop reason across', () => {
 		expect(mapped).toEqual({ kind: 'error', message: 'boom' })
 	})
 })
+
+describe('compaction is reported, not silent', () => {
+	// Compaction deletes messages irrecoverably. The kernel emits both outcomes
+	// specifically so a host can surface the loss; this host used to drop them
+	// at `default: return null`, one function from the screen.
+	it('says which counts became which, and nothing it cannot substantiate', () => {
+		const mapped = toAgentEvent({
+			type: 'compaction_completed',
+			runId: 'run_1',
+			iteration: 3,
+			messagesBefore: 42,
+			messagesAfter: 9,
+			tokensBefore: 120_000,
+			tokensAfter: 38_000,
+			measuredBy: 'provider',
+			contextWindowTokens: 200_000,
+			windowSource: 'model-table',
+			reachedResetThreshold: true,
+		} as never)
+
+		expect(mapped).toMatchObject({ kind: 'context', shed: true })
+		const text = (mapped as { text: string }).text
+		expect(text).toContain('42')
+		expect(text).toContain('9')
+		expect(text).toContain('120k')
+		// It must NOT claim to know what was lost — only the counts are checkable.
+		expect(text).not.toMatch(/turns? \d+-\d+|removed the/i)
+	})
+
+	it('marks an estimate as an estimate', () => {
+		// Quoting an estimate as a measurement is the same lie as quoting a
+		// summary as an enumeration, in miniature.
+		const mapped = toAgentEvent({
+			type: 'compaction_completed',
+			runId: 'run_1',
+			iteration: 3,
+			messagesBefore: 10,
+			messagesAfter: 4,
+			tokensBefore: 9000,
+			tokensAfter: 3000,
+			measuredBy: 'estimate',
+			contextWindowTokens: 200_000,
+			windowSource: 'default',
+			reachedResetThreshold: false,
+		} as never)
+
+		expect((mapped as { text: string }).text).toContain('estimated')
+	})
+})
+
+describe('the three decline causes get three sentences', () => {
+	// Collapsing them into "compaction failed" puts the reader back where the
+	// silence did — the same reason a rule denial had to quote the rule.
+	function failure(cause: string, error?: string): string {
+		const mapped = toAgentEvent({
+			type: 'compaction_failed',
+			runId: 'run_1',
+			iteration: 2,
+			cause,
+			messages: 31,
+			...(error ? { error } : {}),
+		} as never)
+		expect(mapped).toMatchObject({ kind: 'context', shed: false })
+		return (mapped as { text: string }).text
+	}
+
+	it('a thrown reducer may work next time, and carries its own error', () => {
+		const text = failure('reducer_threw', 'provider returned 400')
+
+		expect(text).toContain('provider returned 400')
+		expect(text).toContain('a later pass may succeed')
+	})
+
+	it('shedding nothing is a fact, not an error, and will not change', () => {
+		const text = failure('shed_nothing')
+
+		expect(text).toContain('later passes will answer the same')
+		// Not dressed as a failure: an irreducible history is a true statement
+		// about the conversation, and calling it one sends someone hunting a
+		// bug that is not there.
+		expect(text).not.toMatch(/failed|error/i)
+	})
+
+	it('a split tool pair is a reducer bug and suggests no user action', () => {
+		const text = failure('split_tool_pair')
+
+		expect(text).toContain('bug in the reducer')
+		expect(text).not.toMatch(/try again|later pass|retry/i)
+	})
+
+	it('every cause states the history is unchanged', () => {
+		for (const cause of ['reducer_threw', 'shed_nothing', 'split_tool_pair']) {
+			expect(failure(cause)).toContain('31 messages unchanged')
+		}
+	})
+
+	it('no two causes produce the same sentence', () => {
+		const texts = ['reducer_threw', 'shed_nothing', 'split_tool_pair'].map((c) => failure(c))
+
+		expect(new Set(texts).size).toBe(3)
+	})
+})

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -86,6 +86,22 @@ export type AgentEvent =
 			readonly detail?: readonly string[]
 	  }
 	| { readonly kind: 'usage'; readonly totalTokens: number; readonly costUsd: number }
+	/**
+	 * Context was discarded, or an attempt to discard it declined.
+	 *
+	 * Everything else this session fixed was the run quietly not doing what the
+	 * operator asked. This is the same class with the opposite sign: the run
+	 * quietly doing something they did not ask for. Compaction deletes messages
+	 * irrecoverably, and the first time a user learned it existed was when the
+	 * agent had forgotten something they were relying on — which reads as the
+	 * model being stupid rather than the harness dropping context.
+	 */
+	| {
+			readonly kind: 'context'
+			readonly text: string
+			/** False when the compaction declined and the history is unchanged. */
+			readonly shed: boolean
+	  }
 	| { readonly kind: 'task'; readonly subject: string; readonly status: string }
 	/**
 	 * The turn ended without throwing — which is not the same as succeeding.
@@ -830,8 +846,70 @@ export function toAgentEvent(event: RunEvent): AgentEvent | null {
 				kind: 'error',
 				message: event.failure ? `[${event.failure.code}] ${event.error}` : event.error,
 			}
+		case 'compaction_completed':
+			return { kind: 'context', text: describeCompaction(event), shed: true }
+		case 'compaction_failed':
+			return { kind: 'context', text: describeCompactionFailure(event), shed: false }
 		default:
 			return null
+	}
+}
+
+/**
+ * What a completed compaction may honestly claim.
+ *
+ * Only what is checkable: which counts became which. Compaction summarises, so
+ * it cannot enumerate what was lost — the loss is fidelity, not a set of
+ * removable items, and "removed the file contents from turns 3-8" is a claim
+ * that cannot be substantiated and is worse than silence the first time it is
+ * subtly wrong.
+ *
+ * `measuredBy` is carried for the same reason: an estimate quoted as a
+ * measurement is that same lie in miniature, and the kernel already knows which
+ * it had.
+ */
+function describeCompaction(event: {
+	messagesBefore: number
+	messagesAfter: number
+	tokensBefore: number
+	tokensAfter: number
+	measuredBy: 'provider' | 'estimate'
+}): string {
+	const k = (n: number): string => (n >= 1000 ? `${Math.round(n / 1000)}k` : String(n))
+	const qualifier = event.measuredBy === 'estimate' ? ' (estimated)' : ''
+	return `context compacted — ${event.messagesBefore} messages replaced by ${event.messagesAfter}, ~${k(event.tokensBefore)} → ~${k(event.tokensAfter)} tokens${qualifier}`
+}
+
+/**
+ * What a declined compaction says, which is three different things.
+ *
+ * Collapsing them into "compaction failed" would put the reader back where the
+ * silence did — the same reason a rule denial had to quote the rule rather than
+ * name its type. One may work next pass, one will decline identically forever,
+ * and one is a bug in the reducer with no user action at all.
+ *
+ * Every case states that the history is unchanged, because the kernel installs
+ * a reduction whole or not at all. That is a fact worth giving the reader
+ * rather than making them wonder what survived.
+ */
+function describeCompactionFailure(event: {
+	cause: 'reducer_threw' | 'shed_nothing' | 'split_tool_pair'
+	messages: number
+	error?: string
+}): string {
+	const held = `${event.messages} messages unchanged`
+	switch (event.cause) {
+		case 'reducer_threw':
+			return `context not compacted — the reducer failed${event.error ? `: ${event.error}` : ''}. ${held}; a later pass may succeed`
+		case 'shed_nothing':
+			// Deliberately not phrased as an error. An irreducible history is a
+			// true statement about the conversation, and dressing it as a
+			// failure sends someone looking for a bug that is not there.
+			return `context could not be reduced further — nothing left to shed. ${held}; later passes will answer the same`
+		case 'split_tool_pair':
+			// No suggested action, because there is none for the user. Offering
+			// one would be worse than silence.
+			return `context not compacted — the reducer produced a history splitting a tool call from its result, so it was refused. ${held}; this is a bug in the reducer`
 	}
 }
 


### PR DESCRIPTION
Compaction deletes messages irrecoverably at 70% of the context window. The kernel measures the loss and puts both outcomes on the wire **specifically so a host can show it** — and this host dropped them at `default: return null`, one function from the screen.

So the first time anyone learned compaction existed was when the agent had forgotten something they were relying on, which reads as the model being stupid rather than the harness discarding context.

Everything else fixed recently was *the run quietly not doing what the operator said*. This is the same class with the opposite sign: **the run quietly doing something they did not ask for.**

```
⌫ context compacted — 42 messages replaced by 9, ~120k → ~38k tokens
```

Shown in the TUI transcript, on stderr for `namzu run`, and as an NDJSON event for a host.

## Only what is checkable

Compaction summarises, so it cannot enumerate what was lost — the loss is fidelity, not a set of removable items. "Removed the file contents from turns 3-8" is a claim that cannot be substantiated and is worse than silence the first time it is subtly wrong. A test asserts the notice does **not** produce that phrasing.

An estimated token count says it is estimated. Quoting an estimate as a measurement is the same lie in miniature, and the kernel already knows which it had (`measuredBy`).

## Three causes, three sentences

A compaction that declines says which of three things happened, because they want different responses and "compaction failed" would put the reader back where the silence did:

| Cause | What the sentence says |
|---|---|
| `reducer_threw` | may work next pass; carries the reducer's own error |
| `shed_nothing` | a **fact**, not an error — the history is at its floor and later passes answer the same |
| `split_tool_pair` | a bug in the reducer; suggests **no** user action, because there is none |

Every case states the history is unchanged, which the kernel guarantees by installing a reduction whole or not at all. A test asserts no two causes produce the same sentence.

`shed_nothing` is deliberately not phrased as a failure: an irreducible context is a true statement about the conversation, and dressing it as an error sends someone hunting a bug that is not there.

## Transcript, not a status indicator

An indicator is present while nothing is happening and gone afterwards, so someone reading back could not tell whether the gap they were looking at was compacted. The event is a fact about the conversation and belongs in its record.

## Verification

Applied the convention this work produced to its own first step: verified **both** `compaction_completed` emit sites on main (`compaction.ts:325` and `:645`) rather than finding one and concluding. That also caught a stale SDK dist — `compaction_failed` was missing from the union until a rebuild, which would have read as "the event does not exist" had I trusted the first typecheck.

`run-stream` needed no change, verified rather than assumed: it writes every mapped event unconditionally, so the NDJSON surface follows from the mapping alone.

11 tests; mutation-checked — removing the failure case fails four of them. 375 tests, typecheck, biome from inside the package, external-name audit — all green.

## Still open

`/compact` and the context indicator. The indicator needs a decision I have not made: the transcript notice is an **event**, but "how close am I" is a **state**, and the argument that an indicator is the wrong home for the event does not establish that it is the wrong home for the state. Different questions; the second is unanswered.
