### PR TITLE
fix(cli): a permissions rule you wrote is the one that runs

### DIFF
--- a/.changeset/permission-rules-reach-the-turn.md
+++ b/.changeset/permission-rules-reach-the-turn.md
@@ -1,0 +1,47 @@
+---
+'@namzu/cli': minor
+---
+
+a permissions rule you wrote is the one that runs
+
+A `permissions` table in a config file did nothing. Not in `namzu run`, not in
+`run-stream`, not in the interactive TUI — nowhere, since the table was
+introduced. Three faults in series, each sufficient on its own:
+
+1. **The loader dropped it.** `sanitize()` copied exactly `format` and `quiet`
+   off a parsed config file, so `permissions` never survived being read.
+   `compilePermissions(ctx.config.permissions)` had always been compiling
+   `undefined`.
+2. **The turn discarded it.** The top-level turn passed a module-level gate
+   whose `rules` is a hardcoded empty array, so even a caller handing rules in
+   explicitly had them dropped. The helper that folds them in was called on the
+   sub-agent path only.
+3. **The TUI never asked for it.** Only `run` and `run-stream` compiled the
+   table at all, so interactive sessions had no rules to drop in the first
+   place.
+
+**Nothing looked broken, and that is the worst part.** The gate already falls
+back to asking, and `ask` compiles to no rule — so a discarded `deny` is
+indistinguishable from a config that was honoured. You are prompted, you
+approve, and you never learn your refusal was thrown away. A visible failure
+would have been found in a day.
+
+**What changes for you:** if you have a `permissions` table, it now applies. A
+`deny` refuses instead of prompting, and an `allow` stops asking. Check yours
+before upgrading — it has never actually run, so this is the first release in
+which it means anything. In an interactive session a `deny` is not even
+offered for approval, which is the point of writing one.
+
+Adding a field to the config type now fails to compile until the loader is
+taught to read it. The old code ended in `out as NamzuCliConfig`, and that cast
+is precisely what let `permissions` be declared, documented, type-checked and
+ignored; the loader's field list is now derived from the config type instead of
+restated beside it.
+
+Also documents where the config file lives and what it looks like, which was
+written down nowhere.
+
+`minor`, not `patch`: a table that was inert becomes active, so a `deny` you
+forgot you wrote can stop a command that used to run. Nothing about the API
+changed, but the behaviour a consumer sees does, and that is what the bump is a
+claim about.

--- a/docs/cli/headless.md
+++ b/docs/cli/headless.md
@@ -200,8 +200,10 @@ namzu providers-json               # [{provider, label, detected, default, model
 ## Permission modes
 
 Every tool call is first put to a verification gate, which answers `allow`,
