### PR TITLE
fix(sdk)!: a plan that succeeded is not failed

### DIFF
--- a/.changeset/a-plan-that-succeeded-is-not-failed.md
+++ b/.changeset/a-plan-that-succeeded-is-not-failed.md
@@ -1,0 +1,44 @@
+---
+'@namzu/sdk': major
+---
+
+`PlanManager.completePlan` refuses an unreported step instead of scoring it a failure.
+
+**A plan that fully succeeded was reported as failed.** `completePlan` asked one
+question — "is every step `completed` or `skipped`?" — and everything that was
+not fell to the same branch. A step still `pending` therefore produced
+`status: 'failed'`, indistinguishable from a step that genuinely failed. Since
+`addStep` defaults every step to `pending`, a host that added steps, did the
+work, and settled the plan without calling `updateStepStatus` on each one got
+`failed` for a plan where nothing had gone wrong. That is the path of least
+effort through this API, not an unusual one.
+
+The two cases are different facts and deserve different answers. A step that
+FAILED is an outcome: report the plan failed. A step nobody reported on is not
+an outcome at all — it says the caller and the plan disagree about whether the
+work is over, and answering `failed` settles that disagreement by inventing a
+result.
+
+**What changes for you.** `completePlan()` now throws when any step is still
+`pending` or `running`. The message names the unfinished steps and both ways
+forward, because a caller in this position either forgot to report progress or
+called too early, and only they know which:
+
+- report each step with `updateStepStatus` — `'skipped'` is a valid outcome for
+  work that was planned and then not needed; or
+- call `failPlan` if the plan is being abandoned, which marks unfinished steps
+  `skipped` and settles the plan as failed.
+
+Behaviour is unchanged once every step has reported: all `completed` or
+`skipped` still yields `completed`, and any `failed` still yields `failed`.
+No code in this repository called `completePlan`, so nothing inside the kernel
+changes behaviour; the affected callers are hosts.
+
+**`PlanManager` now says which half of it the kernel drives.** The kernel builds
+a plan, gates it, translates its events, and settles it on failure — it never
+reports a step outcome and never settles a plan that succeeded. That is a
+deliberate split, since `drainQuery` hands the manager to the host through
+`onContextCreated` for exactly this purpose, and a search for callers inside the
+package finds none because the callers are outside it. The absence had already
+been read once as a dead layer and proposed for deletion; what that would have
+deleted is a working human-in-the-loop approval gate. It is written down now.

--- a/packages/sdk/src/manager/plan/__tests__/a-plan-that-succeeded-is-not-failed.test.ts
+++ b/packages/sdk/src/manager/plan/__tests__/a-plan-that-succeeded-is-not-failed.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+
+import type { RunId } from '../../../types/ids/index.js'
+import { PlanManager } from '../lifecycle.js'
+
+/**
+ * `completePlan` scored an unreported step as a failure.
+ *
+ * The test was "is every step completed or skipped", and everything else fell
+ * to the same branch — so a step still `pending` produced `failed`. Since
+ * `addStep` defaults every step to `pending`, a caller that added steps, did
+ * the work, and settled the plan without reporting each one got `failed` for a
+ * plan that had fully succeeded. That is the path of least effort, not an
+ * unusual one.
+ *
+ * A step that FAILED is an outcome. A step nobody reported on is not — it says
+ * the caller and the plan disagree about whether the work is over, and
+ * answering "failed" settles that by inventing a result.
+ */
+
+const RUN = 'run_plan_outcome' as RunId
+
+function planWithSteps(count: number): PlanManager {
+	const manager = new PlanManager(RUN)
+	manager.startGenerating('a plan')
+	for (let i = 0; i < count; i += 1) {
+		manager.addStep({
+			id: `step-${i + 1}`,
+			description: `step ${i + 1}`,
+			dependsOn: [],
+			order: i,
+		})
+	}
+	manager.markReady()
+	return manager
+}
+
+describe('a plan settles on what its steps actually reported', () => {
+	it('completes when every step reported success', () => {
+		const manager = planWithSteps(2)
+		for (const step of manager.active?.steps ?? []) {
+			manager.updateStepStatus(step.id, 'completed')
+		}
+
+		expect(manager.completePlan()?.status).toBe('completed')
+	})
+
+	it('counts a skipped step as settled, not as a failure', () => {
+		const manager = planWithSteps(2)
+		const steps = manager.active?.steps ?? []
+		manager.updateStepStatus(steps[0]?.id as string, 'completed')
+		manager.updateStepStatus(steps[1]?.id as string, 'skipped')
+
+		expect(manager.completePlan()?.status).toBe('completed')
+	})
+
+	it('fails when a step actually failed', () => {
+		const manager = planWithSteps(2)
+		const steps = manager.active?.steps ?? []
+		manager.updateStepStatus(steps[0]?.id as string, 'completed')
+		manager.updateStepStatus(steps[1]?.id as string, 'failed')
+
+		expect(manager.completePlan()?.status).toBe('failed')
+	})
+
+	it('refuses rather than scoring a step nobody reported on', () => {
+		// The defect, in the shape a caller reaches it: steps added, work done,
+		// nothing reported. Answering `failed` here is the invented result.
+		const manager = planWithSteps(2)
+		manager.updateStepStatus(manager.active?.steps[0]?.id as string, 'completed')
+
+		expect(() => manager.completePlan()).toThrow(/have not reported an outcome/)
+	})
+
+	it('names the way out rather than only the refusal', () => {
+		// A caller in this position either forgot to report progress or called
+		// too early, and only they know which — so the message has to carry
+		// both moves, not just the complaint.
+		const manager = planWithSteps(1)
+
+		expect(() => manager.completePlan()).toThrow(/updateStepStatus/)
+		expect(() => manager.completePlan()).toThrow(/failPlan/)
+	})
+
+	it('still returns null when there is no plan at all', () => {
+		expect(new PlanManager(RUN).completePlan()).toBeNull()
+	})
+})

