### PR TITLE
fix(cli): a delegated run joins its parent trace and shows its own label

### DIFF
--- a/.changeset/a-delegation-belongs-to-its-turn.md
+++ b/.changeset/a-delegation-belongs-to-its-turn.md
@@ -1,0 +1,39 @@
+---
+'@namzu/cli': patch
+---
+
+A delegated sub-agent joins its parent's trace, and shows the label it was made to write
+
+Two fixes to the `Agent` tool.
+
+**The child run started its own root trace.** `createTask` was called without
+`parentSpan`, so a sub-agent opened a disconnected root and the one structure a
+delegation trace exists to record — which turn dispatched which child — was the
+part that went missing. Anyone reading a trace saw N unrelated roots where there
+was one tree. The kernel already carries the span the whole way (executing
+tool → `createTask` → child run → child iterations); only the first hop was
+dropped. It now passes the executing tool's span, matching the SDK coordinator.
+
+If no span is in scope the key is omitted rather than sent as `undefined`: a
+top-level run with no parent is correct to start its own root, and inventing a
+parent would be a different wrong answer.
+
+**`description` was required and never read.** The schema forced the model to
+write a short label on every call, and the transcript then rendered a truncated
+`JSON.stringify` of the raw arguments instead — so a delegation appeared as
+`{"description":"Audit the auth flow","prompt":"Read every fi…` rather than
+`Agent(Audit the auth flow)`.
+
+We now **read it** rather than dropping the requirement. The model already
+writes a good label, the field costs nothing to keep, and removing it would
+leave delegations with no honest one-line summary at all — the fallback would
+still be the blob. `description` is consulted **last**, after `command`, `path`,
+`file_path`, `pattern` and `query`, so tools that already summarised correctly
+are unaffected; it only speaks for tools that were falling through to JSON. Two
+SDK coordinator tools whose `description` is likewise a user-facing label pick
+up the same improvement.
+
+Note for anyone verifying the trace fix in a terminal: the CLI registers no
+telemetry provider by default, so spans are no-ops until `@namzu/telemetry` is
+installed and a provider registered. The parenting is correct either way; it
+becomes visible when there is an exporter to see it.

--- a/packages/cli/src/integrations/subagents/__tests__/delegation-trace.test.ts
+++ b/packages/cli/src/integrations/subagents/__tests__/delegation-trace.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { type LLMProvider, LocalTaskGateway, type ToolContext } from '@namzu/sdk'
+
+import { createSubagentRuntime } from '../runtime.js'
+
+/**
+ * A delegated run belongs inside the turn that asked for it.
+ *
+ * The kernel supports this end to end — the executing tool's span reaches
+ * `createTask`, survives `configOverrides`, is stamped onto the child config
+ * after the host's `configBuilder` runs, and becomes the child run's trace
+ * parent. Every hop was built and tested. The `Agent` tool simply did not pass
+ * the first one, so a sub-agent opened its own ROOT trace and the delegation
+ * structure — the one thing a delegation trace exists to record — was absent.
+ *
+ * The gateway is constructed inside the runtime, so the spy goes on its
+ * prototype: this drives the real tool through the real wiring rather than
+ * re-deriving what the tool ought to do. A unit test on the span helper would
+ * have passed throughout the defect.
+ */
+
+const fakeSpan = { __brand: 'span' } as unknown as NonNullable<ToolContext['parentSpan']>
+
+function toolContext(parentSpan?: ToolContext['parentSpan']): ToolContext {
+	return { runId: 'run_test', ...(parentSpan ? { parentSpan } : {}) } as unknown as ToolContext
+}
+
+async function buildAgentTool() {
+	const created: Record<string, unknown>[] = []
+
+	vi.spyOn(LocalTaskGateway.prototype, 'createTask').mockImplementation(async (options) => {
+		created.push(options as unknown as Record<string, unknown>)
+		return { taskId: 'tsk_1' } as never
+	})
+	vi.spyOn(LocalTaskGateway.prototype, 'waitForTask').mockResolvedValue({
+		state: 'completed',
+		result: { status: 'completed', result: 'done' },
+	} as never)
+
+	const runtime = await createSubagentRuntime({
+		cwd: '/tmp',
+		model: 'test-model',
+		buildProvider: () => ({}) as LLMProvider,
+		buildTools: () => ({}) as never,
+	})
+
+	return { agentTool: runtime.agentTool, created }
+}
+
+afterEach(() => {
+	vi.restoreAllMocks()
+})
+
+describe('the Agent tool parents a delegated run to the turn that asked for it', () => {
+	it('passes the executing tool span through to the child run', async () => {
+		const { agentTool, created } = await buildAgentTool()
+
+		await agentTool.execute({ description: 'audit', prompt: 'do a thing' }, toolContext(fakeSpan))
+
+		expect(created).toHaveLength(1)
+		expect(created[0]?.parentSpan).toBe(fakeSpan)
+	})
+
+	it('omits the key entirely when the turn supplied no span', async () => {
+		// Not the same as passing `undefined`: the kernel branches on the
+		// property's presence, and a top-level run with no parent is correct
+		// to start its own root. Refusing to invent one is the other half of
+		// the fix, not an edge case.
+		const { agentTool, created } = await buildAgentTool()
+
+		await agentTool.execute({ description: 'audit', prompt: 'do a thing' }, toolContext())
+
+		expect(created[0]).not.toHaveProperty('parentSpan')
+	})
+
+	it('parents a dynamically defined specialist too', async () => {
+		// The `role` branch registers a fresh agent before delegating, and it
+		// is a second path to the same `createTask`. One of two paths carrying
+		// a signal is how this class of defect survives a green suite.
+		const { agentTool, created } = await buildAgentTool()
+
+		await agentTool.execute(
+			{ description: 'audit', prompt: 'do a thing', role: 'You are an auditor' },
+			toolContext(fakeSpan),
+		)
+
+		expect(created[0]?.parentSpan).toBe(fakeSpan)
+	})
+})

