### PR TITLE
feat(sdk): the plan a human approves names the agent the model chose

### DIFF
--- a/.changeset/the-plan-a-human-approves.md
+++ b/.changeset/the-plan-a-human-approves.md
@@ -1,0 +1,27 @@
+---
+'@namzu/sdk': minor
+---
+
+The plan a human approves names the agent the model chose.
+
+`approve_plan` asks the model for an `agent_id` per step — "which agent handles
+this" — and reduced the answer to a boolean. The step got
+`toolName: 'create_task'` when any agent was named and nothing when not, so the
+name was dropped between the model saying it and the human being shown the plan.
+
+The approval is the one moment where that difference can still be acted on.
+Approving "delegate this step" is not the same as approving "delegate this step
+to the agent with shell access", and a reviewer who cannot see which agent was
+chosen cannot withhold approval from the wrong one. Two delegated steps reached
+the approver identical in every field.
+
+`PlanStep` gains `agentId?: string`, populated by `approve_plan` from the
+model's choice. A host rendering a plan approval can show it directly. Absent
+still means the step is the orchestrator's own work, which is what omitting
+`agent_id` says — so absent stays absent rather than becoming a placeholder.
+
+Typed rather than folded into the existing `estimatedInput`, which is `unknown`:
+an approval gate's whole job is being readable, and a field a host must cast
+before it can render is one a host renders wrong or not at all. `estimatedInput`
+is now documented as having no producer and no reader, since that is what it
+has, and it is left in place because it is on the published typings.

--- a/packages/sdk/src/tools/coordinator/__tests__/the-plan-a-human-approves.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/the-plan-a-human-approves.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+
+import { PlanManager } from '../../../manager/plan/lifecycle.js'
+import type { TaskGateway } from '../../../types/agent/gateway.js'
+import type { RunId } from '../../../types/ids/index.js'
+import type { PlanApprovalRequest } from '../../../types/plan/index.js'
+import type { ToolContext } from '../../../types/tool/index.js'
+import { buildCoordinatorTools } from '../index.js'
+
+/**
+ * The plan put in front of a human said a step delegates, never to whom.
+ *
+ * `approve_plan` asks the model for an `agent_id` per step — "which agent
+ * handles this" — and reduced the answer to a boolean: the step got
+ * `toolName: 'create_task'` when any agent was named and nothing when not. The
+ * name itself was dropped between the model saying it and the human being
+ * shown the plan.
+ *
+ * The approval is the one moment where that difference can still be acted on.
+ * Approving "delegate this step" is not the same as approving "delegate this
+ * step to the agent with shell access", and a reviewer who cannot see which
+ * agent was chosen cannot withhold approval from the wrong one.
+ */
+
+const RUN = 'run_plan_approval' as RunId
+
+function unusedGateway(): TaskGateway {
+	return {
+		async createTask() {
+			throw new Error('this test never launches')
+		},
+		async waitForTask() {
+			throw new Error('this test never waits')
+		},
+		async continueTask() {},
+		cancelTask() {},
+		getTask() {
+			return undefined
+		},
+		listTasks() {
+			return []
+		},
+		onTaskCompleted() {
+			return () => {}
+		},
+	}
+}
+
+function testToolContext(): ToolContext {
+	return {
+		runId: RUN,
+		workingDirectory: '/tmp/test',
+		abortSignal: new AbortController().signal,
+		env: {},
+		log: () => {},
+	}
+}
+
+/** Run `approve_plan` and hand back exactly what the approver was shown. */
+async function whatTheApproverSaw(
+	steps: Array<{ description: string; agent_id?: string }>,
+): Promise<PlanApprovalRequest> {
+	let seen: PlanApprovalRequest | undefined
+	const pm = new PlanManager(RUN, async (request) => {
+		seen = request
+		return { approved: true }
+	})
+
+	const tools = buildCoordinatorTools({
+		gateway: unusedGateway(),
+		workingDirectory: '/tmp/test',
+		allowedAgentIds: ['researcher', 'shell-runner'],
+		getPlanManager: () => pm,
+	})
+
+	const approvePlan = tools.find((tool) => tool.name === 'approve_plan')
+	if (!approvePlan) throw new Error('approve_plan tool missing from coordinator builder')
+
+	await approvePlan.execute(
+		{ title: 'Do the work', summary: 'A plan with delegated steps.', steps },
+		testToolContext(),
+	)
+
+	if (!seen) throw new Error('the approval handler was never called')
+	return seen
+}
+
+describe('the plan a human approves names the agent the model chose', () => {
+	it('carries the agent per step, not just that there is one', async () => {
+		const request = await whatTheApproverSaw([
+			{ description: 'Gather the sources', agent_id: 'researcher' },
+			{ description: 'Run the migration', agent_id: 'shell-runner' },
+		])
+
+		expect(request.steps.map((s) => s.agentId)).toEqual(['researcher', 'shell-runner'])
+	})
+
+	it('distinguishes two delegated steps that used to look identical', async () => {
+		// The defect in the shape that matters: before this, both steps below
+		// reached the approver as `toolName: 'create_task'` and nothing else, so
+		// the one with shell access was indistinguishable from the one without.
+		const request = await whatTheApproverSaw([
+			{ description: 'Read the docs', agent_id: 'researcher' },
+			{ description: 'Delete the old rows', agent_id: 'shell-runner' },
+		])
+
+		const [first, second] = request.steps
+		expect(first?.toolName).toBe(second?.toolName)
+		expect(first?.agentId).not.toBe(second?.agentId)
+	})
+
+	it('leaves an orchestrator-owned step unattributed', async () => {
+		// Omitting `agent_id` means the orchestrator does it itself. That has to
+		// stay distinguishable from delegation, so absent stays absent rather
+		// than becoming a placeholder name.
+		const request = await whatTheApproverSaw([{ description: 'Summarize what came back' }])
+
+		expect(request.steps[0]?.agentId).toBeUndefined()
+		expect(request.steps[0]?.toolName).toBeUndefined()
+	})
+})

