### PR TITLE
feat(sdk)!: a plan step reports its own outcome

### DIFF
--- a/.changeset/a-plan-step-reports-its-own-outcome.md
+++ b/.changeset/a-plan-step-reports-its-own-outcome.md
@@ -1,0 +1,45 @@
+---
+'@namzu/sdk': major
+---
+
+A plan step reports its own outcome, so a plan that succeeded can say so.
+
+A plan's steps had no relationship to the work that carried them out.
+`approve_plan` built steps, `create_task` launched workers, and nothing
+connected the two — so no step could ever be observed, `updateStepStatus` had no
+production caller anywhere, and a plan could reach `failed` (the error path
+calls `failPlan`) or sit at `executing` forever, but never `completed`. A host
+reading `plan.status` after a fully successful run was told the work was still
+going.
+
+**Two bindings, because there are two kinds of step.**
+
+- A **delegated** step reports through the launch that carries it out:
+  `create_task` gains `plan_step_id`. The step goes `running` when the worker
+  starts and `completed` or `failed` when it settles — from the same
+  two-authority check the tool result uses, so a worker that returned
+  `status: 'failed'` under a gateway state of `completed` fails its step.
+- An **orchestrator-owned** step — one with no `agent_id` — has no tool call to
+  bind to at all. The new `update_plan_step` tool is how it reports, and without
+  it a plan containing one could never settle however well it went. `skipped` is
+  a first-class outcome there: a plan that turned out not to need a step went
+  right, and forcing that into `completed` or `failed` would make the plan lie
+  in one direction or the other.
+
+**`approve_plan` now tells the model the step ids**, in its output and in
+`data.steps`. Both bindings name ids, and a binding whose caller has never been
+told the ids is a binding that does not exist.
+
+**The run settles the plan on success**, but only when every step has reported.
+The check is a read — the new `PlanManager.unreportedSteps` — rather than a
+caught throw: `completePlan` refuses an unreported step on purpose, and letting
+that throw at the end of a successful run would turn a run that worked into a
+run that crashed on its way out. A plan with silent steps is left `executing`,
+which is the honest answer.
+
+**Breaking:** `update_plan_step` is a new name in the coordinator tool set, so a
+host that registers its own tool under that name will now get
+`ToolNameCollisionError` at run start. `approve_plan`'s approved output is no
+longer byte-identical — it opens with the same sentence and continues with the
+step roster; the historical text is still the prefix, and `data.steps` is there
+so a host need not parse prose.

--- a/packages/sdk/src/manager/plan/lifecycle.ts
+++ b/packages/sdk/src/manager/plan/lifecycle.ts
@@ -95,6 +95,20 @@ export class PlanManager {
 		return this.currentPlan?.status === 'pending_approval'
 	}
 
