### PR TITLE
fix(sdk)!: a knob nobody can turn is not a feature

### DIFF
--- a/.changeset/a-knob-nobody-can-turn.md
+++ b/.changeset/a-knob-nobody-can-turn.md
@@ -1,0 +1,48 @@
+---
+'@namzu/sdk': major
+---
+
+A delegated run is built with the config its caller asked for, and a supervisor can select its sibling-failure policy.
+
+Two capabilities were declared, documented, typed, and unreachable. Both are the
+same defect: a knob wired to nothing, which reads to a caller as a knob that
+works.
+
+**`CreateTaskOptions.configOverrides` was accepted and dropped.**
+`LocalTaskGateway.createTask` built its own `configOverrides` object out of
+`parentSpan` alone and never read the field, so a caller pinning a delegated run
+to a cheaper model, or capping its iterations, got the agent's defaults and no
+indication anything had been ignored. It is forwarded now. A caller who sets
+both the field and the dedicated `parentSpan` option gets the dedicated one for
+the span — that is the specific field for the job — and keeps every other
+override alongside it.
+
+**`siblingFailurePolicy` could not be selected by any host.**
+`LocalTaskGateway` has honoured it since it was written and the cancellation
+machinery behind `'cancel-siblings'` is complete — but it was the fifth
+constructor argument of a gateway `SupervisorAgent` builds itself, and the
+supervisor passed four. Every host in existence ran `'continue'`, and the only
+route to the other value was to construct the gateway by hand and pass it as
+`config.gateway`. It is now `SupervisorAgentConfig.siblingFailurePolicy`.
+
+`'continue'` remains the default and deliberately so: partial results are
+usually worth having, and tearing down healthy siblings on any failure lets one
+flaky child waste four good ones. `'cancel-siblings'` is for a fan-out whose
+parts only mean something together. The choice is now expressible; the answer
+has not changed. The field is ignored when the host supplies its own `gateway`,
+which owns its policy.
+
+**Breaking:** `CreateTaskOptions.configOverrides` is now typed
+`Partial<BaseAgentConfig>` instead of `Record<string, unknown>`. It lands on
+`SendMessageOptions.configOverrides`, which is already that shape, and the loose
+type let a misspelled key type-check and then silently do nothing — the same
+silence the field was already producing. If you pass a key that is not on
+`BaseAgentConfig`, it will now fail to compile; that key was never being applied.
+
+**Also:** the two-authority failure check in `LocalTaskGateway` moves to
+`taskFailed` in `tools/coordinator/outcome.ts`, next to `taskSucceeded`. It is
+deliberately *not* the negation of that predicate — a task that is still running
+satisfies neither, and cancelling a fan-out on `!taskSucceeded` would tear down
+siblings the moment the first child had merely not finished yet. The gateway's
+copy was correct; a rule each caller has to remember is one a caller eventually
+forgets, which is what happened to `taskSucceeded` before it was consolidated.

--- a/packages/sdk/src/agents/SupervisorAgent.ts
+++ b/packages/sdk/src/agents/SupervisorAgent.ts
@@ -159,7 +159,14 @@ export class SupervisorAgent extends AbstractAgent<SupervisorAgentConfig, Superv
 				projectId,
 				parentActor,
 			}
-			gateway = new LocalTaskGateway(config.agentManager, taskContext, listener, input)
+			// The only hop between the config and the gateway's policy. Omit it
+			// and the field is settable, documented, and read by nothing —
+			// which is exactly the state it was in before.
+			gateway = new LocalTaskGateway(config.agentManager, taskContext, listener, input, {
+				...(config.siblingFailurePolicy
+					? { siblingFailurePolicy: config.siblingFailurePolicy }
+					: {}),
+			})
 		} else {
 			throw new Error("SupervisorAgentConfig requires either 'gateway' or 'agentManager'")
 		}

