### PR TITLE
feat(sdk): a run reports how much room its context has

### DIFF
--- a/.changeset/a-context-window-you-can-actually-see.md
+++ b/.changeset/a-context-window-you-can-actually-see.md
@@ -1,0 +1,35 @@
+---
+'@namzu/sdk': minor
+---
+
+`token_usage_updated` now carries the current context size and the window it is measured against.
+
+A host built a context indicator, and it could not have been right. The event
+carried `usage` — **cumulative run spend**, summed over every turn, monotonically
+increasing and untouched by compaction — and nothing about the size of the
+conversation being sent. So the host divided cumulative spend by a context
+window guessed from a substring of the model name, and rendered the result as an
+unqualified percentage, continuously.
+
+Both terms were wrong, and the numerator was the worse of the two: a guessed
+window is wrong by a bounded factor, while cumulative spend grows without limit
+and pins such an indicator toward full on any long run regardless of how much
+room the conversation actually has. It would have been most wrong exactly when
+someone needed it most. In the other direction, a driver that reports no usage
+shows 0% for a conversation that is really there.
+
+The kernel already computed the right numbers on every iteration and kept them
+to itself. `measureContext()` is now exported, and the event carries four new
+optional fields: `contextTokens`, `contextMeasuredBy` (`'provider' | 'estimate'`),
+`contextWindowTokens` and `windowSource` (`'config' | 'model-table' | 'default'`).
+They are named apart from the cumulative figures beside them deliberately —
+reaching for the wrong one should be a visible mistake, not a plausible guess.
+
+**They are absent when the run has no compaction configuration**, because nothing
+then resolves a window and inventing one would be the guess this replaces. A
+surface should show what it can name rather than a fraction it cannot ground.
+
+**A fraction is only as honest as the weaker of its terms.** `contextMeasuredBy`
+and `windowSource` exist so a surface can pass that on rather than presenting an
+estimate as a measurement. Nothing existing changes: `usage` and `cost` are
+untouched, and the new fields are additive and optional.

--- a/.changeset/a-context-window-you-can-actually-see.md
+++ b/.changeset/a-context-window-you-can-actually-see.md
@@ -11,12 +11,25 @@ conversation being sent. So the host divided cumulative spend by a context
 window guessed from a substring of the model name, and rendered the result as an
 unqualified percentage, continuously.
 
-Both terms were wrong, and the numerator was the worse of the two: a guessed
-window is wrong by a bounded factor, while cumulative spend grows without limit
-and pins such an indicator toward full on any long run regardless of how much
-room the conversation actually has. It would have been most wrong exactly when
-someone needed it most. In the other direction, a driver that reports no usage
-shows 0% for a conversation that is really there.
+Both terms were wrong, and the numerator was the worse of the two. A guessed
+window is wrong by a bounded factor. Cumulative spend has three properties that
+make it not merely imprecise but actively misleading:
+
+- It **never decreases**, by explicit design — the accumulator is documented as
+  monotone so it can never under-report a bill. Compaction does not reduce it.
+- It grows **superlinearly in turn count**, because every turn re-sends the whole
+  history and counts those prompt tokens again. Ten turns over a 50k context
+  accumulate roughly 500k.
+- It measures **spend**, which is the right quantity for cost and the wrong one
+  for occupancy.
+
+So an indicator built on it saturates at full long before the context is, and it
+is **anti-correlated with what it claims in exactly the regime a user cares
+about**: a long conversation reads FULL while the real context may be a fifth of
+the window. That alarms people into compacting or restarting when they have
+room — worse than showing nothing, because silence does not tell you something
+false in red. In the other direction, a driver that reports no usage shows 0%
+for a conversation that is really there.
 
 The kernel already computed the right numbers on every iteration and kept them
 to itself. `measureContext()` is now exported, and the event carries four new

--- a/packages/sdk/src/bridge/sse/mapper.ts
+++ b/packages/sdk/src/bridge/sse/mapper.ts
@@ -227,6 +227,16 @@ const MAPPING: {
 			run_id: runId,
 			usage: e.usage,
 			cost: e.cost,
+			// Carried, and named apart from `usage` on the wire as well as in
+			// the type. A remote surface has exactly the same opportunity to
+			// divide cumulative spend by a context window as a local one, and
+			// no more information with which to notice.
+			...(e.contextTokens !== undefined ? { context_tokens: e.contextTokens } : {}),
+			...(e.contextMeasuredBy !== undefined ? { context_measured_by: e.contextMeasuredBy } : {}),
+			...(e.contextWindowTokens !== undefined
+				? { context_window_tokens: e.contextWindowTokens }
+				: {}),
+			...(e.windowSource !== undefined ? { window_source: e.windowSource } : {}),
 		}),
 	},
 

