### PR TITLE
fix(cli): the context gauge reads the context, not the running bill

### DIFF
--- a/.changeset/the-gauge-was-measuring-the-bill.md
+++ b/.changeset/the-gauge-was-measuring-the-bill.md
@@ -1,0 +1,36 @@
+---
+'@namzu/cli': patch
+---
+
+The context gauge in the status footer reports the context, not the bill
+
+The `ctx` bar divided **cumulative run spend** by a context window guessed from
+a substring of the model name. Neither term was the thing it claimed.
+
+Cumulative spend is monotone by design — it exists so a run can never
+under-report a bill — and it grows superlinearly in turn count, because every
+turn re-sends the whole history and counts those prompt tokens again. Ten turns
+over a 50k context accumulate roughly 500k. So the bar **saturated**: a long
+conversation read FULL while the real context might be a fifth of the window,
+and it was most wrong exactly where a user relies on it. People were compacting
+sessions that had room.
+
+It now reads the figures the kernel already measures and ships on
+`token_usage_updated`: `contextTokens` over `contextWindowTokens`. The
+model-name guess is deleted, so a window is whatever the run actually resolved
+rather than 200k-or-1M.
+
+Two things a reader of the bar should know:
+
+- **A `~` before the percentage means the ratio is inferred, not measured.** It
+  appears when the kernel estimated the prompt size instead of the provider
+  counting it, **and also when the window itself is the assumed default** — an
+  exact count over an invented denominator is still a guess, and marking only
+  the numerator would repeat the original error one level down.
+- **No bar at all when either term is missing.** Runs that resolve no window
+  report no context figures, and a fraction that cannot be grounded is not an
+  approximation of anything. The token and cost figures still show; only the
+  proportion is withheld.
+
+Nothing to change on upgrade — no public export moved. The spend figure beside
+the bar is unchanged and still cumulative.

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -38,7 +38,7 @@ import {
 } from './logo.js'
 import { PermissionOverlay } from './PermissionOverlay.js'
 import { Picker } from './Picker.js'
