### PR TITLE
feat(cli): namzu is told what day it is and which branch it is on

### DIFF
--- a/.changeset/the-agent-knows-what-day-it-is.md
+++ b/.changeset/the-agent-knows-what-day-it-is.md
@@ -1,0 +1,37 @@
+---
+'@namzu/cli': minor
+---
+
+namzu is told what day it is and which branch it is on
+
+The kernel tells the model the working directory and the platform. It does not
+tell it the date, and it says nothing about the repository. Both are facts a
+coding agent needs constantly and cannot get right by guessing.
+
+A model with no clock answers from its training cut-off. It writes that date
+into a changelog entry, into a `last_updated` frontmatter field, into a
+copyright header, and reasons about "the current version" of a dependency from
+a year that has passed. Nothing about the output looks wrong — it is
+confidently, quietly stale. The branch matters for the same reason in a
+different direction: "commit this" means something else on a release branch
+than on a scratch one, and a detached HEAD means a commit goes nowhere
+reachable.
+
+So every turn now carries a short block: today's local calendar date, and
+whether the working directory is a repository, on which branch, or with a
+detached HEAD. Sub-agents get it too, resolved when the child is built rather
+than captured at startup, so a delegated task does not inherit a stale answer
+from a session that began yesterday.
+
+Local date, not UTC: your "today" is the one on your wall, and a machine behind
+UTC would otherwise be told it is tomorrow.
+
+Deliberately absent: anything about uncommitted changes. This block is the
+cached prefix of every request, and a dirty-file count changes whenever the
+agent saves a file — carrying it would re-key that cache on essentially every
+turn to say something `git status` answers on demand. Date and branch change
+rarely enough to be free.
+
+Nothing to configure. Two `git` calls per turn, each bounded at two seconds;
+a directory that is not a repository, a machine with no `git`, and a call that
+times out all resolve to the block simply not claiming the fact.

--- a/docs/cli/project-instructions.md
+++ b/docs/cli/project-instructions.md
@@ -10,6 +10,8 @@ related_packages: ["@namzu/cli"]
 
 A project can tell namzu how it wants work done by committing an `AGENTS.md`. namzu reads it at the start of every session and follows it as standing policy for work in that project.
 
