### PR TITLE
fix(sdk): a fan-out to one agent id is not a fan-out to one agent

### DIFF
--- a/.changeset/a-fan-out-to-one-agent-id-is-not-one-agent.md
+++ b/.changeset/a-fan-out-to-one-agent-id-is-not-one-agent.md
@@ -1,0 +1,41 @@
+---
+'@namzu/sdk': minor
+---
+
+A fan-out naming the same agent runs every child instead of one.
+
+`AgentRegistry` hands out ONE `typedAgent` per registered id, and an agent
+instance refuses a second concurrent `run` — correctly, because its abort
+controller and run id are instance state and two overlapping runs would cancel
+each other. So four `create_task` calls naming the same `agent_id` drove four
+runs at one shell: one produced a result and three died with
+`ConcurrentInvocationError`, while `create_task`'s own description tells a model
+that exactly this fan-out is the thing to do.
+
+The remedy was already written down — "a host that wants parallelism constructs
+a second instance" — and was unreachable from delegation, where the definition
+owns the instance and the caller has only an id.
+
+`Agent` gains an optional `forRun()`, implemented by `AbstractAgent`, returning
+a fresh shell of the same class built from the same metadata. `AgentManager`
+takes one per spawn. Nothing else about a child was ever shared: its abort
+signal is the task's own, its config is rebuilt per spawn by `configBuilder`,
+and the manager cancels through the task rather than the agent. The shell was
+the last shared thing.
+
+`AgentDefinition` also gains `createAgent?`, which wins over `forRun` — for an
+agent that needs real construction arguments, which a metadata-only rebuild
+cannot supply. Most hosts need nothing: agents built on `AbstractAgent` already
+work.
+
+The lock is unchanged and still refuses. That refusal is right for a host
+calling `run` twice on one instance on purpose; what changed is that delegation
+no longer does so by accident. Loosening the lock instead would have been the
+smaller diff and the wrong one — the state it guards is genuinely instance
+state, and serialising same-agent spawns behind it would deadlock a child that
+spawns a grandchild of its own id.
+
+Its message now names the remedy rather than only the refusal.
+
+Found by running a four-way fan-out against the published package, not by a
+test.