--- a/packages/sdk/src/agents/__tests__/a-policy-nobody-can-select.test.ts
+++ b/packages/sdk/src/agents/__tests__/a-policy-nobody-can-select.test.ts
@@ -1,0 +1,202 @@
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { MockLLMProvider, registerMock } from '../../provider/index.js'
+import { ToolRegistry } from '../../registry/index.js'
+import type { Agent } from '../../types/agent/core.js'
+import type { SiblingFailurePolicy } from '../../types/agent/gateway.js'
+import type { AgentManagerContract } from '../../types/agent/manager.js'
+import type {
+	AgentTask,
+	AgentTaskContext,
+	AgentTaskState,
+	SendMessageOptions,
+} from '../../types/agent/task.js'
+import type { RunId, TaskId } from '../../types/ids/index.js'
+import { SupervisorAgent } from '../SupervisorAgent.js'
+
+/**
+ * `'cancel-siblings'` was unreachable from every entry point.
+ *
+ * `LocalTaskGateway` has honoured the policy since it was written and the
+ * cancellation machinery behind it is complete — but the policy was the fifth
+ * constructor argument of a gateway the supervisor builds itself, and the
+ * supervisor passed four. So every host in existence ran `'continue'`, and the
+ * only way to reach the other value was to construct the gateway by hand and
+ * hand it in through `config.gateway`. A policy nobody can select is not a
+ * policy, and the tests it had all constructed the gateway directly, so they
+ * passed while nothing upstream could turn it on.
+ *
+ * The assertion is deliberately the cancellation itself. Asserting that the run
+ * completed would pass with the forwarding deleted — a fan-out under
+ * `'continue'` completes too — and prove nothing.
+ */
+
+registerMock()
+
+const FAILING = 'doomed' as const
+const SLOW = 'patient' as const
+
+/**
+ * A manager whose slow child only settles when someone cancels it — which is
+ * what an abort actually does, and what lets this run terminate at all.
+ */
+class FanOutManager implements AgentManagerContract {
+	readonly cancelled: TaskId[] = []
+	private readonly tasks = new Map<TaskId, AgentTask>()
+	private releaseSlow?: () => void
+	private readonly slowSettled = new Promise<void>((resolve) => {
+		this.releaseSlow = resolve
+	})
+	private markLaunched?: () => void
+	/**
+	 * The doomed child does not settle until BOTH have launched.
+	 *
+	 * Without this the test is a race it usually wins: the sibling policy only
+	 * cancels tasks the gateway is already tracking, so if the failure lands
+	 * before the slow child finishes registering, nothing is cancelled, nothing
+	 * releases the slow child, and the run hangs until the delegation timeout.
+	 * That happened once here. A fan-out where one leg dies while another is
+	 * genuinely in flight is the scenario being tested, so the harness states
+	 * it instead of hoping for it.
+	 */
+	private readonly bothLaunched = new Promise<void>((resolve) => {
+		this.markLaunched = resolve
+	})
+
+	async sendMessage(options: SendMessageOptions): Promise<AgentTask> {
+		const failing = options.agentId === FAILING
+		const taskId = (failing ? 'task_doomed' : 'task_patient') as TaskId
+		const task = {
+			taskId,
+			agentId: options.agentId,
+			agent: {} as Agent<never, never>,
+			childAbortController: new AbortController(),
+			context: {} as AgentTaskContext,
+			// The failing child is `completed` at the gateway layer and
+			// `failed` in its own result — the two-authority split that makes
+			// this worth checking at all.
+			state: (failing ? 'completed' : 'running') as AgentTaskState,
+			pendingMessages: [],
+			createdAt: 1,
+			...(failing
+				? { result: { runId: 'run_child' as RunId, status: 'failed', result: 'it broke' } }
+				: {}),
+		} as AgentTask
+
+		this.tasks.set(taskId, task)
+		if (this.tasks.size === 2) this.markLaunched?.()
+		return task
+	}
+
+	cancel(taskId: TaskId): void {
+		this.cancelled.push(taskId)
+		const task = this.tasks.get(taskId)
+		if (task) task.state = 'failed' as AgentTaskState
+		this.releaseSlow?.()
+	}
+
+	async waitForCompletion(taskId: TaskId): Promise<void> {
+		if (taskId === ('task_patient' as TaskId)) await this.slowSettled
+		// The doomed child fails only once its sibling is actually in flight —
+		// see `bothLaunched`. Registration happens inside `createTask` right
+		// after `sendMessage` returns, so waiting a further microtask turn is
+		// what puts this after it rather than racing it.
+		else {
+			await this.bothLaunched.then(() => undefined)
+			// Safety valve, and it is what makes a REGRESSION legible. If the
+			// policy never reaches the gateway, nothing cancels the slow child
+			// and this run hangs until the delegation timeout — so the test
+			// would report "timed out after 60s" instead of "the sibling was
+			// not cancelled". Releasing it here means the assertion below is
+			// what fails, and it fails in a second.
+			setTimeout(() => this.releaseSlow?.(), 250).unref?.()
+		}
+	}
+
+	getInstance(taskId: TaskId): AgentTask | undefined {
+		return this.tasks.get(taskId)
+	}
+
+	cancelAll(): void {}
+	async continueTask(): Promise<void> {}
+	queueMessage(): void {}
+	drainMessages() {
+		return []
+	}
+	listByParent(): AgentTask[] {
+		return []
+	}
+	listActive(): AgentTask[] {
+		return []
+	}
+	getState(): AgentTaskState | undefined {
+		return undefined
+	}
+	on(): void {}
+	off(): void {}
+	cleanup(): void {}
+	dispose(): void {}
+}
+
+async function fanOut(policy?: SiblingFailurePolicy): Promise<FanOutManager> {
+	const agentManager = new FanOutManager()
+	const agent = new SupervisorAgent({
+		id: 'sup_policy',
+		name: 'Supervisor',
+		version: '1',
+		category: 'test',
+		description: 'coordinates workers',
+	})
+
+	await agent.run(
+		{
+			messages: [{ role: 'user', content: 'go', timestamp: 1 }],
+			workingDirectory: await mkdtemp(join(tmpdir(), 'namzu-sibling-policy-')),
+		} as never,
+		{
+			provider: new MockLLMProvider({
+				turns: [
+					{
+						toolCalls: [
+							{
+								name: 'create_task',
+								args: { agent_id: SLOW, prompt: 'long work', description: 'the patient one' },
+							},
+							{
+								name: 'create_task',
+								args: { agent_id: FAILING, prompt: 'doomed work', description: 'the doomed one' },
+							},
+						],
+					},
+					{ text: 'done' },
+				],
+			}),
+			agentIds: [SLOW, FAILING],
+			agentManager,
+			tools: new ToolRegistry(),
+			systemPrompt: 'You coordinate.',
+			model: 'mock-model',
+			tokenBudget: 100_000,
+			timeoutMs: 30_000,
+			maxIterations: 3,
+			sessionId: 'ses_policy',
+			threadId: 'thd_policy',
+			projectId: 'prj_policy',
+			tenantId: 'tnt_policy',
+			...(policy ? { siblingFailurePolicy: policy } : {}),
+		} as never,
+	)
+
+	return agentManager
+}
+
+describe('a supervisor can say what a failed child means for its siblings', () => {
+	it('reaches the gateway, so cancel-siblings actually stops the rest', async () => {
+		const manager = await fanOut('cancel-siblings')
+
+		expect(manager.cancelled).toContain('task_patient' as TaskId)
+	}, 60_000)
+})

