### PR TITLE
docs: catch up on the plan and delegation surface

### DIFF
--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -62,7 +62,7 @@ The SDK docs are grouped by domain instead of a flat file list:
 | Folder | Purpose |
 | --- | --- |
 | [agents/](./agents/README.md) | agent classes, orchestration, delegation, and manager-facing behavior |
-| [runtime/](./runtime/README.md) | runtime overview, IDs, configuration, and low-level query entrypoints |
+| [runtime/](./runtime/README.md) | runtime overview, IDs, configuration, plan approval, and low-level query entrypoints |
 | [tools/](./tools/README.md) | tool definitions, built-ins, and safety policy |
 | [provider-integration/](./provider-integration/README.md) | SDK-level provider registry and direct provider operations |
 | [integrations/](./integrations/README.md) | connectors, MCP, plugins, and event bridges |

--- a/docs/sdk/agents/README.md
+++ b/docs/sdk/agents/README.md
@@ -1,7 +1,7 @@
 ---
 title: Agents and Orchestration
 description: Choose the right SDK agent class, understand delegation boundaries, and wire orchestration surfaces safely in @namzu/sdk.
-last_updated: 2026-08-05
+last_updated: 2026-08-06
 status: current
 related_packages: ["@namzu/sdk"]
 ---
@@ -202,9 +202,17 @@ That last step matters. From the current implementation, `RouterAgent` forwards 
 
 1. create coordinator tools
 2. launch child tasks through a `gateway` or `agentManager`
-3. keep task handles and launched-task metadata
+3. keep task handles
 4. run the parent loop through `drainQuery()`
 5. collect child task results into the final supervisor result
+
+> **Changed in `@namzu/sdk` 10.0.0.** Step 3 used to also accumulate
+> launched-task metadata into a map threaded through `drainQuery`. Nothing
+> ever read it, so `drainQuery` no longer accepts `launchedTasks` and
+> `LaunchedTaskMeta` is no longer exported. If you passed either, delete the
+> argument — it was not doing anything. To observe launches, pass
+> `onTaskLaunched` to `buildCoordinatorTools`; that signal is unchanged and
+> the canonical `Agent` tool still calls it.
 
 Current hard requirements:
 
@@ -215,6 +223,50 @@ Current hard requirements:
   are available. Its model contract requires `options` to be a JSON array of
   2–4 objects with a `label` (and optional `description`); capable providers
   constrain that shape, while the runtime decoder remains authoritative.
+
+### Bounding the fan-out, and what a failed child means for its siblings
+
+> **New in `@namzu/sdk` 9.0.0.** Both fields existed in the kernel and neither
+> could be selected from `SupervisorAgentConfig`.
+
+| Field | Default | What it decides |
+| --- | --- | --- |
+| `maxToolConcurrency` | kernel default | how many delegated children run **concurrently** |
+| `siblingFailurePolicy` | `'continue'` | whether a failed child tears down the ones still running |
+
+`maxToolConcurrency` bounds concurrency, not launches. A model that emits
+twenty `create_task` blocks still launches twenty; they queue. Previously the
+agent whose entire job is delegation could not set the gate that bounds
+delegation, while `ReactiveAgent` could — a host wanting a narrower fan-out had
+to reach past the supervisor into `drainQuery`.
+
+`'continue'` remains the default deliberately: partial results are usually
+worth having, and tearing down healthy siblings on any failure lets one flaky
+child waste four good ones. `'cancel-siblings'` is for a fan-out whose parts
+only mean something together — if one leg of a comparison dies, the others are
+spending budget on an answer nobody can use. The choice is now expressible; the
+answer has not changed.
+
+`siblingFailurePolicy` is **ignored when you supply your own `gateway`**, which
+owns its own policy.
+
+### Pinning a delegated run's config
+
+> **Changed in `@namzu/sdk` 9.0.0.** `CreateTaskOptions.configOverrides` is
+> forwarded instead of dropped, and is now typed `Partial<BaseAgentConfig>`
+> rather than `Record<string, unknown>`.
+
+A caller pinning a delegated run to a cheaper model, or capping its iterations,
+previously got the agent's defaults and no indication anything had been
+ignored. The overrides now land on the child.
+
+The type change is the breaking half: the loose shape let a misspelled key
+type-check and then silently do nothing. A key that is not on
+`BaseAgentConfig` now fails to compile — and it was never being applied.
+
+A caller who sets both `configOverrides.parentSpan` and the dedicated
+`parentSpan` option gets the dedicated one for the span, and keeps every other
+override alongside it.
 
 ### Declining to delegate at all
 
