### PR TITLE
fix(sdk)!: an id the SDK mints passes the schema the SDK exports

### DIFF
--- a/.changeset/an-id-the-sdk-mints-passes-its-own-schema.md
+++ b/.changeset/an-id-the-sdk-mints-passes-its-own-schema.md
@@ -1,0 +1,43 @@
+---
+'@namzu/sdk': major
+---
+
+An id the SDK mints passes the schema the SDK exports.
+
+`ProjectIdSchema` was `/^prj_[a-z0-9]+$/`. The v0.2.0 filesystem migration
+mints `prj_legacy_<suffix>`. So the SDK's own exported validator rejected every
+project it had itself written to disk during a migration — a host that
+validated an inbound project id, which is the only reason the schema is
+exported, answered "Invalid project ID format" for its own data, with nothing
+saying the id had come from the SDK.
+
+The schema now accepts the two shapes the SDK mints and no others:
+`prj_<12 lowercase alphanumerics>` from `generateProjectId()`, and
+`prj_legacy_<suffix>` from the migration. It is deliberately narrower than the
+`ProjectId` type, which is `prj_${string}`; a host that supplies its own
+`SessionStore` and mints its own ids should validate with its own schema.
+
+**Breaking:** the migration now refuses a legacy `thd_*` folder whose name is
+not a thread id, where it previously migrated it. The migration is the one
+place a project id is built from data rather than generated, and a folder named
+`thd_Not An Id` produced `prj_legacy_Not An Id` — structurally a `ProjectId`,
+accepted by no validator, and thereafter a directory name in the new layout.
+`DefaultFilesystemMigrator.migrate` throws `FilesystemMigrationError` with
+`op: 'validate_thread_id'` and the offending path.
+
+If your store root holds such a folder, rename it to `thd_` plus lowercase
+alphanumerics before upgrading, or move it aside; the migration is idempotent
+and re-running it after the rename completes normally. Folders created by the
+SDK are always of that shape, so a store the SDK wrote is unaffected.
+
+It refuses rather than skipping the folder. Skipping would leave that thread's
+runs on disk and unaddressable, write the completion marker anyway, and return
+`kind: 'migrated'` with the thread absent from the list.
+
+Also documented, not changed: a `projectId` that `runAgent` generates names no
+`Project` record — it takes no store and creates nothing. Carrying one into a
+store-backed `AgentManager` is refused at the first delegation with
+`Project <id> not found for tenant <id> — spawn rejected`, which is the
+enforcement site behaving correctly, since delegation limits live on the
+project. A run that has to delegate should be given the id from
+`store.createProject()`. The `AgentIdentity` doc now says so.

