### PR TITLE
fix(sdk)!: a listing is not a back door into another run

### DIFF
--- a/.changeset/a-listing-is-not-a-back-door.md
+++ b/.changeset/a-listing-is-not-a-back-door.md
@@ -1,0 +1,38 @@
+---
+'@namzu/sdk': major
+---
+
+`agent_task_list` and `wait_for_task` are scoped to the run that launched the task.
+
+A supervisor could read a sibling run's worker output by listing.
+`SupervisorAgentConfig.gateway` exists so a host can hand the SAME gateway to
+several runs, which makes `TaskGateway.listTasks()` gateway-wide by design —
+and `agent_task_list` handed that straight to the model, including each task's
+`result`, the worker's actual output. `wait_for_task` had the same reach through
+`getTask`.
+
+`CompletionInbox` closed exactly this on the push side, because
+`onTaskCompleted` is a broadcast and a shared gateway would otherwise hand each
+supervisor the other's completions. The pull side kept no such record and asked
+the gateway directly, so the same leak stayed open through a different door.
+
+The scope lives in the coordinator tools rather than in `listTasks()`, because
+the two answer different questions. A host calling `listTasks()` is the operator
+and may legitimately want everything on its gateway; a model calling
+`agent_task_list` is one run asking about its own work. Narrowing the gateway
+method would take the operator's view away in order to fix the model's.
+
+`wait_for_task` gives the same answer for a sibling's task as for one that never
+existed. Distinguishing them would confirm a task id to a run that was not
+supposed to know it — the leak in miniature.
+
+**Breaking, for a host that shares one gateway across runs.** A run now sees
+only the tasks it launched through its own `create_task`. If you relied on one
+run listing another's tasks, that path is closed; use `TaskGateway.listTasks()`
+from the host, which is unchanged and still gateway-wide.
+
+**Also breaking in a narrower way:** a task launched through a DIFFERENT surface
+on the same gateway — `buildAgentTool`, or the host directly — is not listed by
+these tools. That is the same rule rather than an exception to it, but it is a
+behaviour change if you mixed surfaces on one gateway and listed through the
+coordinator.