--- a/packages/sdk/src/gateway/__tests__/a-knob-nobody-can-turn.test.ts
+++ b/packages/sdk/src/gateway/__tests__/a-knob-nobody-can-turn.test.ts
@@ -1,0 +1,139 @@
+import type { Span } from '@opentelemetry/api'
+import { describe, expect, it } from 'vitest'
+
+import type { Agent } from '../../types/agent/core.js'
+import type { AgentManagerContract } from '../../types/agent/manager.js'
+import type {
+	AgentTask,
+	AgentTaskContext,
+	AgentTaskState,
+	SendMessageOptions,
+} from '../../types/agent/task.js'
+import type { AgentId, RunId, SessionId, TaskId, TenantId } from '../../types/ids/index.js'
+import type { ProjectId, ThreadId } from '../../types/session/ids.js'
+import { LocalTaskGateway } from '../local.js'
+
+/**
+ * `CreateTaskOptions.configOverrides` was declared, typed, and never read.
+ *
+ * `createTask` built its OWN `configOverrides` object out of `parentSpan`
+ * alone, so a caller pinning a delegated run to a cheaper model, or capping
+ * its iterations, got the agent's defaults and nothing to say otherwise. The
+ * field type-checked, the call succeeded, and the run was not the run that was
+ * asked for.
+ *
+ * Reachability, not behaviour: what `configOverrides` DOES once it lands on
+ * `sendMessage` is the agent manager's business and is tested there. What was
+ * broken is the hop.
+ */
+
+/** Records what the gateway actually asked the manager for. */
+class RecordingManager implements AgentManagerContract {
+	readonly sent: SendMessageOptions[] = []
+
+	async sendMessage(options: SendMessageOptions): Promise<AgentTask> {
+		this.sent.push(options)
+		return {
+			taskId: `task_${this.sent.length}` as TaskId,
+			agentId: options.agentId,
+			agent: {} as Agent<never, never>,
+			childAbortController: new AbortController(),
+			context: {} as AgentTaskContext,
+			state: 'completed' as AgentTaskState,
+			pendingMessages: [],
+			createdAt: 1,
+		} as AgentTask
+	}
+
+	cancel(): void {}
+	cancelAll(): void {}
+	async continueTask(): Promise<void> {}
+	queueMessage(): void {}
+	drainMessages() {
+		return []
+	}
+	async waitForCompletion(): Promise<void> {}
+	getInstance(): AgentTask | undefined {
+		return undefined
+	}
+	listByParent(): AgentTask[] {
+		return []
+	}
+	listActive(): AgentTask[] {
+		return []
+	}
+	getState(): AgentTaskState | undefined {
+		return undefined
+	}
+	on(): void {}
+	off(): void {}
+	cleanup(): void {}
+	dispose(): void {}
+}
+
+function context(): AgentTaskContext {
+	return {
+		parentRunId: 'run_parent' as RunId,
+		parentAgentId: 'supervisor',
+		parentAbortController: new AbortController(),
+		depth: 0,
+		budgetTracker: { total: 100_000, remaining: 100_000 },
+		tenantId: 'tnt_k' as TenantId,
+		threadId: 'thd_k' as ThreadId,
+		sessionId: 'ses_k' as SessionId,
+		projectId: 'prj_k' as ProjectId,
+		parentActor: { kind: 'agent', agentId: 'supervisor' as AgentId, tenantId: 'tnt_k' as TenantId },
+	} as AgentTaskContext
+}
+
+describe('a delegated run is built with the config its caller asked for', () => {
+	it('forwards configOverrides to the spawn', async () => {
+		const manager = new RecordingManager()
+		const gateway = new LocalTaskGateway(manager, context())
+
+		await gateway.createTask({
+			agentId: 'worker',
+			prompt: 'work',
+			workingDirectory: '/tmp',
+			configOverrides: { model: 'cheap-model', maxIterations: 3 },
+		})
+
+		expect(manager.sent[0]?.configOverrides).toMatchObject({
+			model: 'cheap-model',
+			maxIterations: 3,
+		})
+	})
+
+	it('keeps the dedicated parentSpan option winning when both name a span', async () => {
+		// A caller who sets both is saying the same thing twice, and the named
+		// field is the specific one for the job — so it is applied last.
+		const manager = new RecordingManager()
+		const gateway = new LocalTaskGateway(manager, context())
+		const named = { spanContext: () => ({ traceId: 'named' }) } as unknown as Span
+		const buried = { spanContext: () => ({ traceId: 'buried' }) } as unknown as Span
+
+		await gateway.createTask({
+			agentId: 'worker',
+			prompt: 'work',
+			workingDirectory: '/tmp',
+			parentSpan: named,
+			configOverrides: { parentSpan: buried, model: 'cheap-model' },
+		})
+
+		expect(manager.sent[0]?.configOverrides?.parentSpan).toBe(named)
+		// ...and the rest of the caller's overrides survive alongside it.
+		expect(manager.sent[0]?.configOverrides?.model).toBe('cheap-model')
+	})
+
+	it('still sends no configOverrides at all when the caller set neither', async () => {
+		// The absent case has to stay absent: an empty object here would put
+		// `configOverrides: {}` on every spawn and override nothing, which is
+		// harmless until something starts reading its presence as intent.
+		const manager = new RecordingManager()
+		const gateway = new LocalTaskGateway(manager, context())
+
+		await gateway.createTask({ agentId: 'worker', prompt: 'work', workingDirectory: '/tmp' })
+
+		expect(manager.sent[0]).not.toHaveProperty('configOverrides')
+	})
+})