+> namzu also tells the agent, on every turn, what today's date is and whether the working directory is a git repository and on which branch — see [What namzu already knows](#what-namzu-already-knows) below.
+
 This is separate from [memory](./memory.md). Memory is about **you** and lives under your home directory; it travels with you between projects. `AGENTS.md` is about **the project** and lives in the repository; it applies to everyone who works there, including a teammate's namzu and namzu's own sub-agents.
 
 ```markdown
@@ -72,6 +74,17 @@ namzu names the files it loaded, so "namzu read my conventions and disagreed" is
 - A file is read up to 32,000 characters. If it is longer, the rest is not included and the agent is told so explicitly, in place, along with how many characters were dropped — a truncated policy is never presented as a whole one.
 - An empty or whitespace-only file is skipped.
 - The files are read once, when the session opens. That is what makes the list namzu prints exactly the set that went into the prompt, and it keeps the prompt cache from being re-keyed on every file you save. Edit a file and restart namzu (or run a new one-shot) for the change to take effect.
+
+## What namzu already knows
+
+You do not need to write these into `AGENTS.md`; namzu tells the agent itself, freshly on every turn:
+
+- **Today's date**, as the local calendar date on your machine. Without it a model answers from its training cut-off, and writes that year into a changelog entry or a `last_updated` field without anything looking wrong.
+- **Whether the working directory is a git repository**, and if so the branch that is checked out — or that HEAD is detached, in which case a commit made there is not reachable from any branch.
+
+Sub-agents are told the same, resolved when the sub-agent is built rather than when the session started.
+
+Deliberately not included: anything about uncommitted changes. That block is the cached prefix of every request and a dirty-file count changes whenever the agent saves a file, so carrying it would re-key the cache on nearly every turn to say what `git status` answers on demand.
 
 ## What they can and cannot do
 

--- a/packages/cli/src/__tests__/environment-reaches-the-turn.test.ts
+++ b/packages/cli/src/__tests__/environment-reaches-the-turn.test.ts
@@ -1,0 +1,150 @@
+/**
+ * The agent is told what day it is and which branch it is on, in the request
+ * that is actually sent.
+ *
+ * A composer test proves the sentence is well formed and nothing about whether
+ * anyone says it. The failure this invites is the block existing, being
+ * correct, and never being joined into the prompt — which is silent: the model
+ * keeps answering from its training cut-off, confidently, and every date it
+ * writes into a changelog or a frontmatter field looks like an ordinary answer.
+ *
+ * So this starts at a REAL repository on disk and ends at the `systemPrompt`
+ * `query()` was called with, and it drives the sub-agent path as well, because
+ * a delegated task dating a file from the wrong year is the same defect one
+ * hop further out.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { type AgentDefinition, AgentRegistry } from '@namzu/sdk'
+
+import { localIsoDate } from '../context/environment.js'
+import type { DetectedProvider, Preferences } from '../integrations/providers/index.js'
+
+const queryCalls: Record<string, unknown>[] = []
+vi.mock('@namzu/sdk', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@namzu/sdk')>()
+	return {
+		...actual,
+		query: (params: Record<string, unknown>) => {
+			queryCalls.push(params)
+			return (async function* () {})()
+		},
+	}
+})
+
+let root: string
+let repo: string
+
+beforeEach(() => {
+	queryCalls.length = 0
+	root = mkdtempSync(join(tmpdir(), 'namzu-env-turn-'))
+	repo = join(root, 'repo')
+	mkdirSync(repo, { recursive: true })
+	execFileSync('git', ['init', '--quiet'], { cwd: repo })
+	execFileSync('git', ['checkout', '-q', '-b', 'feature/parser'], { cwd: repo })
+})
+
+afterEach(() => {
+	vi.restoreAllMocks()
+	rmSync(root, { recursive: true, force: true })
+})
+
+const prefs = {
+	version: 2,
+	provider: 'anthropic',
+	subagents: { active: [] },
+} as Preferences
+
+function detectedAnthropic(): DetectedProvider[] {
+	return [
+		{
+			entry: {
+				id: 'anthropic',
+				label: 'Anthropic',
+				defaultModel: 'claude-sonnet-4-5',
+				requiresApiKey: true,
+				envVars: ['ANTHROPIC_API_KEY'],
+			},
+			source: 'env',
+			apiKey: 'sk-ant-not-a-real-key',
+			alternatives: [],
+		} as unknown as DetectedProvider,
+	]
+}
+
+async function openSessionIn(cwd: string) {
+	const { createAgentSession } = await import('../tui/agent.js')
+	return createAgentSession(prefs, detectedAnthropic(), { cwd })
+}
+
+async function drive(cwd: string): Promise<string> {
+	const session = await openSessionIn(cwd)
+	for await (const _ of session.send([{ role: 'user', content: 'hi', timestamp: 0 }])) {
+		// drain
+	}
+	expect(queryCalls.length, 'the turn must have reached query()').toBe(1)
+	return String(queryCalls[0]?.systemPrompt ?? '')
+}
+
+describe('where and when the agent is', () => {
+	it("is in the system prompt of the turn, with today's date", async () => {
+		const systemPrompt = await drive(repo)
+
+		expect(systemPrompt).toContain(localIsoDate(new Date()))
+	})
+
+	it('names the branch that is actually checked out', async () => {
+		const systemPrompt = await drive(repo)
+
+		expect(systemPrompt).toContain('feature/parser')
+	})
+
+	it('follows the branch when it changes mid-session, instead of repeating the old one', async () => {
+		// The reason this is read per turn. An agent that checks out a branch
+		// itself — an ordinary thing to be asked to do — would otherwise spend
+		// the rest of the session asserting the branch it started on, which is
+		// worse than never having been told.
+		const session = await openSessionIn(repo)
+		for await (const _ of session.send([{ role: 'user', content: 'hi', timestamp: 0 }])) {
+			// drain
+		}
+		execFileSync('git', ['checkout', '-q', '-b', 'feature/lexer'], { cwd: repo })
+		for await (const _ of session.send([{ role: 'user', content: 'again', timestamp: 0 }])) {
+			// drain
+		}
+
+		expect(String(queryCalls[0]?.systemPrompt)).toContain('feature/parser')
+		expect(String(queryCalls[1]?.systemPrompt)).toContain('feature/lexer')
+	})
+
+	it('says a plain directory is not a repository', async () => {
+		const plain = join(root, 'plain')
+		mkdirSync(plain)
+
+		const systemPrompt = await drive(plain)
+
+		expect(systemPrompt).toContain('not a git repository')
+	})
+
+	it('reaches a sub-agent too', async () => {
+		const registered: AgentDefinition[] = []
+		vi.spyOn(AgentRegistry.prototype, 'register').mockImplementation((def) => {
+			for (const d of Array.isArray(def) ? def : [def]) registered.push(d)
+		})
+
+		await openSessionIn(repo)
+
+		const general = registered.find((d) => d.info.id === 'general-purpose')
+		if (!general?.configBuilder) {
+			throw new Error('the sub-agent runtime did not stand up — this test proves nothing')
+		}
+		const config = (await general.configBuilder({})) as { systemPrompt?: string }
+		expect(config.systemPrompt).toContain('feature/parser')
+		expect(config.systemPrompt).toContain(localIsoDate(new Date()))
+	})
+})

--- a/packages/cli/src/context/__tests__/environment.test.ts
+++ b/packages/cli/src/context/__tests__/environment.test.ts
@@ -1,0 +1,109 @@
+/**
+ * What the block says about a directory, and what it refuses to claim.
+ *
+ * The facts here are read from a real repository created in a temp directory
+ * rather than from a stubbed git: the two calls this makes are the part that
+ * can be wrong on a real machine, and a fake `git` proves only that the
+ * composer agrees with itself.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+	type EnvironmentFacts,
+	composeEnvironmentPrompt,
+	localIsoDate,
+	readEnvironmentFacts,
+} from '../environment.js'
+
+let root: string
+
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), 'namzu-env-'))
+})
+
+afterEach(() => {
+	rmSync(root, { recursive: true, force: true })
+})
+
+function initRepo(dir: string, branch: string): void {
+	mkdirSync(dir, { recursive: true })
+	execFileSync('git', ['init', '--quiet'], { cwd: dir })
+	// `checkout -b` on an unborn HEAD, so no commit and no identity config are
+	// needed — and it is the case `rev-parse --abbrev-ref HEAD` cannot answer,
+	// which is why the reader uses `symbolic-ref`.
+	execFileSync('git', ['checkout', '-q', '-b', branch], { cwd: dir })
+}
+
+describe('the date', () => {
+	it('is the local calendar date, not the UTC one', () => {
+		// A machine behind UTC would otherwise be told it is tomorrow, and would
+		// write tomorrow's date into a changelog — the exact mistake this block
+		// exists to prevent, made by the block.
+		const lateEvening = new Date(2026, 7, 6, 23, 30, 0)
+
+		expect(localIsoDate(lateEvening)).toBe('2026-08-06')
+	})
+
+	it('zero-pads a single-digit month and day', () => {
+		expect(localIsoDate(new Date(2026, 0, 5))).toBe('2026-01-05')
+	})
+})
+
+describe('the repository', () => {
+	it('reports the branch that is checked out', async () => {
+		const repo = join(root, 'repo')
+		initRepo(repo, 'feature/parser')
+
+		const facts = await readEnvironmentFacts(repo)
+
+		expect(facts.isRepository).toBe(true)
+		expect(facts.branch).toBe('feature/parser')
+		expect(composeEnvironmentPrompt(facts)).toContain('feature/parser')
+	})
+
+	it('says a directory is not a repository rather than staying quiet', async () => {
+		const plain = join(root, 'plain')
+		mkdirSync(plain)
+
+		const facts = await readEnvironmentFacts(plain)
+
+		expect(facts.isRepository).toBe(false)
+		expect(facts.branch).toBeNull()
+		expect(composeEnvironmentPrompt(facts)).toContain('not a git repository')
+	})
+
+	it('distinguishes a detached HEAD from not being a repository at all', async () => {
+		// The two collapse into one if the reader only asks `symbolic-ref`, and
+		// the difference is load-bearing: a commit made on a detached HEAD is not
+		// reachable from any branch, which an agent about to commit should be
+		// told.
+		const facts: EnvironmentFacts = { today: '2026-08-06', branch: 'detached', isRepository: true }
+
+		const prompt = composeEnvironmentPrompt(facts)
+
+		expect(prompt).toContain('detached HEAD')
+		expect(prompt).toContain('not reachable from any branch')
+		expect(prompt).not.toContain('not a git repository')
+	})
+})
+
+describe('what the block does not claim', () => {
+	it('says nothing about uncommitted changes', async () => {
+		// Deliberate. This text is the CACHED prefix of every request, and a
+		// dirty-file count changes whenever the agent saves a file — carrying it
+		// would re-key the cache on essentially every turn to say something
+		// `git status` answers on demand. If a reader adds it, this test is what
+		// tells them the cost.
+		const repo = join(root, 'repo')
+		initRepo(repo, 'main')
+
+		const prompt = composeEnvironmentPrompt(await readEnvironmentFacts(repo))
+
+		expect(prompt).not.toMatch(/uncommitted|modified file|dirty/i)
+	})
+})

--- a/packages/cli/src/context/environment.ts
+++ b/packages/cli/src/context/environment.ts
@@ -1,0 +1,118 @@
+/**
+ * Where the agent is and when it is.
+ *
+ * The kernel already tells the model the working directory and the platform.
+ * It does not tell it the DATE, and it does not tell it anything about the
+ * repository. Both are missing facts a coding agent needs constantly and
+ * cannot get right by guessing:
+ *
+ * - **The date.** A model with no clock answers from its training cut-off. It
+ *   writes that date into a changelog entry, into the `last_updated` frontmatter
+ *   this repository's own docs carry, into a copyright header — and reasons
+ *   about "the current version" of everything from a year that has passed.
+ *   Nothing about the output looks wrong; it is confidently, quietly stale.
+ * - **The branch.** "Commit this" means something different on a release branch
+ *   than on a scratch one, and an agent that has to spend a tool call to find
+ *   out spends it on every session.
+ *
+ * ## What is deliberately NOT here
+ *
+ * **The working tree's dirty state.** It is the fact a reader will most want to
+ * add, and adding it would cost real money for nothing. This block goes into
+ * the system prompt, which is the CACHED prefix of every request; a file count
+ * that changes whenever the agent saves a file would re-key that prefix on
+ * essentially every turn. The date changes once a day and a branch changes
+ * rarely, so those two are cheap to carry — and `git status` is one tool call
+ * away for an agent that actually needs it, which is the right place to pay.
+ *
+ * Read fresh each turn for the same reason the branch is worth having at all: a
+ * session that crosses midnight, or in which the agent checks out a branch
+ * itself, must not keep asserting what was true when it started. Because the
+ * text only changes when the fact changes, a fresh read costs a cache miss
+ * exactly when a cache hit would have been wrong.
+ */
+
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const run = promisify(execFile)
+
+/** Bound on a single git call. A wedged repository must not stall a turn. */
+const GIT_TIMEOUT_MS = 2_000
+
+export interface EnvironmentFacts {
+	/** ISO calendar date, `YYYY-MM-DD`, in the machine's own timezone. */
+	readonly today: string
+	/**
+	 * `branch` when on one, `null` when the working directory is not a
+	 * repository, `'detached'` when it is one with no branch checked out.
+	 */
+	readonly branch: string | null
+	readonly isRepository: boolean
+}
+
+/**
+ * The machine's local calendar date.
+ *
+ * Local, not UTC: the user's "today" is the one on their wall, and an agent
+ * that writes tomorrow's date into a changelog because the machine is eight
+ * hours behind UTC has made exactly the mistake this exists to prevent.
+ */
+export function localIsoDate(now: Date): string {
+	const pad = (n: number): string => String(n).padStart(2, '0')
+	return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`
+}
+
+async function git(cwd: string, args: readonly string[]): Promise<string | null> {
+	try {
+		const { stdout } = await run('git', [...args], { cwd, timeout: GIT_TIMEOUT_MS })
+		const out = stdout.trim()
+		return out.length > 0 ? out : null
+	} catch {
+		// No git on the machine, not a repository, or the call timed out. All
+		// three mean the same thing to a caller: this fact is unavailable, and
+		// the block below simply does not claim it.
+		return null
+	}
+}
+
+export async function readEnvironmentFacts(
+	cwd: string,
+	now: Date = new Date(),
+): Promise<EnvironmentFacts> {
+	// `symbolic-ref` rather than `rev-parse --abbrev-ref HEAD`, because it
+	// answers on an unborn branch — a freshly initialised repository with no
+	// commit yet, where `rev-parse HEAD` fails and would be read as "not a
+	// repository". Both calls at once: they are independent and each is a
+	// process.
+	const [insideWorkTree, branch] = await Promise.all([
+		git(cwd, ['rev-parse', '--is-inside-work-tree']),
+		git(cwd, ['symbolic-ref', '--short', 'HEAD']),
+	])
+	const isRepository = insideWorkTree === 'true'
+	return {
+		today: localIsoDate(now),
+		// A repository with no symbolic HEAD is on a detached one. Distinguishing
+		// that from "not a repository" matters: on a detached HEAD a commit goes
+		// nowhere reachable, and an agent about to commit should know.
+		branch: isRepository ? (branch ?? 'detached') : null,
+		isRepository,
+	}
+}
+
+export function composeEnvironmentPrompt(facts: EnvironmentFacts): string {
+	const lines = [`Today's date is ${facts.today}.`]
+	if (!facts.isRepository) {
+		lines.push('The working directory is not a git repository.')
+	} else if (facts.branch === 'detached') {
+		lines.push(
+			'The working directory is a git repository with a detached HEAD — no branch is checked out, so a commit made here is not reachable from any branch.',
+		)
+	} else {
+		lines.push(`The working directory is a git repository on branch \`${facts.branch}\`.`)
+	}
+	lines.push(
+		'These are facts about right now. Prefer them over any date or branch you would otherwise assume.',
+	)
+	return `## Environment\n\n${lines.join('\n')}`
+}