--- a/packages/sdk/src/tools/coordinator/__tests__/a-listing-is-not-a-back-door.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/a-listing-is-not-a-back-door.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest'
+
+import type { TaskGateway, TaskHandle } from '../../../types/agent/gateway.js'
+import type { TaskId } from '../../../types/ids/index.js'
+import type { ToolContext } from '../../../types/tool/index.js'
+import { buildCoordinatorTools } from '../index.js'
+
+/**
+ * A supervisor could read a sibling run's worker output by listing.
+ *
+ * `SupervisorAgentConfig.gateway` exists so a host can hand the SAME gateway to
+ * several runs, which makes `listTasks()` gateway-wide by design.
+ * `agent_task_list` handed that straight to the model — including each task's
+ * `result`, the worker's actual output — and `wait_for_task` had the same reach
+ * through `getTask`.
+ *
+ * `CompletionInbox` closed exactly this on the push side, because
+ * `onTaskCompleted` is a broadcast and a shared gateway would otherwise hand
+ * each supervisor the other's completions. The pull side kept no such record
+ * and asked the gateway directly, so the same leak stayed open through a
+ * different door.
+ */
+
+const AGENTS = ['reviewer', 'researcher']
+
+function makeContext(): ToolContext {
+	return {
+		runId: 'run_scope' as never,
+		workingDirectory: '/tmp/test',
+		abortSignal: new AbortController().signal,
+		env: {},
+		log: () => {},
+	}
+}
+
+/** One gateway, as a host sharing it between two supervisors would have. */
+function sharedGateway() {
+	const handles = new Map<string, TaskHandle>()
+	let seq = 0
+
+	const gateway = {
+		createTask: async (opts: { agentId: string }) => {
+			seq += 1
+			const taskId = `tsk_${seq}` as TaskId
+			const handle: TaskHandle = {
+				taskId,
+				agentId: opts.agentId,
+				state: 'completed',
+				createdAt: 1_000,
+				completedAt: 2_000,
+				result: {
+					status: 'completed',
+					result: `output of ${opts.agentId} on ${taskId}`,
+				} as TaskHandle['result'],
+			}
+			handles.set(taskId, handle)
+			return handle
+		},
+		waitForTask: async (taskId: TaskId) => handles.get(taskId) as TaskHandle,
+		getTask: (taskId: TaskId) => handles.get(taskId),
+		listTasks: () => [...handles.values()],
+		cancelTask: () => undefined,
+		continueTask: async () => undefined,
+		onTaskCompleted: () => () => {},
+	} as unknown as TaskGateway
+
+	return gateway
+}
+
+/** A run's own coordinator surface over a gateway it may be sharing. */
+function runOver(gateway: TaskGateway) {
+	const tools = buildCoordinatorTools({
+		gateway,
+		workingDirectory: '/tmp/test',
+		allowedAgentIds: AGENTS,
+	})
+	const named = (name: string) => {
+		const t = tools.find((tool) => tool.name === name)
+		if (!t) throw new Error(`${name} missing from coordinator builder`)
+		return t
+	}
+	return {
+		launch: (agentId: string) =>
+			named('create_task').execute(
+				{ agent_id: agentId, prompt: 'work', description: `${agentId} work` },
+				makeContext(),
+			),
+		list: () => named('agent_task_list').execute({}, makeContext()),
+		waitFor: (taskId: string) => named('wait_for_task').execute({ task_id: taskId }, makeContext()),
+	}
+}
+
+describe('one run cannot read another run through the listing', () => {
+	it('lists only the tasks this run launched', async () => {
+		const gateway = sharedGateway()
+		const first = runOver(gateway)
+		const second = runOver(gateway)
+
+		await first.launch('reviewer')
+		await second.launch('researcher')
+
+		const listed = await second.list()
+
+		// Its own, yes.
+		expect(listed.output).toContain('tsk_2')
+		// The sibling's task, and — the part that matters — the sibling's
+		// worker output, which the listing renders inline.
+		expect(listed.output).not.toContain('tsk_1')
+		expect(listed.output).not.toContain('output of reviewer')
+	})
+
+	it('counts only its own in the summary', async () => {
+		// The summary is what a supervisor reads to decide "done vs not done".
+		// A total that includes a sibling's tasks is a wrong answer to that
+		// question even when no output leaks with it.
+		const gateway = sharedGateway()
+		const first = runOver(gateway)
+		const second = runOver(gateway)
+
+		await first.launch('reviewer')
+		await first.launch('reviewer')
+		await second.launch('researcher')
+
+		const listed = await second.list()
+		const data = listed.data as { summary: { total: number }; items: unknown[] }
+
+		expect(data.summary.total).toBe(1)
+		expect(data.items).toHaveLength(1)
+	})
+
+	it('refuses to wait on a task another run launched', async () => {
+		const gateway = sharedGateway()
+		const first = runOver(gateway)
+		const second = runOver(gateway)
+
+		await first.launch('reviewer')
+
+		const waited = await second.waitFor('tsk_1')
+
+		expect(waited.success).toBe(false)
+		expect(waited.output).not.toContain('output of reviewer')
+	})
+
+	it('says the same thing about a task that never existed', async () => {
+		// The refusal must not distinguish "belongs to someone else" from
+		// "never existed". Confirming a real id to a run that should not know
+		// it is the leak in miniature.
+		const gateway = sharedGateway()
+		const first = runOver(gateway)
+		const second = runOver(gateway)
+
+		await first.launch('reviewer')
+
+		const sibling = await second.waitFor('tsk_1')
+		const fictional = await second.waitFor('tsk_9999')
+
+		expect(sibling.output).toBe(fictional.output.replace('tsk_9999', 'tsk_1'))
+	})
+
+	it('still lets a run wait on its own task', async () => {
+		// The scope has to be a filter, not a wall — a run that launched a task
+		// must still be able to read it back, or the fix breaks delegation.
+		const gateway = sharedGateway()
+		const only = runOver(gateway)
+
+		await only.launch('reviewer')
+		const waited = await only.waitFor('tsk_1')
+
+		expect(waited.success).toBe(true)
+	})
+})

