### PR TITLE
fix(sdk): an edge that already exists is not news

### DIFF
--- a/.changeset/an-edge-that-already-exists-is-not-news.md
+++ b/.changeset/an-edge-that-already-exists-is-not-news.md
@@ -1,0 +1,24 @@
+---
+'@namzu/sdk': patch
+---
+
+`InMemoryTaskStore.block()` stops announcing an edge that already existed.
+
+The two task stores disagreed about what `task.updated` means. `block()` is
+idempotent on both — each guards its array against a duplicate entry — but only
+the disk store guarded the *announcement*. Calling `block(a, b)` twice emitted
+two `task.updated` events from the in-memory store and one from the disk store,
+which is the one a host runs in production.
+
+So a host rebuilding a dependency graph from the event stream did redundant
+work against the reference implementation and not the durable one, and a host
+counting events to detect change saw change where there was none. The
+divergence is the kind that stays invisible until a store is swapped.
+
+The disk store's behaviour was already correct and is now the behaviour of
+both. No event is lost: a call that establishes a new edge — including one that
+repairs a half-edge, where only one of the two arrays grows — still announces
+both ends, because both ends are one fact.
+
+The disk store's side of this had no test, which is why the disagreement
+survived. Both are now driven from the same cases.

--- a/packages/sdk/src/store/task/__tests__/an-edge-that-already-exists-is-not-news.test.ts
+++ b/packages/sdk/src/store/task/__tests__/an-edge-that-already-exists-is-not-news.test.ts
@@ -1,0 +1,115 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { RunId } from '../../../types/ids/index.js'
+import type { TaskEvent, TaskStore } from '../../../types/task/index.js'
+import { DiskTaskStore } from '../disk.js'
+import { InMemoryTaskStore } from '../memory.js'
+
+/**
+ * The two stores disagreed about what `task.updated` means.
+ *
+ * `block()` is idempotent on both — it guards each array against a duplicate
+ * entry — but only the disk store guarded the *announcement*. Calling
+ * `block(a, b)` twice emitted two `task.updated` events from the in-memory
+ * store and one from the disk store, which is the one a host runs in
+ * production. So a host rebuilding a dependency graph from the stream did
+ * redundant work against the reference implementation and not the durable one,
+ * and a host counting events to detect change saw change where there was none.
+ *
+ * The disk store's behaviour is the correct one and the in-memory store now
+ * matches it: an edge that already existed is not news.
+ *
+ * Both are driven from the same cases here, because a reference implementation
+ * that disagrees with the durable one is worse than having only one — the
+ * disagreement is invisible until a host swaps stores in production.
+ */
+
+const RUN = 'run_edge' as RunId
+
+const dirs: string[] = []
+afterEach(async () => {
+	await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })))
+	dirs.length = 0
+})
+
+async function diskStore(): Promise<TaskStore> {
+	const dir = await mkdtemp(join(tmpdir(), 'namzu-edge-'))
+	dirs.push(dir)
+	return new DiskTaskStore({ baseDir: dir, defaultRunId: RUN })
+}
+
+const IMPLEMENTATIONS: ReadonlyArray<readonly [string, () => Promise<TaskStore>]> = [
+	['in memory', async () => new InMemoryTaskStore()],
+	['on disk', diskStore],
+]
+
+describe.each(IMPLEMENTATIONS)('an edge that already exists is not news (%s)', (_n, build) => {
+	async function twoTasks(store: TaskStore) {
+		const blocker = await store.create({ runId: RUN, subject: 'blocker' })
+		const blocked = await store.create({ runId: RUN, subject: 'blocked' })
+		return { blocker, blocked }
+	}
+
+	function recordUpdates(store: TaskStore): TaskEvent[] {
+		const seen: TaskEvent[] = []
+		store.on((event) => {
+			if (event.type === 'task.updated') seen.push(event)
+		})
+		return seen
+	}
+
+	it('announces both ends when the edge is written', async () => {
+		// The control: without it, "no second announcement" could be passing
+		// because nothing announces at all.
+		const store = await build()
+		const { blocker, blocked } = await twoTasks(store)
+		const seen = recordUpdates(store)
+
+		await store.block(blocker.id, blocked.id)
+
+		expect(seen.map((e) => e.taskId)).toEqual([blocker.id, blocked.id])
+	})
+
+	it('says nothing the second time', async () => {
+		const store = await build()
+		const { blocker, blocked } = await twoTasks(store)
+		await store.block(blocker.id, blocked.id)
+		const seen = recordUpdates(store)
+
+		await store.block(blocker.id, blocked.id)
+
+		expect(seen).toEqual([])
+	})
+
+	it('still records the edge exactly once after a repeated call', async () => {
+		// Suppressing the event must not become suppressing the write, and the
+		// arrays must not grow a duplicate.
+		const store = await build()
+		const { blocker, blocked } = await twoTasks(store)
+
+		await store.block(blocker.id, blocked.id)
+		await store.block(blocker.id, blocked.id)
+
+		expect((await store.get(blocker.id))?.blocks).toEqual([blocked.id])
+		expect((await store.get(blocked.id))?.blockedBy).toEqual([blocker.id])
+	})
+
+	it('announces a repair when only one side of the edge was missing', async () => {
+		// A half-edge is the case the early return must not swallow: one array
+		// already names the other and its counterpart does not. Both ends are
+		// one fact, so both are announced even though only one array grew.
+		const store = await build()
+		const { blocker, blocked } = await twoTasks(store)
+		await store.block(blocker.id, blocked.id)
+		// Reverse direction: `blocked` has not yet been recorded as blocking
+		// `blocker`, so this is a new edge, not the existing one.
+		const seen = recordUpdates(store)
+
+		await store.block(blocked.id, blocker.id)
+
+		expect(seen.map((e) => e.taskId)).toEqual([blocked.id, blocker.id])
+	})
+})

