### PR TITLE
fix(sdk): an approver sees which agent, on both surfaces

### DIFF
--- a/.changeset/an-approver-sees-which-agent.md
+++ b/.changeset/an-approver-sees-which-agent.md
@@ -1,0 +1,38 @@
+---
+'@namzu/sdk': minor
+---
+
+An approver sees which agent, on both approval surfaces, and is never shown a step that cannot run.
+
+**There are two approval surfaces, and the previous release fixed one of them.**
+`PlanStep.agentId` was added so an approver could see WHICH agent a step goes to
+rather than only THAT it delegates. It reached `PlanApprovalRequest` — the shape
+a host sees when it installs its own handler on `PlanManager` — and stopped
+there. `PlanApprovalData`, which is what every `resumeHandler` host receives,
+declares its own step shape, and both mappers that build it copy field by field.
+So the busier surface kept showing `toolName: 'create_task'` and nothing else:
+exactly the behaviour that change set out to end.
+
+`PlanApprovalData.steps[]` now carries `agentId`, populated in both mappers.
+
+**A plan may no longer name an agent the run cannot launch.** `create_task`
+constrains `agent_id` with a closed enum while `approve_plan` typed the same
+field as a bare string, so a model could propose — and, now that the name is
+visible, a human could approve — "delegate to X" for an X that `create_task`
+rejects at schema-parse time. `approve_plan` now refuses such a plan.
+
+The check is in `execute`, not in the schema, and both halves of that are
+deliberate:
+
+- **Not the schema.** `approve_plan` is mounted even with an empty roster,
+  because planning with no delegates and a human channel is a supported
+  configuration, and `z.enum([])` renders as `{"not":{}}` — the shape
+  `delegateSchema` already refuses, because a strict tool-schema validator
+  rejects the whole request over it rather than the one tool. `create_task`
+  escapes that by being withheld entirely; this tool cannot be.
+- **In `execute`, before `startGenerating`.** So the refusal leaves no
+  half-built plan behind, and the human is never shown the bad step at all. The
+  message names the roster, so the model corrects itself in one turn.
+
+Enforcing in `execute` as well as the schema is the precedent the canonical
+`Agent` tool set for complete mediation.

--- a/packages/sdk/src/runtime/query/__tests__/the-other-approval-surface-names-the-agent.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/the-other-approval-surface-names-the-agent.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+
+import type { PlanManager } from '../../../manager/plan/lifecycle.js'
+import { MockLLMProvider, registerMock } from '../../../provider/index.js'
+import { ToolRegistry } from '../../../registry/index.js'
+import type { HITLResumeDecision, PlanApprovalData } from '../../../types/hitl/index.js'
+import {
+	generateProjectId,
+	generateSessionId,
+	generateTenantId,
+	generateThreadId,
+} from '../../../utils/id.js'
+import { drainQuery } from '../index.js'
+
+/**
+ * There are TWO approval surfaces, and the fix landed on one of them.
+ *
+ * `PlanStep.agentId` was added so an approver could see WHICH agent a step goes
+ * to rather than only THAT it delegates. It reached `PlanApprovalRequest` — the
+ * shape a host sees when it installs its own handler on `PlanManager` — and the
+ * test written at the time asserted on exactly that, by constructing a
+ * `PlanManager` directly.
+ *
+ * It did not reach `PlanApprovalData`, which is what every `resumeHandler` host
+ * receives, because that type declared its own step shape and both mappers copy
+ * field by field. So the busier surface kept showing `toolName: 'create_task'`
+ * and nothing else — the precise behaviour the change was supposed to end.
+ *
+ * A live run did not catch it either: the run observes `plan_ready`, which
+ * carries whole `PlanStep`s and therefore always had `agentId`. Watching the
+ * event stream confirmed the field existed somewhere, which is not the same
+ * question as whether the approver gets it.
+ */
+
+registerMock()
+
+async function agentIdSeenByResumeHandler(): Promise<PlanApprovalData['steps']> {
+	let seen: PlanApprovalData['steps'] | undefined
+
+	await drainQuery({
+		provider: new MockLLMProvider({ responses: [{ content: 'done' }] } as never),
+		tools: new ToolRegistry(),
+		agentId: 'a',
+		agentName: 'A',
+		messages: [{ role: 'user', content: 'go' }],
+		workingDirectory: process.cwd(),
+		runConfig: { model: 'mock', tokenBudget: 100_000, timeoutMs: 30_000, maxIterations: 4 },
+		projectId: generateProjectId(),
+		sessionId: generateSessionId(),
+		threadId: generateThreadId(),
+		tenantId: generateTenantId(),
+		// The ordinary host path: a resumeHandler, not a hand-installed
+		// PlanManager handler.
+		resumeHandler: async (request: { type: string; plan?: PlanApprovalData }) => {
+			if (request.type === 'plan_approval' && request.plan) seen = request.plan.steps
+			return { action: 'approve_plan' } as HITLResumeDecision
+		},
+		onContextCreated: ({ planManager }: { planManager: PlanManager }) => {
+			planManager.startGenerating('the work')
+			planManager.addStep({
+				id: 'step_1',
+				description: 'delegated work',
+				agentId: 'shell-runner',
+				toolName: 'create_task',
+				dependsOn: [],
+				order: 1,
+			})
+			planManager.addStep({ id: 'step_2', description: 'my own work', dependsOn: [], order: 2 })
+			planManager.markReady()
+			void planManager.requestApproval()
+		},
+	} as never)
+
+	if (!seen) throw new Error('the resume handler never received a plan approval')
+	return seen
+}
+
+describe('the resumeHandler approval surface names the agent too', () => {
+	it('carries agentId through to the host', async () => {
+		const steps = await agentIdSeenByResumeHandler()
+
+		expect(steps.map((s) => s.agentId)).toEqual(['shell-runner', undefined])
+	})
+
+	it('still distinguishes the two steps by more than toolName', async () => {
+		// The defect in the shape that matters: without agentId both delegated
+		// steps reach the approver identical, and an orchestrator-owned step is
+		// told apart only by an absent toolName.
+		const steps = await agentIdSeenByResumeHandler()
+		const delegated = steps.find((s) => s.id === 'step_1')
+
+		expect(delegated?.toolName).toBe('create_task')
+		expect(delegated?.agentId).toBe('shell-runner')
+	})
+})