--- a/packages/sdk/src/agents/AbstractAgent.ts
+++ b/packages/sdk/src/agents/AbstractAgent.ts
@@ -56,6 +56,41 @@ export abstract class AbstractAgent<
 	abstract run(input: AgentInput, config: TConfig, listener?: RunEventListener): Promise<TResult>
 
 	/**
+	 * A fresh shell of this agent, for a run that must not share one.
+	 *
+	 * See {@link Agent.forRun}. An agent is a shell around metadata — every
+	 * per-run decision arrives in `config` and `input` — so a second instance
+	 * costs one object and gives the run its own abort controller and run id,
+	 * which is precisely what the invocation lock is protecting.
+	 *
+	 * Rebuilt from `this.constructor` and `this.metadata`, which covers every
+	 * agent in this package: they all take metadata and nothing else. A
+	 * subclass with a different constructor signature will throw here, and the
+	 * answer to that is `this` — the caller then shares the shell and gets the
+	 * existing refusal on a concurrent run, which is the behaviour before this
+	 * existed. Losing parallelism is a worse outcome than not having it; losing
+	 * the run is not on the table.
+	 *
+	 * A host whose agent needs real construction arguments supplies
+	 * `AgentDefinition.createAgent` instead, which wins over this.
+	 */
+	forRun(): this {
+		try {
+			const Ctor = this.constructor as unknown as new (metadata: AgentMetadata) => this
+			return new Ctor(this.metadata)
+		} catch (err) {
+			this.log.warn(
+				'Could not build a per-run shell; concurrent runs of this agent will still be refused',
+				{
+					agentId: this.metadata.id,
+					error: err instanceof Error ? err.message : String(err),
+				},
+			)
+			return this
+		}
+	}
+
+	/**
 	 * Acquire the invocation lock to prevent concurrent execution.
 	 * Returns a Disposable that must be disposed to release the lock.
 	 *

--- a/packages/sdk/src/agents/lock.ts
+++ b/packages/sdk/src/agents/lock.ts
@@ -11,7 +11,16 @@ export class ConcurrentInvocationError extends Error {
 	readonly agentId: string
 
 	constructor(agentId: string) {
-		super(`Agent ${agentId} is already processing. Concurrent invocations are not allowed.`)
+		// Names the remedy, because the refusal alone sent readers looking for a
+		// concurrency bug in their own code. An agent instance holds per-run
+		// state — an abort controller and the run id — so two overlapping runs
+		// on one shell would cancel each other; the answer is a second shell,
+		// not a second attempt. Delegated spawns get one automatically via
+		// `Agent.forRun`, so reaching this from a fan-out means the agent
+		// could not be rebuilt and wants `AgentDefinition.createAgent`.
+		super(
+			`Agent ${agentId} is already processing. Concurrent invocations of one instance are not allowed, because its abort controller and run id are instance state and two runs would cancel each other. Run a second instance instead — or, for a delegated spawn, give its AgentDefinition a \`createAgent\` factory so each child gets its own.`,
+		)
 		this.name = 'ConcurrentInvocationError'
 		this.agentId = agentId
 	}

--- a/packages/sdk/src/manager/agent/__tests__/a-fan-out-to-one-agent-id.test.ts
+++ b/packages/sdk/src/manager/agent/__tests__/a-fan-out-to-one-agent-id.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+
+import { ReactiveAgent } from '../../../agents/ReactiveAgent.js'
+import { ToolRegistry } from '../../../registry/index.js'
+import type { AgentDefinition } from '../../../types/agent/factory.js'
+
+/**
+ * A fan-out naming the same agent four times ran one child and lost three.
+ *
+ * `AgentRegistry` hands out ONE `typedAgent` per registered id, and an instance
+ * refuses a second concurrent `run` — correctly, because its abort controller
+ * and run id are instance state and two overlapping runs would cancel each
+ * other. So four `create_task` calls at one specialist produced one result and
+ * three `ConcurrentInvocationError`s.
+ *
+ * The prescribed remedy already existed in the docs — "a host that wants
+ * parallelism constructs a second instance" — and was unreachable from
+ * delegation, where the definition owns the instance and the caller has only an
+ * id. Observed live on published 12.0.1: four launches, three lost.
+ *
+ * These cover the shell itself. That the manager USES it per spawn is covered
+ * where the manager is driven; what has to hold here is that asking for a
+ * per-run shell gives you a genuinely separate one.
+ */
+
+const metadata = {
+	id: 'worker',
+	name: 'worker',
+	version: '1.0.0',
+	category: 'general',
+	description: 'a worker',
+}
+
+describe('an agent can hand out a shell a single run has to itself', () => {
+	it('returns a different instance', () => {
+		const agent = new ReactiveAgent(metadata)
+
+		expect(agent.forRun()).not.toBe(agent)
+	})
+
+	it('keeps the identity, because it is the same agent', () => {
+		const agent = new ReactiveAgent(metadata)
+		const shell = agent.forRun()
+
+		expect(shell.metadata.id).toBe('worker')
+		expect(shell.type).toBe(agent.type)
+		expect(shell.getCapabilities()).toEqual(agent.getCapabilities())
+	})
+
+	it('gives each shell its own invocation lock, which is the whole point', async () => {
+		// Locking one must not lock the other. Asserted through the public
+		// surface: a run that never settles holds the lock, and a second run on
+		// a SEPARATE shell must still be admitted.
+		// ONE registered agent, two shells — the registry's shape, and the
+		// shape the fan-out actually hits.
+		const registered = new ReactiveAgent(metadata)
+		const first = registered.forRun()
+		const second = registered.forRun()
+
+		// A provider that starts and never finishes, so each run holds its
+		// shell's lock for the duration of the assertion.
+		const provider = {
+			// biome-ignore lint/correctness/useYield: it never produces anything, on purpose
+			async *chatStream() {
+				await new Promise<never>(() => {})
+			},
+		}
+		const config = {
+			model: 'mock',
+			tokenBudget: 10_000,
+			timeoutMs: 10_000,
+			maxIterations: 2,
+			provider,
+			tools: new ToolRegistry(),
+			systemPrompt: 'hold',
+			sessionId: 'ses_fan' as never,
+			threadId: 'thd_fan' as never,
+			projectId: 'prj_fan' as never,
+			tenantId: 'tnt_fan' as never,
+		}
+
+		// Start one run on each shell; neither resolves, and neither should
+		// refuse. A shared shell would reject the second synchronously.
+		const a = first.run({ messages: [], workingDirectory: '/tmp' } as never, config as never)
+		const b = second.run({ messages: [], workingDirectory: '/tmp' } as never, config as never)
+
+		await expect(
+			Promise.race([
+				Promise.all([a, b]).then(() => 'settled'),
+				new Promise((r) => setTimeout(() => r('still running'), 50)),
+			]),
+		).resolves.toBe('still running')
+
+		void a.catch(() => {})
+		void b.catch(() => {})
+	})
+
+	it('a definition may override the shell with its own factory', () => {
+		// The escape hatch for an agent that needs real construction
+		// arguments, which `forRun`'s metadata-only rebuild cannot supply.
+		let built = 0
+		const definition: AgentDefinition = {
+			info: { ...metadata, tools: [], defaults: {} } as never,
+			typedAgent: new ReactiveAgent(metadata) as never,
+			createAgent: () => {
+				built += 1
+				return new ReactiveAgent(metadata) as never
+			},
+		}
+
+		const one = definition.createAgent?.()
+		const two = definition.createAgent?.()
+
+		expect(built).toBe(2)
+		expect(one).not.toBe(two)
+		expect(one).not.toBe(definition.typedAgent)
+	})
+})