--- a/packages/sdk/src/agents/runAgent.ts
+++ b/packages/sdk/src/agents/runAgent.ts
@@ -22,6 +22,15 @@ import {
  * point: auto-generating alone would make each call its own session, which is
  * right for a one-shot and silently wrong for a conversation — the second turn
  * would start with no history and no shared budget, and nothing would say so.
+ *
+ * **A generated id is a correlation label, not a store handle.** `runAgent`
+ * takes no `SessionStore` and creates no records, so a `projectId` it mints
+ * names no `Project`. Carrying one into a store-backed `AgentManager` is
+ * refused at the first delegation with `Project <id> not found for tenant
+ * <id> — spawn rejected`, which is the enforcement site behaving correctly:
+ * delegation limits live on the project, and a missing project has no limits
+ * to read. A run that has to delegate should be given the id returned by
+ * `store.createProject()`.
  */
 export interface AgentIdentity {
 	sessionId?: SessionId

--- a/packages/sdk/src/contracts/__tests__/an-id-the-sdk-mints-passes-its-own-schema.test.ts
+++ b/packages/sdk/src/contracts/__tests__/an-id-the-sdk-mints-passes-its-own-schema.test.ts
@@ -1,0 +1,84 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+	DefaultFilesystemMigrator,
+	NOOP_FILESYSTEM_MIGRATION_SINK,
+} from '../../session/migration/filesystem.js'
+import { generateProjectId } from '../../utils/id.js'
+import { ProjectIdSchema } from '../schemas.js'
+
+/**
+ * `ProjectIdSchema` was `/^prj_[a-z0-9]+$/` while the v0.2.0 filesystem
+ * migration minted `prj_legacy_<suffix>`. So the SDK's own public validator
+ * rejected ids the SDK itself had written to disk: a host that validated an
+ * inbound project id — the reason the schema is exported at all — refused
+ * every project it had migrated, with "Invalid project ID format" and no hint
+ * that the id came from the SDK.
+ *
+ * Both minters are driven here rather than restated. A test that spells out
+ * `prj_legacy_abc` as a literal would still pass if the migration changed its
+ * shape tomorrow; running the migration means the two cannot drift apart
+ * without this failing.
+ */
+
+const dirs: string[] = []
+afterEach(async () => {
+	await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })))
+	dirs.length = 0
+})
+
+describe('every project id the SDK mints passes the schema the SDK exports', () => {
+	it('accepts what the id generator produces', () => {
+		// 200 draws, because the generator is random over [0-9a-z] and one
+		// sample proves nothing about the alphabet it can reach.
+		for (let i = 0; i < 200; i++) {
+			const id = generateProjectId()
+			const parsed = ProjectIdSchema.safeParse(id)
+			expect({ id, ok: parsed.success }).toEqual({ id, ok: true })
+		}
+	})
+
+	it('accepts what the filesystem migration produces', async () => {
+		const root = await mkdtemp(join(tmpdir(), 'namzu-idschema-'))
+		dirs.push(root)
+		const runDir = join(root, 'threads', 'thd_a1b2c3d4e5f6', 'runs', 'run_seed')
+		await mkdir(runDir, { recursive: true })
+		await writeFile(join(runDir, 'run.json'), JSON.stringify({ id: 'run_seed' }), 'utf-8')
+
+		const result = await new DefaultFilesystemMigrator(NOOP_FILESYSTEM_MIGRATION_SINK).migrate(root)
+
+		expect(result.kind).toBe('migrated')
+		expect(result.migratedThreads).toHaveLength(1)
+		for (const { newProjectId } of result.migratedThreads) {
+			const parsed = ProjectIdSchema.safeParse(newProjectId)
+			expect({ newProjectId, ok: parsed.success }).toEqual({ newProjectId, ok: true })
+		}
+	})
+
+	it('still refuses what no minter produces, because the id is also a directory name', () => {
+		// Widening to accept the legacy form must not widen to accept a path.
+		// Everything here would be joined onto the store root if it got through.
+		const refused = [
+			'prj_../../etc',
+			'prj_..',
+			'prj_a/b',
+			'prj_a\\b',
+			'prj_',
+			'prj_legacy_',
+			'prj_ABC',
+			'prj_a-b',
+			'prj_a b',
+			'proj_abc',
+			'thd_abc',
+			'',
+		]
+
+		for (const candidate of refused) {
+			const parsed = ProjectIdSchema.safeParse(candidate)
+			expect({ candidate, ok: parsed.success }).toEqual({ candidate, ok: false })
+		}
+	})
+})

--- a/packages/sdk/src/contracts/schemas.ts
+++ b/packages/sdk/src/contracts/schemas.ts
@@ -1,6 +1,23 @@
 import { z } from 'zod'
 
-export const ProjectIdSchema = z.string().regex(/^prj_[a-z0-9]+$/, 'Invalid project ID format')
+/**
+ * The two shapes the SDK mints, and nothing else.
+ *
+ * `prj_<12 lowercase alphanumerics>` comes from `generateProjectId()`.
+ * `prj_legacy_<suffix>` comes from the v0.2.0 filesystem migration, which
+ * synthesises a project per legacy `thd_*` folder. The `legacy_` segment is
+ * spelled out rather than covered by a permissive character class, because a
+ * project id is also a directory name: everything this accepts is joined to a
+ * path, so the set it accepts is a containment boundary, not a formatting
+ * preference.
+ *
+ * A host that supplies its own `SessionStore` and mints its own ids should
+ * validate with its own schema — `ProjectId` is `prj_${string}` at the type
+ * level and this schema is deliberately narrower.
+ */
+export const ProjectIdSchema = z
+	.string()
+	.regex(/^prj_(legacy_)?[a-z0-9]+$/, 'Invalid project ID format')
 export const RunIdSchema = z.string().regex(/^run_[a-z0-9]+$/, 'Invalid run ID format')
 export const MessageIdSchema = z.string().regex(/^msg_[a-z0-9]+$/, 'Invalid message ID format')
 