@@ -302,7 +354,7 @@ The supervisor can also reach a task itself:
 | tool | use |
 | --- | --- |
 | `wait_for_task` | block until a running task finishes and return its output |
-| `agent_task_list` | every task with its state, timing and — for finished ones — its output |
+| `agent_task_list` | every task **this run launched**, with its state, timing and — for finished ones — its output |
 | `cancel_task` | stop a task the supervisor no longer needs |
 
 **Do not poll `agent_task_list` to find out whether work finished.** A blocking
@@ -310,6 +362,49 @@ The supervisor can also reach a task itself:
 listing is for taking stock — what is running, how long it has been — not for
 waiting; `wait_for_task` is the wait, and it costs one call rather than a turn
 per check.
+
+#### The listing is scoped to the run that launched the task
+
+> **Changed in `@namzu/sdk` 11.0.0.** `agent_task_list` and `wait_for_task`
+> now see only the tasks their own run launched.
+
+A `TaskGateway` is shared on purpose — `SupervisorAgentConfig.gateway` exists so
+a host can hand the same one to several runs — which makes
+`TaskGateway.listTasks()` gateway-wide by design. `agent_task_list` used to hand
+that straight to the model, including each task's `result`, so a supervisor
+could read a sibling run's worker output by listing. `wait_for_task` had the
+same reach.
+
+The scope lives in the coordinator tools rather than in `listTasks()` because
+the two answer different questions. **A host calling `listTasks()` is the
+operator** and may legitimately want everything on its gateway; a model calling
+`agent_task_list` is one run asking about its own work. Narrowing the gateway
+method would take the operator's view away in order to fix the model's — so if
+you want the wide view, call `TaskGateway.listTasks()` yourself. It is
+unchanged.
+
+`wait_for_task` gives the same answer for a sibling's task as for one that never
+existed. Distinguishing them would confirm a task id to a run that was not
+supposed to know it — the leak in miniature.
+
+**Also worth knowing:** a task launched through a *different* surface on the
+same gateway — `buildAgentTool`, or the host directly — is not listed by these
+tools either. That is the same rule rather than an exception to it, but it is a
+behaviour change if you mixed surfaces on one gateway and listed through the
+coordinator.
+
+#### Reporting a plan step from a delegated launch
+
+`create_task` accepts `plan_step_id`. Pass it and the named step of the approved
+plan goes `running` when the worker starts and `completed` or `failed` when it
+settles, from the same two-authority check the tool result uses.
+
+Steps the model carries out itself report through `update_plan_step` instead.
+Both are covered in [Plans and Step Reporting](../runtime/plans.md).
+
+> **`update_plan_step` is a new name in the coordinator tool set as of
+> `@namzu/sdk` 11.0.0.** A host that registers its own tool under that name now
+> gets `ToolNameCollisionError` at run start.
 
 #### Two clocks bound the wait
 
@@ -450,6 +545,38 @@ stale an answer may be is the host's judgement, not the SDK's.
 Instance-scoped, like the lock: deduplicating across processes needs
 somewhere durable to record the key, which is a store the host owns.
 