--- a/packages/sdk/src/runtime/query/index.ts
+++ b/packages/sdk/src/runtime/query/index.ts
@@ -527,6 +527,7 @@ export async function* query(params: QueryParams): AsyncGenerator<RunEvent, Run>
 					id: s.id,
 					description: s.description,
 					toolName: s.toolName,
+					agentId: s.agentId,
 					dependsOn: s.dependsOn,
 					order: s.order ?? i + 1,
 				})),

--- a/packages/sdk/src/runtime/query/iteration/phases/plan.ts
+++ b/packages/sdk/src/runtime/query/iteration/phases/plan.ts
@@ -29,6 +29,7 @@ export async function* runPlanGate(ctx: IterationContext): AsyncGenerator<RunEve
 				id: s.id,
 				description: s.description,
 				toolName: s.toolName,
+				agentId: s.agentId,
 				dependsOn: s.dependsOn,
 				order: s.order,
 			})),

--- a/packages/sdk/src/tools/coordinator/__tests__/an-approver-is-never-shown-an-impossible-step.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/an-approver-is-never-shown-an-impossible-step.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest'
+
+import { PlanManager } from '../../../manager/plan/lifecycle.js'
+import type { TaskGateway } from '../../../types/agent/gateway.js'
+import type { RunId } from '../../../types/ids/index.js'
+import type { PlanApprovalRequest } from '../../../types/plan/index.js'
+import type { ToolContext } from '../../../types/tool/index.js'
+import { buildCoordinatorTools } from '../index.js'
+
+/**
+ * A plan could name an agent the launch would then refuse.
+ *
+ * `create_task` constrains `agent_id` with a closed enum; `approve_plan` typed
+ * the same field as a bare string. So a model could propose, and a human could
+ * approve, "delegate to X" for an X that `create_task` rejects at schema-parse
+ * time — the run then burns a turn on a step a human had already blessed.
+ *
+ * The check lives in `execute`, not in the schema, and that is deliberate.
+ * `approve_plan` is mounted even with an EMPTY roster, because planning with no
+ * delegates and a human channel is a supported configuration — and `z.enum([])`
+ * renders as `{"not":{}}`, the shape `delegateSchema` already refuses because a
+ * strict tool-schema validator rejects the whole request over it rather than
+ * the one tool. `create_task` escapes that by being withheld entirely; this
+ * tool cannot be. Enforcing in `execute` as well is the precedent the canonical
+ * `Agent` tool set for complete mediation.
+ *
+ * It runs BEFORE `startGenerating`, so the refusal costs no half-built plan and
+ * the human is never shown the bad step at all.
+ */
+
+const RUN = 'run_roster' as RunId
+
+function unusedGateway(): TaskGateway {
+	return {
+		async createTask() {
+			throw new Error('this test never launches')
+		},
+		async waitForTask() {
+			throw new Error('this test never waits')
+		},
+		async continueTask() {},
+		cancelTask() {},
+		getTask() {
+			return undefined
+		},
+		listTasks() {
+			return []
+		},
+		onTaskCompleted() {
+			return () => {}
+		},
+	}
+}
+
+function ctx(): ToolContext {
+	return {
+		runId: RUN,
+		workingDirectory: '/tmp/test',
+		abortSignal: new AbortController().signal,
+		env: {},
+		log: () => {},
+	}
+}
+
+/** Run `approve_plan`, reporting both its result and what the approver saw. */
+async function approve(
+	roster: string[],
+	steps: Array<{ description: string; agent_id?: string }>,
+): Promise<{ result: Awaited<ReturnType<ReturnType<typeof build>>>; seen?: PlanApprovalRequest }> {
+	let seen: PlanApprovalRequest | undefined
+	const pm = new PlanManager(RUN, async (request) => {
+		seen = request
+		return { approved: true }
+	})
+	const run = build(roster, pm)
+	const result = await run(steps)
+	return { result, ...(seen ? { seen } : {}) }
+}
+
+function build(roster: string[], pm: PlanManager) {
+	const tools = buildCoordinatorTools({
+		gateway: unusedGateway(),
+		workingDirectory: '/tmp/test',
+		allowedAgentIds: roster,
+		getPlanManager: () => pm,
+	})
+	const approvePlan = tools.find((t) => t.name === 'approve_plan')
+	if (!approvePlan) throw new Error('approve_plan missing from coordinator builder')
+	return (steps: Array<{ description: string; agent_id?: string }>) =>
+		approvePlan.execute({ title: 'do it', summary: 'a plan', steps }, ctx())
+}
+
+describe('a plan may only name an agent the run can actually launch', () => {
+	it('refuses a step naming an agent outside the roster', async () => {
+		const { result } = await approve(
+			['researcher', 'writer'],
+			[{ description: 'audit the deps', agent_id: 'security-auditor' }],
+		)
+
+		expect(result.success).toBe(false)
+		expect(result.error).toContain('security-auditor')
+	})
+
+	it('names the roster, so the model can correct itself in one turn', async () => {
+		const { result } = await approve(
+			['researcher', 'writer'],
+			[{ description: 'audit', agent_id: 'nobody' }],
+		)
+
+		expect(result.error).toContain('researcher')
+		expect(result.error).toContain('writer')
+	})
+
+	it('never shows the approver the step it refused', async () => {
+		// The whole point of checking before `startGenerating`: a human must
+		// not be asked to approve work that cannot run.
+		const { seen } = await approve(
+			['researcher'],
+			[{ description: 'audit', agent_id: 'security-auditor' }],
+		)
+
+		expect(seen).toBeUndefined()
+	})
+
+	it('leaves no half-built plan behind', async () => {
+		const pm = new PlanManager(RUN, async () => ({ approved: true }))
+		const run = build(['researcher'], pm)
+
+		await run([{ description: 'audit', agent_id: 'ghost' }])
+
+		expect(pm.active).toBeNull()
+	})
+
+	it('says something different when the run has no delegates at all', async () => {
+		// `approve_plan` is mounted on an empty roster on purpose — planning
+		// without delegation is supported — so the message has to explain that
+		// rather than list an empty set.
+		const { result } = await approve([], [{ description: 'audit', agent_id: 'anyone' }])
+
+		expect(result.success).toBe(false)
+		expect(result.error).toContain('no delegates')
+	})
+
+	it('still admits a plan that delegates only within the roster', async () => {
+		const { result, seen } = await approve(
+			['researcher', 'writer'],
+			[{ description: 'gather', agent_id: 'researcher' }, { description: 'summarize' }],
+		)
+
+		expect(result.success).toBe(true)
+		expect(seen?.steps.map((s) => s.agentId)).toEqual(['researcher', undefined])
+	})
+})