-`deny` or **`review`**. `--permission-mode` says what happens to the calls that
-came back `review` — the ones nothing decided either way.
+`deny` or **`review`**. The gate consults the safety floor, then your
+[`permissions` table](./tools.md#the-permissions-file), then the read-only
+allowance. `--permission-mode` says what happens to the calls that came back
+`review` — the ones nothing decided either way.
 
 | Mode | An undecided call is | Default when |
 | --- | --- | --- |
@@ -213,16 +215,30 @@ came back `review` — the ones nothing decided either way.
 namzu run --permission-mode strict "run the test suite"
 ```
 
-`strict` is the mode for an unattended run. Read-only tools still run — `read`,
-`glob`, `grep`, and the memory and task tools observe without changing anything,
-so the gate allows them outright and they never reach the mode. Everything else
-is refused, and the model is told in the refusal that asking again will not
-help, so it stops rather than rewording the same call.
+`strict` is the mode for an unattended run: **nothing executes unless the gate
+allowed it.** Two things reach that bar. Read-only tools — `read`, `glob`,
+`grep`, and the memory and task tools observe without changing anything, so the
+gate allows them outright and they never reach the mode. And anything your
+[`permissions` table](./tools.md#the-permissions-file) allowed by name or
+pattern. Everything else is refused, and the model is told in the refusal that
+asking again will not help, so it stops rather than rewording the same call.
 
 Before `strict` existed an unattended run could only be `auto`, so a CI job
 either trusted the agent with every tool it might reach for or could not use it
 at all. `strict` makes a headless run something you can reason about: it can
-look, and it cannot touch.
+look, and it can touch exactly what you wrote down.
+
+```yaml
+# a CI job that may run the tests and nothing else
+permissions:
+  bash:
+    "pnpm test*": allow
+```
+
+Until `@namzu/cli` 0.7.0 the table was dropped before it reached the gate, so
+`strict` meant read-only-tools-only no matter what you wrote. Adding an `allow`
+is the difference between a job that can do one thing and one that can only
+look.
 
 `--yolo` and `--dangerously-skip-permissions` mean `--permission-mode auto`.
 They were previously accepted and documented as doing nothing, which was true
@@ -240,12 +256,13 @@ The direction is deliberate. A gate rule is a durable statement someone
 reviewed; a flag is typed in a hurry by someone who wants to get on with it. A
 prohibition a flag can lift is not a prohibition.
 
-Which rules the gate holds is set by the host that builds the session. For the
-rule vocabulary and how to supply it, see
-[Tool Safety](../sdk/tools/safety.md) — `namzu` itself currently runs the gate
-with its two standing policies (deny catastrophic shell patterns, allow
-read-only tools) and no additional rules, so in practice the mode is the whole
-of the operator-facing control here.
+Which rules the gate holds is set by the host that builds the session. `namzu`
+runs it with its two standing policies — deny catastrophic shell patterns, allow
+read-only tools — plus whatever your
+[`permissions` table](./tools.md#the-permissions-file) compiles to. So the mode
+is not the whole of the operator-facing control: the table decides calls, and
+the mode only settles what the table left open. For the underlying rule
+vocabulary a custom host can use, see [Tool Safety](../sdk/tools/safety.md).
 
 ## Resuming a conversation
 

--- a/docs/cli/tools.md
+++ b/docs/cli/tools.md
@@ -1,6 +1,6 @@
 ---
 title: Tools & permission
-description: Builtin tools, agent memory + task tools, deferred tools and search_tools, how a tool call is decided, permission modes, the safety gate, and bypass mode.
+description: Builtin tools, agent memory + task tools, deferred tools and search_tools, how a tool call is decided, the permissions file, the safety gate, and bypass mode.
 last_updated: 2026-08-05
 status: current
 related_packages: ["@namzu/cli", "@namzu/sdk"]
@@ -44,7 +44,15 @@ A sub-agent runs without a task store, so it has nothing deferred, and `search_t
 
 Every call goes through the same two stages, in this order.
 
-**1. The verification gate** answers `allow`, `deny`, or `review`. It hard-denies a narrow set of catastrophic shell patterns (see [The safety gate](#the-safety-gate)) and allows tools that only observe. Everything else comes back `review` — the gate has no opinion, and the decision moves on.
+**1. The verification gate** answers `allow`, `deny`, or `review`, consulting three things in this order:
+
+1. **The safety floor** — a narrow set of catastrophic shell patterns is denied outright and outranks everything below (see [The safety gate](#the-safety-gate)).
+2. **Your rules** — the [`permissions` table](#the-permissions-file), if you wrote one. An `allow` or `deny` here settles the call.
+3. **The read-only allowance** — a tool that only observes is allowed.
+
+Anything still undecided comes back `review` — the gate has no opinion, and the decision moves on.
+
+Your rules are consulted *before* the read-only allowance, which is what makes `read: ask` reachable: were the order reversed, a rule asking to be prompted about a read would be silently unreachable.
 
 **2. The mode** decides what happens to a `review`. Which mode is in force depends on where you are:
 
@@ -56,7 +64,58 @@ Every call goes through the same two stages, in this order.
 
 `--permission-mode` is a headless flag — see [Headless runs](./headless.md#permission-modes). The TUI is `prompt` unless you launched it with bypass.
 
-**A mode never reopens what the gate closed.** A denied call was already stopped and an allowed one never asked, so neither reaches the mode. That is why `--yolo` cannot run a catastrophic command: the denial happens a stage earlier.
+**A mode never reopens what the gate closed.** A denied call was already stopped and an allowed one never asked, so neither reaches the mode. That is why `--yolo` cannot run a catastrophic command: the denial happens a stage earlier — and equally why a `deny` you wrote is not something bypass can undo.
+
+## The permissions file
+
+A `permissions` table says what a tool may do without asking. namzu reads two
+config files, and the later one wins:
+
+| File | Scope |
+| --- | --- |
+| `~/.namzu/config.yaml` | you, everywhere |
+| `./namzu.config.json` | this project |
+
+```yaml
+# ~/.namzu/config.yaml
+permissions:
+  read: allow
+  bash:
+    "git status": allow
+    "git push*": deny
+  write: deny
+```
+
+```json
+// ./namzu.config.json
+{
+  "permissions": {
+    "read": "allow",
+    "bash": { "git status": "allow", "git push*": "deny" }
+  }
+}
+```
+
+An effect is `allow`, `ask` or `deny`, either for a whole tool or per argument
+pattern. More specific patterns are matched first.
+
+**`ask` is the default, so writing it changes nothing** — an unmatched call is
+already asked about. It is spelled out so a table can say what it means rather
+than leaving a reader to infer it from an absence, and it is why there is no way
+to widen by omission: the only way to allow something is to say so.
+
+**The table is replaced, not merged.** A project file's `permissions` overrides
+a user file's entirely rather than combining key by key, so a project config that
+sets one rule does not inherit the rest.
+
+**It applies to the interactive TUI as well as `run` and `run-stream`** (since
+0.7.0 — before that the table was dropped before it reached any of them). A
+`deny` in an interactive session means the call is refused outright rather than
+prompted, which is the point of writing one: it protects you from approving by
+reflex.
+
+For what happens to calls no rule covered, see
+[permission modes](./headless.md#permission-modes).
 
 ## The permission prompt
 

--- a/packages/cli/src/__tests__/permission-rules-reach-the-turn.test.ts
+++ b/packages/cli/src/__tests__/permission-rules-reach-the-turn.test.ts
@@ -1,0 +1,153 @@
+/**
+ * An operator's `permissions` config reaches the turn that enforces it.
+ *
+ * There was no test that started from a real config FILE and ended at a real
+ * turn, and that gap is the whole reason this shipped: the chain is broken in
+ * two independent places, in series, and every existing test sits on one side
+ * or the other of a break.
+ *
+ *   config file → loadConfig() → compilePermissions() → createAgentSession()
+ *               ↑ break 1                                        → query()
+ *                                                          ↑ break 2
+ *
+ * - **Break 1.** `sanitize()` in `config/load.ts` copies exactly `format` and
+ *   `quiet` off a parsed config, so `permissions` is dropped from every file
+ *   namzu reads. `compilePermissions(ctx.config.permissions)` in `run.ts` and
+ *   `run-stream.ts` is therefore always compiling `undefined`.
+ * - **Break 2.** `runTurn` destructures `rules` and passes the module-level
+ *   `VERIFICATION_GATE` — whose `rules` is a hardcoded `[]` — to `query()`.
+ *   So even a caller that hands rules in explicitly has them dropped.
+ *
+ * Either break alone is enough to make a configured rule do nothing, which is
+ * why this test is end-to-end: fixing one and testing that one would report
+ * success while the feature stayed broken.
+ *
+ * The failure is silent by construction. `ask` compiles to no rule because the
+ * gate's fallback is already to ask, so a dropped `deny` looks exactly like a
+ * config that was honoured — the tool prompts instead of refusing, and a user
+ * who clicks approve never learns their `deny` was ignored.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { loadConfig } from '../config/load.js'
+import type { DetectedProvider, Preferences } from '../integrations/providers/index.js'
+import { compilePermissions } from '../permissions/rules.js'
+
+const queryCalls: Record<string, unknown>[] = []
+vi.mock('@namzu/sdk', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@namzu/sdk')>()
+	return {
+		...actual,
+		query: (params: Record<string, unknown>) => {
+			queryCalls.push(params)
+			return (async function* () {})()
+		},
+	}
+})
+
+let workDir: string
+
+beforeEach(() => {
+	queryCalls.length = 0
+	workDir = mkdtempSync(join(tmpdir(), 'namzu-perms-'))
+})
+
+afterEach(() => {
+	rmSync(workDir, { recursive: true, force: true })
+})
+
+/** A real config file, in the real project-config location and format. */
+function writeProjectConfig(permissions: Record<string, unknown>): void {
+	writeFileSync(join(workDir, 'namzu.config.json'), JSON.stringify({ permissions }, null, 2))
+}
+
+const prefs = {
+	version: 2,
+	provider: 'anthropic',
+	subagents: { active: [] },
+} as Preferences
+
+function detectedAnthropic(): DetectedProvider[] {
+	return [
+		{
+			entry: {
+				id: 'anthropic',
+				label: 'Anthropic',
+				defaultModel: 'claude-sonnet-4-5',
+				requiresApiKey: true,
+				envVars: ['ANTHROPIC_API_KEY'],
+			},
+			source: 'env',
+			apiKey: 'sk-ant-not-a-real-key',
+			alternatives: [],
+		} as unknown as DetectedProvider,
+	]
+}
+
+describe('a permissions rule written in a config file', () => {
+	it('survives loadConfig', () => {
+		writeProjectConfig({ bash: 'deny' })
+
+		const cfg = loadConfig({ cwd: workDir, home: workDir, env: {} })
+
+		expect(
+			cfg.permissions,
+			'the loader dropped the permissions table off a config file it parsed',
+		).toBeDefined()
+		expect(cfg.permissions?.bash).toBe('deny')
+	})
+
+	it('reaches the gate of the turn that has to enforce it', async () => {
+		writeProjectConfig({ bash: 'deny' })
+
+		// Exactly what `run.ts` does, from the same starting point a user has.
+		const cfg = loadConfig({ cwd: workDir, home: workDir, env: {} })
+		const compiled = compilePermissions(cfg.permissions)
+
+		const { createAgentSession } = await import('../tui/agent.js')
+		const session = await createAgentSession(prefs, detectedAnthropic(), {
+			cwd: workDir,
+			rules: compiled.rules,
+		})
+		for await (const _ of session.send([{ role: 'user', content: 'hi', timestamp: 0 }])) {
+			// drain
+		}
+
+		expect(queryCalls.length, 'the turn must have reached query()').toBe(1)
+		const gate = queryCalls[0]?.verificationGate as { rules?: unknown[] } | undefined
+		expect(gate?.rules).toEqual([{ type: 'deny_by_name', toolNames: ['bash'] }])
+	})
+
+	it('is not silently replaced by the empty default when handed in directly', async () => {
+		// DO NOT DELETE THIS AS REDUNDANT WITH THE TEST ABOVE. It looks like a
+		// subset of it and it is the opposite: it is the only test that isolates
+		// the turn path from the loader.
+		//
+		// There were two faults, in series. Rules were dropped by the loader AND
+		// again by the turn, and either one alone makes a configured rule do
+		// nothing. A suite with only the end-to-end test above would go green the
+		// moment ONE of them was fixed — reporting success on a feature that was
+		// still dead — and a suite with only a loader test would never have looked
+		// at the turn at all.
+		//
+		// So: no config file here, rules handed straight to the session. When this
+		// fails and the end-to-end one fails, the turn drops them. When only the
+		// end-to-end one fails, the loader is the sole fault. The pair of results
+		// is the diagnosis; neither test gives it alone.
+		const { createAgentSession } = await import('../tui/agent.js')
+		const session = await createAgentSession(prefs, detectedAnthropic(), {
+			cwd: workDir,
+			rules: [{ type: 'deny_by_name', toolNames: ['bash'] }],
+		})
+		for await (const _ of session.send([{ role: 'user', content: 'hi', timestamp: 0 }])) {
+			// drain
+		}
+
+		const gate = queryCalls[0]?.verificationGate as { rules?: unknown[] } | undefined
+		expect(gate?.rules).toEqual([{ type: 'deny_by_name', toolNames: ['bash'] }])
+	})
+})

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -36,10 +36,16 @@ describe('runCli', () => {
 		// Commander prints help to stdout.
 		expect(stdout).toContain('namzu')
 		expect(stdout).toContain('doctor')
-		expect(stdout).toContain('tools')
 		expect(stdout).toContain('providers')
 		expect(stdout).toContain('skills')
 		expect(stdout).toContain('serve')
+		// `tools` was asserted here until the peer-daemon removal deleted the
+		// command. The assertion kept passing, because "tools" also occurs in
+		// the --dangerously-skip-permissions description ("Run tools without
+		// asking…") — a substring match on whole help output cannot tell a
+		// command from a word in a sentence. Anchored to the command column so
+		// it means what it says.
+		expect(stdout).not.toMatch(/^\s+tools\b/m)
 		// `chat` was a misread of the product shape — the TUI IS the chat,
 		// not a separate subcommand. `chat` must not appear in help.
 		expect(stdout).not.toContain('chat')

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -29,6 +29,7 @@ import type { CommandContext } from './commands/types.js'
 import { loadConfig } from './config/load.js'
 import { EXIT_INTERNAL_ERROR } from './exit-codes.js'
 import { type FormatName, createFormatter, isFormatName } from './output/index.js'
+import { compilePermissions } from './permissions/rules.js'
 
 /** sysexits EX_USAGE — command-line argument error. */
 const EX_USAGE = 64
@@ -124,8 +125,22 @@ export async function runCli(opts: RunCliOptions): Promise<number> {
 		if (process.stdout.isTTY) {
 			const launchOpts = program.opts<{ dangerouslySkipPermissions?: boolean; yolo?: boolean }>()
 			const skipPermissions = Boolean(launchOpts.dangerouslySkipPermissions || launchOpts.yolo)
+			// The same three lines `run` and `run-stream` use. The TUI compiled
+			// nothing at all, so a `permissions` table in a config file did nothing
+			// in the mode most people actually use.
+			const tuiCtx = getContext()
+			const permissions = compilePermissions(tuiCtx.config.permissions)
+			for (const d of permissions.diagnostics) {
+				const where = d.pattern ? `permissions.${d.tool}."${d.pattern}"` : `permissions.${d.tool}`
+				tuiCtx.formatter.error({ message: `${where}: ${d.message}` })
+			}
 			const { launchTui } = await import('./tui/index.js')
-			await launchTui({ cwd: process.cwd(), version: CLI_VERSION, skipPermissions })
+			await launchTui({
+				cwd: process.cwd(),
+				version: CLI_VERSION,
+				skipPermissions,
+				rules: permissions.rules,
+			})
 			const code = await Promise.resolve(0)
 			setExitCode(code)
 			return

--- a/packages/cli/src/config/load.ts
+++ b/packages/cli/src/config/load.ts
@@ -19,7 +19,8 @@ import { join, resolve } from 'node:path'
 
 import { parse as yamlParse } from 'yaml'
 
-import { type FormatName, isFormatName } from '../output/index.js'
+import { isFormatName } from '../output/index.js'
+import type { PermissionsConfig } from '../permissions/rules.js'
 import { DEFAULT_CONFIG, type NamzuCliConfig } from './schema.js'
 
 export interface LoadConfigOptions {
@@ -66,9 +67,40 @@ function readJsonIfExists(path: string): MutableConfig {
 	}
 }
 
-interface MutableConfig {
-	format?: FormatName
-	quiet?: boolean
+/**
+ * A writable mirror of the public config, derived from it rather than
+ * restated.
+ *
+ * It used to be a hand-written pair of fields, and `mergeConfigs` ended in
+ * `out as NamzuCliConfig` — so this type could omit a field the public config
+ * declared and nothing complained. `permissions` was added to `NamzuCliConfig`,
+ * could not be represented here, and was silently dropped from every config
+ * file namzu read. The cast is what made that possible: it told the compiler to
+ * stop checking exactly where the gap was.
+ */
+type MutableConfig = { -readonly [K in keyof NamzuCliConfig]?: NamzuCliConfig[K] }
+
+/**
+ * One reader per public config field. The mapped type has no `?`, so **every**
+ * key of `NamzuCliConfig` must appear here — adding a field to the public
+ * config now fails to compile until it is given a reader.
+ *
+ * That is the point. The previous version was an allowlist a new field had to
+ * be manually added to, and the cost of forgetting was a config key that
+ * parsed, validated, type-checked and did nothing.
+ */
+type ConfigReaders = {
+	[K in keyof Required<NamzuCliConfig>]: (value: unknown) => NamzuCliConfig[K] | undefined
+}
+
+const CONFIG_READERS: ConfigReaders = {
+	format: (v) => (typeof v === 'string' && isFormatName(v) ? v : undefined),
+	quiet: (v) => (typeof v === 'boolean' ? v : undefined),
+	// Shape only. Per-entry validation belongs to `compilePermissions`, which
+	// reports a bad effect or an unusable pattern as a diagnostic the user
+	// sees; dropping those entries here would silence it.
+	permissions: (v) =>
+		typeof v === 'object' && v !== null && !Array.isArray(v) ? (v as PermissionsConfig) : undefined,
 }
 
 function readEnv(env: NodeJS.ProcessEnv): MutableConfig {
@@ -87,15 +119,23 @@ function sanitize(value: unknown): MutableConfig {
 	if (typeof value !== 'object' || value === null) return {}
 	const v = value as Record<string, unknown>
 	const out: MutableConfig = {}
-	if (typeof v.format === 'string' && isFormatName(v.format)) out.format = v.format
-	if (typeof v.quiet === 'boolean') out.quiet = v.quiet
+	for (const key of Object.keys(CONFIG_READERS) as (keyof NamzuCliConfig)[]) {
+		if (!(key in v)) continue
+		const parsed = CONFIG_READERS[key](v[key])
+		// One assignment through a widened view, rather than a cast on the
+		// result: the key/reader pairing is what `ConfigReaders` proves.
+		if (parsed !== undefined) (out as Record<string, unknown>)[key] = parsed
+	}
 	return out
 }
 
+// Returns `MutableConfig`, which is assignable to `NamzuCliConfig` because it
+// is derived from it. No cast — a field this function cannot carry is now a
+// compile error rather than a value that quietly never arrives.
 function mergeConfigs(...sources: readonly MutableConfig[]): NamzuCliConfig {
 	const out: MutableConfig = {}
 	for (const src of sources) Object.assign(out, src)
-	return out as NamzuCliConfig
+	return out
 }
 
 function safeRead(path: string): string | null {

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -184,7 +184,11 @@ export function App({ ctx }: AppProps) {
 	const hydrateSession = useCallback(
 		async (prefs: Preferences, detectedNow: readonly DetectedProvider[]) => {
 			const scope = await ensureSessions()
-			const s = await createAgentSession(prefs, detectedNow, { scope, cwd: ctx.cwd })
+			const s = await createAgentSession(prefs, detectedNow, {
+				scope,
+				cwd: ctx.cwd,
+				rules: ctx.rules,
+			})
 			setSession(s)
 			setCurrentProvider(prefs.provider)
 			if (s.hasProvider) {
@@ -198,7 +202,7 @@ export function App({ ctx }: AppProps) {
 				if (s.errorHint) pushMessage('system', s.errorHint)
 			}
 		},
-		[ctx.cwd, pushMessage],
+		[ctx.cwd, ctx.rules, pushMessage],
 	)
 
 	const runProbe = useCallback(async () => {

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -648,7 +648,11 @@ async function* runTurn({
 			tools,
 			taskStore,
 			...(taskGateway ? { taskGateway } : {}),
-			verificationGate: VERIFICATION_GATE,
+			// `gateFor`, not the bare default: the default's `rules` is a hardcoded
+			// empty array, so passing it here discarded the operator's rules on the
+			// path that runs every top-level turn. The sub-agent path called
+			// `gateFor` and this one did not.
+			verificationGate: gateFor(rules),
 			compactionConfig: COMPACTION_CONFIG,
 			// The CLI owns its process end to end, so it can safely hand the
 			// termination path to the kernel: a Ctrl-C mid-run now leaves a

--- a/packages/cli/src/tui/types.ts
+++ b/packages/cli/src/tui/types.ts
@@ -4,6 +4,8 @@
  * the React/Ink layer.
  */
 
+import type { VerificationRule } from '@namzu/sdk'
+
 export type MessageRole = 'user' | 'assistant' | 'system' | 'tool'
 
 export interface TranscriptMessage {
@@ -26,4 +28,15 @@ export interface TuiContext {
 	readonly version: string
 	/** When true, tools run without the approval prompt (--dangerously-skip-permissions / --yolo). */
 	readonly skipPermissions?: boolean
+	/**
+	 * The operator's `permissions` table, compiled to kernel rules.
+	 *
+	 * A config file belongs to the user, not to a command: someone who writes
+	 * `bash = "deny"` and then types `namzu` expects it to hold. Interactive
+	 * mode having a human present is an argument about the default, not a
+	 * licence to drop a rule they wrote — and `deny` in a session means "do not
+	 * even ask me", which is exactly what protects someone from approving by
+	 * reflex.
+	 */
+	readonly rules?: readonly VerificationRule[]
 }


### PR DESCRIPTION
Follows #145 (merged). Rebased onto `main`, so this is one commit.

A `permissions` table in a config file did nothing. Not in `namzu run`, not in `run-stream`, not in the interactive TUI — nowhere, since the table was introduced.

## Three faults, in series

```
config file → loadConfig() → compilePermissions() → createAgentSession() → query()
            ↑ 1                  ↑ 3 (TUI never called it)            ↑ 2
```

1. **The loader dropped it.** `sanitize()` copied exactly `format` and `quiet` off a parsed config, so `compilePermissions(ctx.config.permissions)` in `run.ts` and `run-stream.ts` had always been compiling `undefined`.
2. **The turn discarded it.** The top-level turn passed a module-level gate whose `rules` is a hardcoded `[]`, so even a caller handing rules in explicitly lost them. `gateFor` exists and was called on the sub-agent path only.
3. **The TUI never asked for it.** Only `run` and `run-stream` compiled the table at all.

Each is sufficient alone, so fixing one and testing that one would go green with the feature still dead. That is why the reproduction came first and why all three ship together.

## Why it survived two PRs whose subject was rules reaching the gate

**Nothing looked broken.** The gate already falls back to asking, and `ask` compiles to no rule — so a discarded `deny` is indistinguishable from a config that was honoured. You are prompted, you approve, and you never learn your refusal was thrown away. A visible failure would have been found in a day; this one wears the appearance of working.

## The finding under the finding: a cast, not a style wart

`mergeConfigs` ended in `return out as NamzuCliConfig`. `MutableConfig` was a hand-written pair of fields that could omit anything the public config declared, and the cast told the compiler to stop checking exactly there. `permissions` was added to the public type, could not be represented, and was silently dropped.

The loader's field list is now **derived** from the config type, and a `ConfigReaders` mapped type with no optional keys requires one reader per public field. Adding a field to `NamzuCliConfig` now fails the build until it is given a reader — verified by adding a probe field and watching `tsc` reject it:

```
src/config/load.ts(96,7): error TS2741: Property 'mutationProbe' is missing
  in type '{ format: …; quiet: …; permissions: … }' but required in type 'ConfigReaders'.
```

**Audit of the rest of the allowlist:** `NamzuCliConfig` declares exactly three fields. Only `permissions` was missing, so nothing else was being dropped — and it cannot happen again silently.

## Tests

Three, end-to-end from a real config file to a real turn. The third hands rules straight to the session with no config file, and its comment says in capitals not to delete it as redundant: it is the only test that isolates the turn from the loader.

Mutations, each reverted after:

| Mutation | Fails |
| --- | --- |
| loader drops `permissions` again | tests 1 + 2, **not** 3 |
| parent turn back to the bare default gate | tests 2 + 3, **not** 1 |

Complementary signatures — the pair localises the fault; neither test gives that alone.

## A test that had stopped testing anything

`cli.test.ts` asserted `--help` lists `tools` and **kept passing after the command was deleted**, because "tools" also occurs in the `--dangerously-skip-permissions` description ("Run tools without asking…"). A substring match against whole help output cannot tell a command from a word in a sentence. Now anchored to the command column and inverted, and mutation-checked by re-registering a `tools` command.

## Docs

Where the config file lives and what it looks like was written down nowhere — only a passing reference to a `[permissions]` table in TOML syntax, while the loader reads `~/.namzu/config.yaml` and `./namzu.config.json`. Added, with both formats, the replace-not-merge precedence between them, and why writing `ask` changes nothing.

**Picks up the paragraph #143 deliberately left.** That PR rewrote these pages and removed the `[permissions]` documentation on the grounds that no loader could read the table — correct then, and wrong the moment this lands. It flagged `--permission-mode strict` as accurate-until-this-change and left the edit to whoever altered the behaviour. Done here: `strict` now means *nothing runs unless the gate allowed it*, which is read-only tools **plus whatever your table allowed by name or pattern**, with a worked CI example.

**A second paragraph went stale that was not flagged.** Under "What a mode cannot do", the page said namzu runs the gate "with its two standing policies … and no additional rules, so in practice the mode is the whole of the operator-facing control here." That becomes false by exactly the same change. Both are fixed.

Their "How a tool call is decided" section is better than what I had, so it is kept and the gate's third input — your rules, consulted *before* the read-only allowance, which is what makes `read: ask` reachable — is folded into it rather than described separately.

## Gates

`pnpm typecheck`, `pnpm lint`, `pnpm test` (**334** CLI tests), and `scripts/audit-external-names.mjs` all green.