+### A fan-out naming one agent gets one shell per child
+
+> **New in `@namzu/sdk` 12.1.0.** `Agent` gains an optional `forRun()`, and
+> `AgentDefinition` gains `createAgent`.
+
+Constructing a second instance is the remedy above, and until 12.1.0 it was
+unreachable from delegation, where the definition owns the instance and the
+caller has only an id. `AgentRegistry` hands out one `typedAgent` per
+registered id, so four `create_task` calls naming the same `agent_id` drove
+four runs at one shell: one produced a result and three died with
+`ConcurrentInvocationError` — while `create_task`'s own description tells a
+model that exactly this fan-out is the thing to do.
+
+`AgentManager` now takes a fresh shell per spawn:
+
+| Hook | Who implements it | When you need it |
+| --- | --- | --- |
+| `Agent.forRun()` | `AbstractAgent`, already | nothing — agents built on `AbstractAgent` just work |
+| `AgentDefinition.createAgent` | you | your agent needs real construction arguments a metadata-only rebuild cannot supply |
+
+`createAgent` wins over `forRun` when both are present. **Most hosts need
+neither.**
+
+Nothing else about a child was ever shared: its abort signal is the task's own,
+its config is rebuilt per spawn by `configBuilder`, and the manager cancels
+through the task rather than the agent. The shell was the last shared thing.
+
+The lock itself is unchanged and still refuses — that refusal is right for a
+host calling `run` twice on one instance on purpose. What changed is that
+delegation no longer does so by accident. Its message now names the remedy
+rather than only the refusal.
+
 ## 9. Common Mistakes
 
 | Mistake | Why it hurts |
@@ -464,6 +591,7 @@ somewhere durable to record the key, which is a store the host owns.
 
 - [SDK Quickstart](../quickstart.md)
 - [Low-Level Runtime](../runtime/low-level.md)
+- [Plans and Step Reporting](../runtime/plans.md)
 - [Run Configuration](../runtime/configuration.md)
 - [Run Identities](../runtime/identities.md)
 - [Sessions, Workspaces, and Retention](../sessions/README.md)

--- a/docs/sdk/integrations/event-bridges.md
+++ b/docs/sdk/integrations/event-bridges.md
@@ -1,7 +1,7 @@
 ---
 title: Event Bridges
 description: Bridge internal Namzu runtime events to SSE and A2A wire formats, and convert messages, runs, and agent metadata into protocol-friendly shapes.
-last_updated: 2026-08-05
+last_updated: 2026-08-06
 status: current
 related_packages: ["@namzu/sdk"]
 ---
@@ -77,6 +77,17 @@ Typical mapped wire events include:
 - `checkpoint.created`
 - `compaction.completed`
 - `compaction.failed`
+- `plan.ready`, `plan.approved`, `plan.rejected`, `plan.step_updated`,
+  `plan.completed`, `plan.failed`
+
+> **`plan.completed` and `plan.failed` are new in `@namzu/sdk` 12.0.0.** They
+> were folded into a bare `break` in the translator and emitted nothing, so a
+> host watching the stream saw a plan's steps report and then silence — it
+> could learn a plan had been approved and never that it closed, which leaves
+> a plan rendered as in-flight indefinitely. `StreamEventType` is wider as a
+> result; a consumer that switches exhaustively over it needs the two new
+> arms. `plan.failed` carries a `reason`. See
+> [Plans and Step Reporting](../runtime/plans.md).
 
 The two compaction events are both worth forwarding to a UI, and the second is
 the one that is easy to leave out. A compaction pass that shed **nothing** is
@@ -232,6 +243,11 @@ Important runtime choices baked into the mapper:
 - `provider_retry` maps to `running`, because a backoff is a task still
   working, not a failure
 - `tool_review_requested`, `plan_ready`, and `run_paused` map to `input-required`
+- **only `plan_ready` crosses of the six plan events.** `plan_approved`,
+  `plan_rejected`, `plan_step_updated`, `plan_completed`, and `plan_failed`
+  map to `null` here while all six are forwarded on SSE — same reasoning as
+  the compaction events: a peer models a task lifecycle, and how this runtime
+  gates and settles its own plan is not something the peer can act on
 - **neither compaction event is forwarded.** A peer models a task lifecycle and
   cannot act on how this runtime manages its own context — the loss is real, but
   it is this runtime's business rather than the peer's. On SSE, where the

--- a/docs/sdk/runtime/README.md
+++ b/docs/sdk/runtime/README.md
@@ -1,7 +1,7 @@
 ---
 title: Runtime
 description: Reference map for the runtime building blocks exposed by @namzu/sdk.
