### PR TITLE
fix(sdk)!: a fan-out does not overspend, reports honestly, and reaches a host

### DIFF
--- a/.changeset/a-failed-worker-is-not-an-answer.md
+++ b/.changeset/a-failed-worker-is-not-an-answer.md
@@ -1,0 +1,40 @@
+---
+'@namzu/sdk': major
+---
+
+A failed worker is reported as a failure, and a plan task can say it failed.
+
+**`create_task` reported a failed worker as a success.** Two layers can disagree
+about whether a delegated run succeeded: the gateway's `TaskHandle.state`, and
+the run's own `BaseAgentResult.status`. The kernel's `finalizeChild` always calls
+`markCompleted`, so `state === 'completed'` holds for a child that ran and
+returned `status: 'failed'` — and `create_task` asked only that layer. The model
+received the failure text as an answer, the tool result carried
+`isError: false`, and the plan task was written closed as though the work had
+been done.
+
+The correct two-authority predicate was already written, twenty lines away, in
+the canonical `Agent` tool — put there because a review caught it on that site,
+and nothing carried the answer to the other one. It now lives in one place both
+reach.
+
+**`TaskStatus` gains `failed`, and that is the breaking part.** A unit that did
+not succeed had nowhere to say so, which is why a failed delegation was recorded
+as `completed` with the failure encoded as prose in `description`: a reader
+scanning statuses saw work that had been done, and a dependent unit had no way
+to tell at all.
+
+If you switch exhaustively over `TaskStatus`, or hold a `Record<TaskStatus, T>`,
+you need a `failed` arm. `isTerminalTaskStatus` now returns `true` for it —
+terminal means "will not change on its own", not "succeeded", and a unit blocked
+on something that failed would otherwise wait forever for a status that will
+never arrive. In the store's transition ranking `failed` sits alongside
+`completed` rather than after it, so `in_progress → failed` is allowed and
+`completed → failed` is not.
+
+**Two smaller repairs ride along.** A background launch refused for want of a
+completion inbox now marks its plan task failed rather than leaving it in
+progress with no worker behind it — nothing later closes a task whose launch
+never happened. And the `Agent` tool passes `parentSpan` when creating its
+child, so a delegated run joins the turn that asked for it instead of starting
+its own root trace; `create_task` has done this all along.

--- a/.changeset/a-fan-out-does-not-overspend.md
+++ b/.changeset/a-fan-out-does-not-overspend.md
@@ -1,0 +1,30 @@
+---
+'@namzu/sdk': patch
+---
+
+A concurrent fan-out no longer allocates more budget than the parent has.
+
+`sendMessage` read the parent's remaining budget at the top and debited it after
+`provisionSpawn` — putting the two halves of a read-modify-write on either side
+of an await, with the only critical section in between. So siblings launched
+from one assistant turn all read the same undebited number and each took a
+fraction of it. Measured: **four concurrent children were handed 50 000 + 50 000
++ 50 000 + 50 000 from a pool of 100 000.**
+
+`create_task`'s own description instructs exactly the shape that triggers it —
+*"'fan out 8 specialists' is one assistant message with 8 create_task blocks"* —
+so the documented usage was the reproduction.
+
+The read, the refusal when an allocation floors to zero, and the debit now all
+happen inside the per-parent spawn lock. That keeps the property the debit's
+placement was chosen for — a spawn this call rejects burns no allocation — while
+closing the race that placement opened. It was introduced by a correct fix to a
+different bug: moving the debit after the provisioning put it outside the lock.
+
+**Nothing pinned it**, and the reason is worth knowing if you write tests here:
+the existing concurrency test builds a fresh context per call, so each spawn got
+its own tracker — it measures width, not budget. The sequential tests pass
+because a refund makes the arithmetic close. The regression test holds its
+children open, because a settled child refunds and the refund restores a
+plausible number; a test that measures after settle sees a healthy total and
+reports nothing.

--- a/.changeset/the-plan-graph-reaches-a-host.md
+++ b/.changeset/the-plan-graph-reaches-a-host.md
@@ -1,0 +1,35 @@
+---
+'@namzu/sdk': minor
+---
+
+A host can see the fan-out gate, and the plan graph the model is already keeping.
+
+**`SupervisorAgentConfig` gains `maxToolConcurrency`.** The kernel has honoured
+it all along and `ReactiveAgent` forwards it — it was missing on the one agent
+whose entire job is delegation. So the agent that fans out could not set the gate
+that bounds a fan-out, while the agent that does not fan out could, and a host
+wanting a narrower one had to reach past the supervisor to `drainQuery`.
+
+Note what it bounds: how many delegated children run **concurrently**, not how
+many a turn may launch. A model emitting twenty `create_task` blocks still
+launches twenty; they queue.
+
+**`task_created` and `task_updated` carry `blockedBy`.** The task store
+maintains a full dependency graph — `blocks` and `blockedBy` mirrored on both
+ends, written under a lock, deadlock-avoided — and none of it reached the wire.
+A host could draw a flat list of units and nothing about their order, while the
+model was already maintaining the order.
+
+Absent rather than empty when a unit depends on nothing, so a reader can tell
+"no dependencies" from an emitter that predates the field.
+
+**And `block()` announced nothing at all.** Both stores wrote the edge and
+emitted no event, so the graph was observable only by polling: a listener saw a
+unit created and never learned that something now waits on it. Both stores now
+announce **both ends**, because both changed — a host tracking one side would
+draw half the edge. The disk store announces only when something actually
+changed, so re-establishing an existing edge stays silent.
+
+That second half is the one worth knowing about if you consume these events: the
+field alone would have been useless, because the moment a dependency is created
+was never on the wire in the first place.

--- a/packages/sdk/src/agents/SupervisorAgent.ts
+++ b/packages/sdk/src/agents/SupervisorAgent.ts
@@ -300,6 +300,12 @@ export class SupervisorAgent extends AbstractAgent<SupervisorAgentConfig, Superv
 					},
 					questionParks,
 					pendingAnswers,
