### PR TITLE
feat(sdk): an environment reaches the child it was set for

### DIFF
--- a/.changeset/an-env-reaches-the-child-it-was-set-for.md
+++ b/.changeset/an-env-reaches-the-child-it-was-set-for.md
@@ -1,0 +1,41 @@
+---
+'@namzu/sdk': minor
+---
+
+An environment reaches the child it was set for.
+
+`AgentManager` builds a delegated child's config on two branches. The
+bare-config branch — taken only when a definition has no `configBuilder` — has
+always carried `env`. The `configBuilder` branch, which is what a host
+registering a real agent actually uses, never stamped it. So a run given an
+environment handed its delegates none of it, and the child ran against whatever
+the ambient defaults were.
+
+This is the third field to go the same way. `parentSpan` and `resumeHandler` are
+both stamped after the builder returns, each with a comment saying the builder is
+written by whoever registered the agent and cannot be expected to forward
+something it was never told about. `env` was missed, and it went unnoticed
+because a missing environment does not fail — the child just runs somewhere else.
+
+Both delegation surfaces now forward the parent's `ToolContext.env` as a
+`configOverrides.env`, and the manager merges it **per key** rather than
+replacing the map: `configOverrides` is a `Partial`, so assignment would drop
+every key the builder set and the caller did not restate. The override wins per
+key, the same direction it already wins for `model`, `thinking` and `effort`.
+
+**Widening worth naming:** a delegating agent's `config.env` now reaches every
+descendant, on both surfaces. That is what setting an environment was for, and
+it is a behaviour change for anyone who had been relying on delegates not
+inheriting one.
+
+**`env` is for configuration, not credentials**, and the contract now says so
+where it is declared. The map is copied into every descendant, is readable by
+any tool, and enters a model's context and the run transcript the moment a
+command echoes it — properties of the channel, not a judgement about any
+particular value. A value that authenticates to a host belongs on the brokered
+credential path, where the process holds a placeholder and the value is attached
+at egress.
+
+No new field on `ProjectConfig`. It already carries six fields nothing reads,
+and a workspace environment does not need a seventh: the mechanism is the
+environment a run is given, which now actually propagates.

