### PR TITLE
docs: catch up on a day of shipped surface

### DIFF
--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -1,6 +1,6 @@
 ---
 title: CLI
-description: namzu is a terminal AI agent — a TUI that discovers your LLM credentials, runs tools with your approval, and remembers context across sessions.
+description: namzu is a terminal AI agent — a TUI that discovers your LLM credentials, runs tools under a permission model you choose, and remembers context across sessions.
 last_updated: 2026-08-05
 status: current
 related_packages: ["@namzu/cli", "@namzu/sdk", "@namzu/anthropic", "@namzu/openai", "@namzu/openrouter", "@namzu/ollama"]
@@ -13,17 +13,24 @@ related_packages: ["@namzu/cli", "@namzu/sdk", "@namzu/anthropic", "@namzu/opena
 ```bash
 namzu                      # launch the interactive TUI
 namzu run "fix the build"  # headless one-shot — prints the reply (for scripts/CI)
-echo "..." | namzu run     # prompt from stdin; add --format json for {"text": "..."}
+echo "..." | namzu run     # prompt from stdin
+namzu --format json run "fix the build"        # reply as {"text": "..."}
 namzu run --cwd ../other "which tests fail?"   # work in another checkout
+namzu run --continue "and now the e2e suite"   # reopen the last conversation here
 namzu --help               # utility subcommands (doctor, providers, run, …)
 ```
+
+`--format` and `--quiet` are program-level options and go **before** the
+subcommand. `run` and `run-stream` refuse an option they do not recognize
+rather than treating it as prompt text, so `namzu run --format json "…"` exits
+`64` — see [Headless runs](./headless.md#options).
 
 ## What it does
 
 - **Discovers credentials, never asks you to log in.** On first run it finds your LLM provider credentials (env vars, an OAuth credential in the macOS Keychain, or a local Ollama) and lets you pick which provider to chat through. See [Providers & credentials](./providers.md).
-- **Runs tools, with your approval.** The agent reads files, runs shell commands, edits code, searches, tracks a plan, and remembers — via the SDK builtins plus its memory and task tools. Mutating actions prompt for approval; a safety gate hard-denies catastrophic commands. See [Tools & permission](./tools.md).
+- **Runs tools, under a permission model you choose.** The agent reads files, runs shell commands, edits code, searches, tracks a plan, and remembers — via the SDK builtins plus its memory and task tools. Mutating actions prompt for approval in the TUI; a headless run approves them unless you ask for `--permission-mode strict`. A safety gate hard-denies catastrophic commands in every mode. See [Tools & permission](./tools.md).
 - **Remembers across sessions.** User facts in `~/.namzu/USER.md` / `MEMORY.md` are injected every turn; the agent also keeps its own structured memory. See [Memory](./memory.md).
-- **Resumes past conversations.** Every conversation is saved; `/resume` continues a previous one in this folder.
+- **Resumes past conversations.** Every conversation is saved. `/resume` continues a previous one in this folder from the TUI; `namzu run --continue` and `--resume <id>` do the same from a script. Neither ever silently starts a fresh conversation when the one you asked for cannot be reopened.
 - **Loads skills on demand.** Author `SKILL.md` capability docs and activate them per session. See [Skills](./skills.md).
 - **Polished TUI.** Markdown-rendered replies, collapsible tool diffs (Ctrl+O), slash-command autocomplete, message queuing, and paste handling. See [The TUI](./tui.md).
 
@@ -32,9 +39,9 @@ namzu --help               # utility subcommands (doctor, providers, run, …)
 | Page | What it covers |
 | --- | --- |
 | [The TUI](./tui.md) | Header, transcript/composer, slash commands + autocomplete, queuing, `/resume`, Ctrl+O, interrupting |
-| [Headless runs](./headless.md) | `run` and `run-stream`, their shared options, `--cwd`, exit codes, the NDJSON event stream |
+| [Headless runs](./headless.md) | `run` and `run-stream`, their shared options, `--cwd`, permission modes, resuming, exit codes, the NDJSON event stream |
 | [Providers & credentials](./providers.md) | How credentials are discovered, the first-run picker, switching providers |
-| [Tools & permission](./tools.md) | Builtin + memory + task tools, deferred tools and `search_tools`, the permission prompt, the safety gate, bypass mode |
+| [Tools & permission](./tools.md) | Builtin + memory + task tools, deferred tools and `search_tools`, how a call is decided, permission modes, the safety gate, bypass mode |
 | [Memory](./memory.md) | `USER.md` / `MEMORY.md` injection, `/remember`, `/memory`, the agent's structured memory |
 | [Skills](./skills.md) | `SKILL.md` format, discovery, `/skills`, `/skill <name>` |
 

--- a/docs/cli/headless.md
+++ b/docs/cli/headless.md
@@ -166,9 +166,28 @@ every line on stdout is a valid event.
 | `tool-start` | `toolUseId`, `toolName`, `summary`, optional `detail` lines |
 | `tool-end` | `toolUseId`, `toolName`, `isError`, `summary`, optional `detail` lines |
 | `usage` | `totalTokens`, `costUsd` |
+| `context` | `text`, `shed` — a compaction pass ran (see below) |
 | `task` | `subject`, `status` — the agent's own plan items |
 | `error` | `message` |
 | `done` | optional `stopReason` |
+
+### `context`, and why it is on the stream at all
+
+A long turn compacts: the runtime discards old history to keep the conversation
+inside the model's window. That deletion is irreversible, and until it was
+reported the first a user knew of it was the agent having forgotten something
+they were relying on — which reads as the model being stupid rather than as the
+harness dropping context.
+
+`shed` distinguishes the two outcomes. `true` means history was discarded and
+`text` says which counts became which. `false` means a pass ran and declined, so
+**the history is unchanged** — worth surfacing rather than swallowing, because a
+run that could not shed carries on at full context toward a provider rejection
+several turns later that will name none of this. `text` says which of the three
+declines it was.
+
+Render both. A host that shows only `shed: true` reproduces the original silence
+on exactly the runs that are in trouble.
 
 Two read-only helpers exist for a host building pickers, both taking `--cwd` and
 both printing `[]` rather than failing:

--- a/docs/cli/headless.md
+++ b/docs/cli/headless.md
@@ -55,8 +55,9 @@ and pick one — see [Providers & credentials](./providers.md).
 
 ## Options
 
-Both commands take the same options, parsed by the same code. Everything that is
-not an option is the prompt.
+Both commands are parsed by the same code, so an option spelled one way for one
+is spelled the same way for the other. Everything that is not an option is the
+prompt.
 
 | Option | Effect |
 | --- | --- |
@@ -65,6 +66,10 @@ not an option is the prompt.
 | `--model <id>` | Answer with this model instead of the stored preference. |
 | `--skills <a,b,c>` | Load these skills as context for the turn. See [Skills](./skills.md). |
 | `--session <key>` | Bind the turn to a persisted conversation (see below). |
+| `--permission-mode <m>` | `prompt`, `auto` or `strict` — what happens to a call no rule decided. See [Permission modes](#permission-modes). |
+| `--yolo` / `--dangerously-skip-permissions` | `--permission-mode auto`. |
+| `--continue` (`-c`) | Reopen the most recent conversation here. `namzu run` only. |
+| `--resume <id>` | Reopen the conversation you name. `namzu run` only. |
 | `--` | End of options. Everything after it is prompt text, verbatim. |
 
 An option that is not on this list is refused. It is not passed to the model:
@@ -84,12 +89,13 @@ namzu run -- --force means what in this codebase?
 
 ### Tool approval
 
-A headless turn never prompts for approval — there is nobody to ask — so tools
-run without asking. The safety gate that refuses catastrophic shell commands
-still applies and cannot be turned off. `--yolo` and
-`--dangerously-skip-permissions` are accepted for symmetry with the interactive
-launch and do nothing here, because there is no prompt to skip. See
-[Tools & permission](./tools.md).
+A headless turn has nobody to ask, so `prompt` is not a mode it can end up in:
+with no flag, the mode resolves to `auto` and every call runs, which is what a
+headless run has always done. [`--permission-mode`](#permission-modes) is how
+you change that.
+
+The safety gate that refuses catastrophic shell commands sits above every mode
+and cannot be turned off by any flag. See [Tools & permission](./tools.md).
 
 ## The working directory
 
@@ -174,8 +180,9 @@ namzu providers-json               # [{provider, label, detected, default, model
 
 ## Permission modes
 
-The `[permissions]` table says what a tool may do. `--permission-mode` says what
-happens to everything it did not cover.
+Every tool call is first put to a verification gate, which answers `allow`,
+`deny` or **`review`**. `--permission-mode` says what happens to the calls that
+came back `review` — the ones nothing decided either way.
 
 | Mode | An undecided call is | Default when |
 | --- | --- | --- |
@@ -187,25 +194,39 @@ happens to everything it did not cover.
 namzu run --permission-mode strict "run the test suite"
 ```
 
-`strict` is the mode for an unattended run: nothing executes unless a rule
-allowed it by name or pattern, and the model is told that asking again will not
-help. Before it existed an unattended run could only be `auto`, so a CI job
-either trusted the agent with everything or could not use it at all.
+`strict` is the mode for an unattended run. Read-only tools still run — `read`,
+`glob`, `grep`, and the memory and task tools observe without changing anything,
+so the gate allows them outright and they never reach the mode. Everything else
+is refused, and the model is told in the refusal that asking again will not
+help, so it stops rather than rewording the same call.
+
+Before `strict` existed an unattended run could only be `auto`, so a CI job
+either trusted the agent with every tool it might reach for or could not use it
+at all. `strict` makes a headless run something you can reason about: it can
+look, and it cannot touch.
 
 `--yolo` and `--dangerously-skip-permissions` mean `--permission-mode auto`.
+They were previously accepted and documented as doing nothing, which was true
+and unsatisfying.
 
-### Precedence between the flag and the file
+### What a mode cannot do
 
-**A mode only governs calls no rule decided, so it can never reopen what a rule
-closed.** A rule that denied a call already stopped it and a rule that allowed
-one never asked, so neither reaches the mode. `--permission-mode auto` cannot
-run something the config says `deny`, and neither can `--yolo`. The
-dangerous-pattern floor sits above both.
+**A mode only governs calls the gate sent to review, so it can never reopen what
+the gate closed.** A denied call was already stopped and an allowed one never
+asked, so neither reaches the mode at all. `--permission-mode auto` cannot run
+something the gate denies, and neither can `--yolo`; the dangerous-pattern floor
+sits above both and no flag reaches it.
 
-The direction is deliberate. The config file is written once, read by whoever
-reviews the repository, and changed on purpose; a flag is typed in a hurry by
-someone who wants to get on with it. A prohibition a flag can lift is not a
-prohibition.
+The direction is deliberate. A gate rule is a durable statement someone
+reviewed; a flag is typed in a hurry by someone who wants to get on with it. A
+prohibition a flag can lift is not a prohibition.
+
+Which rules the gate holds is set by the host that builds the session. For the
+rule vocabulary and how to supply it, see
+[Tool Safety](../sdk/tools/safety.md) — `namzu` itself currently runs the gate
+with its two standing policies (deny catastrophic shell patterns, allow
+read-only tools) and no additional rules, so in practice the mode is the whole
+of the operator-facing control here.
 
 ## Resuming a conversation
 
@@ -214,9 +235,13 @@ namzu run --continue "and now the integration tests"
 namzu run --resume ses_abc123 "what did we decide about the cache?"
 ```
 
-`--continue` takes the most recent conversation in the working directory;
-`--resume <id>` takes the one you name and no other. `namzu history` lists what
-is there.
+`--continue` (short form `-c`) takes the most recent conversation in the working
+directory; `--resume <id>` takes the one you name and no other. `namzu history`
+lists what is there.
+
+**Both are `namzu run` only.** `run-stream` gets its prior turns from `--session`
+or from a JSON `Message[]` on stdin; that is the channel a host UI already has,
+and it is the one to use there.
 
 **Both refuse when the conversation cannot be reopened, and say why. Neither
 ever falls back to starting a new one.**

--- a/docs/cli/tools.md
+++ b/docs/cli/tools.md
@@ -1,6 +1,6 @@
 ---
 title: Tools & permission
-description: Builtin tools, agent memory + task tools, deferred tools and search_tools, the permission prompt, the safety gate, and bypass mode.
+description: Builtin tools, agent memory + task tools, deferred tools and search_tools, how a tool call is decided, permission modes, the safety gate, and bypass mode.
 last_updated: 2026-08-05
 status: current
 related_packages: ["@namzu/cli", "@namzu/sdk"]
@@ -40,12 +40,32 @@ A sub-agent runs without a task store, so it has nothing deferred, and `search_t
 
 > Earlier versions bridged an external daemon's ~70-tool catalog in as deferred tools, and the connect line reported them as `(+N on demand)`. That integration was removed in `@namzu/cli` 0.7.0 — see the changelog.
 
+## How a tool call is decided
+
+Every call goes through the same two stages, in this order.
+
+**1. The verification gate** answers `allow`, `deny`, or `review`. It hard-denies a narrow set of catastrophic shell patterns (see [The safety gate](#the-safety-gate)) and allows tools that only observe. Everything else comes back `review` — the gate has no opinion, and the decision moves on.
+
+**2. The mode** decides what happens to a `review`. Which mode is in force depends on where you are:
+
+| Mode | A reviewed call is | In force when |
+| --- | --- | --- |
+| `prompt` | put to you (see below) | the TUI, normally |
+| `auto` | approved | any headless run with no flag; the TUI under bypass |
+| `strict` | refused | `namzu run --permission-mode strict` |
+
+`--permission-mode` is a headless flag — see [Headless runs](./headless.md#permission-modes). The TUI is `prompt` unless you launched it with bypass.
+
+**A mode never reopens what the gate closed.** A denied call was already stopped and an allowed one never asked, so neither reaches the mode. That is why `--yolo` cannot run a catastrophic command: the denial happens a stage earlier.
+
 ## The permission prompt
 
-Mutating actions ask before they run:
+Under `prompt`, mutating actions ask before they run:
 
 - **Read-only / agent-state tools** (`read`/`glob`/`grep`, the memory + task tools) run silently.
 - **Anything else** — `write`, `edit`, `bash`, and any tool not on the safe allowlist — shows a prompt with each proposed call, plus a preview for the riskiest: the content for `write`, a `- old` / `+ new` diff for `edit`.
+
+An unrecognized tool is treated as needing consent. That direction is deliberate: a tool added tomorrow prompts, rather than inheriting a permission nobody granted it.
 
 | Key | Decision |
 | --- | --- |
@@ -57,10 +77,22 @@ Mutating actions ask before they run:
 
 ## The safety gate
 
-Independent of the prompt, a verification gate hard-denies a narrow set of catastrophic shell patterns **before they ever run** — `rm -rf /`, `mkfs`, `dd if=`, fork bombs, `sudo` / `su -`, `chmod 777 /`, `curl|sh` / `wget|sh`, `ssh user@host`, and dynamic `eval`. This applies even in bypass mode, so namzu can't be made to brick the machine. The list is deliberately narrow — everyday commands like `rm -rf node_modules` are unaffected.
+Independent of the prompt, a verification gate hard-denies a narrow set of catastrophic shell patterns **before they ever run** — `rm -rf /`, `mkfs`, `dd if=`, fork bombs, `sudo` / `su -`, `chmod 777 /`, `curl|sh` / `wget|sh`, `ssh user@host`, and dynamic `eval`. This applies in every mode including bypass, so namzu can't be made to brick the machine. The list is deliberately narrow — everyday commands like `rm -rf node_modules` are unaffected.
 
 ## Bypass mode
 
 Launch with `namzu --dangerously-skip-permissions` (alias `--yolo`) to run tools without the approval prompt — useful in a sandbox or a folder you fully trust. A red banner warns while it's active, and the safety gate above still applies.
 
+On the headless commands the same two flags mean `--permission-mode auto`, which is what a headless run already defaults to. They were previously accepted there and did nothing.
+
+The name overstates what the flag can do, and that is on purpose: it should read as more dangerous than it is rather than less.
+
 > The permission prompt is interactive only in the TUI. Programmatic/embedded use of the session auto-approves unless a permission handler is supplied.
+
+## Unattended runs
+
+`--permission-mode strict` is the one to reach for in CI. Read-only tools still run; everything else is refused, and the refusal tells the model that asking again will not help, so it stops rather than rewording the same call.
+
+Before it existed an unattended run could only be `auto`, so a scheduled job either trusted the agent with every tool it might reach for or could not use it at all.
+
+If you need an unattended run that may also write or execute, the rule surface for that lives one layer down, in the SDK's verification gate — see [Tool Safety](../sdk/tools/safety.md) for the rule vocabulary and how a host supplies it.

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -1,7 +1,7 @@
 ---
 title: Anthropic Provider
-description: Configure @namzu/anthropic for the Anthropic Messages API through Namzu.
-last_updated: 2026-07-30
+description: Configure @namzu/anthropic for the Anthropic Messages API through Namzu, including per-model thinking and effort resolution.
+last_updated: 2026-08-05
 status: current
 related_packages: ["@namzu/sdk", "@namzu/anthropic"]
 ---
@@ -104,7 +104,63 @@ const result = await agent.run(
 | `maxTokens` | No | Default `max_tokens` value; Anthropic requires this field at request time |
 | `strictToolUse` | No | Constrained tool-input policy: `auto` (default), `on`, or `off` |
 
-## 8. Capability Snapshot
+## 8. Thinking and Effort
+
+`thinking` and `effort` are set on the run, not on the provider — see
+[Run Configuration](../sdk/runtime/configuration.md). What this driver adds is
+resolving them **per model**, because the same request body is accepted by one
+model and rejected outright by its sibling.
+
+### 8.1 Thinking mode is resolved, never passed through
+
+Three modes exist, and a model accepts some subset of them:
+
+| Mode | Meaning |
+| --- | --- |
+| `adaptive` | the model decides whether and how deeply to reason; depth is steered by `effort` |
+| `enabled` | manual: `budgetTokens` fixes the depth and the model reasons on every request |
+| `disabled` | no reasoning |
+
+Newer models refuse `enabled`, older ones refuse `adaptive`, and some refuse
+`disabled` because they cannot stop reasoning at all. Sending the wrong one
+produces a failed request, not a worse answer — so what you set is a declared
+intent, and the driver resolves it against the model it is about to call.
+
+The one asymmetry worth knowing: **a `disabled` request on a model that cannot
+stop reasoning omits the field rather than throwing.** Turning something off is
+not a request that can be refused, and a config that spans several models should
+not fail on the ones that were never going to reason anyway.
+
+### 8.2 Which effort levels a model takes is a set, not a ladder
+
+`effort` is `low | medium | high | xhigh | max`, and it is tempting to read
+those as rungs where anything accepting the top accepts the one below. **They
+are not.** A model can take `max` and refuse `xhigh`, and reading them as a
+ladder is what previously put a level on a capability row that the wire rejects.
+
+The driver keeps two sets per model — the levels accepted generally, and the
+levels accepted *with thinking off*. On most models those two are identical; on
+one family they are not, which is why they are separate rows rather than one
+blanket rule. An earlier blanket rule discarded `xhigh` and `max` whenever
+thinking was off, on the reasoning that the pairing is incoherent — and
+measurement showed one family rejects it while its siblings accept and honour
+it. Looking incoherent is not the same as being rejected, and only the wire
+decides which.
+
+**A level the model does not accept is dropped rather than sent**, because
+effort shapes an answer the model will still produce. A *mode* the model does
+not accept is a different matter and fails the request, because there is no
+answer to shape.
+
+### 8.3 `output_config` is merged, not assigned
+
+`effort` travels in a shared envelope on this wire, alongside a
+structured-output format and a task budget. The driver merges into it. If you
+are extending this driver, keep it that way: assigning means whoever wires the
+next field silently deletes effort, or has effort delete theirs, depending only
+on which line runs last.
+
+## 9. Capability Snapshot
 
 The package exports `ANTHROPIC_CAPABILITIES`:
 
@@ -116,7 +172,7 @@ The package exports `ANTHROPIC_CAPABILITIES`:
 }
 ```
 
-## 9. Operational Notes
+## 10. Operational Notes
 
 - Anthropic requires `max_tokens`, so setting `maxTokens` at provider creation time is a good default.
 - In `auto` mode, tools marked with `enforceModelInput: true` are sent with `strict: true` on recognized Claude 4.5+ model identifiers. Use `on` only for a compatible proxy alias, or `off` to disable constrained tool inputs.
@@ -124,7 +180,7 @@ The package exports `ANTHROPIC_CAPABILITIES`:
 - `baseURL` can point at proxies or gateways, but for Bedrock-hosted Anthropic models [`@namzu/bedrock`](./bedrock.md) is the better fit.
 - The provider also implements `listModels()` and `healthCheck()`.
 
-## 10. Common Errors
+## 11. Common Errors
 
 | Error | Meaning | Fix |
 | --- | --- | --- |
@@ -136,6 +192,8 @@ The package exports `ANTHROPIC_CAPABILITIES`:
 
 - [Providers Overview](./README.md)
 - [Provider Selection Guide](./selection-guide.md)
+- [Run Configuration](../sdk/runtime/configuration.md)
+- [Loop Control and Resilience](../sdk/runtime/loop-control.md)
 - [Bedrock Provider](./bedrock.md)
 - [HTTP Provider](./http.md)
 - [Provider Registry](../sdk/provider-integration/registry.md)

--- a/docs/sdk/agents/README.md
+++ b/docs/sdk/agents/README.md
@@ -216,6 +216,40 @@ Current hard requirements:
   2–4 objects with a `label` (and optional `description`); capable providers
   constrain that shape, while the runtime decoder remains authoritative.
 
+### Declining to delegate at all
+
+`SupervisorAgentConfig.allowDelegation` (default `true`) answers *whether* this
+run may hand work to anyone. The roster answers *who*, and the two are different
+questions.
+
+Set it `false` and `create_task`, `wait_for_task` and `cancel_task` are not
+built. `agent_task_list` stays — a run that may not launch anything may still
+want to see what is running — and `approve_plan` and `ask_user_question` are
+untouched, because they are the human-in-the-loop surface rather than the
+delegation one.
+
+It cannot be derived from the roster, which is why it is a field the caller
+states. A host that runs one specialist by putting its persona into the
+supervisor shell and that specialist's id into the roster has a non-empty roster
+and must still delegate to nobody — and comparing the roster against the
+executing agent fails in exactly that arrangement, because the ids differ. A
+supervisor whose roster holds one specialist and a run that *is* that specialist
+are indistinguishable in the roster alone.
+
+Two properties worth knowing:
+
+- **`false` is absolute.** `runtimeToolOverrides` cannot put the tools back: the
+  override pass runs over the tools this flag declined to build, and both values
+  come from the same caller in the same call, so "must not delegate" plus "give
+  it `create_task`" is a contradiction rather than extra knowledge. `agentIds:
+  []` has always behaved this way.
+- **Absent and `true` are identical**, so opting in explicitly cannot change an
+  existing caller.
+
+Stating the fact rather than deriving it also means the implied tool list cannot
+go stale — which a caller-held list of tool names silently did when this surface
+went from two tools to four.
+
 ### Waiting for a worker, and being told when one finishes
 
 > **Changed in `@namzu/sdk` 8.0.0.** A delegate's output is now framed as
@@ -271,8 +305,40 @@ The supervisor can also reach a task itself:
 | `agent_task_list` | every task with its state, timing and — for finished ones — its output |
 | `cancel_task` | stop a task the supervisor no longer needs |
 
-Prefer `wait_for_task` over listing in a loop: it costs one call and no waiting
-turns.
+**Do not poll `agent_task_list` to find out whether work finished.** A blocking
+`create_task` already returns the output, and a background one is announced. The
+listing is for taking stock — what is running, how long it has been — not for
+waiting; `wait_for_task` is the wait, and it costs one call rather than a turn
+per check.
+
+#### Two clocks bound the wait
+
+One number cannot answer both "is this worker taking too long?" and "has this
+worker stopped?". A bound generous enough for a child doing real work is
+useless as a stall detector, which is why a worker wedged in its second minute
+used to hold the supervisor for another fifty-eight, while a worker making
+steady progress at minute fifty-nine was cut off for being slow rather than for
+being stuck.
+
+| Bound | Measures | Default | Reset by |
+| --- | --- | --- | --- |
+| run | elapsed time since launch | 1 hour (`DELEGATION_TIMEOUT_MS`) | never |
+| idle | time since the worker last did anything | 5 minutes (`NAMZU_DELEGATION_IDLE_MS`) | every progress signal |
+
+Whichever fires first ends the wait, and **the result says which** — "it went
+quiet" and "it ran too long" are different diagnoses leading to different next
+moves, and the message is what the model acts on.
+
+Giving up on the wait does not cancel the worker. The child keeps going and its
+completion still arrives as a task notification, because a wait that ran out is
+a statement about the waiter, not about the work.
+
+The idle bound needs a signal that a task did something, and only a gateway can
+see it: `TaskGateway.onTaskProgress` is **optional**, because not every host can
+observe its children. A gateway without it is bounded by the wall clock alone,
+exactly as before — and that degradation is visible rather than silent, because
+the timeout result carries `idleBoundArmed` and the message says outright that
+this gateway cannot tell a busy worker from a stuck one.
 
 #### The inbox, and what depends on it
 

--- a/docs/sdk/integrations/connectors-and-mcp.md
+++ b/docs/sdk/integrations/connectors-and-mcp.md
@@ -1,7 +1,7 @@
 ---
 title: Connectors and MCP
 description: Build connector catalogs, expose connector instances as tools, consume remote MCP servers, and bridge connected integrations back out through MCP in @namzu/sdk.
-last_updated: 2026-08-03
+last_updated: 2026-08-05
 status: current
 related_packages: ["@namzu/sdk"]
 ---
@@ -257,6 +257,48 @@ rejected by the server one turn later. Other `format` values are advisory
 in JSON Schema and are not turned into validators. `allOf` is flattened
 into a single object rather than left as an intersection, because a flat
 shape is what a model can read.
+
+**Positional arrays keep their positions.** A server that spells out
+`[string, number]` — in either the draft-07 form, where `items` holds a list, or
+the 2020-12 one, where `prefixItems` does — used to reach the model as "an array
+of anything". The positions, their types and their order were all dropped from
+what the model *reads*, not merely from what is validated.
+
+What is emitted now depends on how tightly the server pinned it:
+
+| The server's schema | What the model gets |
+| --- | --- |
+| arity pinned (`minItems` equals the member count) **and** tail closed (`additionalItems: false`, `items: false`, or `maxItems` equal to the count), up to 32 members | a **tuple** |
+| anything looser | a permissive array, plus `Positional array — [0] string, [1] number.` appended to its description |
+
+The gate is narrow on purpose, and the reason is the round trip rather than
+fidelity. A tool schema the receiving wire rejects fails the **entire request**,
+taking down every other tool in the call — so a faithful conversion that cannot
+be sent is strictly worse than a lossy one that can. A pinned, closed tuple
+renders as bounded `prefixItems`, which is the one positional shape measured as
+accepted and the same shape a first-party builtin already ships. Everything
+looser keeps today's permissive array and carries its shape in prose instead,
+appended to whatever description the server wrote rather than replacing it.
+
+If you author these schemas, the inversion worth knowing is that positional
+members **do not constrain length**. Without `minItems` a server is permitting a
+*shorter* array, which a tuple cannot express — so an absent lower bound is a
+reason to keep the loose form, not a detail to round up. Set `minItems` and
+close the tail if you want the model to see the real signature.
+
+**A word on what this means for a host.** Where the server pinned the arity, the
+converted schema is now a tuple, so input a permissive array accepted is refused
+locally. It is only ever refused where the server itself declared it invalid —
+the error moves from the server's response to the local validator — but a host
+driving a bridged tool directly can see a validation failure it did not see
+before, and code branching on the converted type (`instanceof z.ZodArray`) takes
+a different branch.
+
+**Depth is bounded.** Conversion stops at 32 levels and leaves anything deeper
+permissive. That ceiling existed before and never fired: it was compared against
+in one branch that a pure array or a union never reaches, and the counter was
+not passed down the array path at all, so a deeply nested schema from a remote
+tool listing took the process down with a stack overflow instead.
 
 ### Declared return shapes
 

--- a/docs/sdk/integrations/event-bridges.md
+++ b/docs/sdk/integrations/event-bridges.md
@@ -85,6 +85,16 @@ toward a provider rejection several turns later that will name none of this.
 `compaction.failed` carries a `cause` saying which of the three declines
 happened — see [Loop Control](../runtime/loop-control.md).
 
+`token.usage` carries `context_tokens` and `context_window_tokens` alongside the
+cumulative `usage`, each with its provenance (`context_measured_by`,
+`window_source`). **Build a context-fullness indicator from `context_tokens`,
+never from `usage`** — the latter is cumulative spend across every turn and is
+untouched by compaction, so dividing it by a window yields a gauge that climbs
+toward full on any long run regardless of how much room the conversation has. A
+remote surface has exactly the same opportunity to make that mistake as a local
+one and no more information with which to notice it, which is why both numbers
+are named apart on the wire as well as in the type.
+
 ## 3. Important SSE Limitation
 
 Not every `RunEvent` maps to an SSE event, and the final completion does not come from the mapper.

--- a/docs/sdk/integrations/event-bridges.md
+++ b/docs/sdk/integrations/event-bridges.md
@@ -1,7 +1,7 @@
 ---
 title: Event Bridges
 description: Bridge internal Namzu runtime events to SSE and A2A wire formats, and convert messages, runs, and agent metadata into protocol-friendly shapes.
-last_updated: 2026-08-03
+last_updated: 2026-08-05
 status: current
 related_packages: ["@namzu/sdk"]
 ---
@@ -75,6 +75,15 @@ Typical mapped wire events include:
 - `tool.completed`
 - `review.requested`
 - `checkpoint.created`
+- `compaction.completed`
+- `compaction.failed`
+
+The two compaction events are both worth forwarding to a UI, and the second is
+the one that is easy to leave out. A compaction pass that shed **nothing** is
+exactly as consequential as one that did: the run continues at full context
+toward a provider rejection several turns later that will name none of this.
+`compaction.failed` carries a `cause` saying which of the three declines
+happened — see [Loop Control](../runtime/loop-control.md).
 
 ## 3. Important SSE Limitation
 
@@ -213,6 +222,10 @@ Important runtime choices baked into the mapper:
 - `provider_retry` maps to `running`, because a backoff is a task still
   working, not a failure
 - `tool_review_requested`, `plan_ready`, and `run_paused` map to `input-required`
+- **neither compaction event is forwarded.** A peer models a task lifecycle and
+  cannot act on how this runtime manages its own context — the loss is real, but
+  it is this runtime's business rather than the peer's. On SSE, where the
+  consumer is a UI attached to this run, both are forwarded.
 - many internal events intentionally map to `null`
 
 ### Knowing a run is backing off, not hung

--- a/docs/sdk/runtime/configuration.md
+++ b/docs/sdk/runtime/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: Run Configuration
-description: Required and optional runtime config for Namzu agents, including model, limits, permissions, environment, and working directory.
-last_updated: 2026-08-03
+description: Required and optional runtime config for Namzu agents, including model, limits, thinking and effort, permissions, environment, and working directory.
+last_updated: 2026-08-05
 status: current
 related_packages: ["@namzu/sdk"]
 ---
@@ -114,8 +114,77 @@ These settings shape the runtime loop, not only the provider call.
 | `persona` | Structured prompt identity |
 | `skills` | Structured skill bundle list |
 | `advisory` | Advisor configuration |
+| `thinking` | Whether the model reasons before answering, and with how large a budget |
+| `effort` | How much work the model spends on each call |
 
 These fields change how the runtime assembles prompt context before it calls the provider.
+
+### `thinking` and `effort`
+
+Both are declared on `BaseAgentConfig`, which every agent config extends, so they
+are set the same way whichever entry point you use:
+
+```ts
+// Assume `provider`, `tools`, `model`, `projectId`, `sessionId` and `tenantId`
+// were prepared by your runtime bootstrap, as in section 2.
+const agent = new ReactiveAgent()
+
+await agent.run(
+  {
+    messages: [{ role: 'user', content: 'Reconcile these two ledgers.' }],
+    workingDirectory: process.cwd(),
+  },
+  {
+    provider,
+    tools,
+    model,
+    tokenBudget: 32_768,
+    timeoutMs: 120_000,
+    projectId,
+    sessionId,
+    tenantId,
+    thinking: { type: 'adaptive' },
+    effort: 'high',
+  },
+)
+```
+
+They are **siblings**, not one nested in the other. On some models the two are
+independent controls that apply together — effort shapes the answer while a
+token budget sets how deep the reasoning goes — and nesting `effort` inside
+`thinking` would make that combination unsayable.
+
+Which of the two does the work depends on the thinking mode:
+
+| `thinking.type` | Depth is set by | `effort` |
+| --- | --- | --- |
+| `adaptive` | the model, per request | the primary depth lever — low effort may skip thinking entirely on easy input |
+| `enabled` | `budgetTokens` | shapes the answer; does not move thinking depth |
+| `disabled` | — | still applies on models that accept it |
+
+The modes are not interchangeable and a driver must not guess between them:
+newer models refuse `enabled`, older ones refuse `adaptive`, and some refuse
+`disabled` because they cannot stop reasoning at all. What you set here is a
+declared intent, resolved by each driver against the model it is about to call.
+
+Both fields are **run-level rather than per-step.** Effort in particular is a
+property of what the run is *for*, and a value that moves between steps buys a
+different answer shape at the cost of the prompt-cache prefix on every step that
+changes it: the provider does not preserve a cached prefix across a change of
+effort.
+
+**A driver that cannot honour either one refuses the run rather than dropping
+the field.** That is the rule for both, and effort is the reason it matters
+most: a dropped `thinking` leaves an empty reasoning list that someone might
+notice, while a dropped `effort` leaves a perfectly ordinary answer — so a run
+requested at `max` is indistinguishable from one at the default, including in
+what it cost. Turning a capability *off* is not a refusal, so a
+`thinking: { type: 'disabled' }` config shared across models does not fail on
+the ones that were never going to reason anyway.
+
+Which levels a model accepts is the driver's to know; see
+[Anthropic Provider](../../providers/anthropic.md) for how one driver resolves
+them per model.
 
 ## 7. Hierarchy and Advanced Fields
 

--- a/docs/sdk/runtime/loop-control.md
+++ b/docs/sdk/runtime/loop-control.md
@@ -1,7 +1,7 @@
 ---
 title: Loop Control and Resilience
-description: Stop conditions, step records, provider retry, budgets across resume, compaction triggers, and extended thinking in the @namzu/sdk agent loop.
-last_updated: 2026-08-03
+description: Stop conditions, step records, provider retry, budgets across resume, compaction triggers and outcomes, and extended thinking and effort in the @namzu/sdk agent loop.
+last_updated: 2026-08-05
 status: current
 related_packages: ["@namzu/sdk", "@namzu/anthropic"]
 ---
@@ -214,17 +214,51 @@ query({
 ```
 
 The hook receives the run id, the step number, the full message history
-and every completed `StepResult`. It may return `activeTools`, `model`,
-`system`, `temperature` and `maxResponseTokens`; an omitted field keeps
-the run's configured value, and returning nothing is the same as having no
-hook.
+and every completed `StepResult`. It may return `activeTools`, `toolChoice`,
+`skills`, `model`, `system`, `temperature` and `maxResponseTokens`; an omitted
+field keeps the run's configured value, and returning nothing is the same as
+having no hook.
+
+`toolChoice` is the one that *forces* rather than narrows — `'required'`,
+`'none'`, or a named function. It lives here rather than on the run config by
+construction: a forced choice that persisted would make the model call a tool,
+see the result, and be forced again, which is an agent that cannot stop. Each
+step is prepared fresh, so the force cannot outlive the step that asked for it.
+It also costs more cache than `activeTools`, because moving `tool_choice`
+invalidates cached message blocks and not only the tool prefix.
 
 Without it the tool surface and the model are fixed at `query()` time, so
 a phased agent — research, then write, then verify with a cheaper model —
 had to be several separate runs, each starting blind to the last one's
 context.
 
-Four things worth knowing:
+### `activeTools` narrows the kitchen, not only the menu
+
+A tool outside the list is **refused when it is called**, not merely left out
+of the request. The same holds for run-level `allowedTools`, which makes the
+same promise for a whole run.
+
+That distinction is the whole value of the field. Deciding which schemas go
+into the request is a statement about the *menu*; a model names a tool it was
+not offered more often than it sounds — whenever it repeats a call from earlier
+in the context, whenever a gateway carries its own tool list, and whenever a
+cached prompt prefix is replayed. A host using this to fence a step, which is
+the obvious use and the one the type invites, wants the fence to hold on the
+execution path too.
+
+The refusal is an ordinary `tool_result` naming what *is* available, so the
+model can route around it and the turn continues.
+
+Two details that decide behaviour:
+
+- **Absent is not empty.** No list means no restriction; an empty list means the
+  step may call nothing. Reading an empty allow-list as "unrestricted" is a
+  fail-open, and it is one this runtime has already been bitten by once in the
+  delegate roster.
+- **A step's list beats the run's**, matching the precedence the request already
+  used, so the two cannot disagree.
+
+Four more things worth knowing:
 
 - **`system` is one-step guidance.** It is appended to the *request* and
   never pushed onto the run's history, so a long run does not accumulate
@@ -233,13 +267,15 @@ Four things worth knowing:
   0, so changing the set invalidates the cached prefix for that step. That
   is inherent to narrowing — worth paying at a real phase boundary, not
   every step.
-- **It does not touch `tool_choice`.** Anthropic has no `allowed_tools`
-  parameter, and moving `tool_choice` invalidates cached *message* blocks
-  as well: a strictly worse trade for the same effect.
-- **It fails open.** A throwing hook leaves the step with the run's
-  configuration, and tool names that are not registered are dropped with a
-  warning — a phase list that outlives a tool rename should narrow the
-  surface, not kill the agent mid-run.
+- **It does not touch `tool_choice`.** The wires namzu speaks have no
+  `allowed_tools` parameter, and moving `tool_choice` invalidates cached
+  *message* blocks as well: a strictly worse trade for the same effect.
+- **The hook fails open; the list does not.** A throwing hook leaves the step
+  with the run's configuration. But a list the hook *returned* is enforced, and
+  names that are not registered are dropped from it with a warning — so a phase
+  list that outlives a tool rename narrows further than you wrote it. Keep at
+  least one live name in every list: if every name is dropped, what reaches the
+  step is the empty list, which means *may call nothing*.
 
 ### More than one concern
 
@@ -372,9 +408,41 @@ compaction useless — a cap would have to guess which pin mattered, and
 dropping the wrong one quietly is worse than a run that overflows in the
 open.
 
-A pass emits `compaction_completed` (wire: `compaction.completed`) with
-before/after message counts and token sizes. Compaction deletes history
-irrecoverably, so it is worth surfacing.
+### Both outcomes reach the run
+
+A pass that shed history emits `compaction_completed` (wire:
+`compaction.completed`) with before/after message counts and token sizes.
+Compaction deletes history irrecoverably, so it is worth surfacing — and it is
+emitted from **both** strategies, the structured working-state path and the
+reducer path a host takes with its own `contextReducer` or with
+`strategy: 'sliding-window'`.
+
+A pass that shed **nothing** emits `compaction_failed` (wire:
+`compaction.failed`). A shed that did not happen is exactly as consequential as
+one that did: the run carries on at full context toward a provider rejection
+several turns later that will name none of this. A log line is not enough to
+carry that, because a host that silences its logger — which every command-line
+entry point does — makes the decline invisible to the user, to the host *and* to
+the model at once.
+
+The event carries a `cause`, because the three declines want different
+responses:
+
+| `cause` | What happened | What it means for the next pass |
+| --- | --- | --- |
+| `reducer_threw` | the reducer raised | usually a bug, or a failed model call inside a summarizing reducer — the next pass may work |
+| `shed_nothing` | it returned no fewer messages than it was given | history is at its floor, or the reducer's threshold disagrees with the trigger's — every later pass declines identically |
+| `split_tool_pair` | its result separated a `tool_use` from its `tool_result` | a reducer bug; the result was refused wholesale rather than sent to a provider that rejects the pairing |
+
+It also carries the unchanged `messages` count, and `error` for
+`reducer_threw` only. **The history is guaranteed untouched on all three** — a
+reducer's result is installed whole or not at all — so there is no partial state
+to repair and reporting is the whole remedy.
+
+If you switch exhaustively over `RunEvent`, `compaction_failed` needs a case. A
+host that ignores unknown events is unaffected. Neither compaction event is
+forwarded over the A2A bridge: a peer models a task lifecycle and cannot act on
+how this runtime manages its own context.
 
 ## 6b. What a Finished Run Leaves Behind
 
@@ -421,30 +489,57 @@ happened.
   state, and inventing an empty candidate would ask a host to store a
   record of nothing.
 
-## 7. Extended Thinking
+## 7. Extended Thinking and Effort
 
 ```ts
 query({
+  // …
   runConfig: {
-    model: 'claude-opus-5',
-    thinking: { type: 'enabled', budgetTokens: 8_000 },
+    // …
+    thinking: { type: 'adaptive' },
+    effort: 'high',
   },
 })
 ```
 
+`thinking` says whether the model reasons before answering; `effort` says
+how much work it spends on the call. They are **siblings** on `AgentRunConfig`
+rather than one nested in the other, because on some models they are
+independent controls that apply together — see
+[Run Configuration](./configuration.md) for the mode-by-mode breakdown of which
+of the two sets depth.
+
+**They are not exclusive to `query()`.** Both are declared on `BaseAgentConfig`,
+so `runAgent`, `ReactiveAgent`, `SupervisorAgent` and the agent manager's
+bare-config branch all forward them. That is worth stating because it was not
+true until recently: every one of those entry points assembles its run config by
+hand-listing fields, so `thinking` was settable on an agent config and dropped
+in silence by all four — no cast to blame, no error to see, and a perfectly
+ordinary answer at the other end. If you set either field anywhere other than
+`query()` and are on an older kernel, check that it reaches the wire before
+trusting it.
+
+**A driver that cannot honour either one refuses the run rather than dropping
+it.** Effort is the reason this rule matters most: a dropped `thinking` at least
+leaves an empty reasoning list, while a dropped `effort` leaves an answer
+indistinguishable from one the model produced at its default — including in what
+it cost.
+
 Reasoning blocks are stored on the assistant message and replayed
-**verbatim**, signature intact — Anthropic requires the assistant turn
-preceding a `tool_result` to be echoed back unchanged, and a rebuilt turn
-triggers ordering and signature errors.
+**verbatim**, signature intact — the assistant turn preceding a `tool_result`
+has to be echoed back unchanged, and a rebuilt turn triggers ordering and
+signature errors.
 
 The lifecycle surfaces as `reasoning_started` / `reasoning_delta` /
 `reasoning_completed`, so a streaming UI can show that the model is
 working instead of a silent multi-second gap. The delta is ephemeral: the
 completed block carries the full text, and the transcript records that.
 
-Anthropic rejects `temperature`, `top_p` and `top_k` while thinking is
-enabled, so the driver omits them rather than sending a request it knows
-will fail.
+Some wires reject `temperature`, `top_p` and `top_k` while thinking is
+enabled. A driver on such a wire omits them rather than sending a request it
+knows will fail — which sampling parameters and which effort levels a given
+model accepts is the driver's to resolve, not the kernel's. See
+[Anthropic Provider](../../providers/anthropic.md) for one worked example.
 
 ## 8. Guardrails
 

--- a/docs/sdk/runtime/loop-control.md
+++ b/docs/sdk/runtime/loop-control.md
@@ -271,11 +271,22 @@ Four more things worth knowing:
   `allowed_tools` parameter, and moving `tool_choice` invalidates cached
   *message* blocks as well: a strictly worse trade for the same effect.
 - **The hook fails open; the list does not.** A throwing hook leaves the step
-  with the run's configuration. But a list the hook *returned* is enforced, and
-  names that are not registered are dropped from it with a warning — so a phase
-  list that outlives a tool rename narrows further than you wrote it. Keep at
-  least one live name in every list: if every name is dropped, what reaches the
-  step is the empty list, which means *may call nothing*.
+  with the run's configuration. A list the hook *returned* is enforced, and
+  names that are not registered are dropped from it with a warning.
+
+  **Dropping every name leaves the step able to call nothing, and that is
+  deliberate.** The list means *only these*: if a rename outlives a phase list,
+  the only set satisfying "only the tools that no longer exist" is the empty
+  one. Widening back to the run's list would grant precisely the tools the
+  caller excluded, on the grounds that their own list failed — a step that can
+  call nothing is constrained, while a step that can call everything is a
+  control that stopped applying. The step is constrained, not crashed: the model
+  answers from what it has and the run continues.
+
+  The warning is the part to watch. It goes to the logger, and it distinguishes
+  some-names-dropped from all-names-dropped because those have different
+  consequences — but a host that silences its logger sees a phase quietly stop
+  doing anything.
 
 ### More than one concern
 
@@ -443,6 +454,36 @@ If you switch exhaustively over `RunEvent`, `compaction_failed` needs a case. A
 host that ignores unknown events is unaffected. Neither compaction event is
 forwarded over the A2A bridge: a peer models a task lifecycle and cannot act on
 how this runtime manages its own context.
+
+### How full the context is, between passes
+
+Compaction events tell you when history was shed. `token_usage_updated` tells
+you how much room there is the rest of the time:
+
+| Field | Is |
+| --- | --- |
+| `contextTokens` | the size of the conversation being sent **right now** — it falls when a compaction sheds |
+| `contextWindowTokens` | the ceiling that size is measured against |
+| `contextMeasuredBy` | `provider` if the prompt was counted, `estimate` if it was not |
+| `windowSource` | `config`, `model-table` or `default` |
+
+**These are a different quantity from the `usage` beside them, and the naming is
+deliberate because confusing the two is a category error this estate shipped.**
+`usage` is *cumulative spend*: prompt plus completion tokens summed across every
+turn, monotonically increasing, and untouched by compaction. Dividing it by a
+context window produces an indicator that climbs toward full on any long run no
+matter how much room the conversation actually has — most wrong precisely on the
+runs where someone is watching it. `contextTokens` is the numerator that
+question wants.
+
+Both provenance fields exist because **a fraction is only as honest as the
+weaker of its two numbers.** A surface rendering these owes its reader the same
+distinction rather than presenting an estimate as a measurement.
+
+All four are **absent when the run has no compaction configuration** — nothing
+then resolves a window, and inventing one would be the guess these fields exist
+to replace. `measureContext` is exported for a host that wants to compute the
+same figure itself.
 
 ## 6b. What a Finished Run Leaves Behind
 

--- a/docs/sdk/tools/README.md
+++ b/docs/sdk/tools/README.md
@@ -373,6 +373,18 @@ Two runtime bounds apply to every tool, with no configuration required.
 
 **Deadline.** Tools get 120 seconds by default (`toolTimeoutMs` on `query()`, or `timeoutMs` per tool). On expiry the executor stops waiting and returns a model-visible error result, so the agent can route around a slow dependency instead of losing the turn. `context.abortSignal` fires at the same moment, so a cooperative tool actually stops working — `bash` passes it to the child process.
 
+A tool that legitimately runs longer declares its own `timeoutMs`, and the ones that need to already do: `bash` declares a deadline above the ten-minute ceiling its own input accepts, and `create_task` — which runs an entire agent — declares an hour. A tool that runs long without declaring anything inherits the 120-second default, which is how a delegated child that finished in eight minutes was reported to its parent as an abandoned tool at two.
+
+**A cancellation says what stopped it.** If the host aborted with a reason, that reason reaches the tool result:
+
+```
+Tool "bash" was cancelled: run budget exhausted
+```
+
+A cancellation and a deadline arrive by the same mechanism and mean opposite things to whoever reads the result. "Was cancelled" tells a model that something outside it decided and nothing about what — so an operator pressing stop, a budget running out, and a parent abandoning a child were all reported identically, and every one of those wants a different next move.
+
+Two kinds of reason are deliberately reported as *no* reason, so today's honest silence is not replaced by a fake explanation: a bare `abort()` fills `reason` with a platform `AbortError`, which is nobody's message, and a non-`Error` reason is dropped rather than rendered (a bare string `'canceled'` would read as `was cancelled: canceled`). Pass an `Error` with a sentence in it if you want the model to see one.
+
 **Output budget.** A single tool result is capped at 40,000 model-visible characters (`maxToolOutputChars`; `0` disables). Over-budget output is written to `<runDir>/tool-output/<toolUseId>.txt` and replaced with a head+tail preview naming the path, so nothing is lost and tokens are paid only if the agent decides the rest is worth re-reading — with `read` and `grep`, tools it already has.
 
 Relatedly, `read` returns the first 2000 lines when given no window, and says so with a `[PARTIAL view — lines X-Y of Z]` notice naming the exact next call. A truncated read that looks like a short file is the most expensive silent failure a read tool can have.

--- a/docs/sdk/tools/built-in.md
+++ b/docs/sdk/tools/built-in.md
@@ -1,7 +1,7 @@
 ---
 title: Built-In Tools
-description: Reference for the built-in tools exported by @namzu/sdk, including their purpose, safety shape, and common usage patterns.
-last_updated: 2026-08-03
+description: Reference for the built-in tools exported by @namzu/sdk, including their purpose, safety shape, deadlines, and common usage patterns.
+last_updated: 2026-08-05
 status: current
 related_packages: ["@namzu/sdk", "@namzu/computer-use"]
 ---
@@ -127,6 +127,24 @@ Notes:
 - dangerous command patterns are blocked before execution
 - sandbox execution is used when a sandbox exists
 - command output is returned as `STDOUT` and `STDERR` sections
+
+**A failure reports what happened.** A non-zero exit returns `success: false`
+with the exit code on `data.exitCode` and both streams in `output`. A command
+that ran out of time is marked separately, `data.timedOut`, because "timed out"
+and "exited 1" lead the model to different next moves. The two things an agent
+runs a shell for most — a test run and a build — are both non-zero exits, so
+this is the ordinary path rather than an edge case.
+
+**One clock, and it is this tool's.** `timeout` defaults to two minutes and is
+capped at ten, overridable with `NAMZU_BASH_MAX_TIMEOUT_MS`. A request above the
+ceiling is **refused, not clamped** — a number the model was not told had
+changed is how it learns to distrust its own arguments. The tool declares an
+executor deadline slightly above its own ceiling on purpose, so the executor's
+generic per-tool deadline is a backstop rather than a second clock racing this
+one.
+
+A caller-owned abort still propagates as an abort rather than being reported as
+a command failure.
 
 ### 4.5 `glob`
 

--- a/docs/sdk/tools/safety.md
+++ b/docs/sdk/tools/safety.md
@@ -1,7 +1,7 @@
 ---
 title: Tool Safety
-description: Layered tool safety in @namzu/sdk, including tool metadata, availability states, verification gates, plan mode, and sandbox boundaries.
-last_updated: 2026-08-03
+description: Layered tool safety in @namzu/sdk, including tool metadata, availability states, the verification rule vocabulary and its evaluation order, plan mode, and sandbox boundaries.
+last_updated: 2026-08-05
 status: current
 related_packages: ["@namzu/sdk", "@namzu/computer-use"]
 ---
@@ -71,29 +71,59 @@ It evaluates a tool call into one of:
 - `deny`
 - `review`
 
-Built-in rule types include:
+A call that matches no rule is `review`. That is the fallback the whole design
+rests on: widening it has to be something an operator wrote down.
 
-- `allow_read_only`
-- `deny_dangerous_patterns`
-- `allow_by_category`
-- `allow_by_name`
-- `deny_by_name`
-- `custom_pattern`
-- `allow_by_tier`
+### The rule vocabulary
+
+| Rule | Decides on |
+| --- | --- |
+| `allow_read_only` | the tool declaring itself read-only for this input |
+| `deny_dangerous_patterns` | the serialized input matching a catastrophic-command pattern |
+| `allow_by_category` | the tool's `category` |
+| `allow_by_tier` | the tool's `tier` |
+| `allow_by_name` / `deny_by_name` | the tool's name |
+| `argument_pattern` | one named argument of one named set of tools |
+| `custom_pattern` | the tool name, the serialized arguments, or both concatenated |
+
+### Order is the meaning
+
+Rules are evaluated **first-match-wins**, and the gate assembles the list in a
+fixed order that is not the order you wrote:
+
+1. `deny_dangerous_patterns`, when `denyDangerousPatterns` is on. This is the
+   floor. An operator rule cannot open what it closes.
+2. **Your `rules`, in the order you gave them.**
+3. `allow_read_only`, when `allowReadOnlyTools` is on.
+
+The read-only allowance goes **last**, and the position is load-bearing. Ahead
+of the operator's rules it made a rule like "prompt me before every read"
+unreachable whenever the flag was on — not rejected, not warned about, just
+never consulted. Someone who writes a control and is silently ignored gets the
+worst outcome available: they believe it is in force and it is not. Last, it is
+what it always was in substance — a default for tools nobody wrote a rule
+about, rather than an override of the rules they did.
 
 ## 6. Verification Gate Example
 
 ```ts
-import { VerificationGate } from '@namzu/sdk'
-import { getRootLogger } from '@namzu/sdk'
+import { VerificationGate, getRootLogger } from '@namzu/sdk'
 
 const gate = new VerificationGate(
   {
     enabled: true,
     allowReadOnlyTools: true,
     denyDangerousPatterns: true,
+    logDecisions: false,
     rules: [
-      { type: 'deny_by_name', toolNames: ['Write'] },
+      { type: 'deny_by_name', toolNames: ['write'] },
+      {
+        type: 'argument_pattern',
+        toolNames: ['bash'],
+        argument: 'command',
+        pattern: '^git push',
+        decision: 'deny',
+      },
       { type: 'allow_by_category', categories: ['analysis'] },
     ],
   },
@@ -107,6 +137,76 @@ The important boundary is:
 - sandboxing decides what the call can do if it proceeds
 
 High-level agent helpers (`ReactiveAgent.run()`, `SupervisorAgent.run()`) accept `verificationGate` directly via their config — both forward it through to `drainQuery`. Hosts that just need a sane default can pass the exported `defaultSandboxedGateConfig()` or `defaultSandboxedShellGateConfig()` preset.
+
+### 6.1 Writing a pattern rule: which of the two
+
+The two pattern rules look interchangeable and are not. Choosing wrong produces
+a rule that decides nothing and says nothing about it.
+
+**`argument_pattern` tests one argument's own value.** It names both the tools
+it applies to and the argument it reads, so an anchored pattern means what it
+looks like it means:
+
+```ts
+{
+  type: 'argument_pattern',
+  toolNames: ['bash'],
+  argument: 'command',
+  pattern: '^git push',
+  decision: 'deny',
+}
+```
+
+It deliberately decides **nothing** in three cases — the tool was not called,
+the argument is absent, or the argument holds an object or an array. No string
+a pattern could match says anything true about a structured value, and
+serializing one to try would put the rule back where `custom_pattern` already
+is. To refuse a tool over the *shape* of its input, deny it by name. Numbers and
+booleans **are** matched rather than skipped: they render unambiguously, and a
+rule about a numeric argument is a reasonable thing to write.
+
+**`custom_pattern` tests text, and `target: 'args'` is the trap.** The subject
+is `JSON.stringify(toolInput)` — the JSON *text of the whole argument object* —
+not any single argument. So against a `bash` call the subject looks like
+
+```
+{"command":"git push origin main"}
+```
+
+and the natural, anchored thing to write, `^git push`, can never match. The rule
+then decides nothing, silently. `target: 'both'` **prefixes** the tool name to
+that text rather than requiring it, so it is not a tool scope either: a rule
+written with one tool in mind still sees every other tool's arguments.
+
+`custom_pattern` is not deprecated, because matching anywhere in the serialized
+input without caring where is a real use — searching for a credential-shaped
+string across every argument of every tool, for instance. Use it for that, and
+use `argument_pattern` when you mean "this tool, this argument".
+
+### 6.2 Reading a verdict back
+
+`evaluateRule` answers whether a rule matched. `describeRule` gives you the
+sentence for it, and both are exported:
+
+```ts
+import { describeRule, evaluateRule } from '@namzu/sdk'
+```
+
+A host driving the rule primitives directly — rather than through
+`VerificationGate` — was otherwise left holding a verdict with no words for it,
+and the only way to say anything about a refusal was to switch on the rule's
+`type`. That names the *kind* of rule and nothing about what it said: not which
+tool, not which pattern, not whether a different input could ever help.
+
+That difference is behavioural, not cosmetic. Told only that it was denied, a
+model rewords the same call and tries again, because nothing says the retry is
+pointless. Told that a pattern rule denies `git push*`, or that a by-name denial
+is about the tool rather than the input, it can stop and say so. A refusal that
+cannot be reasoned about produces thrashing; one that can produces a route
+around it.
+
+`GateEvaluationResult.reason` is `describeRule(matchedRule)`, so a host
+rendering its own approval UI can show the same sentence the model got.
 
 ## 7. Sandbox Boundary
 


### PR DESCRIPTION
A documentation catch-up for today's twelve merges, written by an agent given the changesets as its source. Docs-only, 12 files.

## Corrections came first

A stale page is believed; a missing one is merely absent. So the sweep for contradictions ran before anything new was written:

- **`docs/cli/headless.md` contradicted itself about `--yolo`** — one section said it does nothing, another that it means `--permission-mode auto`. Its Options table also claimed to be exhaustive while omitting `--permission-mode`, `--continue`/`-c` and `--resume`.
- **`docs/sdk/runtime/loop-control.md` described `activeTools` as narrowing what the model is *shown*.** It narrows what may *run*, and an empty list means nothing may run.
- **`docs/cli/README.md` told readers to write `namzu run … --format json`** — `--format` is program-level and `run` now refuses unknown options, so that line produces exit 64.
- **A pre-existing code sample would not compile**: a `VerificationGate` built without `logDecisions`, where the config type is `z.infer<>` of a schema whose fields all carry `.default()`, making every field required in a literal.

## Then what had no page

`thinking`/`effort` on `BaseAgentConfig` — including that `thinking` was reachable from no ergonomic entry point until today; `compaction_failed` and its three causes; `argument_pattern`, the `custom_pattern` `target: 'args'` trap, `describeRule`, and the rule ordering that makes an operator rule reachable; MCP positional-array conversion and the depth ceiling; the abort reason reaching tool results; `allowDelegation`; the two delegation clocks; the `bash` ceiling and its refuse-rather-than-clamp.

## What was deliberately not documented

Several things found along the way are inert in the shipped code. Publishing them would have put a known-undriven declaration on a user-facing page, so they are reported for fixing instead. They are being tracked separately.

## One paragraph is deliberately stale — please do not "fix" it

`docs/cli/headless.md` describes **`--permission-mode strict` as meaning read-only-tools-only**. That is accurate against `main` as it stands: with no operator rule reachable, the only rules the gate can match are its two standing policies, so `strict` refuses everything that is not read-only.

It stops being accurate the moment the `[permissions]` breaks are fixed, and that work is in flight. **That paragraph belongs to the change that alters the behaviour** — one edit by its author beats two edits racing each other. Reviewers: this is not an oversight.

## Rebased twice; reconciled, not just de-conflicted

`main` moved three times while this was open. The branch is now rebased onto `3d4315e`.

The two textual conflicts (`docs/cli/README.md`, `docs/cli/tools.md`) were resolved by **taking main's account of what exists and re-applying this branch's additions on top**, rather than picking a side. That discipline paid for itself: the merge *corrected* a line this branch had got wrong, where the permission-prompt bullet still named a bridge that had since been removed.

Two SDK changes were reconciled rather than left to coexist with what was already written:

- **#144** corrected the `activeTools` docstring, ruling that an aged-out phase list leaving a step able to call nothing is *deliberate* rather than a filter bug. This branch had framed it as a hazard to work around; it now carries that reasoning, plus the caveat that the warning is a log line a silenced logger swallows.
- **#142** put context size and window with their provenance on `token_usage_updated` and touched no docs. It lands directly beside the `windowSource` this branch had just documented on `compaction_completed`, so omitting it would have left two accounts of the same quantity on one page.

### The conflict that mattered had no markers

`docs/cli/headless.md` conflicted with nothing and was wrong anyway. **#141** added a `context` kind to the CLI's `AgentEvent` union, and `run-stream` writes every event verbatim, so the NDJSON `kind` table — rewritten hours earlier in this branch — was missing a case.

Conflict markers show where two edits touched the same bytes. They say nothing about a page left correct that a *third* change made false. This was found by enumerating the union, which is the only method that could have found it: the names deleted by the conflicting change were not involved.

The table now documents `context` and says to render **both** outcomes. A host that shows only `shed: true` reproduces the silence the event was added to end, on precisely the runs that are in trouble.

## Evidence: the per-commit docs-debt rule

Of the 21 non-release commits in the original range, **5 touched `docs/`**. The `**Docs debt:**` queue step in `AGENTS.md` §flow was followed **zero times out of sixteen**.

The actionable part is not the count but the split:

> The commits that document themselves are the ones where the docs edit is inseparable from the change.

All five that touched docs edited the page *in* the commit, because the change was to the thing the page documents. Nobody queued anything. The step was skipped exactly where it was separable — which is to say, exactly where it was needed.

So the rule succeeds where it is unnecessary and fails where it is not. A per-commit queue step cannot close that, because the commits that skip it are the ones whose author did not perceive a doc consequence, and those are the ones that have one. The question is not *how do we enforce the queue* but *what makes a doc consequence visible at the time* — and those have different answers.

Two mechanical notes for whoever picks this up:

- The debt line lives in `docs.local/`, which is gitignored. A missing one is invisible to review and to CI.
- The `pre-commit` hook gates on `progress.md`'s **mtime**, not its content. Touching the file satisfies it, so the enforced half cannot tell a real entry from an empty one.

The pattern held after the range closed: **#141** and **#142** shipped surface and touched no `docs/`; **#142** put four new fields on a wire event. **#145** did do its docs pass, and did it well — and it is a removal, where the doc consequence is impossible to miss.

## Note on gates

`typecheck` and `lint` do not reach `docs/` (`tsc --build`, `biome check src/`), so the real obligation was the Markdown samples, each checked by hand against its declaring type. The external-name audit passes.