--- a/packages/cli/src/integrations/subagents/runtime.ts
+++ b/packages/cli/src/integrations/subagents/runtime.ts
@@ -77,6 +77,16 @@ export interface SubagentRuntimeOptions {
 	 * the child reports success either way.
 	 */
 	readonly projectInstructions?: string
+	/**
+	 * Produces the "where and when" block for a child, at the moment the child
+	 * is built rather than once for the session.
+	 *
+	 * A function because both facts it carries can change while the parent runs:
+	 * a long session crosses midnight, and the parent may itself have checked
+	 * out a branch since it started. A string captured at startup would hand
+	 * every later sub-agent a confident, stale answer.
+	 */
+	readonly readEnvironment?: () => Promise<string>
 	/** Receives the child's RunEvents (lineage-stamped) — for the tree view. */
 	readonly onEvent?: (event: RunEvent) => void
 }
@@ -279,15 +289,22 @@ function buildDefinition(
 		// ReactiveAgent is Agent<ReactiveAgentConfig,…>; the registry stores the
 		// erased Agent<BaseAgentConfig,…>. configBuilder supplies the richer config.
 		typedAgent: agent as unknown as CoreAgent<BaseAgentConfig, BaseAgentResult>,
-		configBuilder: (options): ReactiveAgentConfig => ({
-			model: options.model ?? opts.model,
-			tokenBudget: options.tokenBudget ?? 200_000,
-			timeoutMs: options.timeoutMs ?? 600_000,
-			maxIterations: 40,
-			provider: opts.buildProvider(),
-			tools: opts.buildTools(),
-			systemPrompt: prompt,
-			...(opts.verificationGate ? { verificationGate: opts.verificationGate } : {}),
-		}),
+		configBuilder: async (options): Promise<ReactiveAgentConfig> => {
+			// Resolved HERE, per child, rather than captured once for the session:
+			// what day it is and which branch is checked out can both have changed
+			// since the parent started, and a sub-agent asserting the stale answer
+			// is worse than one that was never told.
+			const environment = opts.readEnvironment ? await opts.readEnvironment() : null
+			return {
+				model: options.model ?? opts.model,
+				tokenBudget: options.tokenBudget ?? 200_000,
+				timeoutMs: options.timeoutMs ?? 600_000,
+				maxIterations: 40,
+				provider: opts.buildProvider(),
+				tools: opts.buildTools(),
+				systemPrompt: environment ? `${prompt}\n\n${environment}` : prompt,
+				...(opts.verificationGate ? { verificationGate: opts.verificationGate } : {}),
+			}
+		},
 	}
 }

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -48,6 +48,7 @@ import {
 } from '@namzu/sdk'
 
 import { join } from 'node:path'