--- a/packages/sdk/src/manager/agent/__tests__/an-env-reaches-the-child-it-was-set-for.test.ts
+++ b/packages/sdk/src/manager/agent/__tests__/an-env-reaches-the-child-it-was-set-for.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest'
+
+import { EMPTY_TOKEN_USAGE } from '../../../constants/limits.js'
+import { AgentRegistry } from '../../../registry/agent/definitions.js'
+import { DefaultCapacityValidator } from '../../../session/handoff/capacity.js'
+import { SessionSummaryMaterializer } from '../../../session/summary/materialize.js'
+import { WorkspaceBackendRegistry } from '../../../session/workspace/registry.js'
+import { InMemorySessionStore } from '../../../store/session/memory.js'
+import { InMemoryThreadStore } from '../../../store/thread/memory.js'
+import type { BaseAgentConfig, BaseAgentResult } from '../../../types/agent/base.js'
+import type { Agent } from '../../../types/agent/core.js'
+import type { AgentDefinition } from '../../../types/agent/factory.js'
+import type { AgentTaskContext } from '../../../types/agent/task.js'
+import type { AgentId, TenantId } from '../../../types/ids/index.js'
+import type { SummaryId } from '../../../types/session/ids.js'
+import { ZERO_COST } from '../../../utils/cost.js'
+import { ThreadManager } from '../../thread/lifecycle.js'
+import { AgentManager } from '../lifecycle.js'
+
+/**
+ * A delegate registered the normal way inherited no environment at all.
+ *
+ * `AgentManager` builds a child's config on two branches. The bare-config
+ * branch — taken only when a definition has NO `configBuilder` — has always
+ * carried `env`. The `configBuilder` branch, which is what a host registering
+ * a real agent actually uses, never stamped it. So a run given an environment
+ * handed its delegates none of it.
+ *
+ * This is the third field to go the same way: `parentSpan` and `resumeHandler`
+ * are both stamped after the builder returns, each with a comment saying the
+ * builder is written by whoever registered the agent and cannot be expected to
+ * forward something it was never told about. `env` was missed, and it went
+ * unnoticed because a missing environment does not fail — the child just runs
+ * somewhere else.
+ *
+ * These drive the real `AgentManager` rather than re-implementing the merge.
+ * A test that restates the logic proves the logic agrees with itself; what has
+ * to hold is that the manager applies it.
+ */
+
+const TENANT = 'tnt_env' as TenantId
+
+/** Records the config it is run with, so the assertion is on what shipped. */
+function recordingAgent(seen: { config?: BaseAgentConfig }) {
+	return {
+		type: 'reactive',
+		metadata: {
+			id: 'worker',
+			name: 'worker',
+			version: '1.0.0',
+			category: 'general',
+			description: 'records its config',
+			type: 'reactive',
+			capabilities: {},
+		},
+		async run(_input: unknown, config: BaseAgentConfig): Promise<BaseAgentResult> {
+			seen.config = config
+			return {
+				runId: 'run_child',
+				status: 'completed',
+				result: 'ok',
+				usage: { ...EMPTY_TOKEN_USAGE },
+				cost: { ...ZERO_COST },
+				iterations: 1,
+				durationMs: 0,
+				messages: [],
+			} as BaseAgentResult
+		},
+		async cancel() {},
+		getCapabilities() {
+			return {} as never
+		},
+	} as unknown as Agent<BaseAgentConfig, BaseAgentResult>
+}
+
+/** A definition WITH a configBuilder — the branch that dropped `env`. */
+function definitionWithBuilder(
+	agent: Agent<BaseAgentConfig, BaseAgentResult>,
+	builderEnv?: Record<string, string>,
+): AgentDefinition {
+	return {
+		info: {
+			id: 'worker',
+			name: 'worker',
+			version: '1.0.0',
+			category: 'general',
+			description: 'a worker',
+			tools: [],
+			defaults: { model: 'test', tokenBudget: 1_000 },
+		},
+		typedAgent: agent,
+		configBuilder: () =>
+			({
+				model: 'test',
+				tokenBudget: 1_000,
+				timeoutMs: 10_000,
+				...(builderEnv ? { env: builderEnv } : {}),
+			}) as BaseAgentConfig,
+	} as AgentDefinition
+}
+
+async function spawnWith(options: {
+	builderEnv?: Record<string, string>
+	overrideEnv?: Record<string, string>
+}): Promise<BaseAgentConfig | undefined> {
+	const seen: { config?: BaseAgentConfig } = {}
+	const store = new InMemorySessionStore()
+	const threadStore = new InMemoryThreadStore()
+	const project = await store.createProject({ tenantId: TENANT, name: 'p' }, TENANT)
+	const thread = await threadStore.createThread({ projectId: project.id, title: 't' }, TENANT)
+	const parentActor = { kind: 'agent', agentId: 'sup' as AgentId, tenantId: TENANT } as const
+	const parentSession = await store.createSession(
+		{ threadId: thread.id, projectId: project.id, currentActor: parentActor },
+		TENANT,
+	)
+	await store.updateSession({ ...parentSession, status: 'active' }, TENANT)
+
+	const registry = new AgentRegistry()
+	registry.register(definitionWithBuilder(recordingAgent(seen), options.builderEnv))
+
+	let n = 0
+	const manager = new AgentManager(registry, undefined, {
+		sessionStore: store,
+		threadManager: new ThreadManager({ threadStore, sessionStore: store }),
+		workspaceRegistry: new WorkspaceBackendRegistry(),
+		capacity: new DefaultCapacityValidator(store),
+		summaryMaterializer: new SessionSummaryMaterializer({
+			store,
+			generateSummaryId: () => `sum_${++n}` as SummaryId,
+		}),
+	})
+
+	const context: AgentTaskContext = {
+		parentRunId: 'run_parent' as never,
+		parentAgentId: 'sup',
+		parentAbortController: new AbortController(),
+		depth: 0,
+		budgetTracker: { total: 100_000, remaining: 100_000 },
+		tenantId: TENANT,
+		threadId: thread.id,
+		sessionId: parentSession.id,
+		projectId: project.id,
+		parentActor,
+	} as AgentTaskContext
+
+	const task = await manager.sendMessage(
+		{
+			agentId: 'worker',
+			input: { messages: [], workingDirectory: '/tmp' } as never,
+			parentSessionId: parentSession.id,
+			tenantId: TENANT,
+			projectId: project.id,
+			parentActor,
+			...(options.overrideEnv ? { configOverrides: { env: options.overrideEnv } } : {}),
+		} as never,
+		context,
+	)
+
+	await manager.waitForCompletion(task.taskId)
+	return seen.config
+}
+
+describe('an environment survives a configBuilder that never heard of it', () => {
+	it('reaches a child whose builder sets none', async () => {
+		const config = await spawnWith({ overrideEnv: { API_BASE: 'https://staging' } })
+
+		expect(config?.env).toEqual({ API_BASE: 'https://staging' })
+	})
+
+	it('keeps the builder keys the caller did not restate', async () => {
+		// Why this is a merge and not an assignment: `configOverrides` is a
+		// Partial, so replacing the map would drop everything the builder set,
+		// and a caller overriding one variable is not saying the rest should
+		// vanish.
+		const config = await spawnWith({
+			builderEnv: { REGION: 'eu', TIER: 'free' },
+			overrideEnv: { TIER: 'paid' },
+		})
+
+		expect(config?.env).toEqual({ REGION: 'eu', TIER: 'paid' })
+	})
+
+	it('leaves the builder environment alone when nothing overrides it', async () => {
+		const config = await spawnWith({ builderEnv: { REGION: 'eu' } })
+
+		expect(config?.env).toEqual({ REGION: 'eu' })
+	})
+
+	it('gives a child with no environment undefined rather than an empty map', async () => {
+		// An agent that never had an environment must not gain an empty object
+		// that every reader then has to tell apart from a real one.
+		const config = await spawnWith({})
+
+		expect(config?.env).toBeUndefined()
+	})
+})