--- a/packages/sdk/src/session/migration/__tests__/a-migrated-project-id-is-an-id.test.ts
+++ b/packages/sdk/src/session/migration/__tests__/a-migrated-project-id-is-an-id.test.ts
@@ -1,0 +1,92 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { ProjectIdSchema } from '../../../contracts/schemas.js'
+import { FilesystemMigrationError } from '../errors.js'
+import { DefaultFilesystemMigrator, NOOP_FILESYSTEM_MIGRATION_SINK } from '../filesystem.js'
+
+/**
+ * The v0.2.0 migration is the only place a `ProjectId` is built from data
+ * instead of generated: it takes a legacy `thd_*` folder name off disk and
+ * mints `prj_legacy_<that name>`. The only check the name had passed was
+ * `startsWith('thd_')`, so a folder named `thd_Not An Id` produced a project
+ * id that satisfies the TypeScript type, is written into the new layout as a
+ * directory name, and is rejected by the SDK's own `ProjectIdSchema`.
+ *
+ * It refuses such a folder rather than skipping it. Skipping would leave that
+ * thread's runs on disk and unaddressable, write the completion marker anyway,
+ * and return `kind: 'migrated'` with the thread missing from the list — the
+ * failure shape this codebase keeps meeting, where the run did not fail, it
+ * succeeded while quietly not doing what it said.
+ */
+
+const dirs: string[] = []
+afterEach(async () => {
+	await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })))
+	dirs.length = 0
+})
+
+async function seed(root: string, folder: string): Promise<void> {
+	const dir = join(root, 'threads', folder, 'runs', 'run_seed')
+	await mkdir(dir, { recursive: true })
+	await writeFile(join(dir, 'run.json'), JSON.stringify({ id: 'run_seed' }), 'utf-8')
+}
+
+async function newRoot(tag: string): Promise<string> {
+	const root = await mkdtemp(join(tmpdir(), `namzu-mig-${tag}-`))
+	dirs.push(root)
+	return root
+}
+
+describe('the migration only mints project ids that are project ids', () => {
+	it('refuses a legacy folder whose name is not a thread id, and names it', async () => {
+		const root = await newRoot('badname')
+		await seed(root, 'thd_Not An Id')
+
+		const error = await new DefaultFilesystemMigrator(NOOP_FILESYSTEM_MIGRATION_SINK)
+			.migrate(root)
+			.then(
+				() => null,
+				(e: unknown) => e,
+			)
+
+		expect(error).toBeInstanceOf(FilesystemMigrationError)
+		const details = (error as FilesystemMigrationError).details
+		expect(details.op).toBe('validate_thread_id')
+		// An operator has to be able to go and look at the folder.
+		expect(details.path).toContain('thd_Not An Id')
+	})
+
+	it('refuses rather than reporting a migration that left a thread behind', async () => {
+		// The seductive alternative is `continue`. This pins why it is wrong:
+		// the good thread would migrate, the result would say `migrated`, and
+		// the bad one would be absent from `migratedThreads` with no error.
+		const root = await newRoot('partial')
+		await seed(root, 'thd_a1b2c3d4e5f6')
+		await seed(root, 'thd_UPPER')
+
+		await expect(
+			new DefaultFilesystemMigrator(NOOP_FILESYSTEM_MIGRATION_SINK).migrate(root),
+		).rejects.toBeInstanceOf(FilesystemMigrationError)
+	})
+
+	it('still migrates a folder whose name is a thread id, and the id it mints validates', async () => {
+		// The guard must refuse only what is not an id. A guard that refuses
+		// everything passes the two cases above and breaks migration entirely.
+		const root = await newRoot('good')
+		await seed(root, 'thd_a1b2c3d4e5f6')
+
+		const result = await new DefaultFilesystemMigrator(NOOP_FILESYSTEM_MIGRATION_SINK).migrate(root)
+
+		expect(result.kind).toBe('migrated')
+		expect(result.migratedThreads.map((m) => m.legacyThreadId)).toEqual(['thd_a1b2c3d4e5f6'])
+		for (const { newProjectId } of result.migratedThreads) {
+			expect({ newProjectId, ok: ProjectIdSchema.safeParse(newProjectId).success }).toEqual({
+				newProjectId,
+				ok: true,
+			})
+		}
+	})
+})