+					// How wide a fan-out actually runs. Absent leaves the kernel
+					// default — the same forwarding ReactiveAgent has always done,
+					// missing from the one agent whose job is delegation.
+					...(config.maxToolConcurrency !== undefined
+						? { maxToolConcurrency: config.maxToolConcurrency }
+						: {}),
 					agentId: this.metadata.id,
 					agentName: this.metadata.name,
 					workingDirectory: input.workingDirectory,

--- a/packages/sdk/src/manager/agent/__tests__/lifecycle.test.ts
+++ b/packages/sdk/src/manager/agent/__tests__/lifecycle.test.ts
@@ -768,3 +768,77 @@ describe('LocalTaskGateway — what a failed child means for its siblings', () =
 		releaseSlow()
 	})
 })
+
+describe('a concurrent fan-out shares one budget', () => {
+	/**
+	 * Siblings launched from one assistant turn were each allocated a fraction
+	 * of the SAME undebited number.
+	 *
+	 * The allocation is read at the top of `sendMessage`; the debit lands
+	 * after `await provisionSpawn`, which is the only critical section. So N
+	 * siblings all enter, all read an untouched `remaining`, and each takes
+	 * its fraction of it. `create_task`'s own description instructs exactly
+	 * this shape: "'fan out 8 specialists' is one assistant message with 8
+	 * create_task blocks."
+	 *
+	 * **The children must not be allowed to finish.** A child that settles
+	 * refunds its unspent budget, and the refund restores the tracker to a
+	 * plausible number — so a test that measures after settle sees a healthy
+	 * total and reports nothing. The over-commitment is real and transient,
+	 * and transient is enough: every allocation decision taken during the
+	 * window reads a tracker that is already wrong.
+	 *
+	 * The first version of this test did settle its children, passed, and
+	 * would have certified the bug as fixed.
+	 */
+	it('never allocates more than the parent has, while the children are still running', async () => {
+		// What each child was actually HANDED. Asserting on the tracker was the
+		// first attempt and it measured the wrong thing twice over: a settled
+		// child refunds, which restores a plausible number, and the harm is not
+		// the bookkeeping anyway — it is that four children each believe they
+		// may spend half a pool that only has one half to give.
+		const allocations: number[] = []
+		let release: (() => void) | undefined
+		const held = new Promise<void>((resolve) => {
+			release = resolve
+		})
+
+		// The harness's own manager, because a hand-built one here silently
+		// fails to provision and the children never run — which looks exactly
+		// like a passing test.
+		const harness = await buildHarness(
+			makeAgent('child-1', async (_input, config) => {
+				allocations.push(config.tokenBudget)
+				await held
+				return successResult()
+			}),
+		)
+
+		// ONE tracker, shared, as a real parent's context is.
+		const shared = { total: 100_000, remaining: 100_000 }
+		const context = {
+			...buildContext(harness.parentSession.id, harness.projectId, harness.threadId),
+			budgetTracker: shared,
+		}
+
+		await Promise.allSettled(
+			Array.from({ length: 4 }, () =>
+				harness.manager.sendMessage(
+					buildOptions('child-1', harness.parentSession.id, harness.projectId),
+					context,
+				),
+			),
+		)
+
+		// Let the children record what they were handed before any settles.
+		await new Promise((r) => setTimeout(r, 20))
+		const handedOut = allocations.reduce((a, b) => a + b, 0)
+		release?.()
+
+		expect(allocations.length, 'every sibling should have started').toBe(4)
+		expect(
+			handedOut,
+			`four siblings were handed ${allocations.join(' + ')} from a pool of ${shared.total}`,
+		).toBeLessThanOrEqual(shared.total)
+	})
+})

