### PR TITLE
fix(sdk): a gateway that outlives its run forgets the oldest

### DIFF
--- a/.changeset/a-gateway-that-forgets-the-oldest.md
+++ b/.changeset/a-gateway-that-forgets-the-oldest.md
@@ -1,0 +1,22 @@
+---
+'@namzu/sdk': patch
+---
+
+`LocalTaskGateway` stops remembering every task it ever launched.
+
+`trackedTaskIds` and `settledHandles` had `add` and `set` and no removal
+anywhere in the file. The comment above them said "bounded by the number the
+gateway itself launched", which is true and is not a bound: a gateway built per
+run is bounded by that run, but `SupervisorAgentConfig.gateway` lets a host
+supply its own, and a long-lived host reusing one accumulates an id and a
+settled handle for every task it ever launched, for the life of the process.
+
+Both are now capped at 1000 and evicted oldest-first. The cap is far above any
+realistic single run — a fan-out is eight, a long supervisory run is dozens —
+so the listing a supervisor reads at the end of its run is unchanged.
+
+The two are evicted **together**. Dropping a tracked id while keeping its
+handle would leave memory nothing can reach, since `listTasks` walks the ids;
+dropping a handle while keeping its id would make a task that ran read as one
+that never launched, which is the exact defect the settled-handle map exists to
+fix. Removing either half of the paired delete fails a test.

--- a/packages/sdk/src/gateway/__tests__/a-gateway-that-forgets-the-oldest.test.ts
+++ b/packages/sdk/src/gateway/__tests__/a-gateway-that-forgets-the-oldest.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+
+import type { AgentManagerContract } from '../../types/agent/manager.js'
+import type { AgentTask, AgentTaskContext } from '../../types/agent/task.js'
+import type { AgentId, TaskId } from '../../types/ids/index.js'
+import { LocalTaskGateway } from '../local.js'
+
+/**
+ * The gateway's two ledgers — `trackedTaskIds` and `settledHandles` — had `add`
+ * and `set` and no removal anywhere. The doc called them "bounded by the number
+ * the gateway itself launched", which is true and is not a bound: a gateway
+ * built per run is bounded by that run, but `SupervisorAgentConfig.gateway`
+ * lets a host supply its own, and a long-lived host reusing one accumulates an
+ * id and a settled handle for every task it ever launched.
+ *
+ * Eviction is oldest-first and takes both together. Dropping a tracked id while
+ * keeping its handle — or the reverse — would make a task that ran read as one
+ * that never launched, which is precisely the defect the settled-handle map was
+ * added to fix.
+ */
+
+const CAP = 1_000
+
+class CountingManager {
+	private n = 0
+
+	async sendMessage(): Promise<AgentTask> {
+		this.n++
+		return { taskId: `tsk_${this.n}` as TaskId, state: 'running' } as AgentTask
+	}
+	async waitForCompletion(): Promise<void> {}
+	getInstance(): AgentTask | undefined {
+		return undefined
+	}
+	cancel(): void {}
+}
+
+function context(): AgentTaskContext {
+	return {
+		parentRunId: 'run_p' as never,
+		parentAgentId: 'sup',
+		parentAbortController: new AbortController(),
+		depth: 0,
+		budgetTracker: { total: 1_000_000, remaining: 1_000_000 },
+		tenantId: 'tnt_g' as never,
+		sessionId: 'ses_g' as never,
+		projectId: 'prj_g' as never,
+	} as unknown as AgentTaskContext
+}
+
+function tracked(gateway: LocalTaskGateway): Set<TaskId> {
+	return (gateway as unknown as { trackedTaskIds: Set<TaskId> }).trackedTaskIds
+}
+
+function settled(gateway: LocalTaskGateway): Map<TaskId, unknown> {
+	return (gateway as unknown as { settledHandles: Map<TaskId, unknown> }).settledHandles
+}
+
+async function launch(gateway: LocalTaskGateway, count: number): Promise<void> {
+	for (let i = 0; i < count; i++) {
+		await gateway.createTask({
+			agentId: 'w' as AgentId,
+			prompt: 'go',
+			workingDirectory: '/tmp',
+		} as never)
+	}
+}
+
+describe('a gateway that outlives its run forgets the oldest', () => {
+	it('keeps every task of a run that never reaches the cap', async () => {
+		// The control, and the case that must not change: a supervisor reading
+		// its listing at the end of a run sees everything it launched.
+		const gateway = new LocalTaskGateway(
+			new CountingManager() as unknown as AgentManagerContract,
+			context(),
+		)
+
+		await launch(gateway, 50)
+
+		expect(tracked(gateway).size).toBe(50)
+	})
+
+	it('stops growing once the cap is passed', async () => {
+		const gateway = new LocalTaskGateway(
+			new CountingManager() as unknown as AgentManagerContract,
+			context(),
+		)
+
+		await launch(gateway, CAP + 25)
+
+		expect(tracked(gateway).size).toBe(CAP)
+	})
+
+	it('drops the oldest, not the newest', async () => {
+		// A cap that evicted the most recent would keep the ledger small and
+		// answer every question wrongly.
+		const gateway = new LocalTaskGateway(
+			new CountingManager() as unknown as AgentManagerContract,
+			context(),
+		)
+
+		await launch(gateway, CAP + 3)
+
+		const ids = tracked(gateway)
+		expect(ids.has('tsk_1' as TaskId)).toBe(false)
+		expect(ids.has('tsk_3' as TaskId)).toBe(false)
+		expect(ids.has(`tsk_${CAP + 3}` as TaskId)).toBe(true)
+	})
+
+	it('never keeps a settled handle for an id it has forgotten', async () => {
+		// The two must be evicted together. A handle whose id is gone is
+		// unreachable through `listTasks`, which walks the ids — so it would be
+		// retained memory serving nothing, and the leak would survive its own
+		// fix.
+		const gateway = new LocalTaskGateway(
+			new CountingManager() as unknown as AgentManagerContract,
+			context(),
+		)
+		await launch(gateway, 10)
+		const handles = settled(gateway)
+		for (let i = 1; i <= 10; i++) handles.set(`tsk_${i}` as TaskId, { id: i })
+
+		await launch(gateway, CAP + 5)
+
+		const ids = tracked(gateway)
+		for (const id of handles.keys()) {
+			expect({ id, trackedToo: ids.has(id) }).toEqual({ id, trackedToo: true })
+		}
+	})
+})

