### PR TITLE
fix(cli): a workspace its owner closed takes no new conversation

### DIFF
--- a/.changeset/a-closed-workspace-takes-no-conversation.md
+++ b/.changeset/a-closed-workspace-takes-no-conversation.md
@@ -1,0 +1,28 @@
+---
+'@namzu/cli': patch
+---
+
+A workspace its owner closed takes no new conversation from the CLI either
+
+The kernel gained a workspace-closed gate: an archived `Project` accepts no new
+session, enforced at the SDK's own ingress paths. The CLI's conversation store
+calls `createSession` on the store **directly**, and a store deliberately holds
+no view of workspace status — so the invariant did not reach here, and namzu
+kept attaching work to a workspace somebody had deliberately closed.
+
+Whether that was real turned on one question: does the CLI ever reach a project
+it did not just create? It does. `openSessions` reads the project id back out
+of `.namzu/cli.json` and creates a new project only when that pointer is
+missing or stale, so every run after the first attaches to a project that
+already existed. A freshly created project is always open, which is why the
+first run in a directory could never have shown this.
+
+`startConversation` now calls `requireOpenProject` before creating the session,
+and an archived workspace refuses by name.
+
+The sub-agent runtime calls `createSession` directly too and is deliberately
+**not** gated: its store is an in-memory one built four lines earlier, the
+project two lines earlier, and neither outlives the runtime — so the id can
+never be one an owner has closed. A check that cannot fail teaches the next
+reader only that the checks here are decoration, so that site carries a comment
+naming the condition that would make it real instead.

