### PR TITLE
refactor(sdk)!: drop launchedTasks, a map nothing ever read

### DIFF
--- a/.changeset/a-map-nobody-reads.md
+++ b/.changeset/a-map-nobody-reads.md
@@ -1,0 +1,28 @@
+---
+'@namzu/sdk': major
+---
+
+`drainQuery` no longer accepts `launchedTasks`, a map nothing ever read.
+
+`SupervisorAgent` created a `Map<TaskId, LaunchedTaskMeta>`, filled it from
+`onTaskLaunched`, and threaded it through `drainQuery` into the iteration
+context. Nothing consulted it — six mentions across the repository, every one a
+declaration, an assignment, or a hand-off, and no reader at any of them. It is
+what remains of the old non-blocking delegation flow, whose consumer was removed
+when `create_task` became blocking.
+
+For a host the field was inert in both directions: nothing writes a
+host-supplied map, so passing one did nothing and reading it back gave an empty
+map. Removed straight out rather than deprecated, on the rule that a deprecation
+window exists so working code can migrate and there is no working code to
+migrate off a field with no producer and no reader.
+
+**What stays.** `onTaskLaunched` on the coordinator tool options, and the meta it
+carries. The `Agent` tool still calls it, so it remains a real seam for a host
+that builds coordinator tools directly and wants to observe launches. What went
+was the accumulator, not the signal.
+
+**Breaking:** `launchedTasks` is gone from `drainQuery`'s parameters, and
+`LaunchedTaskMeta` is no longer exported from the iteration context module. If
+you passed either, delete the argument — it was not doing anything. To observe
+launches, pass `onTaskLaunched` to `buildCoordinatorTools`.

--- a/packages/sdk/src/agents/SupervisorAgent.ts
+++ b/packages/sdk/src/agents/SupervisorAgent.ts
@@ -3,7 +3,6 @@ import { CompletionInbox } from '../gateway/completion-inbox.js'
 import { LocalTaskGateway } from '../gateway/local.js'
 import { ToolNameCollisionError, ToolRegistry } from '../registry/tool/execute.js'
 import { drainQuery } from '../runtime/query/index.js'
-import type { LaunchedTaskMeta } from '../runtime/query/iteration/phases/context.js'
 import { PendingAnswers, QuestionParkBinding } from '../runtime/query/question-park.js'
 import { buildCoordinatorTools } from '../tools/coordinator/index.js'
 import type { TaskGateway, TaskHandle } from '../types/agent/gateway.js'
@@ -15,7 +14,7 @@ import type {
 	SupervisorAgentResult,
 } from '../types/agent/index.js'
 import type { AgentTaskContext } from '../types/agent/task.js'
-import type { AgentId, RunId, TaskId } from '../types/ids/index.js'
+import type { AgentId, RunId } from '../types/ids/index.js'
 import { deriveChildState } from '../types/invocation/index.js'
 import type { RunEventListener } from '../types/run/index.js'
 import type { ActorRef } from '../types/session/actor.js'
@@ -171,8 +170,6 @@ export class SupervisorAgent extends AbstractAgent<SupervisorAgentConfig, Superv
 			throw new Error("SupervisorAgentConfig requires either 'gateway' or 'agentManager'")
 		}
 
-		const launchedTasks = new Map<TaskId, LaunchedTaskMeta>()
-
 		let planManagerRef: import('../manager/plan/lifecycle.js').PlanManager | undefined
 
 		// Created here because the TOOLS are created here: the durability
@@ -212,9 +209,6 @@ export class SupervisorAgent extends AbstractAgent<SupervisorAgentConfig, Superv
 				taskStore: input.taskStore,
 				runId,
 				getPlanManager: () => planManagerRef,
-				onTaskLaunched: (agentTaskId, meta) => {
-					launchedTasks.set(agentTaskId, meta)
-				},
 				// With a resume handler present the coordinator surface gains
 				// ask_user_question — the model can park the run on a question
 				// routed through the same HITL channel as plan approvals.
@@ -334,7 +328,6 @@ export class SupervisorAgent extends AbstractAgent<SupervisorAgentConfig, Superv
 					runtimeContext: input.runtimeContext,
 					taskGateway: gateway,
 					completionInbox,
-					launchedTasks,
 					advisory: config.advisory,
 					invocationState: childInvocationState,
 					// HITL surface: forward optional review-time hooks so hosts can