--- a/packages/sdk/src/gateway/local.ts
+++ b/packages/sdk/src/gateway/local.ts
@@ -14,6 +14,17 @@ import type { RunEventListener } from '../types/run/events.js'
 import { toErrorMessage } from '../utils/error.js'
 import { getRootLogger } from '../utils/logger.js'
 
+/**
+ * How many launched tasks a gateway remembers.
+ *
+ * High enough that no realistic single run reaches it — a fan-out is eight,
+ * a long supervisory run is dozens — so the listing a supervisor reads at the
+ * end of its run is always complete. It exists for the host that reuses one
+ * gateway across runs, where the alternative is a set and a map that grow for
+ * the life of the process.
+ */
+const GATEWAY_TASK_LEDGER_CAP = 1_000
+
 export class LocalTaskGateway implements TaskGateway {
 	private agentManager: AgentManagerContract
 	private taskContext: AgentTaskContext
@@ -140,6 +151,7 @@ export class LocalTaskGateway implements TaskGateway {
 
 		launched.id = task.taskId
 		this.trackedTaskIds.add(task.taskId)
+		this.forgetOldestBeyondCap()
 
 		this.agentManager
 			.waitForCompletion(task.taskId)
@@ -240,6 +252,30 @@ export class LocalTaskGateway implements TaskGateway {
 	rememberSettled(taskId: TaskId): void {
 		const task = this.agentManager.getInstance(taskId)
 		if (task) this.settledHandles.set(taskId, toHandle(task))
+	}
+
+	/**
+	 * Drop the oldest tasks once the ledger passes {@link GATEWAY_TASK_LEDGER_CAP}.
+	 *
+	 * A gateway constructed per run is bounded by that run and this never
+	 * fires. But `SupervisorAgentConfig.gateway` lets a host supply its own,
+	 * and a long-lived host reusing one accumulates an id and a settled handle
+	 * per task it ever launched, for the life of the process — the doc above
+	 * says "bounded by the number the gateway itself launched", which is true
+	 * and is not a bound when the gateway outlives the run.
+	 *
+	 * Both collections are evicted **together and in insertion order**. Losing
+	 * a tracked id while keeping its handle, or the reverse, would make a task
+	 * that ran read as one that never launched — which is the exact defect the
+	 * settled-handle map was added to fix, reintroduced by its own cleanup.
+	 */
+	private forgetOldestBeyondCap(): void {
+		while (this.trackedTaskIds.size > GATEWAY_TASK_LEDGER_CAP) {
+			const oldest = this.trackedTaskIds.values().next().value
+			if (oldest === undefined) return
+			this.trackedTaskIds.delete(oldest)
+			this.settledHandles.delete(oldest)
+		}
 	}
 
 	listTasks(): TaskHandle[] {


### PR DESCRIPTION
`LocalTaskGateway.trackedTaskIds` and `settledHandles` had `add` and `set` and **no removal anywhere in the file**. The comment above them said "bounded by the number the gateway itself launched" — true, and not a bound.

A gateway built per run is bounded by that run. But `SupervisorAgentConfig.gateway` is a supported path for a host to supply its own, and a long-lived host reusing one accumulates an id and a settled handle for every task it ever launched, for the life of the process.

## The ownership question is what separates this from the one I refuted

An earlier audit finding claimed `wireActivityStore`/`wirePlanManager` leak by discarding their unsubscribe. I checked who owns the emitter, found it is constructed per context and dies with the run, and refuted it. Here the same question has the opposite answer, and only asking it tells them apart.

## A cap, not a removal

These maps exist because a settled task used to vanish from `listTasks` after the manager's 30-second eviction — a supervisor could not tell an evicted task from one that never launched. Clearing them would reintroduce exactly that. So: 1000, oldest-first, far above any realistic run (a fan-out is eight, a long supervisory run is dozens), leaving the listing a supervisor reads at the end of its own run unchanged.

## They evict together

An id without its handle makes a task that ran read as one that never launched. A handle without its id is memory nothing can reach, since `listTasks` walks the ids — the leak surviving its own fix. That pairing has its own test.

## Verification

Mutation: removing the eviction call fails 2 of 4; removing just the `settledHandles.delete` fails the pairing test. Typecheck 0, lint 0, 2858 tests pass.
