### PR TITLE
fix(sdk): a progress tee cannot name a task that does not exist yet

### DIFF
--- a/.changeset/a-progress-tee-cannot-name-a-task-that-does-not-exist.md
+++ b/.changeset/a-progress-tee-cannot-name-a-task-that-does-not-exist.md
@@ -1,0 +1,31 @@
+---
+'@namzu/sdk': patch
+---
+
+A concurrent fan-out no longer kills most of its own launches.
+
+`LocalTaskGateway.createTask` passes a progress tee into `sendMessage`, and that
+callback read `task.taskId` — the `const` that the very same `await` assigns. So
+a child that emitted any run event before `sendMessage` resolved reached that
+line inside the temporal dead zone and threw `Cannot access 'task' before
+initialization`, taking the whole launch down with it.
+
+Two things kept it hidden. A single sequential launch usually resolves before
+the child says anything, so the ordering rarely bit. And the throw only happens
+when a progress listener is actually attached — with an empty subscriber set the
+loop body never runs and the dead zone is never entered, which is why no unit
+test caught it. `create_task` attaches one for its idle bound on every blocking
+launch, so production always had one.
+
+Under a concurrent fan-out both conditions hold. Observed on the published
+package: four `create_task` calls from one assistant turn — the shape that
+tool's own description tells the model to use — and three of the four died with
+`create_task failed: Cannot access 'task' before initialization`.
+
+The tee now reads an id filled in after the spawn resolves, and reports nothing
+before then. That window is not a loss: with no id the caller does not yet hold
+the handle, so no idle bound is running against the task and there is no
+progress to attribute to anyone.
+
+Introduced in #130 with the idle-bound work. Found by running a live concurrent
+fan-out against the published package rather than by any test.