-last_updated: 2026-08-03
+last_updated: 2026-08-06
 status: current
 related_packages: ["@namzu/sdk"]
 ---
@@ -17,7 +17,7 @@ The SDK exports a broad runtime surface, but the pieces follow a consistent shap
 | Providers | `ProviderRegistry`, `LLMProvider` types | A vendor-neutral model boundary |
 | Agents | `ReactiveAgent`, `PipelineAgent`, `RouterAgent`, `SupervisorAgent` | Different execution patterns over the same runtime |
 | Low-level kernel | `query`, `drainQuery` | Direct control over event streaming, verification, sandboxing, and runtime-only features |
-| Lifecycle | `AgentManager`, `RunPersistence`, `EmergencySaveManager`, `PlanManager` | Run orchestration, persistence, and review hooks |
+| Lifecycle | `AgentManager`, `RunPersistence`, `EmergencySaveManager`, `PlanManager` | Run orchestration, persistence, and review hooks — see [Plans](./plans.md) for the plan half |
 | Replay (v1) | `listCheckpoints`, `prepareReplayState`, `MutationNotApplicableError` | Fork an existing run from a checkpoint, optionally mutating the fork point — see [Replay](./replay.md) |
 | Stores | `RunDiskStore`, `DiskTaskStore`, conversation and memory stores | Local durability for runtime data |
 | Session hierarchy | `InMemorySessionStore`, `DiskSessionStore`, handoff, summary, workspace, retention exports | Tenant-scoped project and delegation state |
@@ -90,6 +90,7 @@ If you are implementing against the SDK rather than only consuming the public AP
 | Required IDs and identity mapping | [Runtime Identities](./identities.md) |
 | Agent config and runtime limits | [Runtime Configuration](./configuration.md) |
 | `query()` and `drainQuery()` wiring | [Low-Level Runtime](./low-level.md) |
+| Plan approval, step reporting, and plan events | [Plans and Step Reporting](./plans.md) |
 | Plugin manifests, namespacing, and hook order | [Plugins and MCP Servers](../integrations/plugins.md) |
 | The shipped tool set | [Built-In Tools](../tools/built-in.md) |
 | Verification, plan mode, and sandbox behavior | [Tool Safety](../tools/safety.md) |
@@ -113,6 +114,7 @@ If you are implementing against the SDK rather than only consuming the public AP
 - [SDK Sessions](../sessions/README.md)
 - [Runtime Configuration](./configuration.md)
 - [Low-Level Runtime](./low-level.md)
+- [Plans and Step Reporting](./plans.md)
 - [Connectors and MCP](../integrations/connectors-and-mcp.md)
 - [Plugins and MCP Servers](../integrations/plugins.md)
 - [Event Bridges](../integrations/event-bridges.md)

--- a/docs/sdk/runtime/low-level.md
+++ b/docs/sdk/runtime/low-level.md
@@ -1,7 +1,7 @@
 ---
 title: Low-Level Runtime
 description: Use query() and drainQuery() directly in @namzu/sdk when you need sandbox providers, plugin wiring, event streaming, or other query-only runtime controls.
-last_updated: 2026-08-05
+last_updated: 2026-08-06
 status: current
 related_packages: ["@namzu/sdk", "@namzu/openai"]
 ---