-import { StatusBar } from './StatusBar.js'
+import { type ContextFill, StatusBar } from './StatusBar.js'
 import { Transcript } from './Transcript.js'
 import { createAssistantMessage, createUserMessage } from '@namzu/sdk'
 import {
@@ -91,6 +91,10 @@ export function App({ ctx }: AppProps) {
 		[],
 	)
 	const [usage, setUsage] = useState<{ totalTokens: number; costUsd: number } | null>(null)
+	// Context fill, straight from the kernel and held apart from `usage` —
+	// they are different quantities and conflating them is what made the
+	// gauge climb with turn count instead of with context.
+	const [context, setContext] = useState<ContextFill | null>(null)
 	// Tools currently executing — rendered live (spinner + elapsed) below the
 	// transcript, then committed as static lines on completion.
 	const [activeTools, setActiveTools] = useState<readonly ActiveTool[]>([])
@@ -395,6 +399,20 @@ export function App({ ctx }: AppProps) {
 				}
 				case 'usage':
 					setUsage({ totalTokens: event.totalTokens, costUsd: event.costUsd })
+					// Mirrored verbatim, absences included. A run that reports no
+					// window clears the gauge rather than leaving the last one up:
+					// a stale bar is read as current, and this bar's whole defect
+					// was being read as something it was not.
+					setContext({
+						...(event.contextTokens !== undefined ? { tokens: event.contextTokens } : {}),
+						...(event.contextWindowTokens !== undefined
+							? { windowTokens: event.contextWindowTokens }
+							: {}),
+						...(event.contextMeasuredBy !== undefined
+							? { measuredBy: event.contextMeasuredBy }
+							: {}),
+						...(event.windowSource !== undefined ? { windowSource: event.windowSource } : {}),
+					})
 					break
 				case 'task':
 					pushMessage('tool', event.subject, false, event.status === 'completed' ? '☑' : '☐')
@@ -800,7 +818,7 @@ export function App({ ctx }: AppProps) {
 						state={state}
 						hint={hintForPhase(phase, state)}
 						usage={usage}
-						contextWindow={contextWindowFor(session?.modelSummary ?? null)}
+						context={context}
 					/>
 				</Box>
 			</Box>
@@ -873,14 +891,6 @@ function Banner({
 function TranscriptFrame({ children }: { readonly children: React.ReactNode }) {
 	// Borderless, edge-to-edge — the message glyph gutter provides structure.
 	return <Box flexDirection="column">{children}</Box>
-}
-
-/** Approximate context window (tokens) per model, for the status gauge. The
- *  `[1m]` long-context variants get 1M; everything else defaults to 200k. */
-function contextWindowFor(model: string | null): number {
-	if (!model) return 200_000
-	if (model.includes('[1m]') || model.includes('-1m')) return 1_000_000
-	return 200_000
 }
 
 function ComposerFrame({

--- a/packages/cli/src/tui/StatusBar.tsx
+++ b/packages/cli/src/tui/StatusBar.tsx
@@ -10,6 +10,20 @@ import { Text } from 'ink'
 
 import { theme } from './theme.js'
 
+/**
+ * How full the context is, as the kernel reported it — never derived here.
+ *
+ * Every field is optional because the kernel omits all four when a run
+ * resolved no window, and a partial pair is not something to patch up with a
+ * default. See {@link buildGauge} for what is done with that.
+ */
+export interface ContextFill {
+	readonly tokens?: number
+	readonly windowTokens?: number
+	readonly measuredBy?: 'provider' | 'estimate'
+	readonly windowSource?: 'config' | 'model-table' | 'default'
+}
+
 export interface StatusBarProps {
 	readonly cwd: string
 	readonly provider: string | null
@@ -17,27 +31,16 @@ export interface StatusBarProps {
 	readonly state: 'idle' | 'thinking' | 'tool' | 'awaiting-permission'
 	readonly hint?: string
 	readonly usage?: { totalTokens: number; costUsd: number } | null
-	/** Model context window (tokens) — drives the context-fill gauge. */
-	readonly contextWindow?: number | null
+	/** Kernel-reported context fill — drives the gauge. */
+	readonly context?: ContextFill | null
 }
 
-export function StatusBar({
-	cwd,
-	provider,
-	model,
-	state,
-	hint,
-	usage,
-	contextWindow,
-}: StatusBarProps) {
+export function StatusBar({ cwd, provider, model, state, hint, usage, context }: StatusBarProps) {
 	const segments: string[] = [shortenCwd(cwd)]
 	if (provider) segments.push(provider)
 	if (model) segments.push(model)
 	if (usage && usage.totalTokens > 0) segments.push(formatUsage(usage))
-	const gauge =
-		usage && usage.totalTokens > 0 && contextWindow && contextWindow > 0
-			? buildGauge(usage.totalTokens / contextWindow)
-			: null
+	const gauge = buildGauge(context)
 	const stateLabel = stateGlyph(state)
 	// A single Text with `truncate-end` keeps the footer to exactly one line
 	// on narrow terminals (it shrinks with an ellipsis instead of wrapping),
@@ -48,8 +51,13 @@ export function StatusBar({
 			{gauge ? (
 				<>
 					<Text color={theme.text.muted}> · ctx </Text>
+					{/* The `~` sits on the number rather than in a legend: this
+					    footer is the only place the figure appears, so a reader
+					    who never finds a legend still sees which of the two
+					    readings they are being given. */}
 					<Text color={gauge.color}>
-						{gauge.bar} {gauge.pct}%
+						{gauge.bar} {gauge.approximate ? '~' : ''}
+						{gauge.pct}%
 					</Text>
 				</>
 			) : null}
@@ -100,13 +108,44 @@ function formatUsage(usage: { totalTokens: number; costUsd: number }): string {
 
 const GAUGE_WIDTH = 8
 
-/** Build an 8-cell context-fill bar, greener when empty → red as it fills. */
-function buildGauge(frac: number): { bar: string; pct: number; color: string } {
-	const clamped = Math.max(0, Math.min(1, frac))
+export interface ContextGauge {
+	readonly bar: string
+	readonly pct: number
+	readonly color: string
+	/** Renders a `~` before the percentage. See below for when. */
+	readonly approximate: boolean
+}
+
+/**
+ * Build an 8-cell context-fill bar, greener when empty → red as it fills.
+ *
+ * Returns null unless BOTH terms arrived. The kernel omits them together when
+ * a run resolved no window, and there is no window to substitute: the guess
+ * that used to stand in here was a two-branch match on the model name, which
+ * is the thing this gauge now exists without. A ratio nobody can ground is not
+ * an approximation of anything, so the caller shows the spend alone instead.
+ *
+ * `approximate` keys off BOTH terms, not just the measured one. The kernel
+ * ships each with its own provenance, and a fraction is only as sound as its
+ * weaker half — an exact prompt count over an ASSUMED 128k window is a guess
+ * with a precise-looking numerator, and marking only the numerator would
+ * repeat, one level down, the error of presenting an inference as a reading.
+ */
+export function buildGauge(context: ContextFill | null | undefined): ContextGauge | null {
+	if (!context) return null
+	const { tokens, windowTokens } = context
+	if (tokens === undefined || windowTokens === undefined) return null
+	if (!(windowTokens > 0)) return null
+	const clamped = Math.max(0, Math.min(1, tokens / windowTokens))
 	const filled = Math.round(clamped * GAUGE_WIDTH)
 	const bar = '█'.repeat(filled) + '░'.repeat(GAUGE_WIDTH - filled)
 	const color = clamped < 0.7 ? theme.status.ok : clamped < 0.9 ? theme.status.warn : theme.status.error
-	return { bar, pct: Math.round(clamped * 100), color }
+	return {
+		bar,
+		pct: Math.round(clamped * 100),
+		color,
+		approximate: context.measuredBy !== 'provider' || context.windowSource === 'default',
+	}
 }
 
 function shortenCwd(cwd: string): string {

--- a/packages/cli/src/tui/__tests__/context-gauge.test.ts
+++ b/packages/cli/src/tui/__tests__/context-gauge.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildGauge } from '../StatusBar.js'
+
+/**
+ * What the footer's context bar may honestly claim.
+ *
+ * Two rules, and the second is the one with a history. The gauge must show no
+ * proportion it cannot ground — it previously grounded one on a two-branch
+ * guess at the window and a counter that measured something else entirely. And
+ * when it does show one, the reader must be able to tell a measurement from an
+ * inference, because a bar that looks measured and is not is the same defect
+ * in miniature.
+ */
+describe('buildGauge grounds the ratio or shows nothing', () => {
+	const measured = { measuredBy: 'provider', windowSource: 'model-table' } as const
+
+	it('divides context by window, not spend by a guess', () => {
+		const gauge = buildGauge({ tokens: 50_000, windowTokens: 200_000, ...measured })
+
+		expect(gauge?.pct).toBe(25)
+	})
+
+	it('shows nothing when the window is missing', () => {
+		expect(buildGauge({ tokens: 50_000, ...measured })).toBeNull()
+	})
+
+	it('shows nothing when the measurement is missing', () => {
+		expect(buildGauge({ windowTokens: 200_000, ...measured })).toBeNull()
+	})
+
+	it('shows nothing at all rather than a partial gauge', () => {
+		expect(buildGauge(null)).toBeNull()
+		expect(buildGauge(undefined)).toBeNull()
+		expect(buildGauge({})).toBeNull()
+	})
+
+	it('refuses a zero window instead of dividing by it', () => {
+		// Not reachable from today's kernel, which always resolves a positive
+		// window when it reports one — but Infinity rendered as a bar is a
+		// worse outcome than silence, and the guard costs one comparison.
+		expect(buildGauge({ tokens: 10, windowTokens: 0, ...measured })).toBeNull()
+	})
+
+	it('clamps rather than reporting over 100 percent', () => {
+		const gauge = buildGauge({ tokens: 400_000, windowTokens: 200_000, ...measured })
+
+		expect(gauge?.pct).toBe(100)
+		expect(gauge?.bar).not.toContain('░')
+	})
+})
+
+describe('buildGauge marks a ratio no stronger than its weaker term', () => {
+	it('presents a provider count against a known window as measured', () => {
+		const gauge = buildGauge({
+			tokens: 50_000,
+			windowTokens: 200_000,
+			measuredBy: 'provider',
+			windowSource: 'model-table',
+		})
+
+		expect(gauge?.approximate).toBe(false)
+	})
+
+	it('marks an estimated numerator', () => {
+		const gauge = buildGauge({
+			tokens: 50_000,
+			windowTokens: 200_000,
+			measuredBy: 'estimate',
+			windowSource: 'model-table',
+		})
+
+		expect(gauge?.approximate).toBe(true)
+	})
+
+	it('marks an assumed window even when the count is exact', () => {
+		// The case that makes this rule more than a rename of `measuredBy`.
+		// `windowSource: 'default'` is the kernel falling back to an assumed
+		// 128k because it recognised neither a configured window nor the
+		// model. An exact numerator over an invented denominator is a guess
+		// wearing a precise-looking figure, and marking only the numerator
+		// would repeat one level down the error this whole change fixes.
+		const gauge = buildGauge({
+			tokens: 50_000,
+			windowTokens: 128_000,
+			measuredBy: 'provider',
+			windowSource: 'default',
+		})
+
+		expect(gauge?.approximate).toBe(true)
+	})
+
+	it('treats an unstated provenance as not measured', () => {
+		// Silence is not a claim of accuracy. Defaulting the other way would
+		// let any future producer that forgets the field render as exact.
+		const gauge = buildGauge({ tokens: 50_000, windowTokens: 200_000 })
+
+		expect(gauge?.approximate).toBe(true)
+	})
+})

--- a/packages/cli/src/tui/__tests__/to-agent-event.test.ts
+++ b/packages/cli/src/tui/__tests__/to-agent-event.test.ts
@@ -161,3 +161,71 @@ describe('the three decline causes get three sentences', () => {
 		expect(new Set(texts).size).toBe(3)
 	})
 })
+
+/**
+ * The context figures cross the same seam, and used to stop at it.
+ *
+ * The kernel measured the context and resolved a window; the status gauge
+ * consumed a fraction. Both ends worked. This function threw the four fields
+ * away in between, so the gauge fell back to dividing CUMULATIVE spend by a
+ * window guessed from the model name — a number that rose with turn count and
+ * read FULL on a conversation with room left. Producing a value and consuming
+ * one are not the same as carrying it.
+ */
+describe('toAgentEvent carries the context figures across', () => {
+	const usageEvent = (extra: Record<string, unknown>) =>
+		toAgentEvent({
+			type: 'token_usage_updated',
+			runId,
+			usage: { totalTokens: 90 },
+			cost: { totalCost: 0.5 },
+			...extra,
+		} as unknown as RunEvent)
+
+	it('carries both terms and both provenances', () => {
+		expect(
+			usageEvent({
+				contextTokens: 12_000,
+				contextMeasuredBy: 'provider',
+				contextWindowTokens: 200_000,
+				windowSource: 'model-table',
+			}),
+		).toEqual({
+			kind: 'usage',
+			totalTokens: 90,
+			costUsd: 0.5,
+			contextTokens: 12_000,
+			contextMeasuredBy: 'provider',
+			contextWindowTokens: 200_000,
+			windowSource: 'model-table',
+		})
+	})
+
+	it('leaves an unreported context absent rather than zero', () => {
+		// The kernel omits all four when a run resolved no window. A `0` here
+		// would be indistinguishable from an empty context and would render a
+		// gauge reading 0% — a confident wrong answer where the contract is
+		// to show no proportion at all.
+		const mapped = usageEvent({})
+
+		expect(mapped).toEqual({ kind: 'usage', totalTokens: 90, costUsd: 0.5 })
+		expect(mapped).not.toHaveProperty('contextTokens')
+		expect(mapped).not.toHaveProperty('contextWindowTokens')
+	})
+
+	it('keeps context distinct from cumulative spend', () => {
+		// The defect in one assertion. Ten turns over a 200k window accumulate
+		// far more spend than the window holds, because every turn re-sends the
+		// history and counts it again — while the context stays modest. Any
+		// mapping that reaches for `totalTokens` fails here.
+		expect(
+			usageEvent({
+				usage: { totalTokens: 500_000 },
+				contextTokens: 40_000,
+				contextMeasuredBy: 'provider',
+				contextWindowTokens: 200_000,
+				windowSource: 'model-table',
+			}),
+		).toMatchObject({ totalTokens: 500_000, contextTokens: 40_000 })
+	})
+})

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -84,7 +84,33 @@ export type AgentEvent =
 			/** Output lines shown (collapsible) under the result. */
 			readonly detail?: readonly string[]
 	  }
-	| { readonly kind: 'usage'; readonly totalTokens: number; readonly costUsd: number }
+	| {
+			readonly kind: 'usage'
+			/** CUMULATIVE run spend. Grows every turn; never a context size. */
+			readonly totalTokens: number
+			readonly costUsd: number
+			/**
+			 * How full the context is NOW, and how full it may get.
+			 *
+			 * Separate from `totalTokens` because they answer different
+			 * questions and one was long used to answer the other's: the gauge
+			 * divided cumulative spend by a guessed window, so it climbed with
+			 * turn count and read FULL on a conversation with room to spare.
+			 * Spend is monotone by design, context is not.
+			 *
+			 * Carried with their provenance, and the two travel together. A
+			 * ratio is only as sound as the weaker of its terms, so a surface
+			 * cannot mark an estimated numerator honestly while silently
+			 * treating an assumed window as measured.
+			 *
+			 * All four absent when the run resolved no window — then there is
+			 * no proportion to show, only the spend.
+			 */
+			readonly contextTokens?: number
+			readonly contextMeasuredBy?: 'provider' | 'estimate'
+			readonly contextWindowTokens?: number
+			readonly windowSource?: 'config' | 'model-table' | 'default'
+	  }
 	/**
 	 * Context was discarded, or an attempt to discard it declined.
 	 *
@@ -821,10 +847,25 @@ export function toAgentEvent(event: RunEvent): AgentEvent | null {
 				detail: toolEndDetail(event.toolName, event.result),
 			}
 		case 'token_usage_updated':
+			// The context figures are forwarded, not recomputed. They were
+			// dropped here for as long as the status gauge existed, which left
+			// the bar dividing cumulative spend by a model-name guess — the one
+			// number on screen that got LESS accurate the longer a session ran.
+			// Spread conditionally: absent has to stay absent, because the
+			// renderer's whole contract is that it shows no proportion it
+			// cannot ground, and a `0` here would ground a wrong one.
 			return {
 				kind: 'usage',
 				totalTokens: event.usage.totalTokens,
 				costUsd: event.cost.totalCost,
+				...(event.contextTokens !== undefined ? { contextTokens: event.contextTokens } : {}),
+				...(event.contextMeasuredBy !== undefined
+					? { contextMeasuredBy: event.contextMeasuredBy }
+					: {}),
+				...(event.contextWindowTokens !== undefined
+					? { contextWindowTokens: event.contextWindowTokens }
+					: {}),
+				...(event.windowSource !== undefined ? { windowSource: event.windowSource } : {}),
 			}
 		case 'task_created':
 			return { kind: 'task', subject: event.subject, status: event.status }


### PR DESCRIPTION
The `ctx` bar in the status footer divided **cumulative run spend** by a context
window guessed from a substring of the model name. Neither term was the thing it
claimed to be, and the numerator was the worse of the two.

Spend is monotone by design — it exists so a run can never under-report a bill —
and it grows superlinearly in turn count, because every turn re-sends the whole
history and counts those prompt tokens again. Ten turns over a 50k context
accumulate roughly 500k. So the bar **saturated**: a long conversation read FULL
while the real context might be a fifth of the window. It was anti-correlated
with its own label in exactly the regime a user depends on it, and it pushed
people into compacting sessions that had room.

The kernel already measures both terms and ships them on `token_usage_updated`.
They were dropped one function before the bar, in `toAgentEvent` — the same seam,
and the same shape of defect, that once lost the stop reason: two working ends
and an untested middle.

## What changed

- Numerator `contextTokens`, denominator `contextWindowTokens`.
- `contextWindowFor` deleted — no more 200k-or-1M guess.
- A `~` before the percentage when the ratio is inferred rather than measured.
- No bar at all when either term is absent. Spend and cost still show.

## Two decisions worth review

**The `~` keys off BOTH terms, not just `contextMeasuredBy`.** The SDK's own
docstring on the event is the authority here: *"A fraction of two numbers is only
as honest as the weaker of them."* So `windowSource: 'default'` — the kernel
falling back to an assumed 128k — makes the ratio approximate just as an
estimated numerator does. An exact prompt count over an invented denominator is a
guess wearing a precise-looking figure, and marking only the numerator would have
reproduced this very defect one level down.

**The absent case is defensive, not live.** The fields are omitted when a run
resolves no window, which is gated on the truthiness of `ctx.compactionConfig` —
and the CLI always passes a `COMPACTION_CONFIG`, so this cannot arise on the
parent run today. Implemented anyway: the fields are optional on the type, and a
surface rendering a fraction it cannot ground is the defect being fixed, not a
case to assume away. Flagging it so nobody reads the guard as evidence of a path
that exists.

## Verification

Three mutations, each reverting one rule:

| Mutation | Profile |
|---|---|
| Mapper reverted to the pre-fix drop | 2/24 fail — both carrying tests. The absent-case test correctly **passes** (preservation). |
| `approximate` keyed off `measuredBy` only | 1/24 fails — exactly the test written for the both-terms rule. |
| Grounding replaced by `?? 0` / `?? 200_000` | 4/10 fail — all four grounding tests; the 6 passing are ratio, clamp and provenance. |

Gates: typecheck 0, lint 0, full workspace suite 0 (CLI 353 passed, 2 skipped),
`audit-external-names` clean.

## Notes

Bump intent is `patch`: `AgentEvent`, `StatusBar` and `buildGauge` are internal —
`packages/cli/src/index.ts` exports none of them, so no published surface moved.
Checked rather than assumed, since the CLI is a dual-purpose package that does
ship a library entry.

Stacked branch `fix/cli-delegation-trace-and-label` (A5 + A6) targets this one
and should merge after it.

https://claude.ai/code/session_01RppSzAoxqCxKfD4fLYmnzs