--- a/packages/sdk/src/gateway/__tests__/a-progress-tee-cannot-name-a-task-that-does-not-exist.test.ts
+++ b/packages/sdk/src/gateway/__tests__/a-progress-tee-cannot-name-a-task-that-does-not-exist.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Agent } from '../../types/agent/core.js'
+import type { AgentManagerContract } from '../../types/agent/manager.js'
+import type {
+	AgentTask,
+	AgentTaskContext,
+	AgentTaskState,
+	SendMessageOptions,
+} from '../../types/agent/task.js'
+import type { AgentId, RunId, SessionId, TaskId, TenantId } from '../../types/ids/index.js'
+import type { RunEventListener } from '../../types/run/events.js'
+import type { ProjectId, ThreadId } from '../../types/session/ids.js'
+import { LocalTaskGateway } from '../local.js'
+
+/**
+ * A child that spoke before its own spawn resolved killed the launch.
+ *
+ * The progress tee handed to `sendMessage` read `task.taskId` — the `const`
+ * that the very same `await` assigns. So any run event emitted by the child
+ * before `sendMessage` returned reached that line inside the temporal dead
+ * zone and threw `Cannot access 'task' before initialization`, taking the whole
+ * `create_task` down with it.
+ *
+ * It survived review and a full unit suite because a single sequential launch
+ * usually resolves before the child says anything. A CONCURRENT fan-out does
+ * not — and that is the shape `create_task`'s own description tells the model
+ * to use. Observed live on the published package: four launches from one turn,
+ * three dead.
+ */
+
+const RUN = 'run_tee' as RunId
+
+/** Emits a run event DURING the spawn, before it resolves. */
+class TalksDuringSpawn implements AgentManagerContract {
+	/** Kept so a test can make the child speak AFTER the spawn resolved too. */
+	private lastListener?: RunEventListener
+
+	constructor(private readonly emitsBeforeResolve: number) {}
+
+	/** The child says something once the caller holds its handle. */
+	speakNow(): void {
+		this.lastListener?.({ type: 'iteration_started', runId: RUN, iteration: 99 } as never)
+	}
+
+	async sendMessage(
+		options: SendMessageOptions,
+		_context: AgentTaskContext,
+		listener?: RunEventListener,
+	): Promise<AgentTask> {
+		this.lastListener = listener
+		// The child is alive and streaming before the caller holds its handle.
+		for (let i = 0; i < this.emitsBeforeResolve; i += 1) {
+			listener?.({ type: 'iteration_started', runId: RUN, iteration: i } as never)
+		}
+		await Promise.resolve()
+		return {
+			taskId: 'task_spoke_early' as TaskId,
+			agentId: options.agentId,
+			agent: {} as Agent<never, never>,
+			childAbortController: new AbortController(),
+			context: {} as AgentTaskContext,
+			state: 'completed' as AgentTaskState,
+			pendingMessages: [],
+			createdAt: 1,
+		} as AgentTask
+	}
+
+	cancel(): void {}
+	cancelAll(): void {}
+	async continueTask(): Promise<void> {}
+	queueMessage(): void {}
+	drainMessages() {
+		return []
+	}
+	async waitForCompletion(): Promise<void> {}
+	getInstance(): AgentTask | undefined {
+		return undefined
+	}
+	listByParent(): AgentTask[] {
+		return []
+	}
+	listActive(): AgentTask[] {
+		return []
+	}
+	getState(): AgentTaskState | undefined {
+		return undefined
+	}
+	on(): void {}
+	off(): void {}
+	cleanup(): void {}
+	dispose(): void {}
+}
+
+function context(): AgentTaskContext {
+	return {
+		parentRunId: RUN,
+		parentAgentId: 'supervisor',
+		parentAbortController: new AbortController(),
+		depth: 0,
+		budgetTracker: { total: 100_000, remaining: 100_000 },
+		tenantId: 'tnt_t' as TenantId,
+		threadId: 'thd_t' as ThreadId,
+		sessionId: 'ses_t' as SessionId,
+		projectId: 'prj_t' as ProjectId,
+		parentActor: { kind: 'agent', agentId: 'supervisor' as AgentId, tenantId: 'tnt_t' as TenantId },
+	} as AgentTaskContext
+}
+
+describe('a launch survives a child that speaks before the spawn resolves', () => {
+	it('does not throw when an event arrives mid-spawn', async () => {
+		const gateway = new LocalTaskGateway(new TalksDuringSpawn(3), context())
+		// The listener is what makes this reproduce, and its absence is what
+		// made the bug invisible for so long: with no progress subscriber the
+		// loop body never runs, so `task.taskId` is never evaluated and the
+		// dead zone is never entered. `create_task` attaches one for the idle
+		// bound on every blocking launch, which is why it bit in production and
+		// not in any test.
+		gateway.onTaskProgress?.(() => {})
+
+		await expect(
+			gateway.createTask({ agentId: 'worker', prompt: 'go', workingDirectory: '/tmp' }),
+		).resolves.toMatchObject({ taskId: 'task_spoke_early' })
+	})
+
+	it('still forwards those events to the host listener', async () => {
+		// The tee is what broke, not the forwarding. A host watching the child
+		// must not lose its early events to this fix.
+		const seen: string[] = []
+		const gateway = new LocalTaskGateway(new TalksDuringSpawn(3), context(), (e) => {
+			seen.push(e.type)
+		})
+
+		await gateway.createTask({ agentId: 'worker', prompt: 'go', workingDirectory: '/tmp' })
+
+		expect(seen).toEqual(['iteration_started', 'iteration_started', 'iteration_started'])
+	})
+
+	it('reports progress once the task has an id to report it against', async () => {
+		// Before the id exists nothing is waiting on the task — the caller does
+		// not hold the handle yet — so silence there is correct. What must work
+		// is everything after.
+		const manager = new TalksDuringSpawn(1)
+		const gateway = new LocalTaskGateway(manager, context())
+		const progressed: TaskId[] = []
+		gateway.onTaskProgress?.((id) => progressed.push(id))
+
+		await gateway.createTask({ agentId: 'worker', prompt: 'go', workingDirectory: '/tmp' })
+		// The one emitted mid-spawn is not attributed — there was no id yet.
+		expect(progressed).toEqual([])
+
+		// Now the child speaks with the handle already in the caller's hands,
+		// which is the case an idle bound is actually measuring.
+		manager.speakNow()
+
+		expect(progressed).toEqual(['task_spoke_early' as TaskId])
+	})
+
+	it('survives a concurrent fan-out, which is how this was found', async () => {
+		const gateway = new LocalTaskGateway(new TalksDuringSpawn(2), context())
+		// Same reason as above: the live failure came through the idle bound's
+		// subscriber, so a fan-out test without one would not reproduce the
+		// thing it is named after.
+		gateway.onTaskProgress?.(() => {})
+
+		const launched = await Promise.all(
+			[1, 2, 3, 4].map(() =>
+				gateway.createTask({ agentId: 'worker', prompt: 'go', workingDirectory: '/tmp' }),
+			),
+		)
+
+		expect(launched).toHaveLength(4)
+		expect(launched.every((h) => h.taskId === 'task_spoke_early')).toBe(true)
+	})
+})