@@ -200,6 +200,20 @@ const resumeHandler = async (request) => {
 ```
 
 Use `autoApproveHandler` only when the runtime should continue automatically.
+
+A `plan_approval` request carries the plan on `request.plan`, and each entry of
+`request.plan.steps` names the agent it delegates to on `agentId` — absent means
+the step is the orchestrator's own work. Approving "delegate this step" is not
+the same as approving "delegate this step to the agent with shell access", so an
+auto-approver that ignores the field is approving something it has not read.
+
+> **`PlanApprovalData.steps[].agentId` is new in `@namzu/sdk` 12.2.0.** Earlier
+> versions carried the field only on `PlanApprovalRequest`, the surface you get
+> from installing your own handler on `PlanManager` — not on this one, which is
+> the path a `resumeHandler` is served by.
+
+The full plan lifecycle — approving, reporting each step, and settling — is in
+[Plans and Step Reporting](./plans.md).
 
 ### Remembering an approval, at a scope you choose
 

--- a/docs/sdk/runtime/plans.md
+++ b/docs/sdk/runtime/plans.md
@@ -1,0 +1,186 @@
+---
+title: Plans and Step Reporting
+description: Build a plan, gate it through a human approval, report how each step went, and settle it — the half the kernel drives and the half you do.
+last_updated: 2026-08-06
+status: current
+related_packages: ["@namzu/sdk"]
+---
+
+# Plans and Step Reporting
+
+A plan is what a run declares it is about to do, held still long enough for a human to approve it. `PlanManager` owns that object: its steps, its status, and the events that report both.
+
+> **Changed in `@namzu/sdk` 9.0.0, 11.0.0, and 12.0.0.** `completePlan()` now refuses an unreported step instead of scoring it a failure; steps report their own outcome through `plan_step_id` on `create_task` and through the new `update_plan_step` tool; and `plan_completed` / `plan_failed` reach the run stream. If you drove a plan before 9.0.0, read section 5 first — that is the change that breaks callers.
+
+## 1. The Kernel Drives Half of This
+
+The split is deliberate, and knowing which half is yours is the whole of using this surface correctly.
+
+| Phase | Driven by | How |
+| --- | --- | --- |
+| build | kernel | `approve_plan` calls `startGenerating`, `addStep`, `markReady` |
+| gate | kernel | the iteration context calls `approve` and `startExecution` |
+| report events | kernel | the event translator wires `PlanManager` onto the run stream |
+| **report step outcomes** | **host, or a delegating tool** | `updateStepStatus`, or `plan_step_id` on `create_task` |
+| settle on failure | kernel | the run's error path calls `failPlan` |
+| settle on success | kernel, **once every step has reported** | the run calls `completePlan` when nothing is outstanding |
+
+`drainQuery` hands you the manager through `onContextCreated({ planManager })` before the iteration loop starts, precisely so you can drive the half the kernel does not.
+
+This is why searching the SDK for callers of `updateStepStatus` finds none. The callers are hosts, and they are outside the package. `PlanManager` is exported for exactly this reason.
+
+## 2. Plan and Step Status
+
+Two separate vocabularies. `PlanStatus` describes the plan; each `PlanStep` carries its own narrower status.
+
+| `PlanStatus` | Meaning |
+| --- | --- |
+| `generating` | steps are being added |
+| `ready` | complete and awaiting a decision |
+| `pending_approval` | a decision has been requested |
+| `approved` / `rejected` | the human answered |
+| `executing` | approved and under way |
+| `completed` / `failed` | terminal |
+
+`isTerminalPlanStatus()` returns `true` for `completed`, `failed`, and `rejected`.
+
+| `PlanStep['status']` | Meaning |
+| --- | --- |
+| `pending` | the default from `addStep`; nobody has reported |
+| `running` | started |
+| `completed` | done |
+| `skipped` | planned, then not needed — a **successful** outcome |
+| `failed` | attempted and did not work; `error` carries why |
+
+`skipped` being first-class matters. A plan that turned out not to need a step went right, and forcing that into `completed` or `failed` would make the plan lie in one direction or the other.
+
+## 3. What the Approver Sees
+
+`approve_plan` asks the model for an `agent_id` per step, and that answer reaches the human on both approval surfaces.
+
+The approval is the one moment where the difference can still be acted on. Approving "delegate this step" is not the same as approving "delegate this step to the agent with shell access", and a reviewer who cannot see which agent was chosen cannot withhold approval from the wrong one.
+
+### There are two approval surfaces, and both carry it
+
+They are different types, declared separately, and each mapper copies field by field — so knowing which one you receive matters.
+
+| Surface | You get it by | Step shape |
+| --- | --- | --- |
+| `PlanApprovalRequest` | installing your own handler on `PlanManager` | `PlanStep`, `agentId` since 9.0.0 |
+| `PlanApprovalData` | a `resumeHandler` — **the ordinary path** | its own inline step shape, `agentId` since 12.2.0 |
+
+> **`PlanApprovalData.steps[].agentId` is new in `@namzu/sdk` 12.2.0.** From
+> 9.0.0 through 12.1.0 the field reached `PlanApprovalRequest` and stopped
+> there, so the busier of the two surfaces kept showing
+> `toolName: 'create_task'` and nothing else — which is the exact gap the field
+> was added to close. If you approve plans through a `resumeHandler`, you need
+> 12.2.0 for the agent name to arrive.
+
+An **absent** `agentId` is not missing data — it says the step is the orchestrator's own work, which is what omitting `agent_id` means. That distinction drives section 4.
+
+### A plan cannot name an agent the run could not launch
+
+> **New in `@namzu/sdk` 12.2.0.**
+
+`approve_plan` refuses a step whose `agent_id` is not on the run's delegate roster. The model gets a recoverable error naming the agents it may actually use — or, on a run with no delegates at all, telling it to plan the work as its own steps — and **the human is never shown the step**, because the check runs before the plan is built.
+
+`create_task` has always constrained the same field with a closed enum while `approve_plan` typed it as a bare string. The mismatch was invisible while the name was being dropped on the way to the approver; once a step carries the name, an approver could read "delegate to X" for an X that does not exist and approve a delegation the launch would then reject.
+
+The check lives in `execute` rather than in the schema, deliberately. `approve_plan` is mounted even with an empty roster — planning with no delegates but a human channel is a supported configuration — and an empty enum renders as a schema shape that strict tool-schema validators reject wholesale, taking the entire request down rather than the one tool. `create_task` escapes that by being withheld entirely when the roster is empty; `approve_plan` cannot be.
+
+### Step ids come back to the caller
+
+`approve_plan` returns the step ids, both in its text output and in `data.steps`. Both reporting routes below name a step id, and a binding whose caller has never been told the ids is a binding that does not exist.
+
+## 4. Two Ways a Step Reports, Because There Are Two Kinds of Step
+
+**A delegated step reports through the launch that carries it out.** Pass `plan_step_id` to `create_task`, and the step goes `running` when the worker starts and `completed` or `failed` when it settles:
+
+```
+create_task(agent_id: "reviewer", plan_step_id: "step-2", prompt: "…")
+```
+
+The outcome comes from the same two-authority check the tool result uses, so a worker that returned `status: 'failed'` fails its step even when the gateway recorded the task as completed.
+
+**An orchestrator-owned step has no tool call to bind to at all.** A step with no `agent_id` is work the model does itself, and `update_plan_step` is how it reports:
+
+```
+update_plan_step(step_id: "step-3", status: "skipped")
+```
+
+Without this tool, a plan containing one such step could never settle however well it went.
+
+From a host, the same reporting is one call:
+
+```ts
+planManager.updateStepStatus('step-3', 'skipped')
+```
+
+Report each step as it settles rather than batching at the end. An unreported step is not scored as a failure — it simply leaves the plan unsettled.
+
+## 5. Settling, and the Call That Now Throws
+
+`completePlan()` **throws when any step is still `pending` or `running`.**
+
+Before 9.0.0 it asked one question — is every step `completed` or `skipped`? — and everything else fell to the same branch, producing `status: 'failed'`. Since `addStep` defaults every step to `pending`, a host that added steps, did the work, and settled without reporting got `failed` for a plan where nothing had gone wrong. That is the path of least effort through this API, not an unusual one.
+
+The two cases are different facts. A step that failed is an outcome: report the plan failed. A step nobody reported on is not an outcome at all — it says the caller and the plan disagree about whether the work is over, and answering `failed` settles that disagreement by inventing a result.
+
+Two ways forward, and only you know which applies:
+
+| Situation | Do this |
+| --- | --- |
+| you forgot to report progress | call `updateStepStatus` on each outstanding step — `'skipped'` is valid |
+| you are abandoning the plan | call `failPlan(reason)`, which marks unfinished steps `skipped` and settles the plan as `failed` |
+| you called too early | check `planManager.unreportedSteps` first and wait |
+
+`unreportedSteps` is the read that lets you avoid the throw entirely. The run itself uses it: on a successful run the kernel settles the plan only when nothing is outstanding, and leaves it `executing` otherwise. Letting `completePlan` throw at the end of a run that worked would turn it into a run that crashed on its way out, and a plan with silent steps is honestly unsettled rather than dishonestly closed.
+
+Behaviour is unchanged once every step has reported: all `completed` or `skipped` still yields `completed`, and any `failed` still yields `failed`.
+
+`failPlan(reason)` records its argument on `Plan.failureReason`. This is distinct from `rejectionReason`, which is a human declining a plan *before* it ran; `failureReason` is a plan that ran and did not finish.
+
+## 6. Watching a Plan From Outside
+
+Every transition reaches the run stream. `RunEvent` carries the plan events, and the SSE bridge maps them to wire names:
+
+| `RunEvent` | SSE `StreamEventType` |
+| --- | --- |
+| `plan_ready` | `plan.ready` |
+| `plan_approved` | `plan.approved` |
+| `plan_rejected` | `plan.rejected` |
+| `plan_step_updated` | `plan.step_updated` |
+| `plan_completed` | `plan.completed` |
+| `plan_failed` | `plan.failed` |
+
+Before 12.0.0 the last two emitted nothing, so a host watching the stream saw the steps report and then silence — it could learn a plan had been approved and never that it closed, leaving a plan rendered as in-flight indefinitely.
+
+`plan_failed` carries a `reason`, populated from `Plan.failureReason` — an event that says "failed" without saying why puts the reader back where the missing event did. `plan_rejected` carries a `reason` too, and they are different facts: rejection is a human declining, failure is a plan that ran and did not finish.
+
+The A2A bridge is narrower on purpose: only `plan_ready` crosses, mapping to task state `input-required`. The rest are this runtime's business rather than a peer's.
+
+**If you switch exhaustively over `RunEvent` or `StreamEventType`, both are wider as of 12.0.0** and need arms for the new members.
+
+## 7. Building Your Plan in `onContextCreated`
+
+`onContextCreated` is the callback for this work, and as of 12.0.0 it fires where it can be heard: after the event translator is wired and after run-store initialisation, still before the iteration loop. Previously it ran ahead of the wiring, so a host that built its plan there did it into silence — `plan_ready`, `plan_approved`, and every `plan_step_updated` emitted with nothing subscribed.
+
+```ts
+await drainQuery({
+  // …
+  onContextCreated({ planManager }) {
+    planManager.onEvent((event) => {
+      console.log(event.type, event.plan.status)
+    })
+  },
+})
+```
+
+## Related
+
+- [Low-Level Runtime](./low-level.md) — `drainQuery`, resume handlers, and the HITL park
+- [Agents and Orchestration](../agents/README.md) — `create_task` and the coordinator tool set
+- [Event Bridges](../integrations/event-bridges.md) — SSE and A2A wire mapping
+- [Tool Safety](../tools/safety.md) — plan mode and the tool-review gate
+- [Runtime](./README.md)
+- [Plan Manager Source](https://github.com/cogitave/namzu/blob/main/packages/sdk/src/manager/plan/lifecycle.ts)


### PR DESCRIPTION
Covers @namzu/sdk 8.0.0 through 12.2.0, which shipped across five majors, a
minor and a patch without docs following.

New page for plans and step reporting: which half of the lifecycle the kernel
drives and which half the host does, why completePlan refuses an unreported step
rather than scoring it failed, how a delegated step reports through plan_step_id
and an orchestrator-owned one through update_plan_step, and the two approval
surfaces — PlanApprovalRequest has carried agentId since 9.0.0, PlanApprovalData
only since 12.2.0, and the second is the ordinary path.

The agent page gains the delegation config that had no documentation:
maxToolConcurrency and siblingFailurePolicy, the configOverrides narrowing, the
removal of launchedTasks, and forRun/createAgent for a fan-out that names one
agent more than once.

Written by a peer session; reviewed and landed here. Version attributions were
checked against the changelog rather than taken.