+import { composeEnvironmentPrompt, readEnvironmentFacts } from '../context/environment.js'
 import { loadProjectInstructions } from '../context/project.js'
 import {
 	type DetectedProvider,
@@ -426,6 +427,10 @@ export async function createAgentSession(
 			// does not — the worse half of the feature, because the delegating
 			// turn reports success either way.
 			...(projectInstructions.prompt ? { projectInstructions: projectInstructions.prompt } : {}),
+			// Same argument as the instructions, one step further: a sub-agent that
+			// does not know what day it is dates a changelog entry from a training
+			// cut-off, and the parent reports the delegation as successful.
+			readEnvironment: async () => composeEnvironmentPrompt(await readEnvironmentFacts(cwd)),
 			buildProvider: () =>
 				constructProvider(
 					prefs.provider,
@@ -488,9 +493,22 @@ export async function createAgentSession(
 			// the order is the containment: they are text off the disk of
 			// whatever directory the agent was pointed at, so the rules they must
 			// not be able to rewrite are established before they are read.
+			//
+			// The environment block is read fresh every turn, unlike the project
+			// instructions, because both facts in it can change WHILE the session
+			// runs — midnight passes, and the agent checks out a branch itself.
+			// Its text only changes when a fact changes, so it costs a prompt-cache
+			// miss exactly when a hit would have been a stale claim.
 			const memoryPrompt = composeMemoryPrompt(readMemory())
+			const environmentPrompt = composeEnvironmentPrompt(await readEnvironmentFacts(cwd))
 			const systemPrompt =
-				[NAMZU_IDENTITY, memoryPrompt, projectInstructions.prompt, opts?.extraSystem]
+				[
+					NAMZU_IDENTITY,
+					environmentPrompt,
+					memoryPrompt,
+					projectInstructions.prompt,
+					opts?.extraSystem,
+				]
 					.filter((s): s is string => Boolean(s))
 					.join('\n\n') || undefined
 			yield* runTurn({


### PR DESCRIPTION
The kernel tells the model the working directory and the platform (`runtime/query/prompt.ts:30`). It does not tell it the date, and it says nothing at all about the repository. Both are facts a coding agent needs constantly and cannot get right by guessing.

**A model with no clock answers from its training cut-off.** It writes that year into a changelog entry, into a `last_updated` frontmatter field (which this repo's own docs carry), into a copyright header, and reasons about "the current version" of a dependency from a year that has passed. Nothing about the output looks wrong — it is confidently, quietly stale, which is this repository's whole defect class in miniature.

**The branch matters the same way in a different direction.** "Commit this" means something else on a release branch than on a scratch one, and a detached HEAD means the commit goes nowhere reachable — which an agent about to commit should be told.

## What lands

A short block on every turn: today's local calendar date, and whether the working directory is a git repository, on which branch, or with a detached HEAD. Sub-agents get it too.

Four decisions worth the line:

- **Local calendar date, not UTC.** A machine behind UTC would otherwise be told it is tomorrow, and would write tomorrow's date into a changelog — the exact mistake the block exists to prevent, made by the block.
- **`git symbolic-ref --short HEAD`, not `rev-parse --abbrev-ref HEAD`.** The latter cannot answer on an unborn branch, so a freshly initialised repository would read as "not a repository". Paired with `rev-parse --is-inside-work-tree` so a detached HEAD is distinguishable from a plain directory — collapse those two and the sharper case disappears.
- **Read fresh each turn**, unlike the project instructions from #184, because both facts can change *while* the session runs: midnight passes, and the agent checks out a branch itself. The text only changes when a fact changes, so a fresh read costs a prompt-cache miss exactly when a cache hit would have been a stale claim. Sub-agents resolve it when the child is built, not from a string captured at startup.
- **Nothing about uncommitted changes, and a test asserts its absence.** It is the fact a reader will most want to add. The block is the *cached prefix* of every request, and a dirty-file count moves whenever the agent saves a file — carrying it would re-key that cache on essentially every turn to say what `git status` answers on demand. The test is there so whoever adds it sees the cost first.

Failure is silence, not noise: no `git` on the machine, not a repository, or a call past its two-second bound all resolve to the block not claiming the fact.

## Verification

- **5 front-door tests** driving `createAgentSession(...).send()` from a real `git init`ed temp repository to the `systemPrompt` `query()` was actually called with — including one that checks out a *second* branch mid-session and asserts turn 2 reports the new one, which is the whole reason the read is per-turn.
- 6 unit tests on the date and the three repository shapes.
- Mutation: dropping the block from the composition fails 4 of the 5 front-door tests; the sub-agent one survives, which is why it is separate.
- 387 tests, typecheck, lint, external-name audit green.

Docs: a new section in `docs/cli/project-instructions.md` — "what namzu already knows", so nobody writes the date into their `AGENTS.md`.