--- a/packages/sdk/src/session/migration/filesystem.ts
+++ b/packages/sdk/src/session/migration/filesystem.ts
@@ -248,6 +248,34 @@ export class DefaultFilesystemMigrator implements FilesystemMigrator {
 
 				const legacyThreadId = entry
 				const suffix = legacyThreadId.slice('thd_'.length)
+
+				// The suffix comes off the filesystem, and `startsWith('thd_')`
+				// is the only thing it has passed. A folder named `thd_Not An
+				// Id` mints `prj_legacy_Not An Id`: structurally a `ProjectId`,
+				// accepted by no validator, and now a directory name in the new
+				// layout. The migration is the one place a project id is built
+				// from data rather than generated, so it is the one place the
+				// id contract has to be checked.
+				//
+				// (Not a containment check — it cannot be one. `readdir` yields
+				// path components, which hold no separator, and `..` is never
+				// among them; `prj_legacy_..` is a literal name, not a parent
+				// reference. Nothing here can leave the root.)
+				//
+				// It refuses rather than skipping. A skipped folder is a legacy
+				// thread whose runs are still on disk and no longer addressable,
+				// with nothing in the result saying so — and the marker would be
+				// written as if the migration were complete.
+				if (!/^[a-z0-9]+$/.test(suffix)) {
+					throw new FilesystemMigrationError({
+						op: 'validate_thread_id',
+						path: join(threadsDir, legacyThreadId),
+						cause: new Error(
+							`Legacy thread folder '${legacyThreadId}' is not a thread id: expected 'thd_' followed by lowercase alphanumerics. It is refused rather than migrated because the name is used as a directory name.`,
+						),
+					})
+				}
+
 				const newProjectId = `${LEGACY_DEFAULT_PROJECT_PREFIX}${suffix}` as ProjectId
 
 				const legacyRunsDir = join(threadsDir, legacyThreadId, 'runs')


### PR DESCRIPTION
`ProjectIdSchema` was `/^prj_[a-z0-9]+$/` while the v0.2.0 filesystem migration mints `prj_legacy_<suffix>`. The SDK's own exported validator rejected every project the SDK had itself written to disk during a migration — and validating an inbound project id is the only reason that schema is exported.

Closes the first half of the id defects reported against the hierarchy work.

## What changed

- `ProjectIdSchema` accepts the two shapes the SDK mints — `prj_<12 lowercase alphanumerics>` from `generateProjectId()` and `prj_legacy_<suffix>` from the migration — and nothing else. It stays deliberately narrower than the `ProjectId` type (`prj_\`).
- **Breaking.** `DefaultFilesystemMigrator.migrate` refuses a legacy `thd_*` folder whose name is not a thread id, throwing `FilesystemMigrationError` with `op: 'validate_thread_id'`. It previously migrated it, minting `prj_legacy_Not An Id` — structurally a `ProjectId`, accepted by no validator, and thereafter a directory name. Migration is the only place a project id is built from data rather than generated. Folders the SDK created are always of the accepted shape, so a store the SDK wrote is unaffected.
- `AgentIdentity` now documents that a `runAgent`-generated `projectId` names no `Project` record, and that carrying one into a store-backed `AgentManager` is refused at the first delegation. No behaviour change — the enforcement site was already correct; nothing said so.

## Why it refuses rather than skips

Skipping the folder would leave that thread's runs on disk and unaddressable, write the completion marker anyway, and return `kind: 'migrated'` with the thread absent from the list.

## Verification

- Both tests drive the real minters instead of restating their output: 200 draws from `generateProjectId()`, and an actual migration whose returned id is fed to the actual schema. Neither can pass if the two drift apart.
- Mutation: narrowing the schema back fails 2 tests; removing the guard fails 2 tests.
- Typecheck 0, lint 0, 2825 tests pass.