### PR TITLE
feat(sdk)!: a settled plan says so on the run stream

### DIFF
--- a/.changeset/a-settled-plan-reaches-the-host.md
+++ b/.changeset/a-settled-plan-reaches-the-host.md
@@ -1,0 +1,42 @@
+---
+'@namzu/sdk': major
+---
+
+A plan that settles says so on the run stream, and the host callback can be heard.
+
+The plan events stopped one short of the outcome. `plan_ready`, `plan_approved`,
+`plan_rejected` and `plan_step_updated` all reached the wire; `plan.completed`
+and `plan.failed` were folded into a bare `break` in the translator and emitted
+nothing. So a host watching the stream saw the steps report and then silence —
+it could learn a plan had been approved and never that it closed, which leaves a
+plan rendered as in-flight indefinitely.
+
+`RunEvent` gains `plan_completed` and `plan_failed`, and `StreamEventType` gains
+`plan.completed` and `plan.failed` for the SSE bridge.
+
+**`failPlan` stops discarding its argument.** The parameter was spelled `_error`
+because nothing read it, so a failed plan carried no account of what went wrong
+— and an event that says "failed" without saying why puts the reader back where
+the missing event did. `Plan` gains `failureReason`, and `plan_failed` carries
+it.
+
+**`onContextCreated` now fires where it can be heard.** It ran before the event
+translator was wired, so a host that built its plan in that callback — which is
+what the callback is for — did it into silence: `plan_ready`, `plan_approved`
+and every `plan_step_updated` from inside it were emitted with nothing
+subscribed. It now runs after the wiring *and* after `runMgr.init()`; moving it
+only as far as the wiring traded a silent drop for a store that was not yet
+initialised. It is still called before the iteration loop, which is the
+guarantee the callback actually makes.
+
+**How this was found is the part worth repeating.** It came out of the first
+live end-to-end run, not from a test. The settlement tests read the outcome off
+`PlanManager` through `onContextCreated`, so they proved the plan settled
+without ever asking whether a consumer of the event stream could see it — a
+verification that was entirely sound about something other than what needed
+knowing.
+
+**Breaking:** `RunEvent` and `StreamEventType` are wider. A consumer that
+switches exhaustively over either — which the SDK's own A2A mapper, SSE mapper
+and run reporter all do, and which is why the compiler named all three — needs
+arms for the new members.

--- a/packages/sdk/src/bridge/a2a/mapper.ts
+++ b/packages/sdk/src/bridge/a2a/mapper.ts
@@ -210,6 +210,8 @@ const MAPPING: {
 	plan_approved: null,
 	plan_rejected: null,
 	plan_step_updated: null,
+	plan_completed: null,
+	plan_failed: null,
 
 	agent_pending: null,
 	agent_completed: null,

--- a/packages/sdk/src/bridge/sse/mapper.ts
+++ b/packages/sdk/src/bridge/sse/mapper.ts
@@ -286,6 +286,20 @@ const MAPPING: {
 		}),
 	},
 
