### PR TITLE
fix(sdk): a close that means closed

### DIFF
--- a/.changeset/a-close-that-means-closed.md
+++ b/.changeset/a-close-that-means-closed.md
@@ -1,0 +1,19 @@
+---
+'@namzu/sdk': patch
+---
+
+`StdioTransport.close()` resolves when the child is gone, not when the signal
+was sent.
+
+It called `kill('SIGTERM')` and returned. `kill()` returns as soon as the
+signal is delivered, so an awaited `close()` meant "SIGTERM is on its way", and
+a caller that closed a transport and then deleted the child's working directory
+raced the exit — reported as `EBUSY` from a real integration, not inferred. A
+close that does not mean closed makes every teardown built on it a guess, and
+the guess is only wrong sometimes.
+
+`close()` now waits for the child's `exit`. A child ignoring SIGTERM is sent
+SIGKILL after two seconds, and a second timer gives up waiting, so `close()`
+cannot hang; both timers are unreferenced, so neither holds the event loop
+open. A spawn that never produced a process emits `error` and no `exit`, and
+that path settles too rather than waiting for an event that is not coming.

--- a/packages/sdk/src/connector/mcp/__tests__/a-close-that-means-closed.test.ts
+++ b/packages/sdk/src/connector/mcp/__tests__/a-close-that-means-closed.test.ts
@@ -1,0 +1,119 @@
+import type { ChildProcess } from 'node:child_process'
+import { describe, expect, it } from 'vitest'
+
+import { StdioTransport } from '../stdio.js'
+
+/**
+ * `close()` sent SIGTERM and returned without waiting, so a resolved close
+ * meant "the signal is on its way", not "the child is gone". A caller that
+ * closed a transport and then deleted the child's working directory raced the
+ * exit and saw EBUSY — reported from a real integration, not inferred.
+ *
+ * A close that does not mean closed makes every teardown built on top of it a
+ * guess, and the guess is only wrong sometimes, which is the worst kind.
+ *
+ * These assert on the operating system rather than on the transport's own
+ * state: `process.kill(pid, 0)` throws ESRCH once the pid is gone, so the
+ * assertion cannot pass by the transport merely believing it closed.
+ */
+
+/** The child the transport spawned, read before `close()` clears the field. */
+function childOf(transport: StdioTransport): ChildProcess {
+	const child = (transport as unknown as { process: ChildProcess | null }).process
+	if (!child) throw new Error('transport spawned no process')
+	return child
+}
+
+function pidOf(transport: StdioTransport): number {
+	const pid = childOf(transport).pid
+	if (pid === undefined) throw new Error('transport spawned no process')
+	return pid
+}
+
+function isAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0)
+		return true
+	} catch {
+		return false
+	}
+}
+
+describe('a close that means closed', () => {
+	it('does not resolve until the child is actually gone', async () => {
+		const transport = new StdioTransport({
+			type: 'stdio',
+			command: process.execPath,
+			args: ['-e', 'setInterval(() => {}, 1000)'],
+		})
+		await transport.connect()
+		const child = childOf(transport)
+		const pid = pidOf(transport)
+		expect(isAlive(pid)).toBe(true)
+
+		await transport.close()
+
+		// The reaped-ness of the child, not the liveness of the pid.
+		//
+		// `isAlive(pid)` alone is sound about the wrong thing: on Windows
+		// `kill('SIGTERM')` terminates the process synchronously, so the pid is
+		// already gone by the next line whether or not `close()` waited — the
+		// assertion passed under a deliberately reintroduced fire-and-forget
+		// kill, which is how this was caught. Node fills `exitCode`/`signalCode`
+		// only when it reaps the child and emits `exit`, a later tick, so these
+		// are non-null here exactly when `close()` awaited that event.
+		expect(child.exitCode !== null || child.signalCode !== null).toBe(true)
+		expect(isAlive(pid)).toBe(false)
+	})
+
+	it('returns rather than hanging when the command does not exist', async () => {
+		// A spawn that fails emits `error` and never `exit`. Waiting on `exit`
+		// alone would turn a bad command into a shutdown that never completes.
+		const transport = new StdioTransport({
+			type: 'stdio',
+			command: 'namzu-no-such-command-exists-here',
+			args: [],
+		})
+		await transport.connect()
+
+		await expect(transport.close()).resolves.toBeUndefined()
+	})
+
+	it('is safe to call twice', async () => {
+		const transport = new StdioTransport({
+			type: 'stdio',
+			command: process.execPath,
+			args: ['-e', 'setInterval(() => {}, 1000)'],
+		})
+		await transport.connect()
+		const pid = pidOf(transport)
+
+		await transport.close()
+		await transport.close()
+
+		expect(isAlive(pid)).toBe(false)
+	})
+
+	it('reports the exit to the handler registered for that session', async () => {
+		// The waiting must not swallow the notification the client depends on
+		// to learn the session ended.
+		const transport = new StdioTransport({
+			type: 'stdio',
+			command: process.execPath,
+			args: ['-e', 'setInterval(() => {}, 1000)'],
+		})
+		await transport.connect()
+		let closes = 0
+		transport.onClose(() => {
+			closes++
+		})
+
+		await transport.close()
+		// `close` on a ChildProcess follows `exit` by a tick once the stdio
+		// streams drain; give the loop that tick rather than asserting on a
+		// race.
+		await new Promise((resolve) => setTimeout(resolve, 50))
+
+		expect(closes).toBe(1)
+	})
+})

