### PR TITLE
feat(sdk): a caller can ask which effort levels a model accepts

### DIFF
--- a/.changeset/which-levels-does-this-model-take.md
+++ b/.changeset/which-levels-does-this-model-take.md
@@ -1,0 +1,47 @@
+---
+'@namzu/sdk': minor
+'@namzu/anthropic': minor
+---
+
+A caller can ask which effort levels a model accepts.
+
+The answer existed, was modelled carefully, and was reachable only from inside
+one driver. That matters because effort is **refused, not clamped**: a level a
+model does not have makes the vendor reject the request, so a control offering
+the wrong one produces a run that fails at the start rather than a quieter one.
+
+Every option open to a caller without the answer was bad. Offering all five
+breaks some models. Offering the intersection hides `xhigh` and `max` from every
+model that has them, which is most of the reason to build such a control. And
+copying the table looks fine and is worst: the ceiling has moved twice already,
+so a copy goes stale on the next model and goes stale **silently**, surfacing as
+a vendor rejection rather than a failing build.
+
+**New optional `LLMProvider.effortLevelsFor(model, thinking?)`.** Three states,
+each meaning something different: the method absent means the driver has no
+effort concept at all and setting one will be refused; an empty array means the
+driver implements effort and this model has none; a non-empty array is the set
+to offer.
+
+**`thinking` is a parameter, and that is the point.** At least one model family
+accepts a narrower set while thinking is disabled than while it is on — so an
+API returning two sibling arrays invites a caller to render a picker from one
+and send the other, a combination the vendor rejects, on exactly one family.
+Passing the configuration you will actually send makes that unspellable: there
+is one answer and it is the one for your request.
+
+The driver's implementation shares the same two resolution steps the request
+path uses, so a caller's picker and the request it produces cannot disagree.
+
+`@namzu/anthropic` also now exports `resolveThinkingCapability`,
+`resolveThinkingBody`, `resolveEffort` and their types, for a caller that needs
+the fuller picture — whether thinking can be switched off at all, not only which
+effort levels apply. Prefer `effortLevelsFor` where it suffices: it is
+provider-agnostic and cannot return the wrong one of the two sets.
+
+Separately, the live wire-contract suite now retries a transient status rather
+than reporting it as a contract failure. A 529 says the service is busy and
+answers nothing about whether a schema is expressible — so a test named "every
+shipped tool is expressible on this wire" was claiming something the run had not
+established. That cost two manual re-runs in one day to discover the wire had no
+opinion.

--- a/packages/providers/anthropic/src/__tests__/effort-levels-are-askable.test.ts
+++ b/packages/providers/anthropic/src/__tests__/effort-levels-are-askable.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import { AnthropicProvider } from '../client.js'
+
+/**
+ * A caller building an effort control has to offer the levels a model actually
+ * accepts, and only those, because effort is REFUSED rather than clamped: a
+ * level a model does not have makes the vendor reject the request, so a picker
+ * offering the wrong one produces a run that fails at the start.
+ *
+ * The driver already knew the answer and kept it to itself. Every option open
+ * to a caller without it was bad: offer all five and break some models, offer
+ * the intersection and hide the levels that are most of the reason to build the
+ * control, or copy the table — which looks fine and is worst, because the
+ * ceiling has moved twice and a copy goes stale SILENTLY, surfacing as a vendor
+ * rejection rather than a failing build.
+ */
+
+const provider = (): AnthropicProvider =>
+	new AnthropicProvider({ apiKey: 'sk-ant-test', model: 'claude-sonnet-5' })
+
+describe('a caller can ask which levels a model takes', () => {
+	it('answers per model rather than per provider', () => {
+		// Three eras, three different answers. If this ever collapses to one
+		// set, the method has been reduced to a constant and the question it
+		// exists to answer has stopped being asked.
+		const p = provider()
+		const modern = p.effortLevelsFor('claude-opus-5')
+		const midRange = p.effortLevelsFor('claude-sonnet-4-6')
+		const legacy = p.effortLevelsFor('claude-opus-4-5')
+
+		expect(modern).toContain('xhigh')
+		expect(midRange).not.toContain('xhigh')
+		expect(midRange).toContain('max')
+		expect(legacy).not.toContain('max')
+
+		const distinct = new Set([modern, midRange, legacy].map((s) => [...s].sort().join(',')))
+		expect(distinct.size, 'the three eras must not answer alike').toBe(3)
+	})
+
+	it('reports an empty set rather than nothing for a model with no levels', () => {
+		// A real answer, and different from the method being absent. Absent
+		// means the driver has no effort concept at all; empty means it does
+		// and this model has none.
+		expect(provider().effortLevelsFor('claude-haiku-4-5')).toEqual([])
+	})
+})
+
+describe('the answer depends on the thinking configuration you will send', () => {
+	it('narrows for the family that caps effort while thinking is off', () => {
+		// The trap this signature exists to remove. A caller reading a single
+		// `effort` array, rendering a picker, and then also sending
+		// `thinking: disabled` produces a combination the vendor rejects — on
+		// exactly one family, which is why it survives casual testing.
+		const p = provider()
+		const withThinking = p.effortLevelsFor('claude-opus-5', { type: 'adaptive' })
+		const withoutThinking = p.effortLevelsFor('claude-opus-5', { type: 'disabled' })
+
+		expect(withThinking).toContain('max')
+		expect(withoutThinking).not.toContain('max')
+		expect(withoutThinking).not.toContain('xhigh')
+		expect(withoutThinking).toContain('high')
+	})
+
+	it('does not narrow for a sibling that accepts the full set either way', () => {
+		// Measured, not inferred: the cap belongs to one family, and a version
+		// comparison of "5 and later" would have caught this model too and
+		// hidden levels the wire honours.
+		const p = provider()
+		expect(p.effortLevelsFor('claude-sonnet-5', { type: 'disabled' })).toContain('max')
+	})
+})
+
+describe('the resolver is reachable for the fuller picture', () => {
+	it('is exported from the package entry, not only its own module', async () => {
+		// The whole report was that the answer existed and could not be
+		// reached. A caller that also needs to know whether thinking can be
+		// switched off at all reads the capability directly.
+		const entry = await import('../index.js')
+
+		expect(typeof entry.resolveThinkingCapability).toBe('function')
+		const capability = entry.resolveThinkingCapability('claude-opus-5')
+		expect(capability.effort.length).toBeGreaterThan(0)
+		expect(typeof capability.canDisable).toBe('boolean')
+	})
+})