--- a/packages/sdk/src/tools/coordinator/index.ts
+++ b/packages/sdk/src/tools/coordinator/index.ts
@@ -1015,6 +1015,46 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 					return { success: false, output: '', error: dependencies.error }
 				}
 
+				// The roster, checked here rather than in the schema, and BEFORE
+				// the plan is built — so a human is never shown a step naming an
+				// agent that cannot run it.
+				//
+				// `create_task` constrains the same field with a closed enum, so
+				// a plan could name an agent the launch would then refuse. The
+				// mismatch used to be invisible because the name was dropped on
+				// the way to the approver; now that a step carries it, an
+				// approver could read "delegate to X" for an X that does not
+				// exist.
+				//
+				// NOT closed in the schema, deliberately. `approve_plan` is
+				// mounted even with an empty roster — planning with no delegates
+				// and a human channel is a supported configuration — and
+				// `z.enum([])` renders as `{"not":{}}`, the shape `delegateSchema`
+				// already refuses because a strict tool-schema validator rejects
+				// the whole request over it rather than the one tool.
+				// `create_task` escapes that by being withheld entirely; this
+				// tool cannot be.
+				//
+				// Enforcing in `execute` as well as the schema is the precedent
+				// the canonical `Agent` tool set for complete mediation.
+				const unknownAgents = [
+					...new Set(
+						steps
+							.map((s) => s.agent_id)
+							.filter((id): id is string => Boolean(id) && !agentIds.includes(id as string)),
+					),
+				]
+				if (unknownAgents.length > 0) {
+					return {
+						success: false,
+						output: '',
+						error:
+							agentIds.length === 0
+								? `This plan delegates to ${unknownAgents.join(', ')}, but this run has no delegates. Plan the work as your own steps and omit agent_id.`
+								: `No such agent: ${unknownAgents.join(', ')}. Delegate only to ${agentIds.join(', ')}, or omit agent_id for a step you carry out yourself.`,
+					}
+				}
+
 				pm.startGenerating(title)
 				for (let i = 0; i < steps.length; i++) {
 					const step = steps[i]

--- a/packages/sdk/src/types/hitl/index.ts
+++ b/packages/sdk/src/types/hitl/index.ts
@@ -109,6 +109,24 @@ export interface PlanApprovalData {
 		id: string
 		description: string
 		toolName?: string
+
+		/**
+		 * Which agent the step is to be delegated to, when it is delegated.
+		 *
+		 * `PlanStep` gained this so an approver could see WHICH agent a step
+		 * goes to rather than only THAT it delegates — approving "delegate
+		 * this" is not approving "delegate this to the agent with shell
+		 * access". It reached `PlanApprovalRequest`, which is the shape a host
+		 * sees when it installs its own handler on `PlanManager`.
+		 *
+		 * It did not reach here, and this is the ordinary path: every host
+		 * using `resumeHandler` is served by this type, and both mappers that
+		 * build it copy field by field. So the fix landed on one of the two
+		 * approval surfaces and the busier one kept showing
+		 * `toolName: 'create_task'` and nothing else.
+		 */
+		agentId?: string
+
 		dependsOn: string[]
 		order: number
 	}>


### PR DESCRIPTION
fix(sdk): an approver sees which agent, on both surfaces

There are two approval surfaces and the previous release fixed one.
`PlanStep.agentId` reached `PlanApprovalRequest`, the shape a host sees when it
installs its own handler on `PlanManager`, and stopped there.
`PlanApprovalData` — what every `resumeHandler` host receives — declares its own
step shape, and both mappers copy field by field. So the busier surface kept
showing `toolName: 'create_task'` and nothing else, which is exactly what the
change set out to end. It now carries `agentId`.

A plan may also no longer name an agent the run cannot launch. `create_task`
constrains `agent_id` with a closed enum while `approve_plan` typed it as a bare
string, so a model could propose — and, now that the name is visible, a human
could approve — a delegation that `create_task` then rejects at schema-parse
time.

The check is in `execute` rather than the schema because `approve_plan` is
mounted even on an empty roster, planning without delegates being a supported
configuration, and `z.enum([])` renders as `{"not":{}}` — the shape
`delegateSchema` already refuses, because a strict tool-schema validator rejects
the whole request over it rather than the one tool. It runs before
`startGenerating`, so no half-built plan is left behind and the human is never
shown the step at all; the message names the roster so the model corrects itself
in one turn. Enforcing in `execute` as well as the schema is the precedent the
canonical `Agent` tool set for complete mediation.

Found by a peer audit of the coordinator schema, which also caught that the
earlier fix had reached only one of the two surfaces.