--- a/packages/sdk/src/manager/agent/lifecycle.ts
+++ b/packages/sdk/src/manager/agent/lifecycle.ts
@@ -82,6 +82,25 @@ interface ChildSpawnRecord {
 	workspaceRef?: WorkspaceRef
 }
 
+/**
+ * Combine a child's own environment with what its parent passed down.
+ *
+ * Per key, override winning — not whole-value replacement, which would drop
+ * every key a `configBuilder` set and the caller did not happen to restate.
+ * `configOverrides` is a `Partial`, so replacement reads as "the caller
+ * supplied an environment" when what they supplied was one variable.
+ *
+ * Returns `undefined` when both sides are empty, so an agent that never had an
+ * environment does not gain an empty object it then has to be checked for.
+ */
+function mergeEnv(
+	base: Readonly<Record<string, string>> | undefined,
+	override: Readonly<Record<string, string>> | undefined,
+): Record<string, string> | undefined {
+	if (!base && !override) return undefined
+	return { ...base, ...override }
+}
+
 export class AgentManager {
 	private registry: AgentRegistry
 	private instances: Map<TaskId, AgentTask> = new Map()
@@ -289,6 +308,23 @@ export class AgentManager {
 			// covered the top-level run and nothing it delegated.
 			const inheritedHandler = options.configOverrides?.resumeHandler ?? context.resumeHandler
 			if (inheritedHandler) childConfig.resumeHandler = inheritedHandler
+
+			// And the environment, for the third time and the same reason.
+			//
+			// The bare-config branch below has always carried `env`; this one
+			// never did, so a delegate registered WITH a `configBuilder` — the
+			// normal way, and what every host in this repo does — silently ran
+			// with none of the environment its parent had been given. The
+			// builder is written by whoever registered the agent and cannot be
+			// expected to forward a field it was never told about, which is
+			// exactly why `parentSpan` and `resumeHandler` are stamped here too.
+			//
+			// Merged per key rather than replaced. `configOverrides` is a
+			// `Partial`, so assigning the whole map would drop every key the
+			// builder set and the caller did not restate — the override wins per
+			// key, the same direction it already wins for `model` and `effort`.
+			const inheritedEnv = mergeEnv(childConfig.env, options.configOverrides?.env)
+			if (inheritedEnv) childConfig.env = inheritedEnv
 		} else {
 			this.log.warn('No configBuilder, using bare config', {
 				agentId: options.agentId,

--- a/packages/sdk/src/tools/coordinator/agent.ts
+++ b/packages/sdk/src/tools/coordinator/agent.ts
@@ -146,6 +146,13 @@ export function buildAgentTool(opts: AgentToolOptions): ToolDefinition {
 				// surface, and the one it exports as the canonical shape —
 				// did not.
 				...(context.parentSpan ? { parentSpan: context.parentSpan } : {}),
+				// The parent's environment, which is the whole point of setting
+				// one: a delegate that cannot see it runs against different
+				// services than the run that launched it, silently.
+				// `ToolContext.env` is the parent's own resolved map, per run.
+				...(Object.keys(context.env ?? {}).length > 0
+					? { configOverrides: { env: context.env } }
+					: {}),
 			})
 
 			onTaskLaunched?.(handle.taskId, {

--- a/packages/sdk/src/tools/coordinator/index.ts
+++ b/packages/sdk/src/tools/coordinator/index.ts
@@ -484,6 +484,12 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 				// Hang the child run off THIS tool's span, so the delegation
 				// shows up inside the turn that asked for it.
 				...(_context.parentSpan ? { parentSpan: _context.parentSpan } : {}),
+				// Same as the `Agent` tool: a delegate inherits the environment
+				// its parent was given, or it runs against different services
+				// than the run that asked for the work.
+				...(Object.keys(_context.env ?? {}).length > 0
+					? { configOverrides: { env: _context.env } }
+					: {}),
 			})
 
 			// Whose task this is. The inbox ignores completions for anything it

--- a/packages/sdk/src/types/agent/base.ts
+++ b/packages/sdk/src/types/agent/base.ts
@@ -22,6 +22,29 @@ export interface BaseAgentConfig {
 	maxResponseTokens?: number
 	costLimitUsd?: number
 	permissionMode?: PermissionMode
+
+	/**
+	 * Extra environment variables for this agent's tools and sandboxed
+	 * commands, merged over whatever ambient environment the execution path
+	 * supplies. Inherited by every delegated descendant.
+	 *
+	 * **Configuration, not credentials** — and that is a property of the
+	 * CHANNEL rather than a judgement about any particular value. This map is
+	 * copied into every child, is readable by any tool that can run a command,
+	 * and enters a model's context and the run transcript the moment something
+	 * echoes it. Nothing here is scoped, redacted, or revocable.
+	 *
+	 * A value that authenticates to a host belongs on the brokered credential
+	 * path instead, where the process holds a placeholder and the real value is
+	 * attached per-host on egress — so it is never in the environment, never in
+	 * a transcript, and never inherited by a child that had no business with it.
+	 *
+	 * Inheritance was broken until it was not: a child built through a
+	 * `configBuilder` never received this at all, because the builder is
+	 * written by whoever registered the agent and cannot forward a field it was
+	 * never told about. It is stamped after the builder returns now, for the
+	 * same reason `parentSpan` and `resumeHandler` are.
+	 */
 	env?: Record<string, string>
 
 	/**


### PR DESCRIPTION
An environment reaches the child it was set for.

`AgentManager` builds a delegated child's config on two branches. The
bare-config branch — taken only when a definition has no `configBuilder` — has
always carried `env`. The `configBuilder` branch, which is what a host
registering a real agent actually uses, never stamped it. So a run given an
environment handed its delegates none of it, and the child ran against whatever
the ambient defaults were.

This is the third field to go the same way. `parentSpan` and `resumeHandler` are
both stamped after the builder returns, each with a comment saying the builder is
written by whoever registered the agent and cannot be expected to forward
something it was never told about. `env` was missed, and it went unnoticed
because a missing environment does not fail — the child just runs somewhere else.

Both delegation surfaces now forward the parent's `ToolContext.env` as a
`configOverrides.env`, and the manager merges it **per key** rather than
replacing the map: `configOverrides` is a `Partial`, so assignment would drop
every key the builder set and the caller did not restate. The override wins per
key, the same direction it already wins for `model`, `thinking` and `effort`.

**Widening worth naming:** a delegating agent's `config.env` now reaches every
descendant, on both surfaces. That is what setting an environment was for, and
it is a behaviour change for anyone who had been relying on delegates not
inheriting one.

**`env` is for configuration, not credentials**, and the contract now says so
where it is declared. The map is copied into every descendant, is readable by
any tool, and enters a model's context and the run transcript the moment a
command echoes it — properties of the channel, not a judgement about any
particular value. A value that authenticates to a host belongs on the brokered
credential path, where the process holds a placeholder and the value is attached
at egress.

No new field on `ProjectConfig`. It already carries six fields nothing reads,
and a workspace environment does not need a seventh: the mechanism is the
environment a run is given, which now actually propagates.
