### PR TITLE
fix(sdk)!: a delegated child releases its worktree when it succeeds

### DIFF
--- a/.changeset/a-worker-that-succeeds-releases-its-worktree.md
+++ b/.changeset/a-worker-that-succeeds-releases-its-worktree.md
@@ -1,0 +1,39 @@
+---
+'@namzu/sdk': patch
+---
+
+A delegated child releases its workspace when it succeeds, not only when it fails.
+
+`AgentManager` had two workspace dispose sites and both were failure paths — the
+non-success branch of `finalizeChild`, and the rollback in `failSubSession`. The
+success branch disposed nothing, so a git worktree provisioned for a delegated
+child outlived the child that used it. `.namzu/worktrees/` grew once per
+successful delegation: the more reliable the workers, the faster it filled,
+which is the opposite of the signal a leak usually gives.
+
+Disposal now runs on every terminal path, from one shared place, so the two
+cannot drift apart again.
+
+**The archival backstop could not fire either, and now can.**
+`ArchivalManager.archive` resolves a workspace only when `SubSession.workspaceId`
+is set. For a spawn-created sub-session that field was written `null` and never
+updated — `provisionSpawn` kept the ref on an in-memory record and nowhere else
+— so the one persisted record that could have named the leaked worktree said
+there was none. `provisionSpawn` now writes `workspaceRef.id` onto the
+sub-session, inside the same compensating rollback as every other mutation
+there. A sub-session with no provisioned workspace still records `null`; lazy
+provisioning stays legal.
+
+Two consequences worth knowing before you take the upgrade:
+
+- **A worktree is gone once the child that owned it completes.** If you were
+  reading a child's workspace after a successful delegation — through
+  `AgentManager.getSpawnRecord(taskId)`, which is the only way that was
+  available — read it from inside the child, or from a `subsession_idled`
+  listener's own copy, before it settles. Disposal runs before that event.
+- **`archive()` now resolves workspaces for spawn-created sub-sessions.** If you
+  pass a `workspaceResolver`, it will start being called on this path, and an
+  archive bundle may now carry a `workspace` field where it previously never
+  did. The resolver contract is unchanged: return `null` for a ref that is
+  unknown or already disposed, which is what it will be for a child that
+  finished.

--- a/.changeset/a-worker-that-succeeds-releases-its-worktree.md
+++ b/.changeset/a-worker-that-succeeds-releases-its-worktree.md
@@ -1,5 +1,5 @@
 ---
-'@namzu/sdk': patch
+'@namzu/sdk': major
 ---
 
 A delegated child releases its workspace when it succeeds, not only when it fails.
@@ -26,11 +26,18 @@ provisioning stays legal.
 
 Two consequences worth knowing before you take the upgrade:
 
-- **A worktree is gone once the child that owned it completes.** If you were
-  reading a child's workspace after a successful delegation — through
-  `AgentManager.getSpawnRecord(taskId)`, which is the only way that was
-  available — read it from inside the child, or from a `subsession_idled`
-  listener's own copy, before it settles. Disposal runs before that event.
+- **A worktree is gone once the child that owned it completes**, and this is the
+  breaking part. Reading a child's workspace after a successful delegation
+  worked — `AgentManager.getSpawnRecord(taskId).workspaceRef` returned a live
+  ref, and the directory then persisted indefinitely because nothing removed
+  it. That was the leak, but a host inspecting a worker's artifacts afterwards
+  could reasonably have been built on it.
+
+  There is no host-side replacement, so take what you need from inside the
+  child: have the worker write its output where the result can carry it, or
+  copy the files out before its run settles. In particular a `subsession_idled`
+  listener is **too late** — disposal runs before that event is emitted,
+  deliberately, so nothing can reach into a workspace that is already going.
 - **`archive()` now resolves workspaces for spawn-created sub-sessions.** If you
   pass a `workspaceResolver`, it will start being called on this path, and an
   archive bundle may now carry a `workspace` field where it previously never

