### PR TITLE
feat(cli): namzu can connect to the tool servers you declare

### DIFF
--- a/.changeset/namzu-can-reach-your-own-tools.md
+++ b/.changeset/namzu-can-reach-your-own-tools.md
@@ -1,0 +1,53 @@
+---
+'@namzu/cli': minor
+---
+
+namzu can connect to the tool servers you declare
+
+The kernel has spoken this protocol for a long time — `MCPClient`,
+`StdioTransport`, `StreamableHttpTransport` and the tool adapter are all
+exported from `@namzu/sdk`. `packages/cli` imported none of them. So the
+capability existed and was unreachable from the product: a namzu user could not
+connect an external tool server at all, whatever the kernel could do.
+
+Declare them under `mcpServers` in `namzu.config.json`:
+
+```json
+{
+  "mcpServers": {
+    "tickets": { "command": "node", "args": ["./tools/tickets-server.js"] },
+    "search":  { "url": "https://tools.example.internal/mcp" }
+  }
+}
+```
+
+Their tools join the roster the agent works with, prefixed with the server's
+name — `mcp_tickets_create` — so two servers offering the same tool do not
+collide and the transcript says where a call went. A `[permissions]` rule can
+name a bridged tool like any other, and the server's own read-only and
+destructive hints are carried through to the gate.
+
+**A server that does not come up is named, with the reason.** That is the whole
+hazard this carries: an operator declares a server, watches the agent work
+without its tools, and concludes the model is bad at the task. An entry naming
+both a command and a url — or neither — is refused by name rather than guessed
+at. One server failing never takes the working ones with it.
+
+What happens next differs by who is watching, deliberately. The TUI prints the
+failure and carries on: you are there, you can read it and fix your config, and
+taking the session away would not help you do that. `namzu run` and
+`namzu run-stream` **refuse** — nobody is watching a headless run, and a script
+that quietly does half the job is worse than one that stops. `run` exits `1`;
+`run-stream` emits the reason as an `error` event.
+
+Each server gets ten seconds to start, hand shake and list its tools. A request
+timeout cannot cover a process that starts and never speaks, and without a
+bound one wedged server keeps namzu from starting at all — no error, no
+failure.
+
+A local server is a child process, and namzu now shuts its servers down when a
+session ends: when a one-shot finishes, and when switching providers in the TUI
+replaces one session with another. Nothing else in the CLI owned a child
+process, which is why a session had no shutdown path before this.
+
+Nothing to configure if you declare no servers; the roster is what it was.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -29,6 +29,7 @@ rather than treating it as prompt text, so `namzu run --format json "…"` exits
 
 - **Discovers credentials, never asks you to log in.** On first run it finds your LLM provider credentials (env vars, an OAuth credential in the macOS Keychain, or a local Ollama) and lets you pick which provider to chat through. See [Providers & credentials](./providers.md).
 - **Runs tools, under a permission model you choose.** The agent reads files, runs shell commands, edits code, searches, tracks a plan, and remembers — via the SDK builtins plus its memory and task tools. Mutating actions prompt for approval in the TUI; a headless run approves them unless you ask for `--permission-mode strict`. A safety gate hard-denies catastrophic commands in every mode. See [Tools & permission](./tools.md).
+- **Connects to your own tool servers.** Declare them in `namzu.config.json` and their tools join the agent's roster under the server's name. A server that does not come up is named, with the reason, rather than quietly missing. See [External tool servers](./tool-servers.md).
 - **Follows the project's own instructions.** An `AGENTS.md` in the working directory — and in every directory up to the repository root — is loaded into the agent's context and followed as standing policy for work in that project. namzu names the files it loaded, so you can tell it read them. See [Project instructions](./project-instructions.md).
 - **Remembers across sessions.** User facts in `~/.namzu/USER.md` / `MEMORY.md` are injected every turn; the agent also keeps its own structured memory. See [Memory](./memory.md).
 - **Resumes past conversations.** Every conversation is saved. `/resume` continues a previous one in this folder from the TUI; `namzu run --continue` and `--resume <id>` do the same from a script. Neither ever silently starts a fresh conversation when the one you asked for cannot be reopened.
@@ -43,6 +44,7 @@ rather than treating it as prompt text, so `namzu run --format json "…"` exits
 | [Headless runs](./headless.md) | `run` and `run-stream`, their shared options, `--cwd`, permission modes, resuming, exit codes, the NDJSON event stream |
 | [Providers & credentials](./providers.md) | How credentials are discovered, the first-run picker, switching providers |
 | [Tools & permission](./tools.md) | Builtin + memory + task tools, deferred tools and `search_tools`, how a call is decided, permission modes, the safety gate, bypass mode |
+| [External tool servers](./tool-servers.md) | Declaring tool servers in `namzu.config.json`, naming, failures, lifetime |
 | [Project instructions](./project-instructions.md) | `AGENTS.md` discovery from the working directory upward, ordering and overrides, limits |
 | [Memory](./memory.md) | `USER.md` / `MEMORY.md` injection, `/remember`, `/memory`, the agent's structured memory |
 | [Skills](./skills.md) | `SKILL.md` format, discovery, `/skills`, `/skill <name>` |

--- a/docs/cli/meta.json
+++ b/docs/cli/meta.json
@@ -6,6 +6,7 @@
     "headless",
     "providers",
     "tools",
+    "tool-servers",
     "project-instructions",
     "memory",
     "skills"

