### PR TITLE
test(cli): record what the pid assertion actually proves, and how it was checked

### DIFF
--- a/packages/cli/src/integrations/mcp/__tests__/connect.test.ts
+++ b/packages/cli/src/integrations/mcp/__tests__/connect.test.ts
@@ -38,7 +38,22 @@ afterEach(async () => {
 	rmSync(dir, { recursive: true, force: true })
 })
 
-/** Resolves once the process is gone, or throws after the deadline. */
+/**
+ * Resolves once the process is gone, or throws after the deadline.
+ *
+ * This asserts the SYMPTOM — the pid no longer exists — and not the mechanism,
+ * and that distinction is worth stating because the same shape can be sound
+ * about the wrong thing: a child that would have exited on its own the moment
+ * its stdin pipe closed would satisfy this whether or not anything killed it,
+ * and the test would report that `close()` works while `close()` did nothing.
+ *
+ * MEASURED, not reasoned about. With `close()` replaced by an early `return`,
+ * this test fails with "process N was still alive after 5000ms" — so the child
+ * does not go away by itself here, and the pid disappearing is caused by the
+ * shutdown path under test. The symptom is the right claim for this package:
+ * whether the runtime also REAPS the child is the transport's business, and
+ * "no process left behind" is what a user is owed.
+ */
 async function waitForExit(pid: number, deadlineMs = 5_000): Promise<void> {
 	const until = Date.now() + deadlineMs
 	for (;;) {


### PR DESCRIPTION
The SDK side flagged that their own first version of this assertion — `kill(pid, 0)` throwing after close — survived a deliberately reintroduced fire-and-forget kill, because on Windows SIGTERM terminates synchronously and the pid is gone by the next line either way. Sound about the symptom, silent about the mechanism. They asked whether mine had the same shape.

**Checked rather than argued.** Replacing `close()` with an early `return` fails the test with "process N was still alive after 5000ms" — the child does not go away by itself here (its stdin listener keeps the loop alive while the transport holds the pipe), so the pid disappearing is caused by the shutdown path under test.

So no behaviour change and no test change: the assertion was already load-bearing. What lands is the reasoning, as a comment, so the next reader does not have to rerun the mutation to learn it — and so anyone who later makes the server exit on stdin close sees why that would quietly hollow the test out.

The distinction is kept explicitly: this asserts the **symptom** — no process left behind — which is the right claim for this package. Whether the runtime also *reaps* the child is the transport's business.

11 tests, lint and typecheck green.