+	plan_completed: {
+		wire: 'plan.completed',
+		transform: (e, runId) => ({ run_id: runId, plan_id: e.planId }),
+	},
+
+	plan_failed: {
+		wire: 'plan.failed',
+		transform: (e, runId) => ({
+			run_id: runId,
+			plan_id: e.planId,
+			reason: e.reason,
+		}),
+	},
+
 	plan_step_updated: {
 		wire: 'plan.step_updated',
 		transform: (e, runId) => ({

--- a/packages/sdk/src/contracts/api.ts
+++ b/packages/sdk/src/contracts/api.ts
@@ -206,6 +206,11 @@ export type StreamEventType =
 	| 'plan.approved'
 	| 'plan.rejected'
 	| 'plan.step_updated'
+	// The outcome. Without these the plan stream stopped one event short of
+	// saying how it went, so a client could render a plan as in-flight
+	// indefinitely — it learned the plan was approved and never that it closed.
+	| 'plan.completed'
+	| 'plan.failed'
 	| 'agent.pending'
 	| 'agent.completed'
 	| 'agent.failed'

--- a/packages/sdk/src/manager/plan/lifecycle.ts
+++ b/packages/sdk/src/manager/plan/lifecycle.ts
@@ -276,11 +276,16 @@ export class PlanManager {
 		return this.currentPlan
 	}
 
-	failPlan(_error: string): Plan | null {
+	failPlan(error: string): Plan | null {
 		if (!this.currentPlan) return null
 
 		this.currentPlan.status = 'failed'
 		this.currentPlan.completedAt = Date.now()
+		// Recorded rather than discarded. This argument was named `_error`
+		// because nothing read it, so a failed plan carried no account of what
+		// went wrong — and the event that now reports the failure would have
+		// had nothing to say beyond the word.
+		this.currentPlan.failureReason = error
 
 		for (const step of this.currentPlan.steps) {
 			if (step.status === 'pending' || step.status === 'running') {

--- a/packages/sdk/src/run/reporter.ts
+++ b/packages/sdk/src/run/reporter.ts
@@ -93,6 +93,8 @@ export function createRunReporter(parentLogger?: Logger): RunReporter {
 			case 'plan_approved':
 			case 'plan_rejected':
 			case 'plan_step_updated':
+			case 'plan_completed':
+			case 'plan_failed':
 			case 'tool_review_requested':
 			case 'tool_review_completed':
 			case 'checkpoint_created':

--- a/packages/sdk/src/runtime/query/__tests__/a-settled-plan-reaches-the-host.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/a-settled-plan-reaches-the-host.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+
+import type { PlanManager } from '../../../manager/plan/lifecycle.js'
+import { MockLLMProvider, registerMock } from '../../../provider/index.js'
+import { ToolRegistry } from '../../../registry/index.js'
+import type { RunEvent } from '../../../types/run/index.js'
+import {
+	generateProjectId,
+	generateSessionId,
+	generateTenantId,
+	generateThreadId,
+} from '../../../utils/id.js'
+import { drainQuery } from '../index.js'
+
+/**
+ * The plan stream stopped one event short of the outcome.
+ *
+ * `plan_ready`, `plan_approved`, `plan_rejected` and `plan_step_updated` all
+ * reached the wire; `plan.completed` and `plan.failed` were folded into a bare
+ * `break` in the translator and emitted nothing. So a host watching the stream
+ * saw the steps report and then silence — it could learn a plan had been
+ * approved and never that it closed, which leaves a plan rendered as in-flight
+ * indefinitely.
+ *
+ * **This was found by a live end-to-end run, not by a test, and that is the
+ * point worth keeping.** The settlement tests read the outcome off
+ * `PlanManager` through `onContextCreated`, so they proved the plan settled
+ * without ever asking whether a consumer of the EVENT STREAM could see it. A
+ * verification can be entirely sound about a thing that is no longer the thing
+ * you need to know.
+ */
+
+registerMock()
+
+async function runWithPlan(seed: (pm: PlanManager) => void): Promise<RunEvent[]> {
+	const events: RunEvent[] = []
+
+	await drainQuery(
+		{
+			provider: new MockLLMProvider({ responses: [{ content: 'done' }] } as never),
+			tools: new ToolRegistry(),
+			agentId: 'a',
+			agentName: 'A',
+			messages: [{ role: 'user', content: 'go' }],
+			workingDirectory: process.cwd(),
+			runConfig: { model: 'mock', tokenBudget: 100_000, timeoutMs: 30_000, maxIterations: 4 },
+			projectId: generateProjectId(),
+			sessionId: generateSessionId(),
+			threadId: generateThreadId(),
+			tenantId: generateTenantId(),
+			onContextCreated: ({ planManager }: { planManager: PlanManager }) => seed(planManager),
+		} as never,
+		(event: RunEvent) => {
+			events.push(event)
+		},
+	)
+
+	return events
+}
+
+function twoStepPlan(pm: PlanManager): void {
+	pm.startGenerating('the work')
+	pm.addStep({ id: 'step_1', description: 'first', dependsOn: [], order: 1 })
+	pm.addStep({ id: 'step_2', description: 'second', dependsOn: [], order: 2 })
+	pm.markReady()
+	pm.approve()
+	pm.startExecution()
+}
+
+const typesOf = (events: RunEvent[]) => events.map((e) => e.type)
+
+describe('a settled plan says so on the run stream', () => {
+	it('emits plan_completed when the run settles a successful plan', async () => {
+		const events = await runWithPlan((p) => {
+			twoStepPlan(p)
+			p.updateStepStatus('step_1', 'completed')
+			p.updateStepStatus('step_2', 'skipped')
+		})
+
+		expect(typesOf(events)).toContain('plan_completed')
+	})
+
+	it('emits plan_failed, carrying the reason failPlan was given', async () => {
+		// `failPlan` took this argument and discarded it — the parameter was
+		// spelled `_error`. An event that says "failed" without saying why puts
+		// the reader back where the missing event did.
+		const events = await runWithPlan((p) => {
+			twoStepPlan(p)
+			p.failPlan('the provider refused the request')
+		})
+
+		const failed = events.find((e) => e.type === 'plan_failed')
+		expect(failed).toBeDefined()
+		expect((failed as { reason?: string }).reason).toBe('the provider refused the request')
+	})
+
+	it('emits plan_failed when a step actually failed', async () => {
+		const events = await runWithPlan((p) => {
+			twoStepPlan(p)
+			p.updateStepStatus('step_1', 'completed')
+			p.updateStepStatus('step_2', 'failed')
+		})
+
+		expect(typesOf(events)).toContain('plan_failed')
+		expect(typesOf(events)).not.toContain('plan_completed')
+	})
+
+	it('says nothing terminal while a step has not reported', async () => {
+		// The plan is genuinely unsettled, so the silence here is correct — it
+		// is the silence AFTER settlement that was the defect.
+		const events = await runWithPlan((p) => {
+			twoStepPlan(p)
+			p.updateStepStatus('step_1', 'completed')
+		})
+
+		expect(typesOf(events)).not.toContain('plan_completed')
+		expect(typesOf(events)).not.toContain('plan_failed')
+		// ...and the step that DID report is still announced, so this is not a
+		// stream that has simply gone quiet.
+		expect(typesOf(events)).toContain('plan_step_updated')
+	})
+})

--- a/packages/sdk/src/runtime/query/events.ts
+++ b/packages/sdk/src/runtime/query/events.ts
@@ -193,10 +193,28 @@ export class EventTranslator {
 						})
 					}
 					break
+				case 'plan.completed':
+					await this.emitEvent({
+						type: 'plan_completed',
+						runId,
+						planId: plan.id,
+					})
+					break
+				case 'plan.failed':
+					await this.emitEvent({
+						type: 'plan_failed',
+						runId,
+						planId: plan.id,
+						...(plan.failureReason ? { reason: plan.failureReason } : {}),
+					})
+					break
+				// Deliberately silent, and not for the same reason the terminal
+				// pair used to be. `plan.generating` and `plan.executing` are
+				// already bracketed by `plan_ready` and `plan_approved` — a
+				// consumer learns both facts from events it already gets, so an
+				// event here would carry nothing a reader did not have.
 				case 'plan.generating':
 				case 'plan.executing':
-				case 'plan.completed':
-				case 'plan.failed':
 					break
 				default: {
 					// `PlanEvent.type` is scoped to plan-manager events; sub-session

--- a/packages/sdk/src/runtime/query/index.ts
+++ b/packages/sdk/src/runtime/query/index.ts
@@ -552,14 +552,13 @@ export async function* query(params: QueryParams): AsyncGenerator<RunEvent, Run>
 		return { approved: false, feedback: `Action: ${decision.action}` }
 	})
 
-	params.onContextCreated?.({ planManager: ctx.planManager })
-
 	const eventTranslator = new EventTranslator(ctx.runMgr)
 	eventTranslator.wireActivityStore(ctx.activityStore, ctx.runId)
 	eventTranslator.wirePlanManager(ctx.planManager, ctx.runId)
 	const unsubscribeTaskStore = params.taskStore
 		? eventTranslator.wireTaskStore(params.taskStore, ctx.runId)
 		: undefined
+
 
 	if (params.taskStore) {
 		const taskTools = buildTaskTools(params.taskStore, ctx.runId)
@@ -976,6 +975,21 @@ export async function* query(params: QueryParams): AsyncGenerator<RunEvent, Run>
 
 		try {
 			await ctx.runMgr.init()
+
+			// Handed over here, and the position is load-bearing in BOTH
+			// directions. It has to follow `wirePlanManager`, or a host that
+			// builds its plan in this callback — which is what the callback is
+			// for — does it into silence: `plan_ready`, `plan_approved` and
+			// every `plan_step_updated` are emitted with nothing subscribed,
+			// and the host then watches a stream that never mentions the plan
+			// it just created. It also has to follow `runMgr.init()`, because
+			// emitting appends to the run store and an uninitialised store
+			// throws — moving it up to the wiring alone traded a silent drop
+			// for 25 unhandled rejections.
+			//
+			// Still before the iteration loop, which is the guarantee the
+			// callback actually makes.
+			params.onContextCreated?.({ planManager: ctx.planManager })
 
 			ctx.log.info('Starting query', {
 				runId: ctx.runMgr.id,

--- a/packages/sdk/src/runtime/query/index.ts
+++ b/packages/sdk/src/runtime/query/index.ts
@@ -559,7 +559,6 @@ export async function* query(params: QueryParams): AsyncGenerator<RunEvent, Run>
 		? eventTranslator.wireTaskStore(params.taskStore, ctx.runId)
 		: undefined
 
-
 	if (params.taskStore) {
 		const taskTools = buildTaskTools(params.taskStore, ctx.runId)
 		const overrides = params.runtimeToolOverrides

--- a/packages/sdk/src/types/plan/index.ts
+++ b/packages/sdk/src/types/plan/index.ts
@@ -68,6 +68,20 @@ export interface Plan {
 	rejectedAt?: number
 	completedAt?: number
 	rejectionReason?: string
+
+	/**
+	 * Why the plan failed, when it did.
+	 *
+	 * `failPlan` has always taken this and thrown it away — the parameter was
+	 * spelled `_error` because nothing read it. So a plan settled as `failed`
+	 * carried no account of what went wrong, and the `plan_failed` event that
+	 * reports it would have said "failed" and nothing else, which puts a reader
+	 * exactly where the silence did.
+	 *
+	 * Distinct from {@link rejectionReason}: that is a human declining a plan
+	 * before it ran, this is a plan that ran and did not finish.
+	 */
+	failureReason?: string
 }
 
 export interface PlanApprovalRequest {

--- a/packages/sdk/src/types/run/events.ts
+++ b/packages/sdk/src/types/run/events.ts
@@ -434,6 +434,30 @@ type CoreRunEvent =
 			stepId: string
 			status: PlanStep['status']
 	  }
+	/**
+	 * The plan is over, and it went the way it was supposed to.
+	 *
+	 * The plan events used to stop before the outcome: `plan_ready`,
+	 * `plan_approved`, `plan_rejected` and `plan_step_updated` all reached the
+	 * wire, and the two terminal ones were folded into a bare `break` in the
+	 * translator. So a host watching the stream saw the steps report and then
+	 * silence — it could tell a plan had been approved and never that it
+	 * closed, which leaves a plan rendered as in-flight forever.
+	 *
+	 * Found by the first live end-to-end run rather than by a test, and the
+	 * reason is worth keeping: the tests read the outcome off `PlanManager`
+	 * through `onContextCreated`, so they proved the plan settled without ever
+	 * asking whether a consumer of the EVENT STREAM could see it.
+	 */
+	| { type: 'plan_completed'; runId: RunId; planId: PlanId }
+	/**
+	 * The plan is over and it did not finish.
+	 *
+	 * `reason` is the text handed to `failPlan`, which used to be discarded —
+	 * an event that says "failed" without saying why puts the reader back
+	 * where the missing event did.
+	 */
+	| { type: 'plan_failed'; runId: RunId; planId: PlanId; reason?: string }
 	| {
 			type: 'agent_pending'
 			runId: RunId


### PR DESCRIPTION
feat(sdk)!: a settled plan says so on the run stream

The plan events stopped one short of the outcome. `plan_ready`,
`plan_approved`, `plan_rejected` and `plan_step_updated` all reached the wire;
`plan.completed` and `plan.failed` were folded into a bare `break` in the
translator and emitted nothing. A host watching the stream saw the steps report
and then silence — it could learn a plan had been approved and never that it
closed, which leaves a plan rendered as in-flight indefinitely.

`RunEvent` gains `plan_completed` and `plan_failed`; `StreamEventType` gains
`plan.completed` and `plan.failed` for the SSE bridge.

`failPlan` stops discarding its argument. The parameter was spelled `_error`
because nothing read it, so a failed plan carried no account of what went wrong
— and an event that says "failed" without saying why puts the reader back where
the missing event did. `Plan` gains `failureReason` and `plan_failed` carries it.

`onContextCreated` now fires where it can be heard. It ran before the event
translator was wired, so a host that built its plan in that callback — which is
what the callback is for — did it into silence. It now runs after the wiring AND
after `runMgr.init()`: moving it only as far as the wiring traded a silent drop
for 25 unhandled rejections from a store that was not yet initialised. Still
before the iteration loop, which is the guarantee the callback makes.

Found by the first live end-to-end run rather than by a test, and that is worth
recording. The settlement tests read the outcome off `PlanManager` through
`onContextCreated`, so they proved the plan settled without ever asking whether
a consumer of the event stream could see it.

BREAKING CHANGE: `RunEvent` and `StreamEventType` are wider. A consumer that
switches exhaustively over either needs arms for the new members — the SDK's own
A2A mapper, SSE mapper and run reporter all do, which is how the compiler named
every site that had to change.