--- a/packages/sdk/src/runtime/query/__tests__/context-size-on-the-wire.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/context-size-on-the-wire.test.ts
@@ -1,0 +1,122 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { MockLLMProvider } from '../../../provider/mock.js'
+import { ToolRegistry } from '../../../registry/tool/execute.js'
+import { createUserMessage } from '../../../types/message/index.js'
+import type { RunEvent } from '../../../types/run/index.js'
+import { drainQuery } from '../index.js'
+
+/**
+ * Cumulative spend and current context size are different quantities, and a
+ * host divided the first by a context window and shipped it.
+ *
+ * That indicator climbed toward full on any long run no matter how much room
+ * the conversation actually had — most wrong exactly when someone needed it —
+ * because `usage` is summed over every turn and never falls, while the context
+ * is what is being sent right now and falls whenever a compaction sheds.
+ *
+ * The host had no better option: the correct numerator needs internals it
+ * cannot see, and the correct denominator was a two-branch guess on a model
+ * name. So both numbers are on the event, named so that reaching for the wrong
+ * one is a visible mistake rather than a plausible guess.
+ */
+
+let workdirs: string[] = []
+
+afterEach(async () => {
+	await Promise.all(workdirs.map((d) => rm(d, { recursive: true, force: true })))
+	workdirs = []
+})
+
+type UsageEvent = Extract<RunEvent, { type: 'token_usage_updated' }>
+
+async function run(
+	compaction: Record<string, unknown> | undefined,
+	turns: unknown[],
+): Promise<UsageEvent[]> {
+	const seen: UsageEvent[] = []
+	const dir = await mkdtemp(join(tmpdir(), 'namzu-ctxsize-'))
+	workdirs.push(dir)
+
+	await drainQuery(
+		{
+			provider: new MockLLMProvider({ turns: turns as never }),
+			tools: new ToolRegistry(),
+			runConfig: { model: 'mock-model', timeoutMs: 30_000, tokenBudget: 100_000, maxIterations: 3 },
+			...(compaction ? { compactionConfig: compaction } : {}),
+			agentId: 'agent_ctx',
+			agentName: 'Context Agent',
+			workingDirectory: dir,
+			sessionId: 'ses_ctx',
+			threadId: 'thd_ctx',
+			projectId: 'prj_ctx',
+			tenantId: 'tnt_ctx',
+			messages: [createUserMessage('go')],
+		} as never,
+		(event: RunEvent) => {
+			if (event.type === 'token_usage_updated') seen.push(event)
+		},
+	)
+
+	return seen
+}
+
+const COMPACTION = {
+	strategy: 'sliding-window',
+	triggerThreshold: 0.9,
+	contextWindowTokens: 50_000,
+	keepRecentMessages: 4,
+}
+
+describe('a run reports how much room its context has', () => {
+	it('carries the context size and the window together', async () => {
+		const events = await run(COMPACTION, [{ text: 'done' }])
+
+		expect(events.length).toBeGreaterThan(0)
+		const event = events[0] as UsageEvent
+		expect(event.contextTokens).toBeGreaterThan(0)
+		expect(event.contextWindowTokens).toBe(50_000)
+	})
+
+	it('says whether each number was measured or guessed', async () => {
+		// A fraction is only as honest as the weaker of its two terms, so a
+		// surface rendering these owes a reader the distinction. It cannot
+		// pass it on if it never receives it.
+		const event = (await run(COMPACTION, [{ text: 'done' }]))[0] as UsageEvent
+
+		expect(['provider', 'estimate']).toContain(event.contextMeasuredBy)
+		// The window was stated in config here, so its provenance is not a guess.
+		expect(event.windowSource).toBe('config')
+	})
+
+	it('keeps the context size distinct from cumulative spend', async () => {
+		// The whole defect in one assertion, and this driver demonstrates it
+		// more sharply than a real one would: it reports no usage at all, so
+		// cumulative spend stays at zero while the context genuinely fills.
+		//
+		// A surface dividing spend by a window would show 0% here, for a
+		// conversation that is really there. The same surface on a long run
+		// shows 100% for a conversation that was compacted down to nothing.
+		// Both directions, same category error — which is why the two numbers
+		// are reported separately rather than left to be inferred from each
+		// other.
+		const events = await run(COMPACTION, [{ text: 'one' }, { text: 'two' }])
+		const last = events[events.length - 1] as UsageEvent
+
+		expect(last.contextTokens).toBeGreaterThan(0)
+		expect(last.contextTokens).not.toBe(last.usage.totalTokens)
+	})
+
+	it('reports nothing rather than a guess when no window is configured', async () => {
+		// Without a compaction config nothing resolves a window, and inventing
+		// one would be the guess this replaces. Absent is a fact a surface can
+		// act on; a fabricated default is not.
+		const event = (await run(undefined, [{ text: 'done' }]))[0] as UsageEvent
+
+		expect(event.contextTokens).toBeUndefined()
+		expect(event.contextWindowTokens).toBeUndefined()
+		expect(event.windowSource).toBeUndefined()
+	})
+})

