### PR TITLE
docs(sdk): activeTools said it would not silence a step, and it does

### DIFF
--- a/.changeset/a-phase-list-that-aged-out.md
+++ b/.changeset/a-phase-list-that-aged-out.md
@@ -1,0 +1,28 @@
+---
+'@namzu/sdk': patch
+---
+
+`PrepareStepResult.activeTools` documented the opposite of what it does.
+
+Its comment promised that unregistered names are dropped so a phase list
+outliving a tool rename would "narrow the surface, not kill the agent mid-run".
+Since the list began bounding what may RUN rather than only what the model is
+shown, dropping every name leaves the step able to call nothing — so the code
+and its own documentation had said different things.
+
+**The behaviour is right and the comment was wrong.** This list means "only
+these": when a rename outlives it, the only set satisfying "only the tools that
+no longer exist" is the empty one. Widening back to the run's list would grant
+precisely the tools the caller asked to exclude, on the grounds that their own
+list failed — a control that stops applying because it was aged out, which is
+worse than a step that answers from what it already has. The run continues
+either way; nothing crashes.
+
+The warning now distinguishes the two cases, because they have different
+consequences: some names dropped narrows the step, and all of them dropped
+leaves it unable to call anything. "Ignoring them" was accurate for the first
+and misleading for the second.
+
+**Worth knowing if you rely on this:** the warning goes to the logger, so a host
+that silences its logger sees a phase quietly stop doing anything. That is a real
+gap and it is named here rather than papered over.

--- a/packages/sdk/src/runtime/query/iteration/index.ts
+++ b/packages/sdk/src/runtime/query/iteration/index.ts
@@ -1144,15 +1144,29 @@ export class IterationOrchestrator {
 		} = {}
 
 		if (result.activeTools) {
-			// A phase list that outlives a tool rename should narrow the
-			// surface, not kill the agent mid-run.
 			const known = result.activeTools.filter((name: string) => this.ctx.tools.has(name))
 			const unknown = result.activeTools.filter((name: string) => !this.ctx.tools.has(name))
 			if (unknown.length > 0) {
-				this.ctx.log.warn('prepareStep named tools that are not registered — ignoring them', {
+				// The all-unknown case gets its own sentence because it has its
+				// own consequence. Some names dropped narrows the step; ALL of
+				// them dropped leaves it able to call nothing — which is the
+				// honest reading of "only these tools" when none of them exist,
+				// and is not what a reader of "ignoring them" would expect.
+				//
+				// Widening back to the run's list would be worse: it grants
+				// exactly the tools the caller asked to exclude, on the grounds
+				// that their own list failed. A step that can call nothing is
+				// constrained; a step that can call everything is a control
+				// that stopped applying.
+				const message =
+					known.length === 0
+						? 'prepareStep named only tools that are not registered — this step can call nothing'
+						: 'prepareStep named tools that are not registered — ignoring them'
+				this.ctx.log.warn(message, {
 					runId: this.ctx.runMgr.id,
 					stepNumber,
 					unknown,
+					remaining: known.length,
 				})
 			}
 			prepared.allowedTools = known

--- a/packages/sdk/src/types/run/prepare-step.ts
+++ b/packages/sdk/src/types/run/prepare-step.ts
@@ -44,8 +44,23 @@ export interface PrepareStepResult {
 	/**
 	 * Restrict which tools the model may call this step, by name. Names
 	 * that are not registered are dropped with a warning rather than
-	 * failing the run — a phase list that outlives a tool rename should
-	 * narrow the surface, not kill the agent mid-run.
+	 * failing the run.
+	 *
+	 * **Dropping every name leaves the step able to call nothing**, and that
+	 * is deliberate rather than an accident of the filter. This list means
+	 * "only these": if a rename outlives a phase list, the only set
+	 * satisfying "only the tools that no longer exist" is the empty one, and
+	 * widening back to the run's list would grant precisely what the caller
+	 * did not ask for. The step is constrained, not crashed — the model
+	 * answers from what it has and the run continues.
+	 *
+	 * This changed meaning when the list started bounding what may RUN
+	 * rather than only what the model is shown. Before, an aged-out list hid
+	 * every tool from the model while leaving all of them callable, which
+	 * was neither reading.
+	 *
+	 * The warning is the part to watch: it goes to the logger, and a host
+	 * that silences its logger sees a phase quietly stop doing anything.
 	 *
 	 * **This costs a prompt-cache prefix.** Tools render at position 0, so
 	 * changing the set between steps invalidates the cached prefix for that


### PR DESCRIPTION
A documentation agent reported this as a defect in the code. Checking it inverted the conclusion: **the behaviour is right and the comment was wrong.**

## What the comment promised

> Names that are not registered are dropped with a warning rather than failing the run — a phase list that outlives a tool rename should narrow the surface, **not kill the agent mid-run.**

Since `activeTools` began bounding what may **run** rather than only what the model is shown, dropping every name leaves the step able to call nothing. So the code and its own documentation had been saying different things.

## Why the code is right

`activeTools: ['old_name']` means *only* `old_name`. When a rename outlives the list, the only set satisfying "only the tools that no longer exist" is the empty one.

Widening back to the run's list would grant precisely the tools the caller asked to exclude, on the grounds that their own list failed — a control that stops applying because it aged out. A step that can call nothing is constrained and answers from what it has; a step that can call everything is a control that quietly stopped being one. The run continues either way.

## What changed

The comment, and the warning. Some names dropped narrows the step; **all** of them dropped leaves it unable to call anything, and `ignoring them` was accurate for the first and misleading for the second. They now read differently because they mean differently.

## The gap this does not close, named rather than papered over

The warning goes to the logger, and every command-line entry point sets the logger to silent. So a host whose phase list ages out sees a step quietly stop doing anything, with the only signal going to a channel it has turned off — the same shape as the compaction silence fixed earlier today, which needed an event rather than a log line. That is a larger change and it is not this one.

Gates: typecheck 0 · 415 runtime tests green. No behaviour change, so no test moved.