--- a/packages/cli/src/integrations/sessions/__tests__/archived-workspace.test.ts
+++ b/packages/cli/src/integrations/sessions/__tests__/archived-workspace.test.ts
@@ -1,0 +1,82 @@
+/**
+ * A closed workspace takes no new conversation from the CLI either.
+ *
+ * The kernel gained a workspace-closed gate and it was applied to the SDK's own
+ * ingress paths. `startConversation` calls `createSession` on the store
+ * DIRECTLY, and a store deliberately holds no view of workspace status, so the
+ * invariant did not reach here.
+ *
+ * Whether that mattered turned on one question a grep cannot answer: does the
+ * CLI ever reach a project it did not just create? It does. `openSessions`
+ * reads the project id back out of `.namzu/cli.json` and creates a new project
+ * only when the pointer is missing or stale — so every run after the first
+ * attaches to a project that already existed and may since have been closed.
+ *
+ * That is why this test archives a project created by an EARLIER `openSessions`
+ * and then reopens the same directory. A test that archived a project it made
+ * itself, in one call, would pass against the first-run case the gate can never
+ * fire on.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { ProjectManager, type TenantId, UNKNOWN_TENANT_ID } from '@namzu/sdk'
+
+import { openSessions, startConversation } from '../store.js'
+
+let cwd: string
+
+beforeEach(() => {
+	cwd = mkdtempSync(join(tmpdir(), 'namzu-archived-'))
+})
+
+afterEach(() => {
+	rmSync(cwd, { recursive: true, force: true })
+})
+
+describe('a workspace its owner has closed', () => {
+	it('refuses a new conversation, instead of quietly accepting work', async () => {
+		// First run: creates the project and writes the pointer.
+		const first = await openSessions(cwd)
+		await new ProjectManager({ store: first.store }).archive(
+			first.projectId,
+			UNKNOWN_TENANT_ID as TenantId,
+		)
+
+		// A later run in the same directory reaches the SAME project through the
+		// pointer — the case that exists only from the second run onward.
+		const later = await openSessions(cwd)
+		expect(later.projectId, 'the pointer has to be what makes this reachable').toBe(first.projectId)
+
+		await expect(startConversation(later)).rejects.toThrow(/archiv|closed/i)
+	})
+
+	it('still starts a conversation in an open one', async () => {
+		// The other half. A gate nothing can get past has broken the product,
+		// and this is the assertion that would catch a `requireOpenProject` call
+		// wired to the wrong project id.
+		const sessions = await openSessions(cwd)
+
+		const id = await startConversation(sessions)
+
+		expect(typeof id).toBe('string')
+		expect(id.length).toBeGreaterThan(0)
+	})
+
+	it('names the workspace in the refusal', async () => {
+		// A refusal that does not say which workspace sends the reader nowhere:
+		// the whole point is that an owner closed this one on purpose.
+		const first = await openSessions(cwd)
+		await new ProjectManager({ store: first.store }).archive(
+			first.projectId,
+			UNKNOWN_TENANT_ID as TenantId,
+		)
+
+		const later = await openSessions(cwd)
+
+		await expect(startConversation(later)).rejects.toThrow(new RegExp(later.projectId))
+	})
+})

--- a/packages/cli/src/integrations/sessions/store.ts
+++ b/packages/cli/src/integrations/sessions/store.ts
@@ -21,6 +21,7 @@ import {
 	type TenantId,
 	type ThreadId,
 	UNKNOWN_TENANT_ID,
+	requireOpenProject,
 } from '@namzu/sdk'
 
 const TENANT = UNKNOWN_TENANT_ID as TenantId
@@ -104,8 +105,23 @@ export async function resolveConversation(s: CliSessions, key: string): Promise<
 	return id
 }
 
-/** Start a fresh conversation; returns its session id. */
+/**
+ * Start a fresh conversation; returns its session id.
+ *
+ * The workspace gate runs HERE rather than being assumed from the caller,
+ * because this is a store call and a store deliberately holds no view of
+ * workspace status — the SDK's own note says a direct store caller bypasses
+ * the invariant, and this was such a caller.
+ *
+ * It is not ceremony, and the difference is `openSessions` above: the project
+ * id is read back out of `.namzu/cli.json` and a new project is created only
+ * when the pointer is missing or stale. So on every run after the first, this
+ * attaches a session to a project it did NOT just create — one an owner may
+ * since have closed. A freshly created project is always open, which is why
+ * the first run could never have shown this.
+ */
 export async function startConversation(s: CliSessions): Promise<SessionId> {
+	await requireOpenProject(s.store, s.projectId, s.tenantId, 'cli-session')
 	const session = await s.store.createSession(
 		{ threadId: s.threadId, projectId: s.projectId, currentActor: null },
 		s.tenantId,

--- a/packages/cli/src/integrations/subagents/runtime.ts
+++ b/packages/cli/src/integrations/subagents/runtime.ts
@@ -114,6 +114,19 @@ export async function createSubagentRuntime(
 		{ projectId: project.id, title: 'namzu-cli' },
 		tenantId,
 	)
+	// No workspace gate here, and that is a finding rather than an omission.
+	//
+	// A direct `createSession` bypasses `requireOpenProject`, which is why the
+	// CLI's persistent conversation store now calls it explicitly. This site is
+	// the other shape: the store is a fresh `InMemorySessionStore` built four
+	// lines up, the project was created two lines up, and neither outlives this
+	// runtime — so the id can never be one an owner has closed. A gate on a path
+	// that always creates its own project checks a condition that cannot be
+	// false, and a check that cannot fail teaches the next reader nothing except
+	// that gates here are decoration.
+	//
+	// The trigger to add one is the day this store is replaced by a persistent
+	// one, or the project id starts arriving from a caller.
 	const parentSession = await store.createSession(
 		{ threadId: thread.id, projectId: project.id, currentActor: userActor },
 		tenantId,


### PR DESCRIPTION
14.0.0 added a workspace-closed gate: an archived `Project` accepts no new session, enforced at the SDK's ingress paths. The CLI's conversation store calls `createSession` on the store **directly**, and a store deliberately holds no view of workspace status — so the invariant never reached here.

## Which case is this?

The question that decides whether the gate is real or ceremony is: **does the CLI ever reach a project it did not just create?** A freshly created project is always `open`, so a gate on a path that always makes its own would check a condition that cannot be false.

There are two direct-`createSession` sites, and they are different.

**`integrations/sessions/store.ts` — real.** `openSessions` reads the project id back out of `.namzu/cli.json` and creates a new project only when that pointer is missing or stale:

```ts
if (projectId && !(await store.getProject(projectId, TENANT))) projectId = undefined
if (!projectId) { …createProject…; writeFileSync(pointerPath, …) }
```

So from the **second run in a directory onward**, `startConversation` attaches a session to a project that already existed — one an owner may since have closed. That is why the first run in a directory could never have shown this, and why it is worth a call rather than a comment. Gated with `requireOpenProject(store, projectId, tenantId, 'cli-session')`.

**`integrations/subagents/runtime.ts` — theoretical, deliberately left ungated.** Its store is a fresh `InMemorySessionStore` built four lines earlier and its project two lines earlier; neither outlives the runtime, so the id can never be one anybody closed. A check that cannot fail teaches the next reader only that the checks here are decoration — so the site carries a comment naming the condition that would make it real (a persistent store, or a project id arriving from a caller) instead of a call that always passes.

## Verification

- **3 tests.** The load-bearing one archives a project created by an **earlier** `openSessions` and then reopens the same directory, asserting first that the pointer really does hand back the same project id. A test that archived a project it made itself, in one call, would have exercised only the first-run case the gate can never fire on — which is the same shape as the finding itself.
- The other direction is covered too: a conversation still starts in an open workspace. That is the assertion that catches a `requireOpenProject` wired to the wrong project id, and a gate nothing can get past has broken the product.
- The refusal names the workspace, because the whole point is that somebody closed *this* one on purpose.
- Mutation: removing the call fails two of the three.
- 401 tests, typecheck, lint, external-name audit green.

Raised by the SDK side from their own audit, with the explicit instruction not to add the call blind. Establishing which case applied was most of the work; the fix is one line.