--- a/packages/sdk/src/runtime/query/iteration/index.ts
+++ b/packages/sdk/src/runtime/query/iteration/index.ts
@@ -1,4 +1,5 @@
 import { type Span, SpanStatusCode } from '@opentelemetry/api'
+import { resolveContextWindow } from '../../../compaction/context-window.js'
 import { extractFromAssistantMessage } from '../../../compaction/extractor.js'
 import { AUTO_CONTINUATION_USER_MESSAGE } from '../../../constants/continuation.js'
 import {
@@ -42,7 +43,7 @@ import type { ToolCallOutcome } from '../executor.js'
 import { applyLifecycleHookResults } from '../plugin-hooks.js'
 import { runAdvisoryPhase } from './phases/advisory.js'
 import { runIterationCheckpoint } from './phases/checkpoint.js'
-import { relieveOverflow, runCompactionCheck } from './phases/compaction.js'
+import { measureContext, relieveOverflow, runCompactionCheck } from './phases/compaction.js'
 import type { IterationContext } from './phases/index.js'
 import { runPlanGate } from './phases/plan.js'
 import { runToolReview } from './phases/tool-review.js'
@@ -464,11 +465,38 @@ export class IterationOrchestrator {
 						totalCost: runMgr.costInfo.totalCost,
 					})
 
+					// The context figures ride with the spend figures because a
+					// surface showing one almost always wants the other — and
+					// because the two were confusable enough that a host divided
+					// cumulative spend by a context window and shipped it. They
+					// are measured here rather than left to be derived, since the
+					// only correct derivation needs internals a host cannot see.
+					//
+					// Absent when the run has no compaction config: nothing then
+					// resolves a window, and inventing one would be the guess this
+					// replaces.
+					const contextFigures = this.ctx.compactionConfig
+						? (() => {
+								const measured = measureContext(this.ctx)
+								const window = resolveContextWindow(
+									this.ctx.compactionConfig?.contextWindowTokens,
+									runConfig.model,
+								)
+								return {
+									contextTokens: measured.tokens,
+									contextMeasuredBy: measured.source,
+									contextWindowTokens: window.tokens,
+									windowSource: window.source,
+								}
+							})()
+						: {}
+
 					await this.ctx.emitEvent({
 						type: 'token_usage_updated',
 						runId: runMgr.id,
 						usage: runMgr.tokenUsage,
 						cost: runMgr.costInfo,
+						...contextFigures,
 					})
 
 					// Reasoning rides along with the turn it belongs to, so the

