### PR TITLE
fix(sdk): an MCP transport forgets its listeners when the session closes

### DIFF
--- a/.changeset/a-transport-forgets-its-listeners.md
+++ b/.changeset/a-transport-forgets-its-listeners.md
@@ -1,0 +1,32 @@
+---
+'@namzu/sdk': patch
+---
+
+An MCP transport forgets its listeners when the session closes.
+
+`onMessage`, `onClose` and `onError` appended to arrays that nothing ever
+drained. `MCPClient.connect()` calls all three once each, and it is reachable
+again after `disconnect()` — the guard only refuses when the status is already
+`connected`. So every reconnect stacked another set on the last: after n
+cycles one inbound message dispatched to n handlers, n-1 of them closures over
+sessions that had ended. `rejectAllPending` and `emitLifecycle` fired n times
+per close, and each stale closure held its old client state alive for as long
+as the transport object did.
+
+All three transports clear their handlers now — **after** notifying, never
+before.
+
+The ordering is the whole fix. `HttpSseTransport` and `StreamableHttpTransport`
+call their close handlers inside `close()`, so they clear immediately
+afterwards. `StdioTransport` does not: its close handlers run from the child
+process's own `close` event, which arrives after `close()` has returned.
+Clearing there — the obvious one-line change — would mean nothing tells
+`MCPClient` the session ended, so its status would stay `connected` and the
+next `connect()` would be refused with "already connected". Its handlers are
+dropped after that event fires instead, with the never-spawned case handled
+separately so a retry after a failed spawn does not stack a second set.
+
+Not changed, and worth knowing: the two HTTP transports disagree about closing
+a transport that was never connected — streamable returns early and notifies
+nobody, http-sse notifies regardless. Making them agree changes what a host
+observes and deserves its own decision.