--- a/packages/sdk/src/connector/mcp/stdio.ts
+++ b/packages/sdk/src/connector/mcp/stdio.ts
@@ -6,6 +6,13 @@ import type {
 } from '../../types/connector/index.js'
 import { type Logger, getRootLogger } from '../../utils/logger.js'
 
+/**
+ * How long a child gets to honour SIGTERM before SIGKILL. Two seconds is
+ * long enough for a server flushing a response and short enough that a
+ * shutdown does not read as a hang.
+ */
+const TERMINATE_GRACE_MS = 2_000
+
 export class StdioTransport implements MCPTransport {
 	private process: ChildProcess | null = null
 	private messageHandlers: Array<(message: MCPJsonRpcMessage) => void> = []
@@ -71,9 +78,39 @@ export class StdioTransport implements MCPTransport {
 		}
 		this.connected = false
 		this.exitPending = true
-		this.process.kill('SIGTERM')
+		const child = this.process
 		this.process = null
 		this.buffer = ''
+
+		// Resolve when the child is actually gone, not when the signal was
+		// sent. `kill()` returns as soon as the signal is delivered, so an
+		// awaited `close()` meant only "SIGTERM is on its way" — a caller that
+		// closed and then deleted the child's working directory raced the exit
+		// and saw EBUSY. A close that does not mean closed makes every
+		// teardown after it a guess.
+		//
+		// A spawn that never produced a process emits `error` and no `exit`,
+		// so both settle this, and two timers make a hang impossible: the
+		// first escalates to SIGKILL for a child ignoring SIGTERM, the second
+		// gives up waiting. Neither holds the event loop open.
+		if (child.pid === undefined) return
+		await new Promise<void>((resolve) => {
+			let settled = false
+			const finish = (): void => {
+				if (settled) return
+				settled = true
+				clearTimeout(escalate)
+				clearTimeout(giveUp)
+				resolve()
+			}
+			child.once('exit', finish)
+			child.once('error', finish)
+			child.kill('SIGTERM')
+			const escalate = setTimeout(() => child.kill('SIGKILL'), TERMINATE_GRACE_MS)
+			const giveUp = setTimeout(finish, TERMINATE_GRACE_MS * 2)
+			escalate.unref?.()
+			giveUp.unref?.()
+		})
 		// The handlers deliberately survive this call. `process.on('close')`
 		// fires them when the process actually exits, and dropping them here
 		// would leave `MCPClient` believing it is still connected — so its next


### PR DESCRIPTION
`StdioTransport.close()` called `kill('SIGTERM')` and returned. `kill()` returns as soon as the signal is delivered, so an awaited `close()` meant *"SIGTERM is on its way"*, not *"the child is gone"*. A caller that closed a transport and then deleted the child's working directory raced the exit and saw `EBUSY`.

Reported from a real integration by the agent wiring the MCP client into the CLI — not inferred from reading. A close that does not mean closed makes every teardown built on it a guess, and the guess is only wrong sometimes.

## What changed

`close()` waits for the child's `exit`. A child ignoring SIGTERM is sent SIGKILL after two seconds, and a second timer gives up waiting, so `close()` cannot hang. Both timers are unreferenced, so neither holds the event loop open. A spawn that never produced a process emits `error` and no `exit`, so that path settles on `error` rather than waiting for an event that is not coming.

## The test was wrong first, and the mutation caught it

The obvious assertion — `process.kill(pid, 0)` throws after close — **passes under a deliberately reintroduced fire-and-forget kill** on Windows, where SIGTERM terminates the process synchronously and the pid is gone by the next line either way. It was sound about the symptom and silent about the mechanism.

What discriminates is `child.exitCode !== null || child.signalCode !== null`: Node fills those only when it *reaps* the child and emits `exit`, a later tick. With that assertion the mutation fails; the comment in the test records why, so nobody simplifies it back.

## Verification

4 tests, driving real child processes. Typecheck 0, lint 0, 2854 tests pass.