--- a/packages/sdk/src/gateway/local.ts
+++ b/packages/sdk/src/gateway/local.ts
@@ -1,3 +1,4 @@
+import { taskFailed } from '../tools/coordinator/outcome.js'
 import type { AgentInput } from '../types/agent/base.js'
 import type {
 	CreateTaskOptions,
@@ -75,10 +76,25 @@ export class LocalTaskGateway implements TaskGateway {
 				tenantId: this.taskContext.tenantId,
 				projectId: this.taskContext.projectId,
 				parentActor: this.taskContext.parentActor,
-				// Hang the child run off the span the caller supplied, so a
+				// The caller's overrides, plus the span the caller supplied so a
 				// delegated run joins the trace it belongs to instead of
 				// starting its own root.
-				...(options.parentSpan ? { configOverrides: { parentSpan: options.parentSpan } } : {}),
+				//
+				// `options.configOverrides` used to be dropped here: this built
+				// a fresh object from `parentSpan` and never looked at the
+				// field, so a caller pinning a child to a cheaper model got the
+				// agent's default and no sign anything had been ignored. The
+				// dedicated `parentSpan` option is applied last because it is
+				// the specific field for that job — a caller who sets both is
+				// saying the same thing twice, and the named one is the answer.
+				...(options.configOverrides || options.parentSpan
+					? {
+							configOverrides: {
+								...options.configOverrides,
+								...(options.parentSpan ? { parentSpan: options.parentSpan } : {}),
+							},
+						}
+					: {}),
 			},
 			// The budget tracker is SHARED on purpose and must not be cloned.
 			// `AgentManager.spawn` debits it (`remaining -= allocatedTokens`)
@@ -146,7 +162,7 @@ export class LocalTaskGateway implements TaskGateway {
 	 */
 	private applySiblingPolicy(finished: TaskHandle): void {
 		if (this.siblingFailurePolicy !== 'cancel-siblings') return
-		if (!hasFailed(finished)) return
+		if (!taskFailed(finished)) return
 
 		const cancelled: TaskId[] = []
 		for (const taskId of this.trackedTaskIds) {
@@ -251,10 +267,6 @@ export class LocalTaskGateway implements TaskGateway {
  * would therefore miss the ordinary case — an agent that tried and could
  * not — and catch only the exceptional one.
  */
-function hasFailed(handle: TaskHandle): boolean {
-	return handle.state === 'failed' || handle.result?.status === 'failed'
-}
-
 function toHandle(task: import('../types/agent/task.js').AgentTask): TaskHandle {
 	return {
 		taskId: task.taskId,

--- a/packages/sdk/src/tools/coordinator/outcome.ts
+++ b/packages/sdk/src/tools/coordinator/outcome.ts
@@ -33,6 +33,30 @@ export function taskSucceeded(handle: Pick<TaskHandle, 'state' | 'result'>): boo
 }
 
 /**
+ * Did this worker actually fail? **Not the negation of {@link taskSucceeded}.**
+ *
+ * Three answers exist, not two: succeeded, failed, and not settled yet. A task
+ * still running satisfies neither predicate, and that is the point — a caller
+ * deciding whether to tear down healthy siblings must act on a child that
+ * *failed*, never on one that merely has not succeeded yet. Writing this as
+ * `!taskSucceeded(handle)` would cancel a fan-out the moment the first child
+ * was still working.
+ *
+ * The two-authority rule applies here too, for the same reason: the kernel's
+ * `finalizeChild` always calls `markCompleted`, so a run that returned
+ * `status: 'failed'` carries `state: 'completed'`, and a check that read only
+ * the gateway state would never see it fail.
+ *
+ * Third copy of this knowledge, now in the one place `taskSucceeded` already
+ * lives — it was written independently in `LocalTaskGateway`, which got it
+ * right, but a rule that each caller has to remember is a rule one of them
+ * eventually forgets. That has already happened once with `taskSucceeded`.
+ */
+export function taskFailed(handle: Pick<TaskHandle, 'state' | 'result'>): boolean {
+	return handle.state === 'failed' || handle.result?.status === 'failed'
+}
+
+/**
  * What to call the failure, in the words of whichever layer reported it.
  *
  * The gateway state wins when it is the one that disagrees, because a task that

--- a/packages/sdk/src/types/agent/gateway.ts
+++ b/packages/sdk/src/types/agent/gateway.ts
@@ -1,5 +1,5 @@
 import type { TaskId } from '../ids/index.js'
-import type { AgentRuntimeContext, BaseAgentResult } from './base.js'
+import type { AgentRuntimeContext, BaseAgentConfig, BaseAgentResult } from './base.js'
 import type { AgentTaskState } from './task.js'
 
 export interface TaskHandle {
@@ -40,7 +40,24 @@ export interface CreateTaskOptions {
 
 	runtimeContext?: AgentRuntimeContext
 
-	configOverrides?: Record<string, unknown>
+	/**
+	 * Config the spawned run should be built with, overriding what the
+	 * agent's own definition supplies — the model it runs on, its iteration
+	 * ceiling, its thinking or effort settings.
+	 *
+	 * **This was accepted and dropped.** `LocalTaskGateway.createTask` built
+	 * its own `configOverrides` object out of `parentSpan` alone and never
+	 * read this field, so a caller pinning a delegated run to a cheaper model
+	 * got the agent's default model and no indication otherwise. It is
+	 * forwarded now, with the dedicated {@link parentSpan} option winning if
+	 * both name a span, since that one is the specific field for the job.
+	 *
+	 * Typed as `Partial<BaseAgentConfig>` rather than
+	 * `Record<string, unknown>`: this lands on `SendMessageOptions`, which is
+	 * already that shape, and the loose type let a misspelled key type-check
+	 * and then do nothing — the same silence this field was already producing.
+	 */
+	configOverrides?: Partial<BaseAgentConfig>
 }
 
 export interface TaskGateway {

--- a/packages/sdk/src/types/agent/supervisor.ts
+++ b/packages/sdk/src/types/agent/supervisor.ts
@@ -10,7 +10,7 @@ import type { ToolRegistryContract } from '../tool/index.js'
 import type { VerificationGateConfig } from '../verification/index.js'
 import type { BaseAgentConfig, BaseAgentResult } from './base.js'
 import type { AgentFactoryOptions } from './factory.js'
-import type { TaskGateway } from './gateway.js'
+import type { SiblingFailurePolicy, TaskGateway } from './gateway.js'
 import type { AgentManagerContract } from './manager.js'
 import type { WorkingMemoryProvider } from './working-memory.js'
 
@@ -88,6 +88,28 @@ export interface SupervisorAgentConfig extends BaseAgentConfig {
 	 * launches twenty, and they queue.
 	 */
 	maxToolConcurrency?: number
+
+	/**
+	 * What a failed child means for the siblings still running. Defaults to
+	 * `'continue'`.
+	 *
+	 * `LocalTaskGateway` has honoured this since it was written, and the
+	 * cancellation machinery behind `'cancel-siblings'` is complete — but the
+	 * policy was a constructor argument on a gateway the supervisor builds
+	 * itself, and the supervisor passed nothing. So every host in existence
+	 * ran `'continue'`, and the only way to reach the other value was to
+	 * construct the gateway by hand and hand it in. A policy nobody can select
+	 * is not a policy.
+	 *
+	 * `'continue'` stays the default deliberately: partial results are usually
+	 * worth having, and tearing down healthy siblings on any failure lets one
+	 * flaky child waste four good ones. `'cancel-siblings'` is for a fan-out
+	 * whose parts only mean something together — if one leg of a comparison
+	 * dies, the others are spending budget on an answer nobody can use.
+	 *
+	 * Ignored when the host supplies its own `gateway`, which owns its policy.
+	 */
+	siblingFailurePolicy?: SiblingFailurePolicy
 
 	taskRouter?: TaskRouterConfig
 


### PR DESCRIPTION
Two capabilities were declared, documented, typed, and unreachable. Both are the same defect: a knob wired to nothing, which reads to a caller as a knob that works.

### `CreateTaskOptions.configOverrides` was accepted and dropped

Worse than "declared but never forwarded" — it was declared and then *overwritten*. `LocalTaskGateway.createTask` built its own `configOverrides` object out of `parentSpan` alone and never read the field, so a caller pinning a delegated run to a cheaper model, or capping its iterations, got the agent's defaults and no indication anything had been ignored.

Forwarded now. A caller who sets both the field and the dedicated `parentSpan` option gets the dedicated one for the span — that is the specific field for the job — and keeps every other override alongside it.

### `siblingFailurePolicy` could not be selected by any host

`LocalTaskGateway` has honoured it since it was written and the cancellation machinery behind `'cancel-siblings'` is complete. But it was the fifth constructor argument of a gateway `SupervisorAgent` builds itself, and the supervisor passed four. Every host in existence ran `'continue'`; the only route to the other value was to construct the gateway by hand and pass it as `config.gateway`.

**Why it survived:** the policy's own tests construct `LocalTaskGateway` directly, so they passed while nothing upstream could turn it on. The behaviour was covered; the reachability was not.

It is now `SupervisorAgentConfig.siblingFailurePolicy`. `'continue'` remains the default deliberately — partial results are usually worth having, and tearing down healthy siblings on any failure lets one flaky child waste four good ones. The choice is now expressible; the answer has not changed.

### `taskFailed` joins `taskSucceeded`

The gateway's two-authority failure check moves into `tools/coordinator/outcome.ts`. It is deliberately **not** the negation of `taskSucceeded`: a task still running satisfies neither predicate, and cancelling a fan-out on `!taskSucceeded` would tear down siblings the moment the first child had merely not finished yet. The gateway's copy was correct — but a rule each caller has to remember is one a caller eventually forgets, which is exactly what happened to `taskSucceeded` before it was consolidated.

### Verification

Both tests drive the front door and assert a consequence that **cannot** occur without the fix, per the doctrine already written down in `agents/__tests__/reachability.test.ts`. That file's own warning applied directly here: its first draft asserted `status === 'completed'` and passed with the forwarding deleted. So the sibling test asserts the cancellation itself, not that the run finished — a fan-out under `'continue'` finishes too.

- Mutations: gateway forwarding removed → 2 of 3 fail; supervisor hop removed → the sibling test fails.
- The sibling test hung once at 60s before being fixed: the policy only cancels tasks the gateway already tracks, so the harness was racing its own launch order. It is deterministic now via a `bothLaunched` gate, plus a 250ms safety release so a regression fails in ~300ms with `expected [] to include 'task_patient'` rather than "timed out in 60000ms". A mutation that fails by hanging reads as flake, and flake gets retried rather than read.
- `pnpm typecheck` exit 0; SDK suite **302 files / 2732 passed**, exit code read directly; 0 lint errors.

### Breaking

`CreateTaskOptions.configOverrides` is now typed `Partial<BaseAgentConfig>` instead of `Record<string, unknown>`. It lands on `SendMessageOptions.configOverrides`, which is already that shape, and the loose type let a misspelled key type-check and then silently do nothing — the same silence the field was already producing. A key that is not on `BaseAgentConfig` now fails to compile; it was never being applied.
