### PR TITLE
fix(sdk): an unanswerable precondition is a refusal, not an empty answer

### DIFF
--- a/.changeset/an-unanswerable-precondition-is-a-refusal.md
+++ b/.changeset/an-unanswerable-precondition-is-a-refusal.md
@@ -1,0 +1,24 @@
+---
+'@namzu/sdk': patch
+---
+
+`ProjectManager.archive` refuses when it cannot establish the precondition.
+
+14.0.0 shipped archival that "refuses rather than cascading" — a workspace with
+a live session throws `ProjectNotEmptyError` instead of closing over running
+work. The check read the session list as
+`(await store.listSessionsByProject?.(...)) ?? []`, and `listSessionsByProject`
+is optional. So on a store that does not implement it, "this store cannot tell
+me what is running here" became "nothing is running here": the workspace closed
+over live sessions and the call returned success.
+
+It now throws, naming the missing method and what to do instead. Both stores in
+this package implement it, so nothing in-tree changes; a host with its own
+`SessionStore` gets a refusal where it previously got a wrong answer.
+
+The mistake is worth naming, because the two halves are each correct and only
+the combination is not. Optional-on-the-interface protects implementors: a
+host's own store should not stop compiling because the SDK grew a method. It
+cannot also mean a **safety precondition silently passes**. Where a store
+cannot answer the question the check exists to ask, the answer is a refusal,
+not a default.

--- a/packages/sdk/src/manager/project/__tests__/a-closed-workspace-takes-no-work.test.ts
+++ b/packages/sdk/src/manager/project/__tests__/a-closed-workspace-takes-no-work.test.ts
@@ -22,6 +22,7 @@ import type { AgentDefinition } from '../../../types/agent/factory.js'
 import type { AgentTaskContext } from '../../../types/agent/task.js'
 import type { AgentId, TenantId } from '../../../types/ids/index.js'
 import type { SummaryId } from '../../../types/session/ids.js'
+import type { SessionStore } from '../../../types/session/store.js'
 import { ZERO_COST } from '../../../utils/cost.js'
 import { AgentManager } from '../../agent/lifecycle.js'
 import { ThreadManager } from '../../thread/lifecycle.js'
@@ -264,5 +265,50 @@ describe('a workspace stored before it had a status', () => {
 
 		const archived = await new ProjectManager({ store }).archive(project.id, TENANT)
 		expect(archived.status).toBe('archived')
+	})
+})
+
+describe('a store that cannot answer the precondition', () => {
+	/**
+	 * `listSessionsByProject` is optional on `SessionStore` so a host's own
+	 * store keeps compiling. The archive path read it as
+	 * `(await store.listSessionsByProject?.(...)) ?? []`, which turned "this
+	 * store cannot tell me what is running here" into "nothing is running
+	 * here" — so a host with such a store closed a workspace over live
+	 * sessions and got a success back. The refusal that the whole feature is
+	 * about was skippable by not implementing one method.
+	 */
+	function storeWithoutTheListing(inner: SessionStore): SessionStore {
+		const partial: Record<string, unknown> = {}
+		for (const key of [
+			'getProject',
+			'createProject',
+			'createSession',
+			'getSession',
+			'updateSession',
+			'setProjectStatus',
+		]) {
+			const fn = (inner as unknown as Record<string, unknown>)[key]
+			if (typeof fn === 'function') partial[key] = (fn as (...a: unknown[]) => unknown).bind(inner)
+		}
+		return partial as unknown as SessionStore
+	}
+
+	it('refuses to archive rather than assuming the workspace is empty', async () => {
+		const h = await harness()
+		await h.store.updateSession({ ...h.parentSession, status: 'active' }, TENANT)
+		const blind = new ProjectManager({ store: storeWithoutTheListing(h.store) })
+
+		await expect(blind.archive(h.project.id, TENANT)).rejects.toThrow(/listSessionsByProject/)
+	})
+
+	it('leaves the workspace open after refusing', async () => {
+		// The refusal has to happen before the write, or it is only a message.
+		const h = await harness()
+		const blind = new ProjectManager({ store: storeWithoutTheListing(h.store) })
+
+		await blind.archive(h.project.id, TENANT).catch(() => undefined)
+
+		expect((await h.store.getProject(h.project.id, TENANT))?.status).toBe('open')
 	})
 })

--- a/packages/sdk/src/manager/project/lifecycle.ts
+++ b/packages/sdk/src/manager/project/lifecycle.ts
@@ -101,7 +101,25 @@ export class ProjectManager {
 			throw new Error(`Project ${projectId} not found for tenant ${tenantId} — archive rejected`)
 		}
 
-		const sessions = (await this.deps.store.listSessionsByProject?.(projectId, tenantId)) ?? []
+		// An unanswerable precondition is a refusal, not an empty answer.
+		//
+		// This read used to be `?? []`, which turned "this store cannot tell me
+		// what is running here" into "nothing is running here": a store without
+		// the optional method archived the workspace over live sessions and
+		// reported success. The whole point of the check is that archival does
+		// not cascade over running work, and the check was skippable by any
+		// store that had not implemented one optional method.
+		//
+		// Optional on the interface protects implementors — a host's own store
+		// should not stop compiling because the SDK grew a method. It cannot
+		// also mean a safety precondition silently passes.
+		const listByProject = this.deps.store.listSessionsByProject
+		if (!listByProject) {
+			throw new Error(
+				`Project ${projectId} cannot be archived: this SessionStore does not implement listSessionsByProject, so whether a session is still running in the workspace cannot be established. Implement it, or settle and verify the sessions through your own path before closing the workspace.`,
+			)
+		}
+		const sessions = await listByProject.call(this.deps.store, projectId, tenantId)
 		const blocking = sessions.filter((s) => ARCHIVAL_BLOCKING_STATUSES.has(s.status))
 		if (blocking.length > 0) {
 			throw new ProjectNotEmptyError({


### PR DESCRIPTION
A defect I shipped in 14.0.0, in the feature whose changeset says archival "refuses rather than cascading".

`ProjectManager.archive` read the session list as `(await store.listSessionsByProject?.(...)) ?? []`, and `listSessionsByProject` is **optional** on `SessionStore`. So on a store that does not implement it, *"this store cannot tell me what is running here"* became *"nothing is running here"*: the workspace closed over live sessions and the call returned success. The refusal the whole feature exists for was skippable by not implementing one method.

## The fix

It throws, naming the missing method and what to do instead. Both stores in this package implement it, so nothing in-tree changes; a host with its own `SessionStore` gets a refusal where it previously got a wrong answer.

## Why it happened

The two halves are each correct and only the combination is not. Optional-on-the-interface protects implementors — a host's own store should not stop compiling because the SDK grew a method — and I applied that correctly to three methods. It cannot also mean a **safety precondition silently passes**. An optional dependency may degrade a *feature*; it may never degrade a *check*.

One method away in the same file, `write()` already refuses when `setProjectStatus` is absent. Same class, same change, opposite call.

## Verification

Two tests drive a `SessionStore` with the method removed: archive throws, and the project is still `open` afterwards — the second one matters because a refusal after the write is only a message. Reverting to the old expression fails both. Typecheck 0, lint 0, 2850 tests pass.