--- a/packages/sdk/src/manager/agent/lifecycle.ts
+++ b/packages/sdk/src/manager/agent/lifecycle.ts
@@ -641,6 +641,24 @@ export class AgentManager {
 			if (this.deps.workspaceRegistry.has(backend)) {
 				const driver = this.deps.workspaceRegistry.get(backend)
 				workspaceRef = await driver.create({ label: subSession.id })
+
+				// Write the workspace onto the record that outlives this process.
+				//
+				// The ref was kept only on the in-memory `ChildSpawnRecord`, so
+				// `SubSession.workspaceId` stayed `null` for every spawn-created
+				// child — and `ArchivalManager` resolves a workspace only when
+				// that field is set (`session/retention/archive.ts`). The one
+				// record that could have named the workspace said there was none,
+				// which is why the archival path could never act as a backstop
+				// for a leaked worktree.
+				//
+				// After `create` rather than in `createSubSession`, because the
+				// sub-session id is the workspace's label — the workspace cannot
+				// exist before the record it is named after. Inside the try, so
+				// the compensating rollback below covers it like every other
+				// mutation here.
+				subSession = { ...subSession, workspaceId: workspaceRef.id }
+				await store.updateSubSession(subSession, context.tenantId)
 			}
 		} catch (err) {
 			// Compensating rollback order is mandated by the store's
@@ -764,9 +782,9 @@ export class AgentManager {
 						)
 					}
 				} else {
-					// Non-success: mark sub-session failed and, when we own a
-					// workspace, dispose it. Dispose errors are logged but not
-					// propagated — the sub-session state is already persisted.
+					// Non-success: mark sub-session failed. Disposal is shared with
+					// the success branch below — the workspace was provisioned for
+					// this child either way, and it is this manager that owns it.
 					const subSession = await store.getSubSession(
 						spawnRecord.subSessionId,
 						spawnRecord.tenantId,
@@ -774,21 +792,25 @@ export class AgentManager {
 					if (subSession) {
 						await store.updateSubSession({ ...subSession, status: 'failed' }, spawnRecord.tenantId)
 					}
-					if (spawnRecord.workspaceRef) {
-						const backend = spawnRecord.workspaceRef.meta.backend
-						if (this.deps.workspaceRegistry.has(backend)) {
-							await this.deps.workspaceRegistry
-								.get(backend)
-								.dispose(spawnRecord.workspaceRef)
-								.catch((disposeErr) => {
-									this.log.warn('Workspace dispose failed', {
-										backend,
-										error: toErrorMessage(disposeErr),
-									})
-								})
-						}
-					}
 				}
+
+				// A child is done with its workspace however it ended.
+				//
+				// This used to live only in the branch above, so both dispose
+				// sites in this class were failure paths and a child that
+				// SUCCEEDED released nothing. `.namzu/worktrees/` then grew once
+				// per successful delegation — the more reliable the workers, the
+				// faster it filled, which is the opposite of the signal a leak
+				// usually gives.
+				//
+				// It runs after the summary is sealed and the sub-session flipped
+				// to `idle`, so nothing the terminalization path reads is gone
+				// before it reads it. It also runs BEFORE the `subsession_idled`
+				// emission below: a listener cannot reach into the workspace from
+				// that event. Stated rather than hedged — no consumer does today,
+				// and holding a worktree open for a hypothetical one is what this
+				// is fixing.
+				await this.disposeChildWorkspace(spawnRecord)
 			} catch (err) {
 				this.log.error('Sub-session finalization failed', {
 					taskId: agentTask.taskId,
@@ -937,15 +959,38 @@ export class AgentManager {
 				spawnRecord.tenantId,
 			)
 		}
-		if (spawnRecord.workspaceRef) {
-			const backend = spawnRecord.workspaceRef.meta.backend
-			if (this.deps.workspaceRegistry.has(backend)) {
-				await this.deps.workspaceRegistry
-					.get(backend)
-					.dispose(spawnRecord.workspaceRef)
-					.catch(() => undefined)
-			}
-		}
+		await this.disposeChildWorkspace(spawnRecord)
+	}
+
+	/**
+	 * Release the workspace this manager provisioned for a child.
+	 *
+	 * Called on every terminal path, success included. `has(backend)` before
+	 * `get(backend)` because the registry is deny-by-default and throws on an
+	 * unknown kind — a driver deregistered mid-run must not turn cleanup into
+	 * an exception on a child that already finished.
+	 *
+	 * Never throws. Disposal is cleanup, not part of the child's result: the
+	 * sub-session state is already persisted by the time this runs, and
+	 * failing here would report a delegation that worked as one that did not.
+	 * The failure is logged instead, because a worktree that could not be
+	 * removed is an operator's problem and silence is how it stays one.
+	 */
+	private async disposeChildWorkspace(spawnRecord: ChildSpawnRecord): Promise<void> {
+		if (!spawnRecord.workspaceRef) return
+		const backend = spawnRecord.workspaceRef.meta.backend
+		if (!this.deps.workspaceRegistry.has(backend)) return
+		await this.deps.workspaceRegistry
+			.get(backend)
+			.dispose(spawnRecord.workspaceRef)
+			.catch((disposeErr) => {
+				this.log.warn('Workspace dispose failed', {
+					backend,
+					workspaceId: spawnRecord.workspaceRef?.id,
+					subSessionId: spawnRecord.subSessionId,
+					error: toErrorMessage(disposeErr),
+				})
+			})
 	}
 
 	private markCanceled(taskId: TaskId): void {

--- a/packages/sdk/src/session/__tests__/integration/a-successful-delegation-disposes-its-workspace.test.ts
+++ b/packages/sdk/src/session/__tests__/integration/a-successful-delegation-disposes-its-workspace.test.ts
@@ -1,0 +1,270 @@
+/**
+ * A worktree provisioned for a delegated child outlived the child that used it.
+ *
+ * `finalizeChild` had two dispose sites and both were failure paths — the
+ * non-success branch, and the rollback in `failSubSession`. The success branch
+ * disposed nothing, so `.namzu/worktrees/` grew once per successful delegation:
+ * the more reliable the workers, the faster it filled.
+ *
+ * The backstop could not fire either. `ArchivalManager` resolves a workspace
+ * only when `SubSession.workspaceId` is set, and for a spawn-created
+ * sub-session that field was written `null` and never updated —
+ * `provisionSpawn` kept the ref on the in-memory `ChildSpawnRecord` and nowhere
+ * else. So the one record that could have named the leaked worktree said there
+ * was none.
+ *
+ * Both halves are pinned here, and the failure path is re-asserted alongside
+ * them: a test that only counted disposals would pass on the old code by
+ * reading the failure branch's disposal and calling it the success branch's.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { EMPTY_TOKEN_USAGE } from '../../../constants/limits.js'
+import { AgentManager } from '../../../manager/agent/lifecycle.js'
+import { ThreadManager } from '../../../manager/thread/lifecycle.js'
+import { AgentRegistry } from '../../../registry/agent/definitions.js'
+import { InMemorySessionStore } from '../../../store/session/memory.js'
+import { InMemoryThreadStore } from '../../../store/thread/memory.js'
+import type {
+	AgentCapabilities,
+	AgentInput,
+	BaseAgentConfig,
+	BaseAgentResult,
+} from '../../../types/agent/base.js'
+import type { Agent } from '../../../types/agent/core.js'
+import type { AgentDefinition } from '../../../types/agent/factory.js'
+import type { AgentTaskContext, SendMessageOptions } from '../../../types/agent/task.js'
+import type { RunId, TenantId, UserId, WorkspaceId } from '../../../types/ids/index.js'
+import { createAssistantMessage } from '../../../types/message/index.js'
+import type { ActorRef } from '../../../types/session/actor.js'
+import type { SummaryId } from '../../../types/session/ids.js'
+import type { WorkspaceRef } from '../../../types/workspace/ref.js'
+import { ZERO_COST } from '../../../utils/cost.js'
+import { DefaultCapacityValidator } from '../../handoff/capacity.js'
+import { SessionSummaryMaterializer } from '../../summary/materialize.js'
+import type {
+	BranchWorkspaceParams,
+	CreateWorkspaceParams,
+	WorkspaceBackendDriver,
+	WorkspaceInspection,
+} from '../../workspace/driver.js'
+import { WorkspaceBackendRegistry } from '../../workspace/registry.js'
+
+const tenant = 'tnt_alpha' as TenantId
+
+const capabilities: AgentCapabilities = {
+	supportsTools: false,
+	supportsStreaming: false,
+	supportsConcurrency: false,
+	supportsSubAgents: false,
+}
+
+/** A child that settles the way `outcome` says, so both branches are reachable. */
+function buildAgent(
+	id: string,
+	outcome: 'completed' | 'failed',
+): Agent<BaseAgentConfig, BaseAgentResult> {
+	return {
+		type: 'reactive',
+		metadata: {
+			type: 'reactive',
+			id,
+			name: id,
+			version: '1.0.0',
+			category: 'test',
+			description: id,
+			capabilities,
+		},
+		run: async (_input: AgentInput, _config: BaseAgentConfig): Promise<BaseAgentResult> => ({
+			runId: 'run_child' as RunId,
+			status: outcome,
+			usage: { ...EMPTY_TOKEN_USAGE },
+			cost: { ...ZERO_COST },
+			iterations: 1,
+			durationMs: 1,
+			messages: [createAssistantMessage('child did the work')],
+			result: 'child did the work',
+		}),
+		cancel: async () => undefined,
+		getCapabilities: () => capabilities,
+	}
+}
+
+function buildDefinition(agent: Agent<BaseAgentConfig, BaseAgentResult>): AgentDefinition {
+	return {
+		info: {
+			id: agent.metadata.id,
+			name: agent.metadata.name,
+			version: agent.metadata.version,
+			category: agent.metadata.category,
+			description: agent.metadata.description,
+			tools: [],
+			defaults: { model: 'test', tokenBudget: 1_000 },
+		},
+		typedAgent: agent,
+	}
+}
+
+/** Provisions successfully and records every ref it is asked to dispose. */
+class RecordingWorkspaceDriver implements WorkspaceBackendDriver {
+	readonly kind = 'git-worktree' as const
+	readonly created: WorkspaceRef[] = []
+	readonly disposed: WorkspaceId[] = []
+	private counter = 0
+
+	async create(params: CreateWorkspaceParams): Promise<WorkspaceRef> {
+		const ref: WorkspaceRef = {
+			id: `wsp_test_${++this.counter}` as WorkspaceId,
+			meta: {
+				backend: 'git-worktree',
+				repoRoot: '/tmp/repo',
+				branch: `namzu/${params.label ?? 'unlabelled'}`,
+				worktreePath: `/tmp/repo/.namzu/worktrees/${params.label ?? 'unlabelled'}`,
+			},
+			createdAt: new Date(),
+		}
+		this.created.push(ref)
+		return ref
+	}
+
+	async branch(_source: WorkspaceRef, _params: BranchWorkspaceParams): Promise<WorkspaceRef> {
+		throw new Error('unused in this test')
+	}
+
+	async dispose(ref: WorkspaceRef): Promise<void> {
+		this.disposed.push(ref.id)
+	}
+
+	async inspect(_ref: WorkspaceRef): Promise<WorkspaceInspection> {
+		throw new Error('unused in this test')
+	}
+}
+
+/**
+ * Stands up a Project → Thread → parent Session and an AgentManager wired to a
+ * recording workspace driver. `outcome` decides how the delegated child ends;
+ * `registerBackend: false` leaves the registry empty, which is the supported
+ * lazy-provisioning configuration rather than an error (pattern doc §7.1).
+ */
+async function harness(
+	outcome: 'completed' | 'failed',
+	{ registerBackend = true }: { registerBackend?: boolean } = {},
+) {
+	const store = new InMemorySessionStore()
+	const threadStore = new InMemoryThreadStore()
+	const project = await store.createProject({ tenantId: tenant, name: 'workspace-project' }, tenant)
+	const thread = await threadStore.createThread(
+		{ projectId: project.id, title: 'workspace-topic' },
+		tenant,
+	)
+
+	const userActor: ActorRef = { kind: 'user', userId: 'usr_root' as UserId, tenantId: tenant }
+
+	const parentSession = await store.createSession(
+		{ threadId: thread.id, projectId: project.id, currentActor: userActor },
+		tenant,
+	)
+	await store.updateSession({ ...parentSession, status: 'active' }, tenant)
+
+	let summaryCounter = 0
+	const materializer = new SessionSummaryMaterializer({
+		store,
+		generateSummaryId: () => `sum_test_${++summaryCounter}` as SummaryId,
+	})
+
+	const registry = new AgentRegistry()
+	registry.register(buildDefinition(buildAgent('worker', outcome)))
+
+	const workspaceRegistry = new WorkspaceBackendRegistry()
+	const driver = new RecordingWorkspaceDriver()
+	if (registerBackend) workspaceRegistry.register(driver)
+
+	const manager = new AgentManager(registry, undefined, {
+		sessionStore: store,
+		summaryMaterializer: materializer,
+		workspaceRegistry,
+		capacity: new DefaultCapacityValidator(store),
+		threadManager: new ThreadManager({ threadStore, sessionStore: store }),
+	})
+
+	const taskContext: AgentTaskContext = {
+		parentRunId: 'run_parent' as RunId,
+		parentAgentId: 'supervisor',
+		parentAbortController: new AbortController(),
+		depth: 0,
+		budgetTracker: { total: 100_000, remaining: 100_000 },
+		tenantId: tenant,
+		threadId: thread.id,
+		sessionId: parentSession.id,
+		projectId: project.id,
+		parentActor: userActor,
+	}
+
+	const options: SendMessageOptions = {
+		agentId: 'worker',
+		input: { messages: [], workingDirectory: '/tmp' },
+		parentSessionId: parentSession.id,
+		tenantId: tenant,
+		projectId: project.id,
+		parentActor: userActor,
+		workspaceBackend: 'git-worktree',
+	}
+
+	return { store, manager, driver, parentSession, options, taskContext }
+}
+
+describe('a delegated child does not outlive its workspace', () => {
+	it('disposes the workspace when the child SUCCEEDS', async () => {
+		const { manager, driver, options, taskContext } = await harness('completed')
+
+		const task = await manager.sendMessage(options, taskContext)
+		await manager.waitForCompletion(task.taskId)
+
+		expect(manager.getState(task.taskId)).toBe('completed')
+		expect(driver.created).toHaveLength(1)
+		// The assertion the leak fails: one workspace made, the same one released.
+		expect(driver.disposed).toEqual([driver.created[0]?.id])
+	})
+
+	it('still disposes the workspace when the child FAILS', async () => {
+		const { manager, driver, options, taskContext } = await harness('failed')
+
+		const task = await manager.sendMessage(options, taskContext)
+		await manager.waitForCompletion(task.taskId)
+
+		expect(driver.created).toHaveLength(1)
+		expect(driver.disposed).toEqual([driver.created[0]?.id])
+	})
+
+	it('records the workspace on the sub-session, so archival can find it', async () => {
+		const { store, manager, driver, parentSession, options, taskContext } =
+			await harness('completed')
+
+		const task = await manager.sendMessage(options, taskContext)
+		await manager.waitForCompletion(task.taskId)
+
+		const [subSession] = await store.getChildren(parentSession.id, tenant)
+		expect(subSession).toBeDefined()
+		// Was `null` on every spawn-created sub-session, which is what made
+		// `ArchivalManager`'s `sub.workspaceId &&` guard unreachable here.
+		expect(subSession?.workspaceId).toBe(driver.created[0]?.id)
+	})
+
+	it('leaves workspaceId null when no backend is registered', async () => {
+		// Lazy provisioning stays legal (pattern doc §7.1): an unregistered
+		// backend is not an error, and the record must not claim a workspace
+		// that was never made.
+		const { store, manager, driver, parentSession, options, taskContext } = await harness(
+			'completed',
+			{ registerBackend: false },
+		)
+
+		const task = await manager.sendMessage(options, taskContext)
+		await manager.waitForCompletion(task.taskId)
+
+		expect(manager.getState(task.taskId)).toBe('completed')
+		expect(driver.created).toHaveLength(0)
+		const [subSession] = await store.getChildren(parentSession.id, tenant)
+		expect(subSession?.workspaceId).toBeNull()
+	})
+})


### PR DESCRIPTION
A delegated child releases its workspace when it succeeds, not only when it fails.

`AgentManager` had two workspace dispose sites and both were failure paths — the
non-success branch of `finalizeChild`, and the rollback in `failSubSession`. The
success branch disposed nothing, so a git worktree provisioned for a delegated
child outlived the child that used it. `.namzu/worktrees/` grew once per
successful delegation: the more reliable the workers, the faster it filled,
which is the opposite of the signal a leak usually gives.

Disposal now runs on every terminal path, from one shared place, so the two
cannot drift apart again.

**The archival backstop could not fire either, and now can.**
`ArchivalManager.archive` resolves a workspace only when `SubSession.workspaceId`
is set. For a spawn-created sub-session that field was written `null` and never
updated — `provisionSpawn` kept the ref on an in-memory record and nowhere else
— so the one persisted record that could have named the leaked worktree said
there was none. `provisionSpawn` now writes `workspaceRef.id` onto the
sub-session, inside the same compensating rollback as every other mutation
there. A sub-session with no provisioned workspace still records `null`; lazy
provisioning stays legal.

Two consequences worth knowing before you take the upgrade:

- **A worktree is gone once the child that owned it completes**, and this is the
  breaking part. Reading a child's workspace after a successful delegation
  worked — `AgentManager.getSpawnRecord(taskId).workspaceRef` returned a live
  ref, and the directory then persisted indefinitely because nothing removed
  it. That was the leak, but a host inspecting a worker's artifacts afterwards
  could reasonably have been built on it.

  There is no host-side replacement, so take what you need from inside the
  child: have the worker write its output where the result can carry it, or
  copy the files out before its run settles. In particular a `subsession_idled`
  listener is **too late** — disposal runs before that event is emitted,
  deliberately, so nothing can reach into a workspace that is already going.
- **`archive()` now resolves workspaces for spawn-created sub-sessions.** If you
  pass a `workspaceResolver`, it will start being called on this path, and an
  archive bundle may now carry a `workspace` field where it previously never
  did. The resolver contract is unchanged: return `null` for a ref that is
  unknown or already disposed, which is what it will be for a child that
  finished.