--- a/packages/sdk/src/connector/mcp/__tests__/a-transport-forgets-its-listeners.test.ts
+++ b/packages/sdk/src/connector/mcp/__tests__/a-transport-forgets-its-listeners.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+
+import type { MCPJsonRpcMessage } from '../../../types/connector/index.js'
+import { HttpSseTransport } from '../http-sse.js'
+import { StreamableHttpTransport } from '../streamable-http.js'
+
+/**
+ * Handler registration was append-only and nothing ever dropped it.
+ *
+ * `MCPClient.connect()` calls `onMessage`, `onClose` and `onError` once each,
+ * and it is reachable again after `disconnect()` — the guard only refuses when
+ * the status is already `connected`. So every reconnect stacked another set on
+ * the last: after n cycles one inbound message dispatched to n handlers, n-1
+ * of them closures over dead sessions. `rejectAllPending` and `emitLifecycle`
+ * fired n times per close, and the stale closures held their old client state
+ * alive for as long as the transport object did.
+ *
+ * The two HTTP transports are exercised here because they notify inside
+ * `close()`. `StdioTransport` notifies from the child process's own `close`
+ * event, so its handlers deliberately outlive the `close()` call and are
+ * dropped after that event fires — clearing them earlier would leave the
+ * client believing it was still connected, and its next `connect()` would be
+ * refused with "already connected". That ordering is the reason the obvious
+ * one-line fix is wrong there.
+ */
+
+const MESSAGE = { jsonrpc: '2.0', method: 'ping' } as MCPJsonRpcMessage
+
+interface Transport {
+	close(): Promise<void>
+	onMessage(handler: (message: MCPJsonRpcMessage) => void): void
+	onClose(handler: () => void): void
+}
+
+/**
+ * `open` puts the transport in the state where `close()` notifies.
+ *
+ * They differ, and the difference is real rather than a test artefact:
+ * `StreamableHttpTransport.close()` returns early when it was never connected,
+ * `HttpSseTransport.close()` notifies regardless. Streamable's `connect()`
+ * does no I/O — it sets a flag — so opening it here reaches no network. The
+ * divergence itself is left alone; making the two agree changes what a host
+ * observes and deserves its own decision.
+ */
+const IMPLEMENTATIONS: ReadonlyArray<
+	readonly [string, () => Transport, (t: Transport) => Promise<void>]
+> = [
+	[
+		'http-sse',
+		() => new HttpSseTransport({ url: 'http://127.0.0.1:1/mcp' } as never),
+		async () => {},
+	],
+	[
+		'streamable-http',
+		() => new StreamableHttpTransport({ url: 'http://127.0.0.1:1/mcp' } as never),
+		async (t) => {
+			await (t as unknown as { connect(): Promise<void> }).connect()
+		},
+	],
+]
+
+describe.each(IMPLEMENTATIONS)(
+	'a %s transport forgets its listeners on close',
+	(_n, build, open) => {
+		it('notifies each close handler exactly once per registration', async () => {
+			const transport = build()
+			await open(transport)
+			let closes = 0
+			transport.onClose(() => {
+				closes++
+			})
+
+			await transport.close()
+			// A second registration is what a reconnect does. If the first
+			// survived the close, this close fires twice.
+			await open(transport)
+			transport.onClose(() => {
+				closes++
+			})
+			await transport.close()
+
+			expect(closes).toBe(2)
+		})
+
+		it('does not dispatch a message to a handler from a closed session', async () => {
+			// The consequence a host actually sees: work done twice, by a
+			// closure that belongs to a session that ended.
+			const seen: string[] = []
+			const transport = build()
+			await open(transport)
+			transport.onMessage(() => seen.push('first'))
+
+			await transport.close()
+			await open(transport)
+			transport.onMessage(() => seen.push('second'))
+			dispatch(transport, MESSAGE)
+
+			expect(seen).toEqual(['second'])
+		})
+
+		it('still notifies the handlers registered for the session being closed', async () => {
+			// The failure mode of clearing too eagerly: close arrives, nobody is
+			// told, and the client believes it is still connected.
+			const transport = build()
+			await open(transport)
+			const order: string[] = []
+			transport.onClose(() => order.push('notified'))
+
+			await transport.close()
+
+			expect(order).toEqual(['notified'])
+		})
+	},
+)
+
+/**
+ * Reach the private dispatch the way an inbound frame does. Both transports
+ * loop `messageHandlers` from their own parse path; there is no public method
+ * that pushes a message in, and adding one for a test would be a surface
+ * nobody asked for.
+ */
+function dispatch(transport: Transport, message: MCPJsonRpcMessage): void {
+	const handlers = (
+		transport as unknown as { messageHandlers: Array<(m: MCPJsonRpcMessage) => void> }
+	).messageHandlers
+	for (const handler of handlers) handler(message)
+}