--- a/packages/sdk/src/runtime/query/index.ts
+++ b/packages/sdk/src/runtime/query/index.ts
@@ -420,11 +420,6 @@ export interface QueryParams {
 	 */
 	completionInbox?: import('../../gateway/completion-inbox.js').CompletionInbox
 
-	launchedTasks?: Map<
-		import('../../types/ids/index.js').TaskId,
-		import('./iteration/phases/context.js').LaunchedTaskMeta
-	>
-
 	onContextCreated?: (ctx: {
 		planManager: import('../../manager/plan/lifecycle.js').PlanManager
 	}) => void
@@ -854,7 +849,6 @@ export async function* query(params: QueryParams): AsyncGenerator<RunEvent, Run>
 		taskGateway: params.taskGateway,
 		completionInbox: params.completionInbox,
 		taskStore: params.taskStore,
-		launchedTasks: params.launchedTasks ?? new Map(),
 		// Run-scoped. An approval is a statement about this run's work;
 		// carrying one into a later run would be reuse nobody agreed to.
 		toolGrants: new ToolGrantSet(),

--- a/packages/sdk/src/runtime/query/iteration/phases/context.ts
+++ b/packages/sdk/src/runtime/query/iteration/phases/context.ts
@@ -14,7 +14,6 @@ import type {
 	IterationCheckpoint,
 	ResumeHandler,
 } from '../../../../types/hitl/index.js'
-import type { TaskId } from '../../../../types/ids/index.js'
 import type { LLMProvider } from '../../../../types/provider/index.js'
 import type { TaskRouterConfig } from '../../../../types/router/index.js'
 import type { ReviewAnswer } from '../../../../types/run/answer-review.js'
@@ -35,22 +34,6 @@ import type { ToolExecutor } from '../../executor.js'
 import type { GuardCoordinator } from '../../guard.js'
 import type { SteeringChannel } from '../../steering.js'
 import type { ToolGrantSet } from '../../tool-grants.js'
-
-export interface LaunchedTaskMeta {
-	readonly agentId: string
-	readonly description: string
-	readonly planTaskId?: string
-	/**
-	 * The `tool_use_id` of the assistant `create_task` block that
-	 * spawned this background task. Required to emit the canonical
-	 * `tool_result` content block when the task completes — without
-	 * it we'd fall back to the legacy synthetic-user-message inject
-	 * (see ses_009-task-notification-envelope). Optional because
-	 * older call paths that don't thread `ToolContext.toolUseId`
-	 * still publish the meta without it.
-	 */
-	readonly originalToolUseId?: string
-}
 
 export interface IterationContext {
 	readonly provider: LLMProvider
@@ -114,8 +97,6 @@ export interface IterationContext {
 	readonly completionInbox?: CompletionInbox
 
 	readonly taskStore?: TaskStore
-
-	readonly launchedTasks: Map<TaskId, LaunchedTaskMeta>
 
 	/**
 	 * Approvals a human granted earlier in this run, at a scope they chose.


### PR DESCRIPTION
refactor(sdk)!: drop launchedTasks, a map nothing ever read

`SupervisorAgent` created a `Map<TaskId, LaunchedTaskMeta>`, filled it from
`onTaskLaunched`, and threaded it through `drainQuery` into the iteration
context. Nothing consulted it — six mentions across the repository, every one a
declaration, an assignment, or a hand-off, and no reader at any of them. It is
what remains of the old non-blocking delegation flow, whose consumer was removed
when `create_task` became blocking.

The same host-reachability check that recently saved `PlanManager` from deletion
came out the other way here, which is why it is worth running rather than
assuming. `drainQuery` is public, so a host could pass this map — but nothing
writes a host-supplied one, so passing it did nothing and reading it back gave
an empty map. Inert in both directions.

The `onTaskLaunched` callback stays: the `Agent` tool still calls it, so it
remains a real seam for a host that builds coordinator tools directly and wants
to observe launches. What went was the accumulator, not the signal.

BREAKING CHANGE: `launchedTasks` is removed from `drainQuery`'s parameters and
`LaunchedTaskMeta` is no longer exported from the iteration context module.
Delete the argument if you passed it; it had no effect. To observe launches,
pass `onTaskLaunched` to `buildCoordinatorTools`. Removed without a deprecation
window on the rule that the window exists so working code can migrate, and no
working code depends on a field with no producer and no reader.
