### PR TITLE
docs: what namzu does before it touches your repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,21 @@ newline-delimited events a host UI can consume, `namzu history`,
 `namzu providers`, `namzu doctor`, and `namzu eval`. Run `namzu --help` for
 the current list.
 
+Three things it does on the way in are worth knowing, because they are the
+difference between a toy and something you point at a real repository:
+
+- **A folder nobody has trusted is not one it runs in.** On launch in an
+  unfamiliar working directory it stops and asks, because reading, running
+  commands and editing files there is what it is about to be able to do.
+- **The repository gets to state how it wants work done.** An `AGENTS.md` is
+  read from the working directory upward to the repository root, outermost
+  first, so the file nearest the work has the final word. Before this existed
+  everything the agent was told was about the *user* and global to the
+  machine; a project that had written its conventions down had no way to be
+  heard short of pasting the file in every session.
+- **It connects to the tool servers you declare**, so the tools available in a
+  given checkout are that checkout's business rather than the binary's.
+
 ## What is inside that is independently hard
 
 The reason this repository is larger than a loop is that each of the following


### PR DESCRIPTION
Follow-up to #197, root README only.

The rewritten page described the terminal agent as a list of subcommands. Accurate, and silent on the part a reader actually weighs: what happens when you point it at a repository you care about.

Three mechanisms shipped in the last two days and none was on the page. Each was read in source before being described:

- **Folder trust** — `packages/cli/src/tui/TrustPrompt.tsx`: an untrusted working directory stops and asks on launch, because reading, running commands and editing files there is what is about to become possible.
- **Project instructions** — `packages/cli/src/context/project.ts`: an `AGENTS.md` walk from the working directory up to the first `.git`, applied outermost-first so the file nearest the work has the final word. The module comment records why it exists: before it, everything the agent was told was about the *user* and global to the machine, so a project that had written down how it wants work done had no way to be heard short of pasting the file in every session.
- **Declared tool servers** — `packages/cli/src/config/schema.ts` and `config/load.ts`.

No changeset: the root README is not a published artifact.

`audit-external-names` passes.