--- a/packages/cli/src/integrations/subagents/runtime.ts
+++ b/packages/cli/src/integrations/subagents/runtime.ts
@@ -176,7 +176,7 @@ export async function createSubagentRuntime(
 		readOnly: false,
 		destructive: false,
 		concurrencySafe: true,
-		async execute(input) {
+		async execute(input, context) {
 			const { prompt, role } = input as { prompt: string; role?: string }
 			let agentId = GENERAL_PURPOSE_SUBAGENT
 			const persona = typeof role === 'string' ? role.trim() : ''
@@ -186,7 +186,17 @@ export async function createSubagentRuntime(
 				registry.register(buildDefinition(agentId, `Dynamic specialist: ${agentId}`, persona, opts))
 			}
 			try {
-				const handle = await gateway.createTask({ agentId, prompt, workingDirectory: opts.cwd })
+				const handle = await gateway.createTask({
+					agentId,
+					prompt,
+					workingDirectory: opts.cwd,
+					// Hang the child run off THIS tool's span, so the delegation
+					// shows up inside the turn that asked for it. Without it a
+					// sub-agent opens its OWN root trace, and the one structure
+					// a delegation trace exists to record — who dispatched whom
+					// — is the thing that goes missing.
+					...(context.parentSpan ? { parentSpan: context.parentSpan } : {}),
+				})
 				const completed = await gateway.waitForTask(handle.taskId)
 				const runStatus = completed.result?.status
 				const succeeded =

--- a/packages/cli/src/tui/__tests__/to-agent-event.test.ts
+++ b/packages/cli/src/tui/__tests__/to-agent-event.test.ts
@@ -163,6 +163,49 @@ describe('the three decline causes get three sentences', () => {
 })
 
 /**
+ * A tool the summary list does not know still gets a label, not a blob.
+ *
+ * `Agent` requires a `description` on its schema — the model writes one every
+ * call — and the summariser picked from a key list that did not include it, so
+ * a delegation was rendered as a truncated `JSON.stringify` of its own
+ * arguments. The label was demanded and then discarded.
+ *
+ * Driven through `toAgentEvent` rather than the summariser directly: the
+ * helper's own behaviour was never in doubt, only whether the caller reaches
+ * it with this input.
+ */
+describe('toAgentEvent labels a delegation with the label it required', () => {
+	const executing = (toolName: string, input: unknown) =>
+		toAgentEvent({ type: 'tool_executing', toolName, toolUseId: 'tu_1', input } as RunEvent)
+
+	it('summarises an Agent call with its description', () => {
+		const mapped = executing('Agent', {
+			description: 'Audit the auth flow',
+			prompt: 'Read every file under src/auth and report risks.',
+			role: 'You are a security auditor',
+		})
+
+		expect(mapped).toMatchObject({ summary: 'Audit the auth flow' })
+	})
+
+	it('does not render the arguments as JSON', () => {
+		const mapped = executing('Agent', { description: 'Audit the auth flow', prompt: 'x' })
+
+		expect((mapped as { summary: string }).summary).not.toContain('{')
+		expect((mapped as { summary: string }).summary).not.toContain('prompt')
+	})
+
+	it('still prefers a more specific field when one exists', () => {
+		// `description` is the LAST fallback. A tool with a real subject keeps
+		// it, so adding this key cannot quietly relabel the tools that already
+		// summarised correctly.
+		const mapped = executing('bash', { command: 'ls -la', description: 'list files' })
+
+		expect(mapped).toMatchObject({ summary: 'ls -la' })
+	})
+})
+
+/**
  * The context figures cross the same seam, and used to stop at it.
  *
  * The kernel measured the context and resolved a window; the status gauge

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -969,7 +969,18 @@ function summarizeToolInput(input: unknown): string {
 		const obj = input as Record<string, unknown>
 		const pick = (k: string) => (typeof obj[k] === 'string' ? (obj[k] as string) : undefined)
 		const primary =
-			pick('command') ?? pick('path') ?? pick('file_path') ?? pick('pattern') ?? pick('query')
+			pick('command') ??
+			pick('path') ??
+			pick('file_path') ??
+			pick('pattern') ??
+			pick('query') ??
+			// Last, so it only speaks for a tool none of the above describe.
+			// Those tools were falling through to a truncated `JSON.stringify`
+			// — which is how `Agent` came to show a blob of its own arguments
+			// while requiring the model to write a label nothing then read.
+			// Every input named `description` in this tree is a short
+			// human-facing label, so it is a summary by construction.
+			pick('description')
 		if (primary) return truncate(primary, 120)
 	}
 	if (typeof input === 'string') return truncate(input, 120)


### PR DESCRIPTION
Two defects in the `Agent` tool, both in what a delegation reports about itself.

> **Stacked on #148.** Base is `fix/cli-context-gauge`, so this diff shows only
> A5 + A6. Merge #148 first; GitHub will retarget this to `main` automatically.
> A6 edits `agent.ts`, which #148 also edits, which is why this is stacked rather
> than branched from `main`.

## A5 — the child run started its own root trace

`createTask` was called without `parentSpan`, so every sub-agent opened a
disconnected root and the one structure a delegation trace exists to record —
which turn dispatched which child — was the part that went missing. A reader saw
N unrelated roots where there was one tree.

The kernel carries the span the whole way. I traced it rather than trusting the
coordinator's use of it, because a mechanism being correct at one call site says
nothing about the others:

```
tool ctx -> createTask -> configOverrides -> AgentManager stamp -> ReactiveAgentConfig -> QueryParams -> child root span
```

Unbroken. The stamp at `manager/agent/lifecycle.ts:271-275` happens *after*
`configBuilder` returns — deliberately, so a host builder that knows nothing
about spans cannot lose it. That is why the CLI's hand-built config needs no
change. Only the first hop was missing.

Where no span is in scope the key is **omitted** rather than sent as `undefined`:
a top-level run with no parent is correct to start its own root, and inventing a
parent is a different wrong answer.

**This is invisible until a telemetry provider is registered.** The CLI depends
on no OpenTelemetry package and registers no provider, so spans are non-recording
no-ops today. The parenting is correct either way and becomes observable the
moment an exporter exists — said plainly here and in the changeset so nobody
verifies it by looking for output, finds none, and later deletes it as dead code.

## A6 — `description` was required and never read

The schema forced the model to write a short label on every call, and the
transcript rendered a truncated `JSON.stringify` of the raw arguments instead. So
a delegation appeared as a blob of its own arguments rather than
`Agent(Audit the auth flow)`.

**Decision: read it, do not drop the requirement.** The label is already written
and already good, so it costs nothing to keep. Dropping `required` would fix the
schema's honesty while leaving the user's screen exactly as wrong — the fallback
would still be the blob.

`description` is consulted **last**, after `command`, `path`, `file_path`,
`pattern` and `query`. That ordering is the load-bearing part: it means the key
can only speak for a tool that was already falling through to `JSON.stringify`,
so no tool that summarised correctly changes behaviour. Before touching a helper
shared by every tool I checked what is actually named `description` in this tree
— the two SDK coordinator tools and the two task tools, all of them short
user-facing labels. The key is a summary by construction, not by luck. The
coordinator tools pick up the same improvement.

## Verification

Both tests drive the **caller**, not the helper — a unit test on either helper
would have passed throughout both defects, since neither helper was ever broken.
A5 drives the real `agentTool.execute` with `LocalTaskGateway.prototype` spied;
A6 goes through `toAgentEvent`.

| Mutation | Profile |
|---|---|
| `parentSpan` spread removed | 2/3 fail — both span-carrying paths, including the `role` specialist branch. The "omits the key when no span" test correctly **passes**. |
| `pick('description')` replaced by `undefined` | 2/17 fail — exactly the two Agent-label tests. "Still prefers a more specific field" passes, which is what proves the change is additive rather than a relabelling. |

Gates: typecheck 0, lint 0, full workspace suite 0 (CLI 353 passed, 2 skipped),
`audit-external-names` clean.

## Related, not fixed here

`packages/sdk/src/tools/coordinator/agent.ts:136-141` — `buildAgentTool` takes
`context` and calls `createTask` with no `parentSpan`. The identical defect in
the kernel's own delegation surface, twenty lines from a correct use of the
mechanism. Outside this package's ownership; owner has taken it.

https://claude.ai/code/session_01RppSzAoxqCxKfD4fLYmnzs