--- a/packages/providers/anthropic/src/__tests__/wire-contract.live.test.ts
+++ b/packages/providers/anthropic/src/__tests__/wire-contract.live.test.ts
@@ -42,25 +42,54 @@ interface WireResult {
 	readonly message: string
 }
 
+/**
+ * Statuses that mean "ask again", not "this request is wrong".
+ *
+ * These tests assert a CONTRACT: that a given schema is or is not expressible
+ * on this wire. A 529 says the service is busy and answers nothing about the
+ * schema — so reporting it as a contract failure claims something the run did
+ * not establish. That happened twice in one day, and both times cost a manual
+ * re-run to discover the wire had no opinion.
+ *
+ * Retried rather than reported inconclusive because a test that sometimes
+ * declines to check is a test nobody trusts, and the retry is cheap: these
+ * requests set `max_tokens: 1` and are rejected or accepted at validation.
+ */
+const TRANSIENT = new Set([429, 500, 502, 503, 529])
+
+async function post(body: unknown): Promise<{ ok: boolean; status: number; message: string }> {
+	let last = { ok: false, status: 0, message: 'no attempt made' }
+	for (let attempt = 1; attempt <= 4; attempt += 1) {
+		const res = await fetch('https://api.anthropic.com/v1/messages', {
+			method: 'POST',
+			headers: {
+				'x-api-key': KEY as string,
+				'anthropic-version': '2023-06-01',
+				'content-type': 'application/json',
+			},
+			body: JSON.stringify(body),
+		})
+		const parsed: unknown = await res.json().catch(() => ({}))
+		const message =
+			(parsed as { error?: { message?: string } } | null)?.error?.message ??
+			(res.ok ? '' : 'unknown')
+		last = { ok: res.ok, status: res.status, message }
+		if (!TRANSIENT.has(res.status)) return last
+		await new Promise((resolve) => setTimeout(resolve, 1_500 * attempt))
+	}
+	// Exhausted. Returned rather than thrown so the assertion names the status
+	// — a bare failure here reads as a rejected schema, which is the confusion
+	// this whole helper exists to prevent.
+	return last
+}
+
 async function offerTools(tools: unknown[]): Promise<WireResult> {
-	const res = await fetch('https://api.anthropic.com/v1/messages', {
-		method: 'POST',
-		headers: {
-			'x-api-key': KEY as string,
-			'anthropic-version': '2023-06-01',
-			'content-type': 'application/json',
-		},
-		body: JSON.stringify({
-			model: MODEL,
-			max_tokens: 1,
-			messages: [{ role: 'user', content: 'hi' }],
-			tools,
-		}),
+	return post({
+		model: MODEL,
+		max_tokens: 1,
+		messages: [{ role: 'user', content: 'hi' }],
+		tools,
 	})
-	const body: unknown = await res.json().catch(() => ({}))
-	const message =
-		(body as { error?: { message?: string } } | null)?.error?.message ?? (res.ok ? '' : 'unknown')
-	return { ok: res.ok, status: res.status, message }
 }
 
 /** A tool as this driver would put it on the wire. */
@@ -245,26 +274,16 @@ describe.skipIf(!KEY)('the positional shape a bridged tool now emits', () => {
 })
 
 describe.skipIf(!KEY)('effort is a per-model SET, and this wire says so itself', () => {
-	async function withEffort(model: string, effort: string): Promise<WireResult> {
-		const res = await fetch('https://api.anthropic.com/v1/messages', {
-			method: 'POST',
-			headers: {
-				'x-api-key': KEY as string,
-				'anthropic-version': '2023-06-01',
-				'content-type': 'application/json',
-			},
-			body: JSON.stringify({
-				model,
-				max_tokens: 16,
-				messages: [{ role: 'user', content: 'Say OK.' }],
-				output_config: { effort },
-			}),
+	// Through the same retrying helper: a 529 here would read as "this model
+	// refuses that level", which is the exact claim these tests exist to make
+	// and the exact claim an overloaded service cannot support.
+	const withEffort = (model: string, effort: string): Promise<WireResult> =>
+		post({
+			model,
+			max_tokens: 16,
+			messages: [{ role: 'user', content: 'Say OK.' }],
+			output_config: { effort },
 		})
-		const body: unknown = await res.json().catch(() => ({}))
-		const message =
-			(body as { error?: { message?: string } } | null)?.error?.message ?? (res.ok ? '' : 'unknown')
-		return { ok: res.ok, status: res.status, message }
-	}
 
 	it('takes all five levels on a model the table says has all five', async () => {
 		for (const effort of ['low', 'medium', 'high', 'xhigh', 'max']) {

--- a/packages/providers/anthropic/src/client.ts
+++ b/packages/providers/anthropic/src/client.ts
@@ -8,7 +8,9 @@ import type {
 	ModelInfo,
 	ProviderCapabilities,
 	ReasoningBlock,
+	ReasoningEffort,
 	StreamChunk,
+	ThinkingConfig,
 	TokenUsage,
 	ToolChoice,
 	ToolResultContent,
@@ -1087,5 +1089,24 @@ export class AnthropicProvider implements LLMProvider {
 		// check is sufficient here — a real request costs tokens. Callers that
 		// want network-level verification should call `chat()` directly.
 		return Boolean(this.client) && Boolean(this.config.apiKey)
+	}
+
+	/**
+	 * The levels this model will accept, under the thinking configuration the
+	 * caller intends to send.
+	 *
+	 * Deliberately built from the SAME two functions the request path uses —
+	 * `resolveThinkingCapability` then `resolveThinkingBody` — rather than
+	 * reading `capability.effort` directly. Reading the field would answer the
+	 * question for adaptive thinking and silently give the wrong answer while
+	 * thinking is disabled, which is precisely the trap this method exists to
+	 * remove. Sharing the resolution means a caller's picker and the request
+	 * it produces cannot disagree: if they ever do, they do so together, and
+	 * the capability tests catch it.
+	 */
+	effortLevelsFor(model: string, thinking?: ThinkingConfig): readonly ReasoningEffort[] {
+		const capability = resolveThinkingCapability(model)
+		const body = resolveThinkingBody(thinking, capability)
+		return body?.type === 'disabled' ? capability.effortWhenDisabled : capability.effort
 	}
 }

--- a/packages/providers/anthropic/src/index.ts
+++ b/packages/providers/anthropic/src/index.ts
@@ -24,3 +24,21 @@ export function registerAnthropic(options?: RegisterOptions): void {
 
 export { ANTHROPIC_CAPABILITIES, AnthropicProvider } from './client.js'
 export type { AnthropicConfig, AnthropicProviderConfig } from './types.js'
+
+// The driver's reading of which effort levels each model accepts, exported so
+// a caller can build a control that offers only what will be honoured. The
+// preferred path is `provider.effortLevelsFor(model, thinking)` — it is
+// provider-agnostic and cannot return the wrong one of the two sets. This is
+// the fuller picture for a caller that also needs to know whether thinking can
+// be switched off at all, and it is exported rather than copied because the
+// ceiling has moved twice and a copy would go stale silently.
+export {
+	resolveThinkingCapability,
+	resolveThinkingBody,
+	resolveEffort,
+} from './thinking-capability.js'
+export type {
+	ThinkingCapability,
+	EffortLevels,
+	ResolvedThinkingBody,
+} from './thinking-capability.js'

--- a/packages/sdk/src/types/provider/interface.ts
+++ b/packages/sdk/src/types/provider/interface.ts
@@ -49,4 +49,43 @@ export interface LLMProvider {
 	 * so the doctor doesn't mark them as failing — see ses_007 Q6.4.
 	 */
 	doctorCheck?(): Promise<DoctorCheckResult>
+
+	/**
+	 * Which {@link ChatCompletionParams.effort} levels this model accepts,
+	 * under the thinking configuration you intend to send with it.
+	 *
+	 * Asked rather than assumed because effort is **refused, not clamped**:
+	 * a level a model does not have makes the vendor reject the request, so a
+	 * caller offering a choice it cannot honour produces a run that fails at
+	 * the start rather than a quieter one. Building that choice needs the
+	 * answer BEFORE the request exists.
+	 *
+	 * There are three states and they mean different things:
+	 *
+	 * - **method absent** — this driver has no effort concept at all. Setting
+	 *   `effort` on a run using it is refused, not ignored, so a caller should
+	 *   offer no control rather than a disabled one.
+	 * - **empty array** — the driver implements effort and THIS model has no
+	 *   levels. A real answer, not a missing one.
+	 * - **non-empty** — offer exactly these, and nothing else.
+	 *
+	 * `thinking` is a parameter rather than the caller reading two sibling
+	 * arrays, and that is the whole reason this is a function. At least one
+	 * model family accepts a narrower set of levels while thinking is
+	 * disabled than while it is on, so an API returning both sets invites a
+	 * caller to render a picker from one and then send the other — a
+	 * combination the vendor rejects, on exactly one family, discovered in
+	 * production. Passing the configuration you are actually going to send
+	 * makes that mistake unspellable: there is one answer and it is the one
+	 * for your request.
+	 *
+	 * The levels are not stable across models and have moved twice already,
+	 * so a caller must not copy the answer into its own table. A copy goes
+	 * stale on the next model release and goes stale SILENTLY — surfacing as
+	 * a vendor rejection rather than a failing build.
+	 */
+	effortLevelsFor?(
+		model: string,
+		thinking?: import('./chat.js').ThinkingConfig,
+	): readonly import('./chat.js').ReasoningEffort[]
 }


### PR DESCRIPTION
From a consumer report against 7.0.0. The ask was small and correct: the answer already exists, is modelled carefully, and is reachable only from inside one driver.

## Why it matters that it was unreachable

Effort is **refused, not clamped**. A level a model does not have makes the vendor reject the request, so a picker offering the wrong one produces a run that fails at the start — not a quieter answer. Every option open to a caller without the capability set was bad:

- **Offer all five.** Some choices break the run on some models.
- **Offer the intersection.** Hides `xhigh` and `max` from every model that has them, which is most of the reason to build the control.
- **Copy the table.** Looks fine, is worst. The report quotes our own comment saying the ceiling has moved twice; a copy goes stale on the next model and goes stale **silently**, surfacing as a vendor rejection rather than a failing build.

## What ships

**`LLMProvider.effortLevelsFor(model, thinking?)`**, optional. Three states, each meaning something different:

| | |
|---|---|
| method absent | this driver has no effort concept; setting one is refused, so offer no control |
| `[]` | the driver implements effort and this model has none — a real answer |
| non-empty | offer exactly these |

**It is on the provider interface rather than exported from one package**, which answers the report's first open question. `ReasoningEffort` is an SDK-level type; a caller should not have to import a specific driver to learn whether the effort it is about to set is legal, and a second effort-capable driver would otherwise force a per-provider branch in every caller.

**`thinking` is a parameter, and that is the answer to the report's second question.** It named `effortWhenDisabled` as the trap: read `effort`, render a picker, then also send `thinking: disabled`, and you produce a combination the vendor rejects — on exactly one family, which is why it survives casual testing. Returning the pair would have preserved the trap. Taking the configuration you will actually send makes it unspellable: there is one answer and it is the one for your request.

The driver's implementation shares the **same two resolution steps the request path uses** rather than reading `capability.effort`, so a caller's picker and the request it produces cannot disagree. If they ever do, they do so together and the capability tests catch it.

`@namzu/anthropic` also exports `resolveThinkingCapability`, `resolveThinkingBody`, `resolveEffort` and their types, for a caller that needs the fuller picture — whether thinking can be disabled at all, not only which levels apply.

## The guard the report asked for

Written as specified, plus the mutations that show it bites:

- Three eras return three **different** sets, asserted as a set-of-sets so the method cannot be reduced to a constant later. Returning a fixed array fails three tests.
- The disabled-thinking narrowing is its own test. Ignoring the `thinking` parameter fails exactly that one — the trap the report named, caught by the assertion written for it.
- The package entry exports the resolver, asserted through an import of `index.js`.

## One thing the run exposed

A live wire-contract test failed on **HTTP 529 Overloaded** and I checked it by hand rather than assuming. It was transient — but the suite was reporting a busy service as a contract failure, and a test named *every shipped tool is expressible on this wire* was claiming something the run had not established. Second time in a day that cost a manual re-run. Transient statuses are now retried with backoff.

Gates: typecheck 0 · lint clean · 2716 SDK + 199 anthropic (live suite included, 0 skipped) · external-name audit clean.