--- a/packages/sdk/src/tools/coordinator/index.ts
+++ b/packages/sdk/src/tools/coordinator/index.ts
@@ -945,6 +945,13 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 						id: `step_${i + 1}`,
 						description: step.description,
 						toolName: step.agent_id ? 'create_task' : undefined,
+						// WHICH agent, not just whether there is one. The schema
+						// asks the model to name an agent per step and the answer
+						// was collapsed to the boolean above, so the human
+						// approving the plan saw that a step delegates and never
+						// to whom — at the one moment the difference can still be
+						// acted on.
+						...(step.agent_id ? { agentId: step.agent_id } : {}),
 						// Was `[]` unconditionally, which dropped every ordering
 						// constraint the model was invited to express — and put an
 						// empty dependency list in front of the human approving it.

--- a/packages/sdk/src/types/plan/index.ts
+++ b/packages/sdk/src/types/plan/index.ts
@@ -18,7 +18,36 @@ export interface PlanStep {
 	id: string
 	description: string
 	toolName?: string
+
+	/**
+	 * Which agent this step is to be delegated to, when it is delegated at all.
+	 *
+	 * `approve_plan` invites the model to name an agent per step, and that
+	 * answer was reduced to a boolean: the step got `toolName: 'create_task'`
+	 * if any agent was named and nothing if not. So the human approving the
+	 * plan was shown THAT a step delegates and never TO WHOM — while the model
+	 * had said, and the approval is the one moment where the difference can
+	 * still be acted on. Approving "delegate this" is not approving "delegate
+	 * this to the agent with shell access".
+	 *
+	 * Typed rather than folded into {@link estimatedInput}, which is `unknown`:
+	 * an approval gate's whole job is being readable, and a field a host has to
+	 * cast before it can render is one a host renders wrong or not at all.
+	 *
+	 * Absent means the step is the orchestrator's own work, which is what
+	 * omitting `agent_id` in `approve_plan` says.
+	 */
+	agentId?: string
+
+	/**
+	 * **No producer and no reader.** Nothing in the SDK writes this and
+	 * nothing reads it; it is declared here and that is all. Noted rather
+	 * than removed because it is on the published typings — see
+	 * {@link agentId}, which is the field the plan approval path actually
+	 * needed and did not have.
+	 */
 	estimatedInput?: unknown
+
 	dependsOn: string[]
 	status: 'pending' | 'running' | 'completed' | 'skipped' | 'failed'
 	error?: string


### PR DESCRIPTION
`approve_plan` asks the model for an `agent_id` per step — "which agent handles this" — and reduced the answer to a boolean:

```ts
toolName: step.agent_id ? 'create_task' : undefined,
```

The name was dropped between the model saying it and the human being shown the plan. Two delegated steps reached the approver identical in every field — the one that runs shell commands indistinguishable from the one that reads documents.

The approval is the one moment where that difference can still be acted on. Approving "delegate this step" is not the same as approving "delegate this step to the agent with shell access", and a reviewer who cannot see which agent was chosen cannot withhold approval from the wrong one.

### The fix

`PlanStep` gains `agentId?: string`, populated by `approve_plan` from the model's choice. A host rendering a plan approval can show it directly.

Typed rather than folded into the existing `estimatedInput`, which is `unknown`: an approval gate's whole job is being readable, and a field a host must cast before it can render is one a host renders wrong or not at all.

Absent still means the step is the orchestrator's own work — which is what omitting `agent_id` says — so absent stays absent rather than becoming a placeholder. The third test pins that, and it is the one that still passes under the mutation.

`estimatedInput` turns out to have **no producer and no reader**: one mention in the whole repository, its own declaration. Documented as such rather than removed, since it is on the published typings.

### Filed, not fixed here — #22

Surfacing the chosen agent creates a new way to mislead the approver. `approve_plan` types `agent_id` as a bare `z.string().optional()`, while `create_task` constrains the same field with the closed `delegateSchema(agentIds)` enum — the one whose empty case deliberately admits nothing, for the fail-safe-defaults reasoning written out above it. So a human can now approve "delegate to X" for an X that `create_task` will refuse. Before this change the name was dropped, so the mismatch was invisible rather than wrong.

It is genuinely two-sided — a plan is partly aspirational, and constraining the schema turns a mis-spelled delegate into a generation-time refusal rather than a plan the model can revise — so it gets a decision rather than a guess.

### Verification

- 3 new cases. Mutation: the `agentId` line removed → 2 of 3 fail; the orchestrator-owned case still passes, which is the point.
- `pnpm typecheck` exit 0; SDK suite **302 files / 2737 passed**, exit code read directly; 0 lint errors.

`minor` — additive optional field, no existing behaviour changes.