--- a/packages/sdk/src/manager/agent/lifecycle.ts
+++ b/packages/sdk/src/manager/agent/lifecycle.ts
@@ -127,44 +127,29 @@ export class AgentManager {
 
 		const childAbortController = createChildAbortController(context.parentAbortController)
 
-		const maxAllocation = Math.floor(
-			context.budgetTracker.remaining * this.config.maxBudgetFraction,
-		)
-		const allocatedTokens = Math.min(
-			options.budgetAllocation?.tokenBudget ?? maxAllocation,
-			maxAllocation,
-		)
-
-		// Budget exhaustion must not INVERT into no budget at all. Downstream,
-		// `tokenBudget: 0` means "uncapped" (`LimitChecker`: `tokenBudget > 0
-		// && total >= tokenBudget`), and `maxAllocation` floors to 0 as soon as
-		// the parent's remaining drops below `1 / maxBudgetFraction`. So the
-		// most depleted parent in the tree was the one that spawned an
-		// unlimited child. Refuse instead: a caller that wants an uncapped
-		// child can say so explicitly with its own `budgetAllocation`.
-		if (allocatedTokens <= 0) {
-			throw new NamzuError({
-				code: 'invalid_config',
-				message: `Cannot spawn "${options.agentId}": the parent has ${context.budgetTracker.remaining} tokens remaining, which allocates 0 to the child — and a token budget of 0 means UNLIMITED downstream.`,
-				details: {
-					agentId: options.agentId,
-					parentRemaining: context.budgetTracker.remaining,
-					maxBudgetFraction: this.config.maxBudgetFraction,
-				},
-			})
-		}
+		// The allocation is computed INSIDE the spawn lock, not here. Reading
+		// the parent's remaining budget at this point and debiting it after
+		// `provisionSpawn` put the two halves of a read-modify-write on either
+		// side of an await — so N siblings launched from one turn all read the
+		// same undebited number and each took a fraction of it. Measured: four
+		// concurrent children were handed 50 000 + 50 000 + 50 000 + 50 000
+		// from a pool of 100 000.
+		//
+		// `create_task`'s own description instructs exactly this shape ("'fan
+		// out 8 specialists' is one assistant message with 8 create_task
+		// blocks"), so the documented usage was the reproduction.
+		//
+		// Nothing pinned it because the only concurrent test built a fresh
+		// context per call — each spawn got its own tracker, which measures
+		// width and not budget.
 
 		// Phase 6: SubSession + child Session + WorkspaceRef triple. Happens
 		// before taskId minting so a capacity failure short-circuits cleanly
 		// with no observable state change.
 		//
-		// The budget debit follows it for the same reason. It used to come
-		// first, so a spawn this call rejected still burned its allocation
-		// from a pool nobody credited back — the one state change the
-		// comment above promised there would not be.
-		const spawnRecord = await this.provisionSpawn(options, context)
-
-		context.budgetTracker.remaining -= allocatedTokens
+		// The allocation now travels with it, because the read and the debit
+		// have to be on the same side of every await to mean anything.
+		const { spawnRecord, allocatedTokens } = await this.provisionSpawn(options, context)
 
 		const taskId = generateTaskId()
 
@@ -449,7 +434,7 @@ export class AgentManager {
 	private async provisionSpawn(
 		options: SendMessageOptions,
 		context: AgentTaskContext,
-	): Promise<ChildSpawnRecord> {
+	): Promise<{ spawnRecord: ChildSpawnRecord; allocatedTokens: number }> {
 		const key = options.parentSessionId
 		const queued = (this.spawnLocks.get(key) ?? Promise.resolve()).then(
 			() => this.provisionSpawnUnlocked(options, context),
@@ -475,7 +460,42 @@ export class AgentManager {
 	private async provisionSpawnUnlocked(
 		options: SendMessageOptions,
 		context: AgentTaskContext,
-	): Promise<ChildSpawnRecord> {
+	): Promise<{ spawnRecord: ChildSpawnRecord; allocatedTokens: number }> {
+		// Read the parent's remaining budget HERE, inside the lock, so that
+		// concurrent siblings queue behind one another rather than all reading
+		// the same untouched number. The debit at the end of this method closes
+		// the pair: read and write are now on the same side of every await.
+		const maxAllocation = Math.floor(
+			context.budgetTracker.remaining * this.config.maxBudgetFraction,
+		)
+		const allocatedTokens = Math.min(
+			options.budgetAllocation?.tokenBudget ?? maxAllocation,
+			maxAllocation,
+		)
+
+		// Budget exhaustion must not INVERT into no budget at all. Downstream,
+		// `tokenBudget: 0` means "uncapped" (`LimitChecker`: `tokenBudget > 0
+		// && total >= tokenBudget`), and `maxAllocation` floors to 0 as soon as
+		// the parent's remaining drops below `1 / maxBudgetFraction`. So the
+		// most depleted parent in the tree was the one that spawned an
+		// unlimited child. Refuse instead: a caller that wants an uncapped
+		// child can say so explicitly with its own `budgetAllocation`.
+		//
+		// Refusing before any provisioning work also preserves the property the
+		// debit's placement was chosen for: a spawn this call rejects makes no
+		// state change at all, and burns no allocation.
+		if (allocatedTokens <= 0) {
+			throw new NamzuError({
+				code: 'invalid_config',
+				message: `Cannot spawn "${options.agentId}": the parent has ${context.budgetTracker.remaining} tokens remaining, which allocates 0 to the child — and a token budget of 0 means UNLIMITED downstream.`,
+				details: {
+					agentId: options.agentId,
+					parentRemaining: context.budgetTracker.remaining,
+					maxBudgetFraction: this.config.maxBudgetFraction,
+				},
+			})
+		}
+
 		// Phase 9: deps are unconditional required. Every spawn produces a
 		// SubSession + Session + WorkspaceRef triple (Convention #0: no
 		// partial/legacy path).
@@ -620,14 +640,24 @@ export class AgentManager {
 			throw err
 		}
 
+		// Debited only now, with the provisioning committed. Every path that
+		// could still have thrown is behind us, so a rejected spawn leaves the
+		// parent's budget untouched — the property the debit's original
+		// placement was chosen for, kept while closing the race that placement
+		// opened.
+		context.budgetTracker.remaining -= allocatedTokens
+
 		return {
-			subSessionId: subSession.id,
-			childSessionId: childSession.id,
-			tenantId: context.tenantId,
-			parentSessionId: options.parentSessionId,
-			rootSessionId,
-			childDepth,
-			workspaceRef,
+			spawnRecord: {
+				subSessionId: subSession.id,
+				childSessionId: childSession.id,
+				tenantId: context.tenantId,
+				parentSessionId: options.parentSessionId,
+				rootSessionId,
+				childDepth,
+				workspaceRef,
+			},
+			allocatedTokens,
 		}
 	}
 

--- a/packages/sdk/src/runtime/query/__tests__/the-plan-graph-reaches-a-host.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/the-plan-graph-reaches-a-host.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import { InMemoryTaskStore } from '../../../store/task/memory.js'
+import type { RunId } from '../../../types/ids/index.js'
+import type { RunEvent } from '../../../types/run/index.js'
+import { EventTranslator } from '../events.js'
+
+/**
+ * The task store maintains a full dependency graph — `blocks` and `blockedBy`
+ * mirrored on both ends, written under a lock, and deadlock-avoided — and none
+ * of it reached the wire.
+ *
+ * So a host could draw a flat list of units and nothing about their order,
+ * while the model was already maintaining the order. Two optional fields is the
+ * smallest change that lets a host draw the plan the model has in mind.
+ */
+
+const RUN = 'run_graph' as RunId
+
+/**
+ * Only what the emitter touches — and it touches more than the id.
+ *
+ * `emitEvent` appends to the run store, so a fake without one produces an
+ * unhandled rejection AFTER the assertions have passed: every test reports
+ * green and the process exits non-zero. Worth stating because that is the
+ * failure shape this session has been unpicking all day, arriving here in a
+ * test fixture.
+ */
+const runMgr = {
+	id: RUN,
+	getRunStore: () => ({ appendEvent: async () => undefined }),
+} as never
+
+async function capture(body: (store: InMemoryTaskStore) => Promise<void>): Promise<RunEvent[]> {
+	const store = new InMemoryTaskStore()
+	const emitter = new EventTranslator(runMgr)
+	const stop = emitter.wireTaskStore(store, RUN)
+
+	await body(store)
+	// The store's listeners are async; let them settle before draining.
+	await new Promise((resolve) => setTimeout(resolve, 20))
+	stop()
+
+	return [...emitter.drainPending()]
+}
+
+type Created = Extract<RunEvent, { type: 'task_created' }>
+type Updated = Extract<RunEvent, { type: 'task_updated' }>
+
+describe('a host can see what a unit waits on', () => {
+	it('carries the edges once a dependency exists', async () => {
+		const events = await capture(async (store) => {
+			const gather = await store.create({ runId: RUN, subject: 'gather' })
+			const summarise = await store.create({ runId: RUN, subject: 'summarise' })
+			await store.block(gather.id, summarise.id)
+		})
+
+		const withEdges = events
+			.filter((e): e is Updated => e.type === 'task_updated')
+			.find((e) => e.blockedBy !== undefined)
+
+		expect(withEdges, 'the dependency the store recorded never reached the wire').toBeDefined()
+		expect(withEdges?.blockedBy).toHaveLength(1)
+	})
+
+	it('says nothing rather than empty when a unit depends on nothing', async () => {
+		// Absent and empty are different claims. A reader must be able to tell
+		// "this unit has no dependencies" from "this emitter predates the
+		// field" — an empty array asserts the first about both.
+		const events = await capture(async (store) => {
+			await store.create({ runId: RUN, subject: 'standalone' })
+		})
+
+		const created = events.find((e): e is Created => e.type === 'task_created')
+
+		expect(created).toBeDefined()
+		expect(created && 'blockedBy' in created).toBe(false)
+	})
+})

--- a/packages/sdk/src/runtime/query/events.ts
+++ b/packages/sdk/src/runtime/query/events.ts
@@ -121,6 +121,10 @@ export class EventTranslator {
 						taskId: task.id,
 						subject: task.subject,
 						status: task.status,
+						// Absent rather than empty: a reader must be able to tell
+						// "depends on nothing" from an emitter that predates these.
+						...(task.blockedBy.length > 0 ? { blockedBy: task.blockedBy } : {}),
+						...(task.owner !== undefined ? { owner: task.owner } : {}),
 					})
 					break
 				case 'task.updated':
@@ -133,6 +137,7 @@ export class EventTranslator {
 						subject: task.subject,
 						status: task.status,
 						owner: task.owner,
+						...(task.blockedBy.length > 0 ? { blockedBy: task.blockedBy } : {}),
 					})
 					break
 				default: {

--- a/packages/sdk/src/store/task/disk.ts
+++ b/packages/sdk/src/store/task/disk.ts
@@ -35,10 +35,16 @@ export interface DiskTaskStoreConfig {
 	logger?: Logger
 }
 
+// `failed` ranks alongside `completed` rather than after it: both are
+// terminal, and neither may transition to the other. Ranking it higher would
+// admit completed -> failed, which would let a settled unit be reopened as a
+// failure; ranking it lower would forbid in_progress -> failed, which is the
+// transition this status exists for.
 const STATUS_ORDER: Record<TaskStatus, number> = {
 	pending: 0,
 	in_progress: 1,
 	completed: 2,
+	failed: 2,
 }
 
 function isForwardTransition(from: TaskStatus, to: TaskStatus): boolean {

--- a/packages/sdk/src/store/task/disk.ts
+++ b/packages/sdk/src/store/task/disk.ts
@@ -399,7 +399,16 @@ export class DiskTaskStore implements TaskStore {
 			}
 			if (!mutated) {
 				this.log.debug('block(): edge already exists', { blockerId, blockedId })
+				return
 			}
+
+			// Announce BOTH ends, and only when something actually changed. The
+			// edge was written and nothing said so, so the graph was observable
+			// only by polling — a listener saw a unit created and never learned
+			// that something now waits on it.
+			const now = Date.now()
+			this.emit({ type: 'task.updated', taskId: blockerId, task: blocker, timestamp: now })
+			this.emit({ type: 'task.updated', taskId: blockedId, task: blocked, timestamp: now })
 		})
 	}
 

--- a/packages/sdk/src/store/task/memory.ts
+++ b/packages/sdk/src/store/task/memory.ts
@@ -10,10 +10,16 @@ import type {
 } from '../../types/task/index.js'
 import { generateTaskId } from '../../utils/id.js'
 
+// `failed` ranks alongside `completed` rather than after it: both are
+// terminal, and neither may transition to the other. Ranking it higher would
+// admit completed -> failed, which would let a settled unit be reopened as a
+// failure; ranking it lower would forbid in_progress -> failed, which is the
+// transition this status exists for.
 const STATUS_ORDER: Record<TaskStatus, number> = {
 	pending: 0,
 	in_progress: 1,
 	completed: 2,
+	failed: 2,
 }
 
 function isForwardTransition(from: TaskStatus, to: TaskStatus): boolean {

--- a/packages/sdk/src/store/task/memory.ts
+++ b/packages/sdk/src/store/task/memory.ts
@@ -183,6 +183,15 @@ export class InMemoryTaskStore implements TaskStore {
 		if (!blocked.blockedBy.includes(blockerId)) {
 			blocked.blockedBy.push(blockerId)
 		}
+
+		// Announce BOTH ends. The edge was written and nothing said so, which
+		// left the graph observable only by polling: a listener saw a unit
+		// created and never learned that something now waits on it. Both sides
+		// changed, so both are announced — a host tracking only one would draw
+		// half the edge.
+		const now = Date.now()
+		this.emit({ type: 'task.updated', taskId: blockerId, task: blocker, timestamp: now })
+		this.emit({ type: 'task.updated', taskId: blockedId, task: blocked, timestamp: now })
 	}
 
 	async reset(): Promise<void> {

--- a/packages/sdk/src/tools/coordinator/__tests__/a-failed-worker-is-not-an-answer.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/a-failed-worker-is-not-an-answer.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest'
+
+import type { TaskGateway, TaskHandle } from '../../../types/agent/gateway.js'
+import type { TaskId } from '../../../types/ids/index.js'
+import type { ToolDefinition } from '../../../types/tool/index.js'
+import { buildCoordinatorTools } from '../index.js'
+import { failureLabel, taskSucceeded } from '../outcome.js'
+
+/**
+ * A worker that ran and failed was reported to the model as an answer.
+ *
+ * Two layers can disagree. `finalizeChild` always calls `markCompleted`, so the
+ * gateway's `state` is `'completed'` for a child whose run returned
+ * `status: 'failed'` — and `create_task` asked only that layer. The model then
+ * read the failure text as a result, the tool result carried `isError: false`,
+ * and the plan task was written closed as though the work had been done.
+ *
+ * The correct predicate existed twenty lines away in the canonical `Agent`
+ * tool, put there because a review caught it on that site. Nothing carried the
+ * answer to the other one. So this file tests the shared predicate, and the
+ * predicate is shared so there is no longer a second place to forget.
+ */
+
+const handle = (
+	state: TaskHandle['state'],
+	status?: string,
+): Pick<TaskHandle, 'state' | 'result'> =>
+	({ state, result: status === undefined ? undefined : { status } }) as Pick<
+		TaskHandle,
+		'state' | 'result'
+	>
+
+describe('success needs both authorities to agree', () => {
+	it('refuses a child the gateway called complete but whose run failed', () => {
+		// The exact shape the kernel produces: markCompleted was called, and
+		// the run underneath it did not succeed.
+		expect(taskSucceeded(handle('completed', 'failed'))).toBe(false)
+	})
+
+	it('accepts a child both layers agree on', () => {
+		expect(taskSucceeded(handle('completed', 'completed'))).toBe(true)
+	})
+
+	it('accepts a gateway that reports no run status at all', () => {
+		// A host gateway need not surface a run status. Treating its absence as
+		// failure would break every such gateway, so absence means "this layer
+		// has no opinion" rather than "it went wrong".
+		expect(taskSucceeded(handle('completed'))).toBe(true)
+	})
+
+	it('refuses a child that never reached a completed state', () => {
+		expect(taskSucceeded(handle('failed', 'completed'))).toBe(false)
+		expect(taskSucceeded(handle('canceled'))).toBe(false)
+	})
+})
+
+describe('the failure is named by whichever layer reported it', () => {
+	it('uses the task state when the task itself did not complete', () => {
+		// "failed" would lose the distinction a reader needs: a cancelled task
+		// and a task whose run errored call for different next moves.
+		expect(failureLabel(handle('canceled', 'completed'))).toBe('canceled')
+	})
+
+	it('uses the run status when the task completed but the run did not', () => {
+		expect(failureLabel(handle('completed', 'failed'))).toBe('failed')
+	})
+
+	it('falls back to a plain word when neither layer said anything useful', () => {
+		expect(failureLabel(handle('completed'))).toBe('failed')
+	})
+})
+
+describe('create_task itself reaches the predicate', () => {
+	/**
+	 * The unit tests above prove the predicate is right. They would all pass
+	 * with `create_task` still asking only the gateway — which is exactly the
+	 * state that shipped, with the correct version sitting twenty lines away in
+	 * a sibling tool.
+	 *
+	 * So this drives the tool.
+	 */
+	function toolFor(handle: TaskHandle): ToolDefinition {
+		const gateway = {
+			createTask: async () => ({ ...handle, state: 'running' }),
+			waitForTask: async () => handle,
+			getTask: () => handle,
+			listTasks: () => [handle],
+			cancelTask: () => undefined,
+			continueTask: async () => undefined,
+			onTaskCompleted: () => () => undefined,
+		} as unknown as TaskGateway
+
+		const tools = buildCoordinatorTools({
+			gateway,
+			workingDirectory: '/tmp/test',
+			allowedAgentIds: ['reviewer'],
+		})
+		const createTask = tools.find((t) => t.name === 'create_task')
+		if (!createTask) throw new Error('create_task was not built')
+		return createTask
+	}
+
+	const settled = (status: string): TaskHandle =>
+		({
+			taskId: 'tsk_1' as TaskId,
+			agentId: 'reviewer',
+			// The kernel's own shape: markCompleted ran regardless of the run.
+			state: 'completed',
+			createdAt: 1_000,
+			completedAt: 2_000,
+			result: { status, result: 'the worker text', lastError: 'it blew up' },
+		}) as unknown as TaskHandle
+
+	it('reports a failed run as a failure', async () => {
+		const tool = toolFor(settled('failed'))
+		const result = await tool.execute(
+			{ agent_id: 'reviewer', prompt: 'go', description: 'a task' },
+			{ toolUseId: 'call_1' } as never,
+		)
+
+		expect(result.success, 'a failed worker was reported as an answer').toBe(false)
+	})
+
+	it('still reports a successful run as a success', async () => {
+		const tool = toolFor(settled('completed'))
+		const result = await tool.execute(
+			{ agent_id: 'reviewer', prompt: 'go', description: 'a task' },
+			{ toolUseId: 'call_1' } as never,
+		)
+
+		expect(result.success).toBe(true)
+	})
+})

--- a/packages/sdk/src/tools/coordinator/agent.ts
+++ b/packages/sdk/src/tools/coordinator/agent.ts
@@ -5,6 +5,7 @@ import type { TaskGateway } from '../../types/agent/gateway.js'
 import type { ToolDefinition } from '../../types/tool/index.js'
 import { defineTool } from '../defineTool.js'
 import { wrapUntrusted } from '../untrusted-envelope.js'
+import { failureLabel, taskSucceeded } from './outcome.js'
 
 import type { TaskLaunchedCallback } from './index.js'
 
@@ -138,6 +139,13 @@ export function buildAgentTool(opts: AgentToolOptions): ToolDefinition {
 				prompt,
 				workingDirectory: cwd,
 				runtimeContext: opts.runtimeContext,
+				// Hang the child off the executing tool's span, so the
+				// delegation appears inside the turn that asked for it rather
+				// than as a disconnected root trace. `create_task` has done
+				// this all along; this tool — the kernel's other delegation
+				// surface, and the one it exports as the canonical shape —
+				// did not.
+				...(context.parentSpan ? { parentSpan: context.parentSpan } : {}),
 			})
 
 			onTaskLaunched?.(handle.taskId, {
@@ -153,26 +161,12 @@ export function buildAgentTool(opts: AgentToolOptions): ToolDefinition {
 
 			const completed = await gateway.waitForTask(handle.taskId)
 
-			// Two layers can disagree on whether the subagent succeeded:
-			//
-			// 1. `TaskHandle.state` — the gateway's terminal task state.
-			//    Some gateways (e.g. vandal's) explicitly map
-			//    `result.status !== 'completed'` to `state = 'failed'`,
-			//    others (e.g. SDK's `LocalTaskGateway`) just forward
-			//    whatever the AgentManager set, which does not always
-			//    reflect run-level failure.
-			// 2. `BaseAgentResult.status` — the run's own status. The
-			//    canonical source of truth for whether the agent actually
-			//    finished its work; `lastError` carries the failure
-			//    message when set.
-			//
-			// Treat the subagent as successful only when BOTH agree.
-			// Reporting a failed subagent as successful would silently
-			// hand the parent garbage output and make debugging
-			// impossible, which is what review flagged on the first cut.
-			const runStatus = completed.result?.status
-			const succeeded =
-				completed.state === 'completed' && (runStatus === undefined || runStatus === 'completed')
+			// Both authorities must agree — see `taskSucceeded` for which two
+			// and why either alone is wrong. The reasoning used to live here
+			// alone, which is exactly how `create_task` came to ship without
+			// it: a review caught this site, and nothing carried the answer to
+			// the other one.
+			const succeeded = taskSucceeded(completed)
 
 			const resultText =
 				typeof completed.result?.result === 'string'
@@ -182,19 +176,17 @@ export function buildAgentTool(opts: AgentToolOptions): ToolDefinition {
 						: ''
 
 			if (!succeeded) {
-				const failureLabel =
-					completed.state !== 'completed' ? completed.state : (runStatus ?? 'failed')
 				const detail =
 					completed.result?.lastError ?? resultText ?? '(subagent provided no failure detail)'
 				return {
 					success: false,
 					output: '',
-					error: `Subagent ${agentId} ${failureLabel}: ${detail}`,
+					error: `Subagent ${agentId} ${failureLabel(completed)}: ${detail}`,
 					data: {
 						task_id: handle.taskId,
 						subagent_type: agentId,
 						state: completed.state,
-						status: runStatus,
+						status: completed.result?.status,
 						lastError: completed.result?.lastError,
 					},
 				}
@@ -221,7 +213,7 @@ export function buildAgentTool(opts: AgentToolOptions): ToolDefinition {
 					subagent_type: agentId,
 					result: resultText,
 					state: completed.state,
-					status: runStatus,
+					status: completed.result?.status,
 				},
 			}
 		},

--- a/packages/sdk/src/tools/coordinator/index.ts
+++ b/packages/sdk/src/tools/coordinator/index.ts
@@ -10,6 +10,7 @@ import type { TaskStore } from '../../types/task/index.js'
 import type { ToolDefinition } from '../../types/tool/index.js'
 import { defineTool } from '../defineTool.js'
 import { wrapUntrusted } from '../untrusted-envelope.js'
+import { failureLabel, taskSucceeded } from './outcome.js'
 import { resolvePlanDependencies } from './plan-dependencies.js'
 import { describeWaitTimeout, waitForTaskWithBounds } from './wait-with-idle-bound.js'
 
@@ -457,6 +458,17 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 			// Naming the missing piece is the only response that tells them
 			// what to change.
 			if (background && !canLaunchInBackground) {
+				// The plan task was marked in progress a few lines above, on the
+				// assumption that a worker was about to run. Nothing is running,
+				// so leaving it there would show a plan step underway with no
+				// worker behind it — indefinitely, since nothing later will
+				// close a task whose launch never happened.
+				if (resolvedPlanTaskId && taskStore) {
+					await taskStore.update(resolvedPlanTaskId as `task_${string}`, {
+						status: 'failed',
+						description: 'Failed: the launch was refused before any worker started',
+					})
+				}
 				return {
 					success: false,
 					output: '',
@@ -533,15 +545,26 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 				}
 			}
 			completionInbox?.claim(handle.taskId)
-			const success = completed.state === 'completed'
+			// Both authorities, not just the gateway's. `finalizeChild` always
+			// calls `markCompleted`, so `state === 'completed'` holds for a
+			// child that ran and returned `status: 'failed'` — and this tool
+			// reported that child's error text to the model as its answer, with
+			// `isError: false`, while writing the plan task closed as though
+			// the work had been done.
+			const success = taskSucceeded(completed)
 			const resultText =
 				completed.result?.result ??
 				completed.result?.lastError ??
-				`Task finished with state: ${completed.state}`
+				`Task finished with state: ${failureLabel(completed)}`
 
 			if (resolvedPlanTaskId && taskStore) {
+				// The status carries the outcome now, rather than `completed`
+				// with the failure written into prose. A reader scanning
+				// statuses saw work that had been done; only a reader of every
+				// description saw otherwise — and a dependent unit had no way
+				// to tell at all.
 				await taskStore.update(resolvedPlanTaskId as `task_${string}`, {
-					status: 'completed',
+					status: success ? 'completed' : 'failed',
 					description: success ? undefined : `Failed: ${resultText.substring(0, 200)}`,
 				})
 			}

--- a/packages/sdk/src/tools/coordinator/outcome.ts
+++ b/packages/sdk/src/tools/coordinator/outcome.ts
@@ -1,0 +1,46 @@
+import type { TaskHandle } from '../../types/agent/gateway.js'
+
+/**
+ * Did this worker actually succeed?
+ *
+ * Two layers can disagree, and asking only one of them is how a failed worker
+ * gets reported as an answer:
+ *
+ * 1. **`TaskHandle.state`** — the gateway's terminal task state. Some gateways
+ *    map a failed run to `state: 'failed'`; others forward whatever the agent
+ *    manager set, which does not always reflect run-level failure. The kernel's
+ *    own `finalizeChild` always calls `markCompleted`, so `state` is
+ *    `'completed'` for a child that ran and returned `status: 'failed'`.
+ * 2. **`BaseAgentResult.status`** — the run's own status, and the canonical
+ *    answer to whether the agent finished its work. `lastError` carries the
+ *    message when it did not.
+ *
+ * So success requires BOTH to agree. Reporting a failed worker as successful
+ * hands the parent garbage output as though it were a result, and makes
+ * debugging impossible — the model reads an error as an answer and builds on
+ * it.
+ *
+ * **This lives here because it was written twice and omitted once**, and the
+ * omission was in `create_task`, the primary delegation surface. The version in
+ * the canonical `Agent` tool was correct because a review caught it there; the
+ * same review never reached the other site. A predicate that is easy to get
+ * wrong, and whose wrong answer is silent, belongs in one place that every
+ * caller reaches rather than in each caller's memory.
+ */
+export function taskSucceeded(handle: Pick<TaskHandle, 'state' | 'result'>): boolean {
+	const runStatus = handle.result?.status
+	return handle.state === 'completed' && (runStatus === undefined || runStatus === 'completed')
+}
+
+/**
+ * What to call the failure, in the words of whichever layer reported it.
+ *
+ * The gateway state wins when it is the one that disagrees, because a task that
+ * never reached `completed` failed in a way the run status cannot describe — it
+ * was cancelled, or it timed out, and saying "failed" for those loses the
+ * distinction a reader needs to decide what to do next.
+ */
+export function failureLabel(handle: Pick<TaskHandle, 'state' | 'result'>): string {
+	if (handle.state !== 'completed') return handle.state
+	return handle.result?.status ?? 'failed'
+}

--- a/packages/sdk/src/types/agent/supervisor.ts
+++ b/packages/sdk/src/types/agent/supervisor.ts
@@ -72,6 +72,23 @@ export interface SupervisorAgentConfig extends BaseAgentConfig {
 	 */
 	maxDepth?: number
 
+	/**
+	 * How many tools may execute at once in one turn — which, for a
+	 * supervisor, is how wide a fan-out actually runs.
+	 *
+	 * The kernel has honoured this all along and `ReactiveAgent` forwards it.
+	 * It was missing here, so the agent whose entire job is delegation could
+	 * not set the gate that bounds delegation, while the agent that does not
+	 * delegate could. A host wanting a narrower fan-out had to reach past the
+	 * supervisor to `drainQuery`.
+	 *
+	 * Absent leaves the kernel default. Note what it does and does not bound:
+	 * it limits how many delegated children run CONCURRENTLY, not how many a
+	 * turn may launch — a model that emits twenty `create_task` blocks still
+	 * launches twenty, and they queue.
+	 */
+	maxToolConcurrency?: number
+
 	taskRouter?: TaskRouterConfig
 
 	factoryOptions?: AgentFactoryOptions

--- a/packages/sdk/src/types/run/events.ts
+++ b/packages/sdk/src/types/run/events.ts
@@ -461,6 +461,21 @@ type CoreRunEvent =
 			taskId: TaskId
 			subject: string
 			status: TaskStatus
+			/**
+			 * What this unit waits on, and who claims it.
+			 *
+			 * The store maintains a full dependency graph — `blocks` and
+			 * `blockedBy` are mirrored on both ends, written under a lock, and
+			 * deadlock-avoided — and none of it reached the wire. So a host
+			 * could show a flat list of units and nothing about their order,
+			 * while the model was already maintaining the order.
+			 *
+			 * Absent rather than empty when the unit depends on nothing, so a
+			 * reader can tell "no dependencies" from an emitter that predates
+			 * these fields.
+			 */
+			blockedBy?: readonly TaskId[]
+			owner?: string
 	  }
 	| {
 			type: 'task_updated'
@@ -469,6 +484,8 @@ type CoreRunEvent =
 			subject: string
 			status: TaskStatus
 			owner?: string
+			/** See `task_created`. Carried on updates because an edge can be added later. */
+			blockedBy?: readonly TaskId[]
 	  }
 	| {
 			type: 'plugin_hook_executing'

--- a/packages/sdk/src/types/task/index.ts
+++ b/packages/sdk/src/types/task/index.ts
@@ -1,9 +1,27 @@
 import type { RunId, TaskId, TenantId } from '../ids/index.js'
 
-export type TaskStatus = 'pending' | 'in_progress' | 'completed'
+/**
+ * `failed` exists because a unit that did not succeed had nowhere to say so.
+ *
+ * Delegation wrote a failed worker's task as `completed` with the failure
+ * encoded as prose in `description` — so a reader scanning statuses saw work
+ * that had been done, and only a reader of every description saw otherwise. A
+ * status nobody can set is a status nobody can act on: a dependent unit cannot
+ * decide whether to wait or give up, and a plan cannot report that it did not
+ * finish.
+ */
+export type TaskStatus = 'pending' | 'in_progress' | 'completed' | 'failed'
 
+/**
+ * Terminal means "will not change on its own", not "succeeded".
+ *
+ * `failed` is terminal for the same reason `completed` is: nothing downstream
+ * should wait on it. That matters most to the blocker check in the task
+ * listing — a dependent unit blocked on something that failed would otherwise
+ * wait forever for a status that will never arrive.
+ */
 export function isTerminalTaskStatus(status: TaskStatus): boolean {
-	return status === 'completed'
+	return status === 'completed' || status === 'failed'
 }
 
 export function assertTaskStatus(status: TaskStatus): void {
@@ -11,6 +29,7 @@ export function assertTaskStatus(status: TaskStatus): void {
 		case 'pending':
 		case 'in_progress':
 		case 'completed':
+		case 'failed':
 			return
 		default: {
 			const _exhaustive: never = status


### PR DESCRIPTION
Two bugs live in published `8.0.0`. Both surfaced from a research pass on fan-out and plan structure, and both were verified by measurement before and after rather than by reading.

## A concurrent fan-out allocated more budget than the parent had

`sendMessage` read the parent's remaining budget at the top and debited it after `provisionSpawn` — putting the two halves of a read-modify-write on either side of an await, with the only critical section in between. Siblings launched from one turn all read the same undebited number:

```
four siblings were handed 50000 + 50000 + 50000 + 50000 from a pool of 100000
```

`create_task`'s own description instructs exactly that shape — *"'fan out 8 specialists' is one assistant message with 8 create_task blocks"* — so the documented usage was the reproduction.

The read, the refusal when an allocation floors to zero, and the debit now all sit inside the per-parent spawn lock. That **keeps** the property the debit's placement was chosen for — a spawn this call rejects burns no allocation — while closing the race that placement opened. It was introduced by a correct fix to a different bug: moving the debit after the provisioning put it outside the lock.

### Getting to the failing test took three passing wrong ones

Worth stating, because each would have certified the bug as fixed:

1. **Measured after settle.** A settled child refunds its unspent budget, so the tracker reads healthy exactly when the transient over-commitment is hidden.
2. **Measured the tracker, not the allocations.** The harm is not the bookkeeping — it is four children each believing they may spend half a pool that has one half.
3. **Hand-built an `AgentManager` with incomplete deps**, so the children never ran and the recorded allocations stayed empty. Indistinguishable from a pass.

The regression test holds its children open for reason 1, and asserts on what each child was handed for reason 2.

## `create_task` reported a failed worker as a success

Two layers can disagree about a delegated run: the gateway's `TaskHandle.state` and the run's own `BaseAgentResult.status`. `finalizeChild` always calls `markCompleted`, so `state === 'completed'` holds for a child that ran and returned `status: 'failed'` — and this tool asked only that layer.

The model received the failure text as an answer, `tool_completed` carried `isError: false`, and the plan task was written closed as though the work had been done.

**The correct predicate was already written, twenty lines away**, in the canonical `Agent` tool — put there because a review caught it on that site, and nothing carried the answer to the other one. It now lives in `coordinator/outcome.ts` with the reasoning, so there is no second place to forget.

Both mutations land, and the second is the one that matters: reverting the predicate fails a unit test, and making `create_task` bypass it fails the caller-level test. Without the second I would have proven the helper correct and not that the caller reaches it — which is exactly the state that shipped.

## `TaskStatus` gains `failed` — the breaking part

A unit that did not succeed had nowhere to say so, which is why a failed delegation was recorded as `completed` with the failure encoded as prose in `description`. A reader scanning statuses saw work that had been done; a dependent unit had no way to tell at all.

If you switch exhaustively over `TaskStatus` or hold a `Record<TaskStatus, T>`, you need a `failed` arm. `isTerminalTaskStatus` returns `true` for it — terminal means *will not change on its own*, not *succeeded*, and a unit blocked on a failure would otherwise wait forever for a status that never arrives. In both stores' transition ranking `failed` sits alongside `completed`, so `in_progress → failed` is allowed and `completed → failed` is not.

## Two smaller repairs

- A background launch refused for want of a completion inbox now marks its plan task failed. It had been left in progress with no worker behind it, and nothing later closes a task whose launch never happened.
- `buildAgentTool` passes `parentSpan` when creating its child, so a delegated run joins the turn that asked for it instead of starting its own root trace. `create_task` has done this all along — third instance today of a mechanism used correctly at some of the sites that need it, and this one is in the surface the kernel exports as canonical.

## Not in this change

Of `create_task`'s four exits, three — background, timeout, abandoned — leave work genuinely in progress, so `in_progress` is the honest status. What is missing is the completion drain closing the plan task when the worker finally finishes, and `planTaskId` does not reach the iteration loop at all. That needs a seam rather than a line, and it is tracked separately.

Gates: typecheck 0 · lint clean · 2726 SDK + 334 CLI + every provider suite green with live tests enabled · external-name audit clean.

---

# Added after the first review pass: the wiring half

Pushed onto this branch rather than stacked, because it is the next bucket of
the same change map and stacking here buys nothing. **Re-check CI: the green
above was the previous head.**

## The supervisor could not bound its own fan-out

`maxToolConcurrency` is declared on `QueryParams`, honoured by the executor, and
forwarded by `ReactiveAgent` — and absent from `SupervisorAgentConfig`. So the
one agent whose entire job is delegation could not set the gate that bounds a
delegation, while the agent that does not delegate could. A host wanting a
narrower fan-out had to reach past the supervisor to `drainQuery`.

It bounds how many children run **concurrently**, not how many a turn may
launch. Twenty `create_task` blocks still launch twenty; they queue.

## The plan graph never reached the wire — and neither did the moment it changed

`task_created` and `task_updated` now carry `blockedBy`. That was the stated
item. **The test for it failed, and found the real defect:** `block()` in both
stores writes the edge and emits nothing. So the field alone would have been
useless — the moment a dependency is created was never on the wire in the first
place, and the graph was observable only by polling.

Both stores now announce **both ends**, because both changed and a host tracking
one side would draw half an edge. The disk store announces only when something
actually changed, so re-establishing an existing edge stays silent.

Two mutations, landing separately: dropping the field fails one test, removing
the emission fails the other. They are independent halves of one feature and the
profile says so.

## One more instance of the day's defect, in my own test

Its fake `runMgr` was `{ id }`, and `emitEvent` appends to the run store — so
after the assertions passed, five unhandled rejections fired and the suite
**exited 1 while every summary line read green.** I nearly took the green. The
exit code is now read directly rather than off the summary.

Gates re-run on the new head: typecheck 0 · lint clean · SDK 300 files / 2728
tests, real exit code 0 · external-name audit clean.