--- a/packages/sdk/src/gateway/local.ts
+++ b/packages/sdk/src/gateway/local.ts
@@ -60,6 +60,12 @@ export class LocalTaskGateway implements TaskGateway {
 	}
 
 	async createTask(options: CreateTaskOptions): Promise<TaskHandle> {
+		// Filled once the spawn resolves. A box rather than a bare binding
+		// because the assignment happens AFTER the `await` that the reader is
+		// passed into — see the progress tee below for why it cannot simply
+		// read the `task` const it is declared beside.
+		const launched: { id?: TaskId } = {}
+
 		const task = await this.agentManager.sendMessage(
 			{
 				agentId: options.agentId,
@@ -109,12 +115,30 @@ export class LocalTaskGateway implements TaskGateway {
 			// idle bound measures. The event itself is not forwarded — a
 			// progress signal that carried the child's output would be a
 			// second, undocumented way to read a worker's work.
+			//
+			// The id comes from `launched.id`, NOT from the `task` const
+			// below. This callback is handed to the very `await` that assigns
+			// `task`, so a child that emits anything before `sendMessage`
+			// resolves reached it inside the temporal dead zone and threw
+			// `Cannot access 'task' before initialization` — killing the launch
+			// outright.
+			//
+			// It survived because a single sequential launch usually resolves
+			// before the child says anything. A concurrent fan-out does not:
+			// with four `create_task` calls from one turn — the shape this
+			// tool's own description tells the model to use — the event loop
+			// interleaves and three of the four died. Found by running one.
 			(event) => {
 				this.listener?.(event)
-				for (const notify of this.progressListeners) notify(task.taskId)
+				// No id yet means nothing is waiting on this task: the caller
+				// does not hold the handle, so an idle bound cannot be running
+				// against it. There is no progress to report to anyone.
+				if (launched.id === undefined) return
+				for (const notify of this.progressListeners) notify(launched.id)
 			},
 		)
 
+		launched.id = task.taskId
 		this.trackedTaskIds.add(task.taskId)
 
 		this.agentManager


### PR DESCRIPTION
`LocalTaskGateway.createTask` passes a progress tee into `sendMessage`, and that
callback read `task.taskId` — the const that the very same `await` assigns. A
child that emitted any run event before the spawn resolved reached that line
inside the temporal dead zone and threw `Cannot access 'task' before
initialization`, taking the whole launch down with it.

Two things kept it hidden. A single sequential launch usually resolves before
the child says anything. And the throw only happens when a progress listener is
attached — with an empty subscriber set the loop body never runs, which is why
no unit test caught it while production, where `create_task` attaches one for
its idle bound, always had one.

Under a concurrent fan-out both conditions hold. Observed on the published
package: four `create_task` calls from one assistant turn, three dead.

The tee now reads an id filled in after the spawn resolves and reports nothing
before then. That window is not a loss — with no id the caller does not hold the
handle, so no idle bound is running against the task and there is no progress to
attribute to anyone.

Introduced in #130 with the idle-bound work. Found by running a live concurrent
fan-out, not by a test.