--- a/packages/sdk/src/manager/plan/lifecycle.ts
+++ b/packages/sdk/src/manager/plan/lifecycle.ts
@@ -26,6 +26,33 @@ export type PlanEventListener = (event: PlanEvent) => void
 
 export type PlanApprovalHandler = (request: PlanApprovalRequest) => Promise<PlanApprovalResponse>
 
+/**
+ * The plan a run declares, and the gate a host approves it through.
+ *
+ * **The kernel deliberately drives only part of this class.** It builds a plan
+ * (`approve_plan` calls `startGenerating` / `addStep` / `markReady`), gates it
+ * (`iteration/phases/context.ts` calls `approve` and `startExecution`),
+ * translates its events onto the run stream (`EventTranslator.wirePlanManager`),
+ * and settles it on failure (`runtime/query/result.ts` calls `failPlan`). It
+ * never reports a step outcome and never settles a plan that succeeded.
+ *
+ * That is a split, not an omission — `drainQuery` hands the manager to the host
+ * through `onContextCreated({ planManager })` BEFORE the iteration loop starts,
+ * precisely so a host can drive the half the kernel does not. So a grep for
+ * callers of `updateStepStatus` or `completePlan` inside this package finds
+ * none, and that is not evidence the methods are dead: the callers are hosts,
+ * and they are outside the repository. `PlanManager` is exported from
+ * `public-runtime.ts` for this reason.
+ *
+ * Recorded here because the absence has already been read once as a dead layer
+ * and proposed for deletion. What it would have deleted is a working
+ * human-in-the-loop approval gate.
+ *
+ * The one genuine gap in the split is tracked separately: nothing settles a
+ * plan that SUCCEEDED, so its status can reach `failed` or stay `executing`
+ * but never `completed`. Fixing that needs a decision about what a
+ * kernel-built plan's steps mean, not a guessed status — see `completePlan`.
+ */
 export class PlanManager {
 	private currentPlan: Plan | null = null
 	private runId: RunId
@@ -185,8 +212,42 @@ export class PlanManager {
 		return step
 	}
 
+	/**
+	 * Settle the plan, computing its outcome from its steps.
+	 *
+	 * A step that is still `pending` or `running` used to land here as
+	 * **`failed`**, because the test was "is every step completed or skipped"
+	 * and anything else fell to the same branch. So a caller that added steps,
+	 * did the work, and settled the plan without reporting each step got
+	 * `failed` for a plan that fully succeeded — and `addStep` defaults every
+	 * step to `pending`, so that is the path of least effort, not an unusual
+	 * one.
+	 *
+	 * The two cases are different facts and want different responses. A step
+	 * that FAILED is an outcome: the plan failed, report it. A step nobody
+	 * reported on is not an outcome at all — it says the caller and this plan
+	 * disagree about whether the work is over, and answering "failed" resolves
+	 * that disagreement by inventing a result.
+	 *
+	 * So an unfinished step is refused rather than scored. The message names
+	 * the steps and the two ways out, because a caller in this position either
+	 * forgot to report progress or called too early, and only they know which.
+	 */
 	completePlan(): Plan | null {
 		if (!this.currentPlan) return null
+
+		const unfinished = this.currentPlan.steps.filter(
+			(s) => s.status === 'pending' || s.status === 'running',
+		)
+		if (unfinished.length > 0) {
+			const named = unfinished.slice(0, 3).map((s) => s.description)
+			const rest = unfinished.length - named.length
+			const listed = rest > 0 ? `${named.join('; ')}, and ${rest} more` : named.join('; ')
+			const counted = `${unfinished.length} of ${this.currentPlan.steps.length} steps`
+			throw new Error(
+				`Cannot complete plan "${this.currentPlan.title}": ${counted} have not reported an outcome (${listed}). Report each step with updateStepStatus — 'skipped' is a valid outcome — or call failPlan if the plan is being abandoned. Scoring an unreported step as a failure would report a plan that succeeded as one that did not.`,
+			)
+		}
 
 		const allDone = this.currentPlan.steps.every(
 			(s) => s.status === 'completed' || s.status === 'skipped',


### PR DESCRIPTION
`completePlan` asked one question — "is every step `completed` or `skipped`?" — and let everything else fall to the same branch. So a step still `pending` produced `status: 'failed'`, indistinguishable from a step that genuinely failed. Since `addStep` defaults every step to `pending`, a host that added steps, did the work, and settled the plan without calling `updateStepStatus` on each one got `failed` for a plan where nothing had gone wrong. That is the path of least effort through this API, not an unusual one.

A step that FAILED is an outcome: report the plan failed. A step nobody reported on is not an outcome at all — it says the caller and the plan disagree about whether the work is over, and answering `failed` resolves that disagreement by inventing a result. An unfinished step is now refused rather than scored, and the message names the unfinished steps and both ways forward, because a caller here either forgot to report progress or called too early and only they know which.

### How this was found, and what was nearly deleted instead

The change map recommended deleting this layer as dead. Verification refused it: `PlanManager` is exported from `public-runtime.ts:227`, and `drainQuery` hands it to hosts at `runtime/query/index.ts:560` through `onContextCreated({ planManager })` **before** the iteration loop — so `markReady()` reaches the plan approval gate. "Zero callers in this package" is not "zero callers"; the callers are hosts, outside the repository. What the deletion would have removed is a working human-in-the-loop approval gate.

The real defect was inside the layer proposed for removal. `PlanManager` now carries a doc comment stating which half of it the kernel drives — it builds a plan, gates it, translates its events, and settles it on failure, and never reports a step outcome — so the next audit does not re-flag the absence as death.

### Filed, not fixed here

Nothing settles a plan that **succeeded**: `result.ts:143` calls `failPlan` on the error path, the success path at `result.ts:43` never touches the manager, and no production code calls `updateStepStatus` or `completePlan` at all. A plan status can therefore reach `failed` or stay `executing` forever, never `completed`.

It is deliberately not fixed in this PR, because the fix is not symmetry with `failPlan`. That marks unfinished steps `skipped`, which is honest when the run ended before they ran; on the success path the model may well have *done* the work of a step nobody reported, so both `skipped` and `completed` would invent a result — the thing this PR stops doing. The gap underneath is that a kernel-built plan's steps have no binding to the tool calls that do the work. That needs a design decision, not a guess.

### Verification

- 6 new cases in `a-plan-that-succeeded-is-not-failed.test.ts`.
- Mutation: refusal disabled ⇒ exactly 2 of 6 fail (the refusal and the message), the other 4 still pass.
- `pnpm typecheck` exit 0; full SDK suite **2734 passed**, exit code read directly rather than off the summary. The 7 skips are `skipIf(!CAN_SYMLINK)` / `skipIf(IS_WINDOWS)` — platform-gated with the reason in the file, and CI runs them on Linux.

### Breaking

`PlanManager.completePlan()` throws when any step is still `pending` or `running`, where it previously returned a plan with `status: 'failed'`. Report each step with `updateStepStatus` (`'skipped'` is a valid outcome) or call `failPlan` to abandon the plan. Behaviour is unchanged once every step has reported. No code in this repository calls `completePlan`, so nothing inside the kernel changes behaviour.