--- a/packages/sdk/src/manager/agent/lifecycle.ts
+++ b/packages/sdk/src/manager/agent/lifecycle.ts
@@ -123,7 +123,27 @@ export class AgentManager {
 			)
 		}
 
-		const agent = this.registry.resolve(options.agentId)
+		// A shell this task has to itself, not the registry's shared instance.
+		//
+		// `resolve` returns one `typedAgent` per registered id, and an instance
+		// refuses a second concurrent `run` because it holds per-run state. So
+		// a fan-out naming the same `agent_id` four times drove four runs at one
+		// shell: one worked and three died with `ConcurrentInvocationError` —
+		// while `create_task`'s own description tells the model that this
+		// fan-out is the thing to do. Observed live on 12.0.1, four launches,
+		// three lost.
+		//
+		// The remedy was already written down — "a host that wants parallelism
+		// constructs a second instance" — and was unreachable here, because the
+		// definition owns the instance and this path only has an id.
+		//
+		// Nothing else about the child is shared: its abort signal is the task's
+		// own (`input.signal` below), its config is rebuilt per spawn by
+		// `configBuilder`, and the manager cancels through the task rather than
+		// the agent. The shell was the only shared thing left.
+		const definitionForSpawn = this.registry.getOrThrow(options.agentId)
+		const sharedAgent = definitionForSpawn.typedAgent
+		const agent = definitionForSpawn.createAgent?.() ?? sharedAgent.forRun?.() ?? sharedAgent
 
 		const childAbortController = createChildAbortController(context.parentAbortController)
 

--- a/packages/sdk/src/types/agent/core.ts
+++ b/packages/sdk/src/types/agent/core.ts
@@ -17,6 +17,28 @@ export interface Agent<
 
 	run(input: AgentInput, config: TConfig, listener?: RunEventListener): Promise<TResult>
 