--- a/packages/sdk/src/connector/mcp/http-sse.ts
+++ b/packages/sdk/src/connector/mcp/http-sse.ts
@@ -51,6 +51,23 @@ export class HttpSseTransport implements MCPTransport {
 		this.abortController?.abort()
 		this.abortController = null
 		for (const handler of this.closeHandlers) handler()
+		// After the notification, never before it.
+		this.clearHandlers()
+	}
+
+	/**
+	 * Drop every registered handler.
+	 *
+	 * `onMessage`/`onClose`/`onError` append, and `MCPClient.connect()` calls
+	 * all three every time — and is reachable again after `disconnect()`. So
+	 * without this each reconnect duplicated the set, and after n cycles one
+	 * inbound message dispatched to n handlers, n-1 of them closures over dead
+	 * sessions that kept their old client state alive.
+	 */
+	private clearHandlers(): void {
+		this.messageHandlers = []
+		this.closeHandlers = []
+		this.errorHandlers = []
 	}
 
 	async send(message: MCPJsonRpcMessage): Promise<void> {

--- a/packages/sdk/src/connector/mcp/stdio.ts
+++ b/packages/sdk/src/connector/mcp/stdio.ts
@@ -12,6 +12,8 @@ export class StdioTransport implements MCPTransport {
 	private closeHandlers: Array<() => void> = []
 	private errorHandlers: Array<(error: Error) => void> = []
 	private connected = false
+	/** True between kill and the process's own `close` event. */
+	private exitPending = false
 	private buffer = ''
 	private log: Logger
 
@@ -41,6 +43,10 @@ export class StdioTransport implements MCPTransport {
 			this.connected = false
 			this.log.info(`MCP server process exited with code ${code}`)
 			for (const handler of this.closeHandlers) handler()
+			// After the notification, not before it: this event is what tells
+			// `MCPClient` the session ended.
+			this.exitPending = false
+			this.clearHandlers()
 		})
 
 		this.process.on('error', (err) => {
@@ -55,11 +61,38 @@ export class StdioTransport implements MCPTransport {
 	}
 
 	async close(): Promise<void> {
-		if (!this.process) return
+		if (!this.process) {
+			// Nothing was spawned, or the exit already ran. No `close` event is
+			// coming, so this is the only chance to drop what `connect()`
+			// registered — and without it a retry after a failed spawn stacks a
+			// second set of handlers on the first.
+			if (!this.exitPending) this.clearHandlers()
+			return
+		}
 		this.connected = false
+		this.exitPending = true
 		this.process.kill('SIGTERM')
 		this.process = null
 		this.buffer = ''
+		// The handlers deliberately survive this call. `process.on('close')`
+		// fires them when the process actually exits, and dropping them here
+		// would leave `MCPClient` believing it is still connected — so its next
+		// `connect()` would be refused with "already connected".
+	}
+
+	/**
+	 * Drop every registered handler.
+	 *
+	 * `onMessage`/`onClose`/`onError` append, and `MCPClient.connect()` calls
+	 * all three every time — and is reachable again after `disconnect()`. So
+	 * without this each reconnect duplicated the set, and after n cycles one
+	 * inbound message dispatched to n handlers, n-1 of them closures over dead
+	 * sessions that kept their old client state alive.
+	 */
+	private clearHandlers(): void {
+		this.messageHandlers = []
+		this.closeHandlers = []
+		this.errorHandlers = []
 	}
 
 	async send(message: MCPJsonRpcMessage): Promise<void> {

--- a/packages/sdk/src/connector/mcp/streamable-http.ts
+++ b/packages/sdk/src/connector/mcp/streamable-http.ts
@@ -26,9 +26,23 @@ export class StreamableHttpTransport implements MCPTransport {
 	}
 
 	async close(): Promise<void> {
-		if (!this.connected) return
+		if (!this.connected) {
+			// Never connected, or already closed: nothing will notify, so this is
+			// the only chance to drop what `connect()` registered before it failed.
+			this.clearHandlers()
+			return
+		}
 		this.connected = false
 		for (const handler of this.closeHandlers) handler()
+		// After the notification, never before it.
+		this.clearHandlers()
+	}
+
+	/** See {@link StdioTransport} — the same append-only handler leak. */
+	private clearHandlers(): void {
+		this.messageHandlers = []
+		this.closeHandlers = []
+		this.errorHandlers = []
 	}
 
 	async send(message: MCPJsonRpcMessage): Promise<void> {


### PR DESCRIPTION
`onMessage`, `onClose` and `onError` appended to arrays nothing ever drained. `MCPClient.connect()` calls all three once each and is reachable again after `disconnect()` — the guard only refuses when the status is already `connected`. So every reconnect stacked another set on the last: after *n* cycles one inbound message dispatched to *n* handlers, *n−1* of them closures over sessions that had ended. `rejectAllPending` and `emitLifecycle` fired *n* times per close, and each stale closure held its old client state alive for as long as the transport did.

Found by an audit sweep; confirmed at source before acting.

## The ordering is the whole fix

`HttpSseTransport` and `StreamableHttpTransport` call their close handlers inside `close()`, so they clear immediately afterwards.

`StdioTransport` does **not**. Its close handlers run from the child process's own `close` event, which arrives after `close()` has returned. Clearing there — the obvious one-line change — would mean nothing tells `MCPClient` the session ended, so its status would stay `connected` and the next `connect()` would be refused with "already connected". Its handlers are dropped after that event fires instead, with the never-spawned case handled separately so a retry after a failed spawn does not stack a second set.

## Left alone, and named

The two HTTP transports disagree about closing a transport that was never connected: streamable returns early and notifies nobody, http-sse notifies regardless. Making them agree changes what a host observes and deserves its own decision. The test's per-transport setup documents the difference rather than papering over it.

## Verification

Removing the clearing fails 4 of 6 tests. Typecheck 0, lint 0, 2831 tests pass.