--- a/packages/sdk/src/runtime/query/iteration/phases/compaction.ts
+++ b/packages/sdk/src/runtime/query/iteration/phases/compaction.ts
@@ -135,7 +135,17 @@ function estimateTokens(ctx: IterationContext): number {
  * estimated rather than measured because no provider in the repo exposes a
  * token-count call; an approximate tail beats a certain omission.
  */
-function measureContext(ctx: IterationContext): {
+/**
+ * How large the context being sent is right now, and whether that number was
+ * counted or estimated.
+ *
+ * Exported because it is the only honest answer to "how much room is left",
+ * and the surfaces that ask are outside this file. It was internal, so a host
+ * wanting the figure had to derive one — and a host did, from cumulative run
+ * spend divided by a window guessed from a model name, which is neither term
+ * of the right fraction.
+ */
+export function measureContext(ctx: IterationContext): {
 	tokens: number
 	source: 'provider' | 'estimate'
 } {

--- a/packages/sdk/src/types/run/events.ts
+++ b/packages/sdk/src/types/run/events.ts
@@ -363,6 +363,39 @@ type CoreRunEvent =
 			runId: RunId
 			usage: TokenUsage
 			cost: CostInfo
+			/**
+			 * How large the CONTEXT is right now, and how large it may get.
+			 *
+			 * These are a different quantity from `usage` beside them and the
+			 * distinction is the whole reason they are named this explicitly.
+			 * `usage` is CUMULATIVE SPEND over the run: prompt plus completion
+			 * tokens summed across every turn, monotonically increasing, and
+			 * untouched by compaction. `contextTokens` is the size of the
+			 * conversation being sent right now, which falls when a compaction
+			 * sheds.
+			 *
+			 * Dividing the first by a context window is a category error, and
+			 * it is one this estate shipped: a host did exactly that, so its
+			 * indicator climbed toward full on any long run no matter how much
+			 * room the conversation actually had — most wrong precisely when
+			 * someone needed it most. The numbers are here so nobody has to
+			 * reach for the wrong one, and named so reaching for it is a
+			 * visible mistake rather than a plausible guess.
+			 *
+			 * `contextMeasuredBy` says whether the provider counted the prompt
+			 * or we estimated it, and `windowSource` where the ceiling came
+			 * from. A fraction of two numbers is only as honest as the weaker
+			 * of them, and a surface rendering these owes a reader the same
+			 * distinction rather than presenting an estimate as a measurement.
+			 *
+			 * Absent when the run has no compaction configuration, because
+			 * nothing then resolves a window and inventing one would be the
+			 * guess this exists to replace.
+			 */
+			contextTokens?: number
+			contextMeasuredBy?: 'provider' | 'estimate'
+			contextWindowTokens?: number
+			windowSource?: 'config' | 'model-table' | 'default'
 	  }
 	| {
 			type: 'activity_created'


### PR DESCRIPTION
The CLI agent was asked to build a context indicator. It found one already shipped — and found it doing exactly what I had told it in advance I would not accept. Checking it myself made it worse.

## The indicator could not have been right

`token_usage_updated` carried `usage: runMgr.tokenUsage` — **cumulative run spend**, summed over every turn, monotonically increasing, untouched by compaction — and nothing at all about the size of the conversation being sent. The denominator was a two-branch guess on a model-name substring: 1M if the name contains `[1m]`, 200k for everything else.

So both terms were wrong, and **the numerator was the worse of the two.** A guessed window is wrong by a bounded factor. Cumulative spend grows without limit, so the bar climbs toward full on any long run no matter how much room the conversation actually has — most wrong precisely when someone needs it. In the other direction, a driver reporting no usage shows 0% for a conversation that is really there.

The host had no better option. The correct numerator needs internals it cannot see, and the correct denominator was not on any event it receives.

## What ships

`measureContext()` is exported — it already ran on every iteration and returned exactly the right pair — and `token_usage_updated` gains four optional fields:

`contextTokens` · `contextMeasuredBy` (`'provider' | 'estimate'`) · `contextWindowTokens` · `windowSource` (`'config' | 'model-table' | 'default'`)

They are named apart from the cumulative figures sitting beside them deliberately. Reaching for the wrong one should be a visible mistake, not a plausible guess — and the type says loudly that cumulative spend and current context are different quantities, because that confusion is the bug and the next reader will be one field away from repeating it.

**Absent when the run has no compaction configuration.** Nothing then resolves a window, and inventing one would be the guess this replaces. A surface should show what it can name rather than a fraction it cannot ground.

**A fraction is only as honest as the weaker of its terms**, so the provenance fields travel with the numbers. A surface that renders these owes a reader the same distinction the kernel makes.

## The test I did not plan

The case demonstrating the defect came from a failure. The mock driver reports **no usage at all**, so cumulative spend stays at zero while the context genuinely fills — meaning a surface dividing one by the other shows `0%` for a real conversation. Same category error as the 100% case, opposite direction, and a sharper demonstration than the assertion I had written for it.

Gates: typecheck 0 · lint clean · 2716 SDK tests + every other package · external-name audit clean. Mutation: dropping the spread fails 3 of 4.