### PR TITLE
docs(sdk): seven drivers ship, the README named two

### DIFF
--- a/.changeset/seven-drivers-not-two.md
+++ b/.changeset/seven-drivers-not-two.md
@@ -1,0 +1,23 @@
+---
+"@namzu/sdk": patch
+---
+
+Stop the package README naming two providers when seven ship
+
+"Provider abstraction. OpenRouter and AWS Bedrock today" has been wrong for a
+long time. Seven driver packages ship — and a reader deciding whether this
+kernel can talk to the service they already pay for was being told, on the
+registry page, that it probably cannot.
+
+That is the expensive direction for this particular sentence to be wrong in:
+it does not cause a bug, it causes someone to close the tab.
+
+Also removed the third-party product names from "What Namzu Is Not". That
+section explained namzu's scope by listing other people's products, which is
+the one thing this repository's own naming rule refuses — a design explained
+by reference to somebody else's has borrowed its shape, and the borrowing
+outlives the sentence. The scope boundaries are unchanged and now stated as
+categories: no front-end framework bindings, no web-framework or edge-runtime
+plumbing, no embedded vector engine.
+
+Prose only. No runtime change.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,21 @@ newline-delimited events a host UI can consume, `namzu history`,
 `namzu providers`, `namzu doctor`, and `namzu eval`. Run `namzu --help` for
 the current list.
 
+Three things it does on the way in are worth knowing, because they are the
+difference between a toy and something you point at a real repository:
+
+- **A folder nobody has trusted is not one it runs in.** On launch in an
+  unfamiliar working directory it stops and asks, because reading, running
+  commands and editing files there is what it is about to be able to do.
+- **The repository gets to state how it wants work done.** An `AGENTS.md` is
+  read from the working directory upward to the repository root, outermost
+  first, so the file nearest the work has the final word. Before this existed
+  everything the agent was told was about the *user* and global to the
+  machine; a project that had written its conventions down had no way to be
+  heard short of pasting the file in every session.
+- **It connects to the tool servers you declare**, so the tools available in a
+  given checkout are that checkout's business rather than the binary's.
+
 ## What is inside that is independently hard
 
 The reason this repository is larger than a loop is that each of the following

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -40,7 +40,7 @@ Namzu is a single-process TypeScript kernel with the following responsibilities:
 - **Human-in-the-loop.** Structured plan review, per-tool approval with destructiveness flags, typed decision contracts, checkpoint/resume across sessions.
 - **Plugin system.** Lifecycle-hooked plugin loader with MCP contributions, tool contributions, and manifest-driven resolution.
 - **Multi-tenant isolation from day one.** Connector registries, vaults, config, and stores are tenant-scoped. Two organizations can share a process without cross-contamination.
-- **Provider abstraction.** OpenRouter and AWS Bedrock today; the `Provider` interface is narrow enough that adding another vendor is an afternoon. BYOK everywhere, no hidden hot paths for any vendor.
+- **Provider abstraction.** Seven drivers ship today, each its own package installed only if you use it, plus a scriptable mock pre-registered in the kernel. The `LLMProvider` interface is narrow enough that adding another is an afternoon. BYOK everywhere, no hidden hot paths for any vendor.
 - **Telemetry.** OpenTelemetry-native spans and metrics. Cost accounting (input tokens, output tokens, cached tokens, cache write tokens, cache discount) flows from the provider into per-run, per-tenant rollups.
 - **Prompt cache integration.** Hash-based system-prompt cache per thread, integrated with provider cache controls (OpenRouter `cacheControl` today, more planned), plus full cache telemetry in every run.
 - **Vault.** BYOK credentials and secrets, tenant-scoped, pluggable backend.
@@ -52,11 +52,11 @@ Every one of those bullets points at code that exists today in `src/`. The archi
 
 Equally important for scoping expectations:
 
-- **Not a chat SDK.** There are no React, Svelte, or Vue hooks, no generative UI components, no `useChat`. Your UI framework is your choice; the kernel hands you a typed event stream.
+- **Not a chat SDK.** No front-end framework bindings, no generative UI components, no ready-made chat hook. Your UI framework is your choice; the kernel hands you a typed event stream.
 - **Not a hosted service.** There is no dashboard, no Namzu Cloud, no billing page. You run it in your own process.
-- **Not a deployment adapter.** No Next.js, Hono, Express, or Cloudflare Workers plumbing in the kernel. Those belong in separate packages or your own infra code.
+- **Not a deployment adapter.** No web-framework or edge-runtime plumbing in the kernel. That belongs in separate packages or your own infra code.
 - **Not a dev studio.** No bundled playground UI. A playground that consumes the kernel's event protocol could exist as a separate tool; it would not live inside `@namzu/sdk`.
-- **Not a vector database.** RAG ships with a pluggable `VectorStore` interface, but the kernel does not embed pgvector or Pinecone. Bring your own.
+- **Not a vector database.** RAG ships with a pluggable `VectorStore` interface; the kernel embeds no vector engine of its own. Bring your own.
 - **Not an LLM router service.** Task routing is an in-process policy, not a hosted service.
 - **Not a prompt management UI.** Personas are code-defined (YAML files in your repo), not database rows behind a web form.
 


### PR DESCRIPTION
Second and last correction to the package README that ships inside the SDK
tarball. Follow-up to #198.

## The provider bullet was wrong

> **Provider abstraction.** OpenRouter and AWS Bedrock today

Seven driver packages ship, each installed only if you use it, plus a
scriptable mock pre-registered in the kernel.

This is wrong in the expensive direction for that particular sentence. It
causes no bug. It causes a reader whose vendor **is** supported to read the
registry page, conclude it is not, and close the tab.

## Third-party names out of the scope section

"What Namzu Is Not" explained namzu's scope by listing other people's
products — front-end frameworks, web frameworks, edge runtimes, vector
engines. That is the one thing this repository's naming rule refuses: a design
explained by reference to somebody else's has borrowed its shape, and the
borrowing outlives the sentence.

The boundaries themselves are unchanged; they are now stated as categories
rather than as a list of competitors. Note that this half is **not** caught by
CI — those particular names are not on the audit's forbidden list, so this is
the rule rather than the gate.

Prose only. No runtime change. `patch`.

`audit-external-names` 0 · `lint` 0.