+	/**
+	 * Steps that have not said how they went — the reason `completePlan` may
+	 * refuse, exposed so a caller can ask before it commits.
+	 *
+	 * The kernel settles a successful plan only when this is empty. It cannot
+	 * catch the refusal instead: a throw on the success path would turn a run
+	 * that worked into a run that crashed on its way out, which is a worse
+	 * version of the bug the refusal exists to prevent.
+	 */
+	get unreportedSteps(): readonly PlanStep[] {
+		if (!this.currentPlan) return []
+		return this.currentPlan.steps.filter((s) => s.status === 'pending' || s.status === 'running')
+	}
+
 	startGenerating(title: string): Plan {
 		const plan: Plan = {
 			id: generatePlanId(),

--- a/packages/sdk/src/runtime/query/__tests__/a-plan-that-succeeded-says-so.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/a-plan-that-succeeded-says-so.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+
+import type { PlanManager } from '../../../manager/plan/lifecycle.js'
+import { MockLLMProvider, registerMock } from '../../../provider/index.js'
+import { ToolRegistry } from '../../../registry/index.js'
+import {
+	generateProjectId,
+	generateSessionId,
+	generateTenantId,
+	generateThreadId,
+} from '../../../utils/id.js'
+import { drainQuery } from '../index.js'
+
+/**
+ * Nothing settled a plan that SUCCEEDED.
+ *
+ * The error path calls `failPlan`, so a run that blew up said so. The success
+ * path never touched the plan manager at all — so a plan could reach `failed`
+ * or sit at `executing` forever, but never `completed`. A host reading
+ * `plan.status` after a successful run was told the work was still going.
+ *
+ * Settlement is conditional on every step having reported, and the condition is
+ * read rather than caught: `completePlan` refuses an unreported step on
+ * purpose, and letting that throw here would turn a run that worked into a run
+ * that crashed on its way out — a worse version of the bug the refusal exists
+ * to prevent.
+ */
+
+registerMock()
+
+/** Run to completion, with a plan seeded through the host's own seam. */
+async function runWithPlan(seed: (pm: PlanManager) => void): Promise<PlanManager> {
+	let captured: PlanManager | undefined
+
+	await drainQuery({
+		provider: new MockLLMProvider({ responses: [{ content: 'done' }] } as never),
+		tools: new ToolRegistry(),
+		agentId: 'a',
+		agentName: 'A',
+		messages: [{ role: 'user', content: 'go' }],
+		workingDirectory: process.cwd(),
+		runConfig: { model: 'mock', tokenBudget: 100_000, timeoutMs: 30_000, maxIterations: 4 },
+		projectId: generateProjectId(),
+		sessionId: generateSessionId(),
+		threadId: generateThreadId(),
+		tenantId: generateTenantId(),
+		// The documented host seam: `drainQuery` hands the plan manager over
+		// BEFORE the iteration loop, which is exactly what makes a host-driven
+		// plan possible at all.
+		onContextCreated: ({ planManager }: { planManager: PlanManager }) => {
+			captured = planManager
+			seed(planManager)
+		},
+	} as never)
+
+	if (!captured) throw new Error('onContextCreated never fired')
+	return captured
+}
+
+function twoStepPlan(pm: PlanManager): void {
+	pm.startGenerating('the work')
+	pm.addStep({ id: 'step_1', description: 'first', dependsOn: [], order: 1 })
+	pm.addStep({ id: 'step_2', description: 'second', dependsOn: [], order: 2 })
+	pm.markReady()
+	pm.approve()
+	pm.startExecution()
+}
+
+describe('a run that succeeded settles the plan it was executing', () => {
+	it('reports completed when every step reported', async () => {
+		const pm = await runWithPlan((p) => {
+			twoStepPlan(p)
+			p.updateStepStatus('step_1', 'completed')
+			p.updateStepStatus('step_2', 'skipped')
+		})
+
+		expect(pm.active?.status).toBe('completed')
+	})
+
+	it('reports failed when a step actually failed', async () => {
+		const pm = await runWithPlan((p) => {
+			twoStepPlan(p)
+			p.updateStepStatus('step_1', 'completed')
+			p.updateStepStatus('step_2', 'failed')
+		})
+
+		expect(pm.active?.status).toBe('failed')
+	})
+
+	it('leaves it executing — and does not throw — when a step never reported', async () => {
+		// The honest answer. The caller and the plan disagree about whether the
+		// work is over, and the end of a successful run is not the place to
+		// resolve that by guessing. The run itself must still finish cleanly,
+		// which is the half that would break if the refusal were caught here
+		// instead of checked.
+		const pm = await runWithPlan((p) => {
+			twoStepPlan(p)
+			p.updateStepStatus('step_1', 'completed')
+		})
+
+		expect(pm.active?.status).toBe('executing')
+	})
+
+	it('does nothing when the run had no plan at all', async () => {
+		const pm = await runWithPlan(() => {})
+
+		expect(pm.active).toBeNull()
+	})
+})

--- a/packages/sdk/src/runtime/query/result.ts
+++ b/packages/sdk/src/runtime/query/result.ts
@@ -37,10 +37,27 @@ export class ResultAssembler {
 	}
 
 	async *completeRun(rootSpan: Span): AsyncGenerator<RunEvent> {
-		const { runMgr, activityStore, log, emitEvent, drainPending } = this.config
+		const { runMgr, planManager, activityStore, log, emitEvent, drainPending } = this.config
 
 		if (runMgr.status === 'running') {
 			runMgr.markCompleted(runMgr.stopReason)
+		}
+
+		// Settle the plan, which nothing did on this path — so a plan could
+		// reach `failed` (the error path calls `failPlan`) or stay `executing`
+		// forever, but never `completed`. A host reading `plan.status` after a
+		// successful run saw "still running".
+		//
+		// Only when every step has reported, and the check is a read rather
+		// than a caught throw: `completePlan` refuses an unreported step on
+		// purpose, and turning a run that worked into a run that crashed on its
+		// way out would be a worse version of the bug the refusal prevents.
+		//
+		// A plan with steps nobody reported is LEFT `executing`, which is the
+		// honest answer — the caller and the plan disagree about whether the
+		// work is over, and this is not the place to resolve that by guessing.
+		if (planManager.isActive && planManager.unreportedSteps.length === 0) {
+			planManager.completePlan()
 		}
 
 		await emitEvent({

--- a/packages/sdk/src/tools/coordinator/__tests__/a-plan-step-reports-its-own-outcome.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/a-plan-step-reports-its-own-outcome.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest'
+
+import { PlanManager } from '../../../manager/plan/lifecycle.js'
+import type { TaskGateway, TaskHandle } from '../../../types/agent/gateway.js'
+import type { RunId, TaskId } from '../../../types/ids/index.js'
+import type { ToolContext, ToolDefinition } from '../../../types/tool/index.js'
+import { buildCoordinatorTools } from '../index.js'
+
+/**
+ * A plan's steps had no relationship to the work that carried them out.
+ *
+ * `approve_plan` built steps, `create_task` launched workers, and nothing
+ * connected the two — so no step could ever be observed, `updateStepStatus` had
+ * no production caller, and a plan could reach `failed` (the error path calls
+ * `failPlan`) or sit at `executing` forever, but never `completed`.
+ *
+ * Two bindings close it, because there are two kinds of step. A DELEGATED step
+ * reports through the `create_task` that carries it out. An ORCHESTRATOR-OWNED
+ * step has no tool call to bind to at all, and reports through
+ * `update_plan_step` — without which a plan containing one could never settle
+ * however well it went.
+ */
+
+const RUN = 'run_step_binding' as RunId
+
+function gatewayReturning(outcome: 'ok' | 'failed'): TaskGateway {
+	const handle = (taskId: TaskId): TaskHandle => ({
+		taskId,
+		agentId: 'worker',
+		state: 'completed',
+		createdAt: 1_000,
+		completedAt: 2_000,
+		result: (outcome === 'ok'
+			? { status: 'completed', result: 'the work' }
+			: { status: 'failed', lastError: 'the worker died' }) as TaskHandle['result'],
+	})
+	return {
+		async createTask() {
+			return handle('tsk_1' as TaskId)
+		},
+		async waitForTask(id) {
+			return handle(id)
+		},
+		async continueTask() {},
+		cancelTask() {},
+		getTask(id) {
+			return handle(id)
+		},
+		listTasks() {
+			return []
+		},
+		onTaskCompleted() {
+			return () => {}
+		},
+	}
+}
+
+function ctx(): ToolContext {
+	return {
+		runId: RUN,
+		workingDirectory: '/tmp/test',
+		abortSignal: new AbortController().signal,
+		env: {},
+		log: () => {},
+	}
+}
+
+/** An approved two-step plan: one delegated, one the orchestrator's own. */
+function approvedPlan(): PlanManager {
+	const pm = new PlanManager(RUN, async () => ({ approved: true }))
+	pm.startGenerating('do the work')
+	pm.addStep({
+		id: 'step_1',
+		description: 'delegated work',
+		agentId: 'worker',
+		dependsOn: [],
+		order: 1,
+	})
+	pm.addStep({ id: 'step_2', description: 'my own work', dependsOn: [], order: 2 })
+	pm.markReady()
+	pm.approve()
+	pm.startExecution()
+	return pm
+}
+
+function toolsOver(pm: PlanManager, gateway: TaskGateway): (name: string) => ToolDefinition {
+	const tools = buildCoordinatorTools({
+		gateway,
+		workingDirectory: '/tmp/test',
+		allowedAgentIds: ['worker'],
+		getPlanManager: () => pm,
+	})
+	return (name: string) => {
+		const t = tools.find((tool) => tool.name === name)
+		if (!t) throw new Error(`${name} missing from coordinator builder`)
+		return t
+	}
+}
+
+const stepStatus = (pm: PlanManager, id: string) =>
+	pm.active?.steps.find((s) => s.id === id)?.status
+
+describe('a delegated step reports through the launch that carries it out', () => {
+	it('completes the step when the worker succeeded', async () => {
+		const pm = approvedPlan()
+		const named = toolsOver(pm, gatewayReturning('ok'))
+
+		await named('create_task').execute(
+			{ agent_id: 'worker', prompt: 'go', description: 'do it', plan_step_id: 'step_1' },
+			ctx(),
+		)
+
+		expect(stepStatus(pm, 'step_1')).toBe('completed')
+	})
+
+	it('fails the step when the worker failed, from both authorities', async () => {
+		// The handle is `state: 'completed'` with `result.status: 'failed'` —
+		// the split that made a failed worker read as an answer. The step must
+		// follow the run status, not the gateway state.
+		const pm = approvedPlan()
+		const named = toolsOver(pm, gatewayReturning('failed'))
+
+		await named('create_task').execute(
+			{ agent_id: 'worker', prompt: 'go', description: 'do it', plan_step_id: 'step_1' },
+			ctx(),
+		)
+
+		expect(stepStatus(pm, 'step_1')).toBe('failed')
+	})
+
+	it('leaves the plan alone when the launch names no step', async () => {
+		// A launch outside the approved plan must not silently settle one.
+		const pm = approvedPlan()
+		const named = toolsOver(pm, gatewayReturning('ok'))
+
+		await named('create_task').execute(
+			{ agent_id: 'worker', prompt: 'go', description: 'unrelated work' },
+			ctx(),
+		)
+
+		expect(stepStatus(pm, 'step_1')).toBe('pending')
+	})
+})
+
+describe('an orchestrator-owned step reports through update_plan_step', () => {
+	it('records the outcome and says what is still outstanding', async () => {
+		const pm = approvedPlan()
+		const named = toolsOver(pm, gatewayReturning('ok'))
+
+		const result = await named('update_plan_step').execute(
+			{ step_id: 'step_2', status: 'completed' },
+			ctx(),
+		)
+
+		expect(result.success).toBe(true)
+		expect(stepStatus(pm, 'step_2')).toBe('completed')
+		// step_1 has not reported, and saying so is the point — this is what
+		// tells the model the plan cannot settle yet.
+		expect(result.output).toContain('step_1')
+	})
+
+	it('treats skipped as a real outcome, not a failure', async () => {
+		const pm = approvedPlan()
+		const named = toolsOver(pm, gatewayReturning('ok'))
+
+		await named('update_plan_step').execute({ step_id: 'step_2', status: 'skipped' }, ctx())
+
+		expect(stepStatus(pm, 'step_2')).toBe('skipped')
+	})
+
+	it('refuses an id the plan does not have, and names the ones it does', async () => {
+		const pm = approvedPlan()
+		const named = toolsOver(pm, gatewayReturning('ok'))
+
+		const result = await named('update_plan_step').execute(
+			{ step_id: 'step_9', status: 'completed' },
+			ctx(),
+		)
+
+		expect(result.success).toBe(false)
+		expect(result.error).toContain('step_1')
+		expect(result.error).toContain('step_2')
+	})
+})
+
+describe('the two bindings together let a plan settle', () => {
+	it('reaches completed once every step has reported', async () => {
+		const pm = approvedPlan()
+		const named = toolsOver(pm, gatewayReturning('ok'))
+
+		await named('create_task').execute(
+			{ agent_id: 'worker', prompt: 'go', description: 'do it', plan_step_id: 'step_1' },
+			ctx(),
+		)
+		await named('update_plan_step').execute({ step_id: 'step_2', status: 'completed' }, ctx())
+
+		expect(pm.unreportedSteps).toHaveLength(0)
+		expect(pm.completePlan()?.status).toBe('completed')
+	})
+
+	it('leaves the plan unsettled while a step is still silent', async () => {
+		// The state the kernel reads before deciding whether to settle. An
+		// unreported step means the caller and the plan disagree about whether
+		// the work is over, and the run must not resolve that by guessing.
+		const pm = approvedPlan()
+		const named = toolsOver(pm, gatewayReturning('ok'))
+
+		await named('create_task').execute(
+			{ agent_id: 'worker', prompt: 'go', description: 'do it', plan_step_id: 'step_1' },
+			ctx(),
+		)
+
+		expect(pm.unreportedSteps.map((s) => s.id)).toEqual(['step_2'])
+	})
+})

--- a/packages/sdk/src/tools/coordinator/__tests__/approve-plan.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/approve-plan.test.ts
@@ -88,14 +88,30 @@ describe('coordinator approve_plan tool', () => {
 		])
 	})
 
-	it('keeps the bare-approve tool_result output byte-identical', async () => {
+	it('opens with the historical approval sentence, then names the steps', async () => {
+		// This assertion used to be `toBe` on the whole string, guarding the
+		// approve-with-edits change against disturbing the bare-approve path.
+		// It was never a promise that the output would carry nothing more, and
+		// it now carries the step roster — without which `plan_step_id` and
+		// `update_plan_step` name ids the model has never been told.
 		const result = await executeApprovePlan({ approved: true })
 
 		expect(result.success).toBe(true)
-		expect(result.output).toBe(
-			'Plan approved by user. Proceed with execution — launch workers via create_task.',
-		)
-		expect(result.data).toEqual({ approved: true, feedback: undefined })
+		expect(
+			result.output.startsWith(
+				'Plan approved by user. Proceed with execution — launch workers via create_task.',
+			),
+		).toBe(true)
+		expect(result.output).toContain('step_1 — Extract uploaded DOCX files')
+		expect(result.data).toMatchObject({ approved: true, feedback: undefined })
+	})
+
+	it('carries the step ids in data, so a host does not have to parse prose', async () => {
+		const result = await executeApprovePlan({ approved: true })
+
+		expect((result.data as { steps: unknown }).steps).toEqual([
+			{ step_id: 'step_1', description: 'Extract uploaded DOCX files', agent_id: undefined },
+		])
 	})
 
 	it('embeds approve-with-edits feedback in the output and data', async () => {
@@ -105,12 +121,17 @@ describe('coordinator approve_plan tool', () => {
 		})
 
 		expect(result.success).toBe(true)
-		expect(result.output).toBe(
-			'Plan approved by user with required edits — apply them during execution:\n' +
-				'Skip step 2 and use the staging database instead.\n' +
-				'Proceed with execution — launch workers via create_task.',
-		)
-		expect(result.data).toEqual({
+		expect(
+			result.output.startsWith(
+				'Plan approved by user with required edits — apply them during execution:\n' +
+					'Skip step 2 and use the staging database instead.\n' +
+					'Proceed with execution — launch workers via create_task.',
+			),
+		).toBe(true)
+		// The edits stay ahead of the roster: what the user demanded is the
+		// first thing read, and the step list is reference material after it.
+		expect(result.output.indexOf('staging database')).toBeLessThan(result.output.indexOf('step_1'))
+		expect(result.data).toMatchObject({
 			approved: true,
 			feedback: 'Skip step 2 and use the staging database instead.',
 		})

--- a/packages/sdk/src/tools/coordinator/index.ts
+++ b/packages/sdk/src/tools/coordinator/index.ts
@@ -386,6 +386,12 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 				.describe(
 					'Existing planning task ID to link. If omitted, a planning task is auto-created.',
 				),
+			plan_step_id: z
+				.string()
+				.optional()
+				.describe(
+					'The approve_plan step this launch carries out (e.g. "step_2"). Pass it and the step reports its own outcome — running on launch, completed or failed when the worker settles — so the plan can say how it went. Omit it only when this launch is not part of the approved plan.',
+				),
 			...(canLaunchInBackground
 				? {
 						background: z
@@ -407,8 +413,23 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 		// children were observed at 8m04s, which it would have survived by
 		// under two minutes.
 		timeoutMs: DELEGATION_TIMEOUT_MS,
-		async execute({ agent_id, prompt, description, plan_task_id, background }, _context) {
+		async execute(
+			{ agent_id, prompt, description, plan_task_id, plan_step_id, background },
+			_context,
+		) {
 			let resolvedPlanTaskId = plan_task_id
+
+			// The binding between a plan step and the work that carries it out.
+			// Without it a plan's steps had no relationship to any tool call, so
+			// nothing could ever observe how a step went — which is why a plan
+			// could report `failed` or stay `executing` forever but never
+			// `completed`.
+			const planStepId = plan_step_id
+			const reportStep = (status: 'running' | 'completed' | 'failed', error?: string): void => {
+				if (!planStepId) return
+				getPlanManager?.()?.updateStepStatus(planStepId, status, error)
+			}
+			reportStep('running')
 
 			if (taskStore) {
 				if (resolvedPlanTaskId) {
@@ -469,6 +490,10 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 						description: 'Failed: the launch was refused before any worker started',
 					})
 				}
+				// Same reason the plan task is closed here: nothing is running,
+				// so a step left `running` would show work underway with no
+				// worker behind it, and the plan could never settle.
+				reportStep('failed', 'the launch was refused before any worker started')
 				return {
 					success: false,
 					output: '',
@@ -568,6 +593,11 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 					description: success ? undefined : `Failed: ${resultText.substring(0, 200)}`,
 				})
 			}
+
+			// The step reports the same outcome, from the same two authorities.
+			// This is the only point in a delegated launch where the answer is
+			// actually known.
+			reportStep(success ? 'completed' : 'failed', success ? undefined : resultText.slice(0, 200))
 
 			return {
 				success,
@@ -965,17 +995,38 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 
 				if (response.approved) {
 					pm.startExecution()
+
+					// The step ids, because nothing else tells the model what
+					// they are. `plan_step_id` on create_task and `step_id` on
+					// update_plan_step are both unusable without them — a
+					// binding the caller cannot name is a binding that does not
+					// exist. Rendered from the plan as approved, so a plan the
+					// user edited lists the steps they actually approved.
+					const roster = (pm.active?.steps ?? [])
+						.map((s) => `  ${s.id} — ${s.description}${s.agentId ? ` (${s.agentId})` : ''}`)
+						.join('\n')
+					const howToReport = roster
+						? `\nSteps, and how each reports its outcome:\n${roster}\nPass plan_step_id to create_task for a delegated step; call update_plan_step for one you do yourself. The plan cannot report success until every step has reported.`
+						: ''
+
 					// Approve-with-edits: when the user attached feedback to an
 					// approval, embed it in the model-visible output so the
-					// supervisor applies the edits during execution. A bare
-					// approve keeps the historical output byte-identical.
+					// supervisor applies the edits during execution.
 					const output = response.feedback
-						? `Plan approved by user with required edits — apply them during execution:\n${response.feedback}\nProceed with execution — launch workers via create_task.`
-						: 'Plan approved by user. Proceed with execution — launch workers via create_task.'
+						? `Plan approved by user with required edits — apply them during execution:\n${response.feedback}\nProceed with execution — launch workers via create_task.${howToReport}`
+						: `Plan approved by user. Proceed with execution — launch workers via create_task.${howToReport}`
 					return {
 						success: true,
 						output,
-						data: { approved: true, feedback: response.feedback },
+						data: {
+							approved: true,
+							feedback: response.feedback,
+							steps: (pm.active?.steps ?? []).map((s) => ({
+								step_id: s.id,
+								description: s.description,
+								agent_id: s.agentId,
+							})),
+						},
 					}
 				}
 
@@ -991,6 +1042,76 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 			},
 		})
 		tools.push(approvePlan)
+
+		/**
+		 * How a step the ORCHESTRATOR did reports its own outcome.
+		 *
+		 * `create_task` reports the steps it carries out, which covers every
+		 * delegated step. A step with no `agent_id` is the orchestrator's own
+		 * work and has no tool call to bind to — so without this there is no
+		 * way for it to ever report, and a plan containing one could never
+		 * settle no matter how well it went.
+		 *
+		 * `skipped` is a first-class outcome and not a euphemism for failure:
+		 * a plan that turned out not to need a step went right, and forcing
+		 * that into `completed` or `failed` would make the plan lie in one
+		 * direction or the other.
+		 */
+		const updatePlanStep = defineTool({
+			name: 'update_plan_step',
+			description:
+				'Report how a step of the approved plan went. Use it for steps YOU carried out — steps delegated with create_task report themselves when you pass plan_step_id. Call it as each step settles, not in a batch at the end: the plan cannot say it succeeded until every step has reported, and an unreported step is not scored as a failure, it simply leaves the plan unsettled. Use "skipped" for a step that turned out not to be needed; that is a successful outcome, not a failure.',
+			inputSchema: z.object({
+				step_id: z.string().describe('The plan step id, e.g. "step_2".'),
+				status: z
+					.enum(['completed', 'skipped', 'failed'])
+					.describe(
+						'How it went. "skipped" means the step was not needed and the plan is still on track.',
+					),
+				error: z
+					.string()
+					.optional()
+					.describe('What went wrong. Only meaningful with status "failed".'),
+			}),
+			category: 'custom',
+			permissions: [],
+			readOnly: false,
+			destructive: false,
+			concurrencySafe: true,
+			async execute({ step_id, status, error }) {
+				const pm = getPlanManager?.()
+				if (!pm?.active) {
+					return {
+						success: false,
+						output: '',
+						error: 'There is no active plan to report against. Call approve_plan first.',
+					}
+				}
+
+				const step = pm.updateStepStatus(step_id, status, error)
+				if (!step) {
+					const known = pm.active.steps.map((s) => s.id).join(', ')
+					return {
+						success: false,
+						output: '',
+						error: `No plan step "${step_id}". This plan's steps are: ${known || '(none)'}.`,
+					}
+				}
+
+				const outstanding = pm.unreportedSteps
+				return {
+					success: true,
+					output:
+						outstanding.length === 0
+							? `Step ${step_id} reported as ${status}. Every step has now reported.`
+							: `Step ${step_id} reported as ${status}. Still unreported: ${outstanding
+									.map((s) => s.id)
+									.join(', ')}.`,
+					data: { step_id, status, unreported: outstanding.map((s) => s.id) },
+				}
+			},
+		})
+		tools.push(updatePlanStep)
 	}
 
 	if (resumeHandler && runId) {


### PR DESCRIPTION
feat(sdk)!: a plan step reports its own outcome

A plan's steps had no relationship to the work that carried them out.
`approve_plan` built steps, `create_task` launched workers, and nothing
connected the two — so no step could ever be observed, `updateStepStatus` had no
production caller anywhere, and a plan could reach `failed` (the error path
calls `failPlan`) or sit at `executing` forever, but never `completed`.

Two bindings, because there are two kinds of step. A DELEGATED step reports
through the launch that carries it out: `create_task` gains `plan_step_id`, and
the step goes running on launch, then completed or failed from the same
two-authority check the tool result uses. An ORCHESTRATOR-OWNED step has no tool
call to bind to at all, and reports through the new `update_plan_step` — without
which a plan containing one could never settle however well it went.

`skipped` is a first-class outcome there rather than a euphemism for failure: a
plan that turned out not to need a step went right, and forcing that into
completed or failed would make the plan lie in one direction or the other.

`approve_plan` now tells the model the step ids, in its output and in
`data.steps`. Both bindings name ids, and a binding whose caller has never been
told the ids is a binding that does not exist.

The run settles the plan on success, but only when every step has reported, and
the check is a read — the new `PlanManager.unreportedSteps` — rather than a
caught throw. `completePlan` refuses an unreported step on purpose, and letting
that throw at the end of a successful run would turn a run that worked into a
run that crashed on its way out. A plan with silent steps is left `executing`,
which is the honest answer.

BREAKING CHANGE: `update_plan_step` is a new name in the coordinator tool set,
so a host registering its own tool under that name now gets
ToolNameCollisionError at run start. `approve_plan`'s approved output is no
longer byte-identical — the historical sentence is still the prefix, followed by
the step roster, and `data.steps` carries the ids so a host need not parse prose.