+	/**
+	 * A shell of this agent that one run may have to itself.
+	 *
+	 * An agent instance holds per-run state — an abort controller, the id of
+	 * the run in flight — and refuses a second concurrent `run` because of it.
+	 * That refusal is correct for a host calling `run` twice on purpose: two
+	 * overlapping runs would share one abort controller, so cancelling either
+	 * kills both.
+	 *
+	 * It is wrong for delegation, which is why this exists. `AgentRegistry`
+	 * hands out ONE instance per registered id, so a fan-out naming the same
+	 * `agent_id` four times drove four runs at one shell: one worked and three
+	 * died with `ConcurrentInvocationError`. The prescribed remedy — "construct
+	 * a second instance" — was unreachable from there, because the definition
+	 * owns the instance and the caller only has an id.
+	 *
+	 * OPTIONAL, and absence is safe: a manager that cannot get a fresh shell
+	 * falls back to the shared one and the refusal stands, which is loud rather
+	 * than wrong. `AbstractAgent` implements it for every agent built on it.
+	 */
+	forRun?(): Agent<TConfig, TResult>
+
 	cancel(): Promise<void>
 	getCapabilities(): AgentCapabilities
 }

--- a/packages/sdk/src/types/agent/factory.ts
+++ b/packages/sdk/src/types/agent/factory.ts
@@ -8,6 +8,26 @@ export type { AgentContextLevel } from './base.js'
 export interface AgentDefinition {
 	info: AgentInfo
 	typedAgent: Agent<BaseAgentConfig, BaseAgentResult>
+
+	/**
+	 * Build a fresh agent for a single spawn.
+	 *
+	 * `typedAgent` is ONE instance, and an instance refuses a second
+	 * concurrent run because it holds per-run state. So a delegation fan-out
+	 * naming the same `agent_id` four times ran one child and lost three to
+	 * `ConcurrentInvocationError` — while `create_task`'s own description tells
+	 * a model that exactly this fan-out is the thing to do.
+	 *
+	 * The manager prefers this over `typedAgent` for every spawn. Supply it
+	 * when your agent needs real construction arguments; agents built on
+	 * `AbstractAgent` already get a working default from `Agent.forRun`, so
+	 * most hosts need nothing here.
+	 *
+	 * `configBuilder` is not a substitute: it produces a fresh CONFIG per
+	 * spawn, and the config was never the part being shared.
+	 */
+	createAgent?: () => Agent<BaseAgentConfig, BaseAgentResult>
+
 	configBuilder?: (options: AgentFactoryOptions) => BaseAgentConfig | Promise<BaseAgentConfig>
 
 	contextLevel?: AgentContextLevel


### PR DESCRIPTION
fix(sdk): a fan-out to one agent id is not a fan-out to one agent

`AgentRegistry` hands out ONE `typedAgent` per registered id, and an agent
instance refuses a second concurrent `run` — correctly, because its abort
controller and run id are instance state and two overlapping runs would cancel
each other. So four `create_task` calls naming the same `agent_id` drove four
runs at one shell: one produced a result and three died with
`ConcurrentInvocationError`, while `create_task`'s own description tells a model
that exactly this fan-out is the thing to do.

The remedy was already written down — "a host that wants parallelism constructs
a second instance" — and was unreachable from delegation, where the definition
owns the instance and the caller has only an id.

`Agent` gains an optional `forRun()`, implemented by `AbstractAgent`, returning
a fresh shell of the same class built from the same metadata; `AgentManager`
takes one per spawn. Nothing else about a child was ever shared: its abort
signal is the task's own (`input.signal`), its config is rebuilt per spawn by
`configBuilder`, and the manager cancels through the task rather than the agent.
The shell was the last shared thing.

`AgentDefinition.createAgent` wins over it, for an agent that needs real
construction arguments a metadata-only rebuild cannot supply. A subclass whose
constructor takes something else falls back to the shared shell and the existing
refusal, which is loud rather than wrong.

The lock is unchanged and still refuses. That refusal is right for a host
calling `run` twice on one instance on purpose; what changed is that delegation
no longer does so by accident. Loosening the lock would have been the smaller
diff and the wrong one — the state it guards is genuinely instance state, and
serialising same-agent spawns behind it would deadlock a child that spawns a
grandchild of its own id. Its message now names the remedy rather than only the
refusal.

Found by running a four-way fan-out against the published package, not by a test.