--- a/packages/sdk/src/tools/coordinator/__tests__/completion-delivery.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/completion-delivery.test.ts
@@ -298,6 +298,13 @@ describe('waiting explicitly beats listing in a loop', () => {
 describe('the task listing carries the output it always had', () => {
 	async function listWith(result: string): Promise<string> {
 		const h = harness()
+		// Launch it first. The listing is scoped to what this run launched, so
+		// settling a task the tools never created describes a sibling run's
+		// work — which the listing now declines to show, correctly.
+		await toolNamed(h.tools, 'create_task').execute(
+			{ agent_id: 'reviewer', prompt: 'go', description: 'review', background: true },
+			{} as never,
+		)
 		h.settle({
 			taskId: 'tsk_1' as TaskId,
 			agentId: 'reviewer',

--- a/packages/sdk/src/tools/coordinator/__tests__/task-list.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/task-list.test.ts
@@ -27,13 +27,27 @@ function makeContext(): ToolContext {
 	}
 }
 
+/**
+ * Hands back the seeded handles in order, one per `createTask`.
+ *
+ * The listing is scoped to what this tool set launched, so a fixture that
+ * only stuffed `listTasks()` would now list nothing — and a gateway holding
+ * tasks these tools never launched is precisely the sibling-run case the
+ * scope exists to refuse. So the tests launch through the front door and the
+ * fixture plays along.
+ */
 function gatewayWith(handles: TaskHandle[]): TaskGateway {
+	let nextLaunch = 0
 	return {
 		async createTask() {
-			throw new Error('not used')
+			const h = handles[nextLaunch++]
+			if (!h) throw new Error('fixture ran out of seeded handles')
+			return h
 		},
-		async waitForTask() {
-			throw new Error('not used')
+		async waitForTask(id) {
+			const h = handles.find((x) => x.taskId === id)
+			if (!h) throw new Error(`fixture has no handle ${id}`)
+			return h
 		},
 		async continueTask() {},
 		cancelTask() {},
@@ -79,12 +93,29 @@ function handle(input: {
 	}
 }
 
-function findAgentTaskList(gateway: TaskGateway) {
+/**
+ * Build the coordinator surface, launch each seeded handle through
+ * `create_task`, and return `agent_task_list`.
+ *
+ * Launching is what puts the tasks in this run's scope. Reaching past it to
+ * seed the gateway directly would test a listing nobody can produce.
+ */
+async function agentTaskListOver(seeded: TaskHandle[]) {
 	const tools = buildCoordinatorTools({
-		gateway,
+		gateway: gatewayWith(seeded),
 		workingDirectory: '/tmp/test',
 		allowedAgentIds: ['solution-architecture', 'enterprise-architecture'],
 	})
+
+	const createTask = tools.find((tool) => tool.name === 'create_task')
+	if (!createTask) throw new Error('create_task tool missing from coordinator builder')
+	for (const h of seeded) {
+		await createTask.execute(
+			{ agent_id: h.agentId, prompt: 'work', description: `launch ${h.taskId}` },
+			makeContext(),
+		)
+	}
+
 	const t = tools.find((tool) => tool.name === 'agent_task_list')
 	if (!t) throw new Error('agent_task_list tool missing from coordinator builder')
 	return t
@@ -92,7 +123,7 @@ function findAgentTaskList(gateway: TaskGateway) {
 
 describe('coordinator agent_task_list tool', () => {
 	it('lists every task with state, agent, and timing', async () => {
-		const gateway = gatewayWith([
+		const seeded = [
 			handle({
 				id: 'task_a',
 				agentId: 'solution-architecture',
@@ -114,9 +145,8 @@ describe('coordinator agent_task_list tool', () => {
 				completedAt: 4000,
 				lastError: 'bash exit 1',
 			}),
-		])
-
-		const tool = findAgentTaskList(gateway)
+		]
+		const tool = await agentTaskListOver(seeded)
 		const result = await tool.execute({}, makeContext())
 		expect(result.success).toBe(true)
 		expect(result.output).toMatch(/Tasks: 3 total/)
@@ -131,7 +161,7 @@ describe('coordinator agent_task_list tool', () => {
 	})
 
 	it('filters by state', async () => {
-		const gateway = gatewayWith([
+		const seeded = [
 			handle({
 				id: 'task_a',
 				agentId: 'solution-architecture',
@@ -145,9 +175,8 @@ describe('coordinator agent_task_list tool', () => {
 				state: 'running',
 				createdAt: 1000,
 			}),
-		])
-
-		const tool = findAgentTaskList(gateway)
+		]
+		const tool = await agentTaskListOver(seeded)
 		const result = await tool.execute({ state: 'running' }, makeContext())
 		expect(result.success).toBe(true)
 		const data = result.data as { items: Array<{ task_id: string }> }
@@ -157,7 +186,7 @@ describe('coordinator agent_task_list tool', () => {
 	})
 
 	it('handles an empty gateway', async () => {
-		const tool = findAgentTaskList(gatewayWith([]))
+		const tool = await agentTaskListOver([])
 		const result = await tool.execute({}, makeContext())
 		expect(result.success).toBe(true)
 		expect(result.output).toMatch(/Tasks: 0 total/)
@@ -224,7 +253,7 @@ describe('agent_task_list frames what a worker said', () => {
 	}
 
 	async function render(text: string): Promise<string> {
-		const tool = findAgentTaskList(gatewayWith([withResult(text)]))
+		const tool = await agentTaskListOver([withResult(text)])
 		const out = await tool.execute({}, makeContext())
 		return out.output
 	}
@@ -263,11 +292,9 @@ describe('agent_task_list frames what a worker said', () => {
 	})
 
 	it('says nothing extra for a task that produced no output', async () => {
-		const tool = findAgentTaskList(
-			gatewayWith([
-				handle({ id: 'task_none', agentId: 'reviewer', state: 'running', createdAt: 0 }),
-			]),
-		)
+		const tool = await agentTaskListOver([
+			handle({ id: 'task_none', agentId: 'reviewer', state: 'running', createdAt: 0 }),
+		])
 
 		const out = await tool.execute({}, makeContext())
 

--- a/packages/sdk/src/tools/coordinator/index.ts
+++ b/packages/sdk/src/tools/coordinator/index.ts
@@ -308,6 +308,33 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 		// compatibility (Agent tool consumes it from its own path).
 	} = opts
 	const cwd = opts.workingDirectory
+
+	/**
+	 * The tasks THIS surface launched — the scope of everything it will read back.
+	 *
+	 * A `TaskGateway` is shared on purpose: `SupervisorAgentConfig.gateway`
+	 * exists so a host can hand the same one to several runs. `listTasks()` is
+	 * therefore gateway-wide by design, and `agent_task_list` used to hand that
+	 * straight to the model — so a supervisor could read a sibling run's worker
+	 * output, including the `result` field, by listing. `wait_for_task` had the
+	 * same reach through `getTask`.
+	 *
+	 * That is the leak `CompletionInbox` closed on the push side, through a
+	 * different door: the inbox refuses a completion for a task it was not told
+	 * about, precisely because `onTaskCompleted` is a broadcast. The pull side
+	 * kept no such record and asked the gateway directly.
+	 *
+	 * The scope lives here rather than in `listTasks()` because the two answer
+	 * different questions. A host calling `listTasks()` is the operator and may
+	 * legitimately want everything on its gateway; a model calling
+	 * `agent_task_list` is one run asking about its own work. Narrowing the
+	 * gateway method would take the operator's view away to fix the model's.
+	 *
+	 * Consequence worth stating: a task launched through a DIFFERENT surface on
+	 * the same gateway — `buildAgentTool`, or the host itself — is not listed
+	 * here. That is the same rule, not an exception to it.
+	 */
+	const launchedHere = new Set<TaskId>()
 	void opts.onTaskLaunched
 
 	const agentIdEnum = delegateSchema(agentIds)
@@ -445,6 +472,9 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 			// blocking one needs it too, because the case the inbox exists for
 			// is exactly the blocking launch whose wait was abandoned.
 			completionInbox?.launched(handle.taskId)
+
+			// ...and whose it is for the READ side too. See `launchedHere`.
+			launchedHere.add(handle.taskId)
 
 			// A background launch asked for with nowhere to deliver it is
 			// REFUSED, not quietly turned into a blocking one.
@@ -631,6 +661,21 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 		// waiting. Same bound as the launch it is waiting on.
 		timeoutMs: DELEGATION_TIMEOUT_MS,
 		async execute({ task_id }, _context) {
+			// Same scope as the listing — see `launchedHere`. Asked FIRST, so a
+			// task belonging to a sibling run on a shared gateway is refused
+			// here rather than waited on and then read.
+			if (!launchedHere.has(task_id as TaskId)) {
+				// Deliberately does not distinguish "never existed" from
+				// "belongs to someone else". The second answer is itself the
+				// leak in miniature: it confirms a task id a run was not
+				// supposed to know about.
+				return {
+					success: false,
+					output: `No task ${task_id} was launched by this run. Call agent_task_list to see the tasks you can wait on.`,
+					data: { task_id },
+				}
+			}
+
 			const known = gateway.getTask(task_id as TaskId)
 			if (!known) {
 				return {
@@ -716,7 +761,7 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 
 	const agentTaskList = defineTool({
 		name: 'agent_task_list',
-		description: `Inspect the live state of every agent task launched on this gateway via create_task: returns each task's id, agent, state (pending/running/completed/failed/canceled), and timing. Distinct from the plan-task store's \`task_list\` (which lists planning tasks): this tool lists running/completed worker invocations. ${listingAdvice}`,
+		description: `Inspect the live state of the agent tasks YOU launched with create_task: returns each task's id, agent, state (pending/running/completed/failed/canceled), and timing. Tasks launched by another run are not listed, even when it shares this gateway. Distinct from the plan-task store's \`task_list\` (which lists planning tasks): this tool lists running/completed worker invocations. ${listingAdvice}`,
 		inputSchema: z.object({
 			state: z
 				.enum(['pending', 'running', 'completed', 'failed', 'canceled'])
@@ -729,7 +774,10 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 		destructive: false,
 		concurrencySafe: true,
 		async execute({ state }) {
-			const handles = gateway.listTasks()
+			// Scoped to this run's own launches — see `launchedHere`. The
+			// gateway may hold a sibling run's tasks, and this listing is not
+			// the door to them.
+			const handles = gateway.listTasks().filter((h) => launchedHere.has(h.taskId))
 			const filtered = state ? handles.filter((h) => h.state === state) : handles
 			const items = filtered.map((h) => {
 				const runStatus = h.result?.status


### PR DESCRIPTION
fix(sdk)!: a listing is not a back door into another run

A supervisor could read a sibling run's worker output by listing.
`SupervisorAgentConfig.gateway` exists so a host can hand the SAME gateway to
several runs, which makes `TaskGateway.listTasks()` gateway-wide by design — and
`agent_task_list` handed that straight to the model, including each task's
`result`, the worker's actual output. `wait_for_task` had the same reach through
`getTask`.

`CompletionInbox` closed exactly this on the push side, because
`onTaskCompleted` is a broadcast and a shared gateway would otherwise hand each
supervisor the other's completions. The pull side kept no such record and asked
the gateway directly, so the same leak stayed open through a different door.

The scope lives in the coordinator tools rather than in `listTasks()`, because
the two answer different questions. A host calling `listTasks()` is the operator
and may legitimately want everything on its gateway; a model calling
`agent_task_list` is one run asking about its own work. Narrowing the gateway
method would take the operator's view away in order to fix the model's.

`wait_for_task` gives the same answer for a sibling's task as for one that never
existed, deliberately. Distinguishing them would confirm a task id to a run that
was not supposed to know it.

Eight existing tests had to change, and what they were doing is the finding.
Each seeded a fixture gateway with tasks the tool set had never launched — which
is exactly the sibling-run state the scope now refuses. They launch through
`create_task` now, so they cover launch-then-list rather than a gateway state no
run can actually produce.

BREAKING CHANGE: a run sees only the tasks it launched through its own
`create_task`. A host that shared one gateway across runs and relied on one run
listing another's tasks should call `TaskGateway.listTasks()` itself, which is
unchanged and still gateway-wide. A task launched through a different surface on
the same gateway — `buildAgentTool`, or the host directly — is likewise not
listed by these tools.