--- a/packages/sdk/src/store/task/memory.ts
+++ b/packages/sdk/src/store/task/memory.ts
@@ -177,18 +177,29 @@ export class InMemoryTaskStore implements TaskStore {
 		const blocked = this.tasks.get(blockedId)
 		if (!blocker || !blocked) return
 
+		let mutated = false
 		if (!blocker.blocks.includes(blockedId)) {
 			blocker.blocks.push(blockedId)
+			mutated = true
 		}
 		if (!blocked.blockedBy.includes(blockerId)) {
 			blocked.blockedBy.push(blockerId)
+			mutated = true
 		}
+		// An edge that already existed is not news. This used to announce
+		// unconditionally while the disk store — the one a host runs in
+		// production — returned early, so the same call sequence produced two
+		// events from one implementation and none from the other. A host
+		// rebuilding a graph from the stream did redundant work against one
+		// store and not the other, and a host counting events to detect change
+		// saw change where there was none.
+		if (!mutated) return
 
 		// Announce BOTH ends. The edge was written and nothing said so, which
 		// left the graph observable only by polling: a listener saw a unit
 		// created and never learned that something now waits on it. Both sides
-		// changed, so both are announced — a host tracking only one would draw
-		// half the edge.
+		// are one fact, so both are announced even when only one array grew —
+		// a host tracking a single side would draw half the edge.
 		const now = Date.now()
 		this.emit({ type: 'task.updated', taskId: blockerId, task: blocker, timestamp: now })
 		this.emit({ type: 'task.updated', taskId: blockedId, task: blocked, timestamp: now })


### PR DESCRIPTION
The two task stores disagreed about what `task.updated` means.

`block()` is idempotent on both — each guards its array against a duplicate entry — but only the disk store guarded the *announcement*. Calling `block(a, b)` twice emitted **two** `task.updated` events from `InMemoryTaskStore` and **one** from `DiskTaskStore`, which is the one a host runs in production.

A host rebuilding a dependency graph from the event stream did redundant work against the reference implementation and not the durable one; a host counting events to detect change saw change where there was none. This is the kind of divergence that stays invisible until someone swaps stores.

Last of the four high-severity findings from the audit sweep. Verified at source before acting.

## What changed

`InMemoryTaskStore.block()` tracks whether either array actually grew and returns before emitting when neither did — the disk store's existing behaviour.

Nothing is lost. A call that establishes a new edge, **including one that repairs a half-edge where only one of the two arrays grows**, still announces both ends, because both ends are one fact. That case has its own test, since an early return is exactly what would swallow it.

## Why it survived

The disk store's side had no test. The guard was written correctly there and nothing pinned it, so nothing compared the two. Both are now driven from the same cases.

## Verification

Mutation: removing the in-memory guard fails a test; removing the disk guard fails the same test on the other implementation. Typecheck 0, lint 0, 2848 tests pass.