--- a/docs/cli/tool-servers.md
+++ b/docs/cli/tool-servers.md
@@ -1,0 +1,81 @@
+---
+title: External tool servers
+description: Declare tool servers in namzu.config.json and their tools join the agent's roster, prefixed with the server's name.
+last_updated: 2026-08-06
+status: current
+related_packages: ["@namzu/cli", "@namzu/sdk"]
+---
+
+# External tool servers
+
+namzu can connect to tool servers you declare, and their tools join the roster the agent works with — alongside `bash`, `read`, `edit` and the rest. That is how namzu reaches anything it does not ship: your issue tracker, an internal search index, a deployment API.
+
+```json
+{
+  "mcpServers": {
+    "tickets": { "command": "node", "args": ["./tools/tickets-server.js"] },
+    "search":  { "url": "https://tools.example.internal/mcp" }
+  }
+}
+```
+
+Put this in `namzu.config.json` — project-level in the working directory, or user-level in your home directory. Both are read; the project one wins.
+
+## An entry
+
+Each key is the server's name. Tools arrive prefixed with it, so `create` from `tickets` becomes `mcp_tickets_create` — two servers offering the same tool name do not collide, and the transcript says where a call went.
+
+An entry names **either** a command **or** a URL, never both.
+
+| Field | For | Meaning |
+| --- | --- | --- |
+| `command` | a local server | The executable to run. |
+| `args` | a local server | Its arguments. |
+| `env` | a local server | Extra environment variables for the child. |
+| `cwd` | a local server | Its working directory. Defaults to the agent's. |
+| `url` | a remote server | The endpoint to connect to. |
+| `headers` | a remote server | Extra headers, for authentication. |
+
+An entry naming both, or neither, is refused **by name** rather than skipped — picking one for you would run something you did not ask to run.
+
+## When a server does not come up
+
+namzu tells you which server, and why. That is the whole hazard this feature carries: an operator declares a server, watches the agent work without its tools, and concludes the model is bad at the task.
+
+- **In the TUI** — a line under the connect banner for each server, connected or not:
+
+  ```
+  Tool server tickets · 4 tools
+  Tool server search is not available: server "search" did not answer within 10000ms
+  ```
+
+  The session continues. You are here, you can read the line and fix the config.
+
+- **In `namzu run` and `namzu run-stream`** — the run **refuses**, naming the server and the reason. Nobody is watching a headless run, and a script that quietly does half the job is worse than one that stops. `run` exits `1`; `run-stream` emits the reason as an `error` event.
+
+Each server gets ten seconds to start, hand shake and list its tools. A server that starts and never answers is reported rather than held on to — otherwise one wedged server keeps namzu from starting at all, with no error and no failure.
+
+One server failing does not take the working ones with it. They connect, they are listed, and the failure is named beside them.
+
+## Lifetime
+
+A local server is a child process. namzu shuts every server down when the session ends — when a one-shot finishes, and when you switch providers in the TUI and a new session replaces the old one.
+
+## Trust
+
+Servers are declared in a config file inside a folder, and `command` runs an executable. A folder namzu works in has to be trusted first — see [The folder has to be trusted](./headless.md#the-folder-has-to-be-trusted). The same decision covers both: a project config that can start a process and a project build script that can start one are not different questions.
+
+## Permissions
+
+A bridged tool is an ordinary tool to the permission layer, under its prefixed name. So a `[permissions]` table can name it:
+
+```json
+{
+  "permissions": {
+    "mcp_tickets_close": "ask",
+    "mcp_search_query": "allow"
+  }
+}
+```
+
+See [Tools & permission](./tools.md). A server's own declaration of whether a tool is read-only or destructive is carried through, so the safety gate and the permission prompt see what the server said about it.

--- a/packages/cli/src/__tests__/headless-trust-gate.test.ts
+++ b/packages/cli/src/__tests__/headless-trust-gate.test.ts
@@ -62,6 +62,9 @@ vi.mock('../tui/agent.js', () => ({
 				toolNames: [],
 				instructionFiles: [] as readonly string[],
 				skippedInstructionFiles: [] as readonly { path: string; reason: string }[],
+				mcpConnected: [] as readonly { name: string; toolCount: number }[],
+				mcpFailed: [] as readonly { name: string; reason: string }[],
+				close: async () => {},
 				errorHint: null,
 				send: () =>
 					(async function* () {

--- a/packages/cli/src/__tests__/mcp-servers-reach-the-session.test.ts
+++ b/packages/cli/src/__tests__/mcp-servers-reach-the-session.test.ts
@@ -1,0 +1,190 @@
+/**
+ * A tool server written into a config file ends up in the roster the model is
+ * shown.
+ *
+ * The chain has three places to break, in series, and `packages/cli` has been
+ * cut by two of them before:
+ *
+ *   namzu.config.json → loadConfig() → createAgentSession() → the tool registry
+ *                     ↑ the reader              ↑ the connect  ↑ the register
+ *
+ * `permissions` was dropped by the loader for its whole existence and again by
+ * the turn, and every test at the time sat on one side or the other of a break.
+ * So this one starts at a real config file and ends at `session.toolNames` —
+ * the list `/tools` prints and the registry the turn is built from.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { loadConfig } from '../config/load.js'
+import type { DetectedProvider, Preferences } from '../integrations/providers/index.js'
+
+vi.mock('@namzu/sdk', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@namzu/sdk')>()
+	return {
+		...actual,
+		query: () => (async function* () {})(),
+	}
+})
+
+let work: string
+
+const SERVER = `
+let buf = ''
+process.stdin.on('data', (chunk) => {
+  buf += chunk
+  let i
+  while ((i = buf.indexOf('\\n')) >= 0) {
+    const line = buf.slice(0, i)
+    buf = buf.slice(i + 1)
+    if (!line.trim()) continue
+    const msg = JSON.parse(line)
+    if (msg.method === 'initialize') {
+      send({ jsonrpc: '2.0', id: msg.id, result: {
+        protocolVersion: msg.params.protocolVersion,
+        serverInfo: { name: 'tickets', version: '1' },
+        capabilities: { tools: {} },
+      }})
+    } else if (msg.method === 'tools/list') {
+      send({ jsonrpc: '2.0', id: msg.id, result: { tools: [
+        { name: 'create', description: 'Open a ticket', inputSchema: {
+          type: 'object', properties: { title: { type: 'string' } }, required: ['title'] } },
+      ]}})
+    } else if (msg.id !== undefined) {
+      send({ jsonrpc: '2.0', id: msg.id, result: {} })
+    }
+  }
+})
+function send(o) { process.stdout.write(JSON.stringify(o) + '\\n') }
+`
+
+beforeEach(() => {
+	work = mkdtempSync(join(tmpdir(), 'namzu-mcp-session-'))
+})
+
+afterEach(async () => {
+	for (let attempt = 0; attempt < 20; attempt++) {
+		try {
+			rmSync(work, { recursive: true, force: true })
+			return
+		} catch {
+			await new Promise((resolve) => setTimeout(resolve, 50))
+		}
+	}
+	rmSync(work, { recursive: true, force: true })
+})
+
+const prefs = {
+	version: 2,
+	provider: 'anthropic',
+	subagents: { active: [] },
+} as Preferences
+
+function detectedAnthropic(): DetectedProvider[] {
+	return [
+		{
+			entry: {
+				id: 'anthropic',
+				label: 'Anthropic',
+				defaultModel: 'claude-sonnet-4-5',
+				requiresApiKey: true,
+				envVars: ['ANTHROPIC_API_KEY'],
+			},
+			source: 'env',
+			apiKey: 'sk-ant-not-a-real-key',
+			alternatives: [],
+		} as unknown as DetectedProvider,
+	]
+}
+
+describe('a tool server declared in namzu.config.json', () => {
+	it('survives the config loader', () => {
+		// The failure this pins: a public config field with no reader is parsed,
+		// type-checks, and never arrives. It happened to `permissions`.
+		writeFileSync(
+			join(work, 'namzu.config.json'),
+			JSON.stringify({ mcpServers: { tickets: { command: 'node', args: ['x.js'] } } }),
+		)
+
+		const cfg = loadConfig({ cwd: work, home: work, env: {} })
+
+		expect(cfg.mcpServers?.tickets?.command).toBe('node')
+		expect(cfg.mcpServers?.tickets?.args).toEqual(['x.js'])
+	})
+
+	it('is in the tool roster the session hands the model', async () => {
+		const server = join(work, 'tickets.js')
+		writeFileSync(server, SERVER)
+		writeFileSync(
+			join(work, 'namzu.config.json'),
+			JSON.stringify({
+				mcpServers: { tickets: { command: process.execPath, args: [server] } },
+			}),
+		)
+
+		const cfg = loadConfig({ cwd: work, home: work, env: {} })
+		const { createAgentSession } = await import('../tui/agent.js')
+		const session = await createAgentSession(prefs, detectedAnthropic(), {
+			cwd: work,
+			...(cfg.mcpServers ? { mcpServers: cfg.mcpServers } : {}),
+		})
+		try {
+			expect(session.mcpFailed).toEqual([])
+			expect(session.mcpConnected).toEqual([{ name: 'tickets', toolCount: 1 }])
+			// The load-bearing one. Connecting and adapting is not the feature —
+			// the model has to be able to see and call it.
+			expect(session.toolNames).toContain('mcp_tickets_create')
+		} finally {
+			await session.close()
+		}
+	}, 20_000)
+
+	it('does not take the builtin tools away', async () => {
+		// Registering an extra set is the ordinary way to lose the existing one.
+		const server = join(work, 'tickets.js')
+		writeFileSync(server, SERVER)
+
+		const { createAgentSession } = await import('../tui/agent.js')
+		const session = await createAgentSession(prefs, detectedAnthropic(), {
+			cwd: work,
+			mcpServers: { tickets: { command: process.execPath, args: [server] } },
+		})
+		try {
+			expect(session.toolNames).toContain('bash')
+			expect(session.toolNames).toContain('read')
+			expect(session.toolNames).toContain('mcp_tickets_create')
+		} finally {
+			await session.close()
+		}
+	}, 20_000)
+
+	it('reports a server that failed, and adds no tools from it', async () => {
+		const { createAgentSession } = await import('../tui/agent.js')
+		const session = await createAgentSession(prefs, detectedAnthropic(), {
+			cwd: work,
+			mcpServers: { tickets: { command: join(work, 'no-such-executable') } },
+		})
+		try {
+			expect(session.mcpConnected).toEqual([])
+			expect(session.mcpFailed.map((f) => f.name)).toEqual(['tickets'])
+			expect(session.toolNames.some((n) => n.startsWith('mcp_'))).toBe(false)
+		} finally {
+			await session.close()
+		}
+	})
+
+	it('adds nothing and reports nothing when none is configured', async () => {
+		const { createAgentSession } = await import('../tui/agent.js')
+		const session = await createAgentSession(prefs, detectedAnthropic(), { cwd: work })
+		try {
+			expect(session.mcpConnected).toEqual([])
+			expect(session.mcpFailed).toEqual([])
+			expect(session.toolNames.some((n) => n.startsWith('mcp_'))).toBe(false)
+		} finally {
+			await session.close()
+		}
+	})
+})

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -140,6 +140,7 @@ export async function runCli(opts: RunCliOptions): Promise<number> {
 				version: CLI_VERSION,
 				skipPermissions,
 				rules: permissions.rules,
+				...(tuiCtx.config.mcpServers ? { mcpServers: tuiCtx.config.mcpServers } : {}),
 			})
 			const code = await Promise.resolve(0)
 			setExitCode(code)

--- a/packages/cli/src/commands/__tests__/run-exit-code.test.ts
+++ b/packages/cli/src/commands/__tests__/run-exit-code.test.ts
@@ -23,6 +23,9 @@ const sessionStub = {
 	// not ship.
 	instructionFiles: [] as readonly string[],
 	skippedInstructionFiles: [] as readonly { path: string; reason: string }[],
+	mcpConnected: [] as readonly { name: string; toolCount: number }[],
+	mcpFailed: [] as readonly { name: string; reason: string }[],
+	close: async () => {},
 	send: undefined as unknown,
 }
 

--- a/packages/cli/src/commands/__tests__/run-flags.test.ts
+++ b/packages/cli/src/commands/__tests__/run-flags.test.ts
@@ -72,6 +72,9 @@ vi.mock('../../tui/agent.js', () => ({
 				// not ship.
 				instructionFiles: instructions.loaded,
 				skippedInstructionFiles: instructions.skipped,
+				mcpConnected: [] as readonly { name: string; toolCount: number }[],
+				mcpFailed: [] as readonly { name: string; reason: string }[],
+				close: async () => {},
 				errorHint: null,
 				send: (messages: Array<{ content: string }>) => {
 					seen.prompt = messages[0]?.content ?? null

--- a/packages/cli/src/commands/__tests__/run-stream-flags.test.ts
+++ b/packages/cli/src/commands/__tests__/run-stream-flags.test.ts
@@ -51,6 +51,14 @@ vi.mock('../../tui/agent.js', () => ({
 				providerSummary: 'stub',
 				modelSummary: 'stub',
 				toolNames: [],
+				// Present because a real session always sets these: a stub missing a
+				// field production always has is a fixture for a system that does not
+				// ship.
+				instructionFiles: [] as readonly string[],
+				skippedInstructionFiles: [] as readonly { path: string; reason: string }[],
+				mcpConnected: [] as readonly { name: string; toolCount: number }[],
+				mcpFailed: [] as readonly { name: string; reason: string }[],
+				close: async () => {},
 				errorHint: null,
 				send: async function* () {},
 			}

--- a/packages/cli/src/commands/run-stream.ts
+++ b/packages/cli/src/commands/run-stream.ts
@@ -203,8 +203,23 @@ export const runStreamCommand: CommandDef = {
 			cwd,
 			rules: permissions.rules,
 			permissionMode: modeResult.mode,
+			...(ctx.config.mcpServers ? { mcpServers: ctx.config.mcpServers } : {}),
 		})
-		if (!session.hasProvider) return fail(session.errorHint ?? 'agent is not ready')
+		if (!session.hasProvider) {
+			await session.close()
+			return fail(session.errorHint ?? 'agent is not ready')
+		}
+		// A configured tool server that is not here means the turn cannot do what
+		// the operator set it up to do, and this command answers a host, not a
+		// person who might notice. Refused rather than run short — in band, like
+		// every other failure here, because that is what the host reads.
+		if (session.mcpFailed.length > 0) {
+			const said = session.mcpFailed
+				.map((f) => `tool server "${f.name}" is not available: ${f.reason}`)
+				.join('; ')
+			await session.close()
+			return fail(said)
+		}
 
 		// --skills <a,b,c>: load the named skills' bodies and inject them as the
 		// turn's extra system context (the same channel the TUI's /skill uses).
@@ -220,8 +235,12 @@ export const runStreamCommand: CommandDef = {
 				write(event)
 			}
 		} catch (err) {
+			await session.close()
 			return fail(err instanceof Error ? err.message : String(err))
 		}
+		// A stdio tool server is a child process; a command that returns without
+		// closing leaves it running.
+		await session.close()
 
 		// Persist the turn so a later `history --session <key>` (and the next
 		// turn's context) sees it. Best-effort — a store failure must not lose

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -241,10 +241,27 @@ export const runCommand: CommandDef = {
 			cwd: resolved.cwd,
 			rules: permissions.rules,
 			permissionMode: modeResult.mode,
+			...(ctx.config.mcpServers ? { mcpServers: ctx.config.mcpServers } : {}),
 		})
 		if (!session.hasProvider) {
+			await session.close()
 			ctx.formatter.error({ message: session.errorHint ?? 'agent is not ready' })
 			return 1
+		}
+		// A configured tool server that is not here means the run cannot do what
+		// the operator set it up to do, and there is nobody watching to notice.
+		// The TUI reports and carries on, because a person can read the line and
+		// decide; a script has no such reader, so it refuses. Same principle as
+		// the permission mode resolving differently when `interactive` is false.
+		if (session.mcpFailed.length > 0) {
+			for (const f of session.mcpFailed) {
+				ctx.formatter.error({ message: `tool server "${f.name}" is not available: ${f.reason}` })
+			}
+			await session.close()
+			return 1
+		}
+		for (const s of session.mcpConnected) {
+			ctx.formatter.info(`tool server ${s.name} · ${s.toolCount} tools`)
 		}
 		ctx.formatter.info(
 			`namzu · ${session.providerSummary}${session.modelSummary ? ` · ${session.modelSummary}` : ''}`,
@@ -291,6 +308,7 @@ export const runCommand: CommandDef = {
 			// specific conversation and got a new one that looks the same finds
 			// out several turns later, having already acted on it.
 			ctx.formatter.error({ message: resume.message })
+			await session.close()
 			return EXIT_USAGE
 		}
 		const prior: readonly Message[] = resume.kind === 'resumed' ? resume.messages : []
@@ -314,6 +332,11 @@ export const runCommand: CommandDef = {
 			else if (event.kind === 'error') failed = event.message
 			else if (event.kind === 'done') stopReason = event.stopReason
 		}
+
+		// Every exit below this point releases the session first. A stdio tool
+		// server is a child process, and a `run` that returns without closing
+		// leaves it behind.
+		await session.close()
 
 		if (failed) {
 			ctx.formatter.error({ message: failed })

--- a/packages/cli/src/config/load.ts
+++ b/packages/cli/src/config/load.ts
@@ -19,6 +19,7 @@ import { join, resolve } from 'node:path'
 
 import { parse as yamlParse } from 'yaml'
 
+import type { McpServersConfig } from '../integrations/mcp/servers.js'
 import { isFormatName } from '../output/index.js'
 import type { PermissionsConfig } from '../permissions/rules.js'
 import { DEFAULT_CONFIG, type NamzuCliConfig } from './schema.js'
@@ -101,6 +102,12 @@ const CONFIG_READERS: ConfigReaders = {
 	// sees; dropping those entries here would silence it.
 	permissions: (v) =>
 		typeof v === 'object' && v !== null && !Array.isArray(v) ? (v as PermissionsConfig) : undefined,
+	// Shape only, for the same reason as `permissions`: an entry that names
+	// neither a command nor a url — or both — is reported by name when the
+	// connection is attempted. Dropping it here would turn a mistake the
+	// operator can see into a server that silently was never there.
+	mcpServers: (v) =>
+		typeof v === 'object' && v !== null && !Array.isArray(v) ? (v as McpServersConfig) : undefined,
 }
 
 function readEnv(env: NodeJS.ProcessEnv): MutableConfig {

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -7,6 +7,7 @@
  * are worth enforcing at runtime — premature now.
  */
 
+import type { McpServersConfig } from '../integrations/mcp/servers.js'
 import type { FormatName } from '../output/index.js'
 import type { PermissionsConfig } from '../permissions/rules.js'
 
@@ -23,6 +24,14 @@ export interface NamzuCliConfig {
 	 * it meant before this existed — the absence of a policy never widens one.
 	 */
 	readonly permissions?: PermissionsConfig
+	/**
+	 * External tool servers to connect, keyed by the name their tools are
+	 * prefixed with.
+	 *
+	 * Each entry names either a `command` to run or a `url` to reach. Absent
+	 * means no external servers, which is what it meant before this existed.
+	 */
+	readonly mcpServers?: McpServersConfig
 }
 
 export const DEFAULT_CONFIG: NamzuCliConfig = Object.freeze({

--- a/packages/cli/src/integrations/mcp/__tests__/connect.test.ts
+++ b/packages/cli/src/integrations/mcp/__tests__/connect.test.ts
@@ -1,0 +1,261 @@
+/**
+ * An external tool server declared in the config is actually reachable.
+ *
+ * The server here is a REAL child process speaking real JSON-RPC over stdio,
+ * written to a temp file and spawned by the shipped transport. A stubbed
+ * transport would prove the adapter agrees with itself and would say nothing
+ * about the thing that actually breaks: a process that spawns, or does not, and
+ * a handshake that answers, or does not.
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { connectMcpServers, transportFor } from '../servers.js'
+
+let dir: string
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), 'namzu-mcp-'))
+})
+
+afterEach(async () => {
+	// A child's working directory is the temp directory, and `close()` sends
+	// SIGTERM without waiting for the exit — so on Windows the directory is
+	// still held for a moment after the last assertion. Retried rather than
+	// ignored: a directory that never frees would mean a process that never
+	// died, which is the failure `close()` exists to prevent.
+	for (let attempt = 0; attempt < 20; attempt++) {
+		try {
+			rmSync(dir, { recursive: true, force: true })
+			return
+		} catch {
+			await new Promise((resolve) => setTimeout(resolve, 50))
+		}
+	}
+	rmSync(dir, { recursive: true, force: true })
+})
+
+/** Resolves once the process is gone, or throws after the deadline. */
+async function waitForExit(pid: number, deadlineMs = 5_000): Promise<void> {
+	const until = Date.now() + deadlineMs
+	for (;;) {
+		try {
+			// Signal 0 tests for existence without delivering anything.
+			process.kill(pid, 0)
+		} catch {
+			return
+		}
+		if (Date.now() > until) throw new Error(`process ${pid} was still alive after ${deadlineMs}ms`)
+		await new Promise((resolve) => setTimeout(resolve, 50))
+	}
+}
+
+/**
+ * The smallest server that satisfies the protocol: initialize, tools/list,
+ * tools/call. Newline-delimited JSON-RPC on stdio, which is the wire the
+ * shipped `StdioTransport` speaks.
+ */
+function writeServer(name: string, body: string): string {
+	const path = join(dir, name)
+	writeFileSync(path, body)
+	return path
+}
+
+const WORKING_SERVER = `
+if (process.argv[2]) require('node:fs').writeFileSync(process.argv[2], String(process.pid))
+let buf = ''
+process.stdin.on('data', (chunk) => {
+  buf += chunk
+  let i
+  while ((i = buf.indexOf('\\n')) >= 0) {
+    const line = buf.slice(0, i)
+    buf = buf.slice(i + 1)
+    if (!line.trim()) continue
+    const msg = JSON.parse(line)
+    if (msg.method === 'initialize') {
+      send({ jsonrpc: '2.0', id: msg.id, result: {
+        protocolVersion: msg.params.protocolVersion,
+        serverInfo: { name: 'tickets', version: '1' },
+        capabilities: { tools: {} },
+      }})
+    } else if (msg.method === 'tools/list') {
+      send({ jsonrpc: '2.0', id: msg.id, result: { tools: [
+        { name: 'create', description: 'Open a ticket', inputSchema: {
+          type: 'object', properties: { title: { type: 'string' } }, required: ['title'] } },
+        { name: 'close', description: 'Close a ticket', inputSchema: {
+          type: 'object', properties: { id: { type: 'string' } }, required: ['id'] } },
+      ]}})
+    } else if (msg.method === 'tools/call') {
+      send({ jsonrpc: '2.0', id: msg.id, result: {
+        content: [{ type: 'text', text: 'opened ' + msg.params.arguments.title }],
+      }})
+    } else if (msg.id !== undefined) {
+      send({ jsonrpc: '2.0', id: msg.id, result: {} })
+    }
+  }
+})
+function send(o) { process.stdout.write(JSON.stringify(o) + '\\n') }
+`
+
+/** Starts, and never answers. The case a request timeout cannot cover. */
+const SILENT_SERVER = `setInterval(() => {}, 1000)\n`
+
+describe('a declared server', () => {
+	it('brings its tools, named after it', async () => {
+		const server = writeServer('tickets.js', WORKING_SERVER)
+
+		const mcp = await connectMcpServers(
+			{ tickets: { command: process.execPath, args: [server] } },
+			{ cwd: dir },
+		)
+		try {
+			expect(mcp.failed).toEqual([])
+			expect(mcp.connected).toEqual([{ name: 'tickets', toolCount: 2 }])
+			// Prefixed with the server name so two servers offering `create` do
+			// not collide and the transcript says where a call went.
+			expect(mcp.tools.map((t) => t.name)).toEqual(['mcp_tickets_create', 'mcp_tickets_close'])
+		} finally {
+			await mcp.close()
+		}
+	})
+
+	it('produces tools that actually call the server', async () => {
+		// The tool objects existing is not the feature. Registering something the
+		// model can see and cannot successfully invoke is worse than having
+		// nothing, because the failure arrives mid-task.
+		const server = writeServer('tickets.js', WORKING_SERVER)
+
+		const mcp = await connectMcpServers(
+			{ tickets: { command: process.execPath, args: [server] } },
+			{ cwd: dir },
+		)
+		try {
+			const create = mcp.tools.find((t) => t.name === 'mcp_tickets_create')
+			const result = await create?.execute({ title: 'the build is red' }, {} as never)
+			expect(result?.success).toBe(true)
+			expect(JSON.stringify(result?.output)).toContain('opened the build is red')
+		} finally {
+			await mcp.close()
+		}
+	})
+
+	it('leaves no child process behind when the session closes', async () => {
+		// The reason `close()` exists. A stdio server is a child process and
+		// nothing else in this package owns one, so before this there was no
+		// shutdown path at all: every TUI session and every one-shot left its
+		// servers running.
+		const server = writeServer('tickets.js', WORKING_SERVER)
+		const pidFile = join(dir, 'server.pid')
+
+		const mcp = await connectMcpServers(
+			{ tickets: { command: process.execPath, args: [server, pidFile] } },
+			{ cwd: dir },
+		)
+		const pid = Number(readFileSync(pidFile, 'utf8'))
+		expect(Number.isInteger(pid), 'the server must have actually started').toBe(true)
+		expect(() => process.kill(pid, 0), 'and must be alive before the close').not.toThrow()
+
+		await mcp.close()
+
+		await waitForExit(pid)
+	}, 20_000)
+
+	it('is absent from the roster when nothing is configured', async () => {
+		const mcp = await connectMcpServers(undefined, { cwd: dir })
+
+		expect(mcp.tools).toEqual([])
+		expect(mcp.connected).toEqual([])
+		expect(mcp.failed).toEqual([])
+		await mcp.close()
+	})
+})
+
+describe('a server that does not work is named, never merely absent', () => {
+	it('reports a command that cannot be spawned', async () => {
+		const mcp = await connectMcpServers(
+			{ tickets: { command: join(dir, 'no-such-executable') } },
+			{ cwd: dir },
+		)
+
+		expect(mcp.connected).toEqual([])
+		expect(mcp.failed).toHaveLength(1)
+		expect(mcp.failed[0]?.name).toBe('tickets')
+		expect(mcp.failed[0]?.reason.length).toBeGreaterThan(0)
+		await mcp.close()
+	})
+
+	it('reports a server that starts and never answers, rather than hanging', async () => {
+		// The client's per-request timeout cannot cover this: the process is up,
+		// the pipe is open, and nothing is coming. Without the connect deadline a
+		// single wedged server holds the whole session open before the first turn
+		// — no error, no failure, just a namzu that does not start.
+		const server = writeServer('silent.js', SILENT_SERVER)
+
+		const started = Date.now()
+		const mcp = await connectMcpServers(
+			{ quiet: { command: process.execPath, args: [server] } },
+			{ cwd: dir },
+		)
+
+		expect(mcp.failed[0]?.name).toBe('quiet')
+		expect(mcp.failed[0]?.reason).toContain('did not answer')
+		expect(Date.now() - started, 'the deadline has to actually bound it').toBeLessThan(30_000)
+		await mcp.close()
+	}, 40_000)
+
+	it('does not let one broken server take the working ones with it', async () => {
+		const good = writeServer('tickets.js', WORKING_SERVER)
+
+		const mcp = await connectMcpServers(
+			{
+				broken: { command: join(dir, 'no-such-executable') },
+				tickets: { command: process.execPath, args: [good] },
+			},
+			{ cwd: dir },
+		)
+		try {
+			expect(mcp.failed.map((f) => f.name)).toEqual(['broken'])
+			expect(mcp.connected.map((c) => c.name)).toEqual(['tickets'])
+		} finally {
+			await mcp.close()
+		}
+	})
+})
+
+describe('a spec that is not a server', () => {
+	it('refuses one that names neither a command nor a url', () => {
+		expect(transportFor({}, dir)).toContain('neither a command nor a url')
+	})
+
+	it('refuses one that names both, rather than picking', () => {
+		// An operator who edited a url into an entry that already had a command
+		// meant one of them. Choosing for them runs something they did not ask
+		// to run.
+		expect(transportFor({ command: 'x', url: 'https://y' }, dir)).toContain('both')
+	})
+
+	it('reports a bad spec by name, alongside the servers that worked', async () => {
+		const good = writeServer('tickets.js', WORKING_SERVER)
+
+		const mcp = await connectMcpServers(
+			{ nonsense: {}, tickets: { command: process.execPath, args: [good] } },
+			{ cwd: dir },
+		)
+		try {
+			expect(mcp.failed[0]?.name).toBe('nonsense')
+			expect(mcp.connected.map((c) => c.name)).toEqual(['tickets'])
+		} finally {
+			await mcp.close()
+		}
+	})
+
+	it('defaults a stdio server to the agent working directory', () => {
+		const transport = transportFor({ command: 'node' }, dir)
+
+		expect(typeof transport).not.toBe('string')
+		expect((transport as { cwd?: string }).cwd).toBe(dir)
+	})
+})

--- a/packages/cli/src/integrations/mcp/__tests__/connect.test.ts
+++ b/packages/cli/src/integrations/mcp/__tests__/connect.test.ts
@@ -101,7 +101,7 @@ function send(o) { process.stdout.write(JSON.stringify(o) + '\\n') }
 `
 
 /** Starts, and never answers. The case a request timeout cannot cover. */
-const SILENT_SERVER = `setInterval(() => {}, 1000)\n`
+const SILENT_SERVER = 'setInterval(() => {}, 1000)\n'
 
 describe('a declared server', () => {
 	it('brings its tools, named after it', async () => {

--- a/packages/cli/src/integrations/mcp/servers.ts
+++ b/packages/cli/src/integrations/mcp/servers.ts
@@ -1,0 +1,202 @@
+/**
+ * External tool servers an operator declares in their config.
+ *
+ * The kernel has spoken this protocol for a long time — `MCPClient`,
+ * `StdioTransport`, `StreamableHttpTransport` and the tool adapter are all
+ * exported from `@namzu/sdk`. `packages/cli` imported none of them, so the
+ * capability existed and was unreachable from the product: a namzu user could
+ * not connect an external tool server at all, whatever the kernel could do.
+ *
+ * A server is declared by name under `mcpServers` in `namzu.config.json`:
+ *
+ *     "mcpServers": {
+ *       "tickets": { "command": "node", "args": ["./tickets-server.js"] },
+ *       "search":   { "url": "https://tools.example.internal/mcp" }
+ *     }
+ *
+ * Its tools arrive prefixed with the server's name (`mcp_tickets_create`), so
+ * two servers offering `search` do not collide and the transcript says where a
+ * call went.
+ *
+ * ## Every failure is named
+ *
+ * A server that does not start, a spec that names neither a command nor a URL,
+ * a handshake that never answers — each becomes an entry in `failed` with a
+ * reason, never an absence. The whole hazard of this feature is the operator
+ * who configures a server, watches the agent run without its tools, and
+ * concludes the model is bad at the task.
+ *
+ * What to DO about a failure is not decided here, because the answer differs
+ * by surface: a person watching the TUI can read the line and fix their config,
+ * and a headless run has nobody to read anything, so it refuses. This module
+ * reports; the callers decide.
+ */
+
+import {
+	MCPClient,
+	type MCPTransportUnion,
+	type ToolDefinition,
+	mcpToolToToolDefinition,
+} from '@namzu/sdk'
+
+/**
+ * How long a single server gets to connect, hand shake and list its tools.
+ *
+ * The client's own `requestTimeoutMs` bounds one round trip; it cannot bound a
+ * process that spawns and never speaks. Without this, one wedged server holds
+ * the whole session open before the first turn — no error, no failure, just a
+ * namzu that does not start.
+ */
+export const CONNECT_TIMEOUT_MS = 10_000
+
+/** A single entry under `mcpServers`. Either a command or a URL, never both. */
+export interface McpServerSpec {
+	/** Stdio: the executable to run. */
+	readonly command?: string
+	readonly args?: readonly string[]
+	readonly env?: Readonly<Record<string, string>>
+	/** Working directory for the child. Defaults to the agent's. */
+	readonly cwd?: string
+	/** HTTP: the server's endpoint. */
+	readonly url?: string
+	readonly headers?: Readonly<Record<string, string>>
+}
+
+export type McpServersConfig = Readonly<Record<string, McpServerSpec>>
+
+export interface ConnectedMcpServer {
+	readonly name: string
+	readonly toolCount: number
+}
+
+export interface FailedMcpServer {
+	readonly name: string
+	/** Phrased for one line in front of a person who has to fix it. */
+	readonly reason: string
+}
+
+export interface McpConnection {
+	/** Adapted tools from every server that connected, ready to register. */
+	readonly tools: readonly ToolDefinition[]
+	readonly connected: readonly ConnectedMcpServer[]
+	readonly failed: readonly FailedMcpServer[]
+	/**
+	 * Shut every connected server down.
+	 *
+	 * A stdio server is a CHILD PROCESS. Nothing else in this package owns one,
+	 * which is why the session had no shutdown path before: without this, a TUI
+	 * session that ends leaves the child running, and a long-lived host that
+	 * opens sessions leaks one per session.
+	 */
+	close(): Promise<void>
+}
+
+/**
+ * Turn one spec into a transport, or say why it is not one.
+ *
+ * Refused rather than guessed. A spec with both a command and a URL is an
+ * operator who edited one into a file that already had the other, and picking
+ * either would run something they did not mean to run.
+ */
+export function transportFor(spec: McpServerSpec, defaultCwd: string): MCPTransportUnion | string {
+	const hasCommand = typeof spec.command === 'string' && spec.command.trim().length > 0
+	const hasUrl = typeof spec.url === 'string' && spec.url.trim().length > 0
+	if (hasCommand && hasUrl) {
+		return 'it declares both a command and a url — pick one'
+	}
+	if (hasCommand) {
+		return {
+			type: 'stdio',
+			command: spec.command as string,
+			...(spec.args ? { args: [...spec.args] } : {}),
+			...(spec.env ? { env: { ...spec.env } } : {}),
+			cwd: spec.cwd ?? defaultCwd,
+		}
+	}
+	if (hasUrl) {
+		return {
+			type: 'streamable-http',
+			url: spec.url as string,
+			...(spec.headers ? { headers: { ...spec.headers } } : {}),
+		}
+	}
+	return 'it declares neither a command nor a url'
+}
+
+async function withDeadline<T>(work: Promise<T>, ms: number, what: string): Promise<T> {
+	let timer: NodeJS.Timeout | undefined
+	try {
+		return await Promise.race([
+			work,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(() => reject(new Error(`${what} did not answer within ${ms}ms`)), ms)
+			}),
+		])
+	} finally {
+		if (timer) clearTimeout(timer)
+	}
+}
+
+const reasonOf = (err: unknown): string => (err instanceof Error ? err.message : String(err))
+
+export async function connectMcpServers(
+	config: McpServersConfig | undefined,
+	options: { readonly cwd: string },
+): Promise<McpConnection> {
+	const entries = Object.entries(config ?? {})
+	const tools: ToolDefinition[] = []
+	const connected: ConnectedMcpServer[] = []
+	const failed: FailedMcpServer[] = []
+	const clients: MCPClient[] = []
+
+	// Sequential, not parallel. Each server may spawn a process and each is
+	// bounded separately; a parallel fan-out would make the worst case the sum
+	// of nothing and the failure output arrive interleaved, for a saving that
+	// matters only to someone running many servers, who has other problems.
+	for (const [name, spec] of entries) {
+		const transport = transportFor(spec, options.cwd)
+		if (typeof transport === 'string') {
+			failed.push({ name, reason: transport })
+			continue
+		}
+		const client = new MCPClient({ serverName: name, transport })
+		try {
+			await withDeadline(client.connect(), CONNECT_TIMEOUT_MS, `server "${name}"`)
+			const listed = await withDeadline(
+				client.listTools(),
+				CONNECT_TIMEOUT_MS,
+				`server "${name}" listing its tools`,
+			)
+			for (const tool of listed) {
+				tools.push(mcpToolToToolDefinition(tool, client, name))
+			}
+			connected.push({ name, toolCount: listed.length })
+			clients.push(client)
+		} catch (err) {
+			failed.push({ name, reason: reasonOf(err) })
+			// A half-connected client still owns a child process. Tearing it down
+			// here is the difference between a failed server and a leaked one.
+			try {
+				await client.disconnect()
+			} catch {
+				// Already gone, or never started. Nothing left to do about it.
+			}
+		}
+	}
+
+	return {
+		tools,
+		connected,
+		failed,
+		close: async () => {
+			await Promise.all(
+				clients.map((c) =>
+					c.disconnect().catch(() => {
+						// Shutting down is best effort by definition: the process may
+						// already be gone, and nothing useful follows from saying so.
+					}),
+				),
+			)
+		},
+	}
+}

--- a/packages/cli/src/integrations/mcp/servers.ts
+++ b/packages/cli/src/integrations/mcp/servers.ts
@@ -49,6 +49,16 @@ import {
  */
 export const CONNECT_TIMEOUT_MS = 10_000
 
+/**
+ * How long shutting one server down may take before it is given up on.
+ *
+ * Shorter than the connect bound because nothing waits on the answer: a
+ * one-shot is exiting and a TUI is replacing the session. What this prevents
+ * is the opposite of a leak — a `close()` that never resolves, holding the
+ * command open past the work it was asked to do.
+ */
+export const CLOSE_TIMEOUT_MS = 2_000
+
 /** A single entry under `mcpServers`. Either a command or a URL, never both. */
 export interface McpServerSpec {
 	/** Stdio: the executable to run. */
@@ -176,10 +186,18 @@ export async function connectMcpServers(
 			failed.push({ name, reason: reasonOf(err) })
 			// A half-connected client still owns a child process. Tearing it down
 			// here is the difference between a failed server and a leaked one.
+			//
+			// Bounded, and deliberately not dependent on what a transport does
+			// when it is closed having never connected — the shipped transports
+			// disagree about that (one returns early, one notifies), the
+			// divergence is a known one, and a shutdown path that only works
+			// under one of the two answers is a shutdown path waiting to hang.
+			// Nothing here reads the client's state afterwards either.
 			try {
-				await client.disconnect()
+				await withDeadline(client.disconnect(), CLOSE_TIMEOUT_MS, `closing "${name}"`)
 			} catch {
-				// Already gone, or never started. Nothing left to do about it.
+				// Already gone, never started, or refusing to answer. The failure is
+				// already recorded and there is nothing further to do about it.
 			}
 		}
 	}
@@ -191,9 +209,11 @@ export async function connectMcpServers(
 		close: async () => {
 			await Promise.all(
 				clients.map((c) =>
-					c.disconnect().catch(() => {
+					withDeadline(c.disconnect(), CLOSE_TIMEOUT_MS, 'closing a tool server').catch(() => {
 						// Shutting down is best effort by definition: the process may
 						// already be gone, and nothing useful follows from saying so.
+						// Bounded so a server that will not close cannot hold the
+						// command open past the work it was asked to do.
 					}),
 				),
 			)

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -108,6 +108,12 @@ export function App({ ctx }: AppProps) {
 	const [selectedResume, setSelectedResume] = useState<number>(0)
 	const exitArmedRef = useRef<boolean>(false)
 	const abortRef = useRef<AbortController | null>(null)
+	/**
+	 * The session currently holding resources, so a re-hydration can release the
+	 * one it replaces. A `/model` switch builds a new session, and a tool
+	 * server's child process outlives the object that opened it.
+	 */
+	const previousSessionRef = useRef<AgentSession | null>(null)
 	// Source of truth for in-flight tools (the event loop runs across renders, so
 	// a ref avoids stale state); `activeTools` mirrors it for rendering.
 	const activeToolsRef = useRef<readonly RunningTool[]>([])
@@ -193,7 +199,13 @@ export function App({ ctx }: AppProps) {
 				scope,
 				cwd: ctx.cwd,
 				rules: ctx.rules,
+				...(ctx.mcpServers ? { mcpServers: ctx.mcpServers } : {}),
 			})
+			// Re-hydration (a provider switch via /model) builds a second session;
+			// without this the first one's tool-server child processes stay alive
+			// for the rest of the TUI's life.
+			void previousSessionRef.current?.close()
+			previousSessionRef.current = s
 			setSession(s)
 			setCurrentProvider(prefs.provider)
 			if (s.hasProvider) {
@@ -218,6 +230,15 @@ export function App({ ctx }: AppProps) {
 						'system',
 						`Skipped ${relative(ctx.cwd, skip.path) || skip.path}: ${skip.reason}`,
 					)
+				}
+				for (const server of s.mcpConnected) {
+					pushMessage('system', `Tool server ${server.name} · ${server.toolCount} tools`)
+				}
+				// Reported and carried on, where a headless run refuses: there is a
+				// person here who can read this and fix their config, and taking the
+				// whole session away from them would not help them do it.
+				for (const server of s.mcpFailed) {
+					pushMessage('system', `Tool server ${server.name} is not available: ${server.reason}`)
 				}
 			} else {
 				setPhase('unhealthy')

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -51,6 +51,12 @@ import { join } from 'node:path'
 import { composeEnvironmentPrompt, readEnvironmentFacts } from '../context/environment.js'
 import { loadProjectInstructions } from '../context/project.js'
 import {
+	type ConnectedMcpServer,
+	type FailedMcpServer,
+	type McpServersConfig,
+	connectMcpServers,
+} from '../integrations/mcp/servers.js'
+import {
 	type DetectedProvider,
 	PROVIDER_REGISTRY,
 	type Preferences,
@@ -204,7 +210,25 @@ export interface AgentSession {
 	 * the failure this whole package keeps finding.
 	 */
 	readonly skippedInstructionFiles: readonly { readonly path: string; readonly reason: string }[]
+	/** External tool servers that connected, and how many tools each brought. */
+	readonly mcpConnected: readonly ConnectedMcpServer[]
+	/**
+	 * External tool servers that were configured and are NOT here, with why.
+	 *
+	 * The hazard this feature carries is an operator who declares a server,
+	 * watches the agent run without its tools and concludes the model is bad at
+	 * the task. An empty tool list is not a signal; a named failure is.
+	 */
+	readonly mcpFailed: readonly FailedMcpServer[]
 	send(messages: readonly Message[], opts?: SendOptions): AsyncIterable<AgentEvent>
+	/**
+	 * Release what the session holds — today, the external tool servers.
+	 *
+	 * A stdio server is a CHILD PROCESS, and nothing else in this package owned
+	 * one, which is why a session had no shutdown path at all. Idempotent, and
+	 * safe to call on a session that connected nothing.
+	 */
+	close(): Promise<void>
 }
 
 export interface AgentSessionContext {
@@ -333,6 +357,11 @@ export interface AgentSessionOptions {
 	readonly rules?: readonly VerificationRule[]
 	/** How calls no rule decided are resolved. Defaults to prompt/auto by TTY. */
 	readonly permissionMode?: PermissionMode
+	/**
+	 * External tool servers to connect for this session, from the operator's
+	 * config. Absent means none, which is what it meant before they existed.
+	 */
+	readonly mcpServers?: McpServersConfig
 }
 
 export async function createAgentSession(
@@ -405,6 +434,11 @@ export async function createAgentSession(
 	// the past. An edited file takes effect on the next session.
 	const projectInstructions = loadProjectInstructions(cwd)
 	const registry = buildToolRegistry(cwd)
+	// External tool servers, before the roster is counted, so `toolNames` and
+	// the `/tools` list a user reads include what they configured. Connecting
+	// after the count would report a session smaller than the one that runs.
+	const mcp = await connectMcpServers(options.mcpServers, { cwd })
+	if (mcp.tools.length > 0) registry.register([...mcp.tools])
 	// This session passes a `taskStore` to query() below, which registers the
 	// task tools deferred — so `search_tools` has something to find here.
 	registry.register([SearchToolsTool])
@@ -479,6 +513,9 @@ export async function createAgentSession(
 		toolNames: activeToolNames,
 		instructionFiles: projectInstructions.files.map((f) => f.path),
 		skippedInstructionFiles: projectInstructions.skipped,
+		mcpConnected: mcp.connected,
+		mcpFailed: mcp.failed,
+		close: () => mcp.close(),
 		errorHint: null,
 		send: async function* (messages, opts) {
 			// Renew a lapsed OAuth token before the turn runs (no-op for valid
@@ -1206,9 +1243,14 @@ function emptySession(errorHint: string): AgentSession {
 		// would claim instructions are in force on a session that has no prompt.
 		instructionFiles: [],
 		skippedInstructionFiles: [],
+		mcpConnected: [],
+		mcpFailed: [],
 		errorHint,
 		send: async function* () {
 			yield { kind: 'error' as const, message: errorHint }
+		},
+		close: async () => {
+			// Nothing was ever connected on this path.
 		},
 	}
 }

--- a/packages/cli/src/tui/types.ts
+++ b/packages/cli/src/tui/types.ts
@@ -6,6 +6,8 @@
 
 import type { VerificationRule } from '@namzu/sdk'
 
+import type { McpServersConfig } from '../integrations/mcp/servers.js'
+
 export type MessageRole = 'user' | 'assistant' | 'system' | 'tool'
 
 export interface TranscriptMessage {
@@ -39,4 +41,10 @@ export interface TuiContext {
 	 * reflex.
 	 */
 	readonly rules?: readonly VerificationRule[]
+	/**
+	 * External tool servers from the operator's config, by the same reasoning as
+	 * `rules`: a config file belongs to the user, not to a command, and a server
+	 * they declared has to be there whichever way they started namzu.
+	 */
+	readonly mcpServers?: McpServersConfig
 }


### PR DESCRIPTION
`MCPClient`, `StdioTransport`, `StreamableHttpTransport` and the tool adapter are all exported from `@namzu/sdk`. **`packages/cli` imported none of them.** So the capability existed, fully built, and was unreachable from the product: a namzu user could not connect an external tool server at all, whatever the kernel could do — and nothing in the code said it was missing.

## What lands

Declare servers under `mcpServers` in `namzu.config.json`, by either a command to run or a URL to reach:

```json
{
  "mcpServers": {
    "tickets": { "command": "node", "args": ["./tools/tickets-server.js"] },
    "search":  { "url": "https://tools.example.internal/mcp" }
  }
}
```

Their tools join the roster the agent works with, prefixed with the server's name (`mcp_tickets_create`), so two servers offering the same tool do not collide and the transcript says where a call went. A `[permissions]` rule names a bridged tool like any other, and the server's own read-only / destructive hints are carried through to the gate.

- **Every failure is named.** That is the whole hazard: an operator declares a server, watches the agent work without its tools, and concludes the model is bad at the task. An entry naming both a command and a URL — or neither — is refused *by name* rather than guessed at, because someone who edited a URL into an entry that already had a command meant one of them and picking either runs something they did not ask to run. One server failing never takes the working ones with it.
- **What happens next differs by who is watching**, which is the split `resolvePermissionMode({ interactive })` already makes. The TUI prints the failure and carries on: a person is there, can read it, and can fix their config — taking the session away would not help them do that. `run` and `run-stream` **refuse**, because nobody is watching a headless run and a script that quietly does half the job is worse than one that stops.
- **A ten-second connect deadline.** `MCPClient.requestTimeoutMs` bounds one round trip and cannot bound a process that spawns and never speaks. Without it, one wedged server holds the whole session open before the first turn — no error, no failure, just a namzu that does not start.
- **`AgentSession` gains `close()`.** A stdio server is a *child process*, and nothing else in this package owned one, which is why a session had no shutdown path at all. Both one-shots close on every exit path; the TUI closes the session that a `/model` provider switch replaces.
- **Both disconnect sites are bounded at two seconds.** The shipped transports disagree about what closing a never-connected transport does (one returns early, one notifies) — a known divergence — and the connect-failure path closes exactly that kind of client. Nothing here reads the client's state afterwards, so the divergence cannot change the outcome, but an unbounded await on it would be a shutdown path that works under one answer and hangs under the other.

The config loader needed no defensive work: its `ConfigReaders` mapped type fails to compile until a new public config field has a reader. That guard exists because `permissions` was silently dropped by the same function for its whole life — and it did its job here.

## Verification

- **16 tests**, and the MCP ones spawn a **real child process speaking real JSON-RPC over stdio**, written to a temp file and started by the shipped transport. A stubbed transport would prove the adapter agrees with itself and say nothing about the thing that actually breaks: a process that spawns, or does not, and a handshake that answers, or does not.
- The load-bearing assertions are not "it connected":
  - `session.toolNames` contains `mcp_tickets_create` — the roster `/tools` prints and the turn is built from, not a connection object.
  - The builtins are still there beside it (registering an extra set is the ordinary way to lose the existing one).
  - After `close()`, the server's pid is polled with `process.kill(pid, 0)` until it is **actually gone**. That is the claim `close()` exists to make.
  - A server that starts and never answers is reported, and the test asserts the deadline actually bounds it.
- **Two mutations, neither survived**: tools not registered (2 red), config reader returning `undefined` (2 red).
- 414 tests, typecheck, lint, external-name audit green.

## An SDK observation, reported rather than worked around

`StdioTransport.close()` sends `SIGTERM` and returns **without awaiting the exit**, so a resolved `close()` does not mean the child is gone. Harmless for a one-shot whose process is exiting anyway. It surfaced here as `EBUSY` on Windows when a test tried to delete the child's working directory immediately after closing — handled by waiting for the process to actually disappear rather than by ignoring the error, since the wait *is* the assertion.

Docs: new `docs/cli/tool-servers.md`, plus the README bullet and map row.
