### PR TITLE
docs: adopt the estate documentation standard, starting with the conventions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,3 +167,27 @@ jobs:
             npx -y publint@latest packages/$pkg
             echo "::endgroup::"
           done
+
+  # Documentation gate. Separate from Build & Test for one reason: its drift
+  # check compares a document's last commit against its `resource:`'s last
+  # commit, and `git log` cannot answer that on the shallow checkout the matrix
+  # uses. Rather than return a pass it could not justify, the gate REFUSES on a
+  # shallow clone -- so it gets its own job with full history instead of a
+  # `fetch-depth: 0` on four matrix entries that do not need it.
+  #
+  # No dependency install: the gate is stdlib-only node by design, so it runs
+  # on the bare tree in seconds and cannot be broken by a lockfile change.
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Docs standard gate
+        run: node tools/check-docs.mjs

--- a/docs/conventions/a-check-that-cannot-fail.md
+++ b/docs/conventions/a-check-that-cannot-fail.md
@@ -1,0 +1,56 @@
+---
+uid: namzu.conventions.a-check-that-cannot-fail
+title: A check that cannot fail is worse than no check
+description: A guard placed where its condition can never be false protects nothing, and it teaches the next reader that the checks in this file are decoration — so the one that matters gets skimmed too.
+type: Convention
+diataxis: explanation
+owner: cogitave/namzu
+status: active
+timestamp: 2026-08-04T00:00:00Z
+lastReviewed: 2026-08-07
+resource: packages/cli/src/integrations/subagents/runtime.ts
+tags: [convention, verification, code-review]
+---
+
+# A check that cannot fail is worse than no check
+
+A guard placed where its condition can never be false does not protect
+anything. It costs a reader's attention, and it teaches the next person that
+the checks in this file are decoration — so the one that matters gets skimmed
+too.
+
+When adding a guard, name the input that makes it fire. If you cannot, either
+the guard belongs somewhere else or the situation it imagines does not exist
+yet. Write a comment saying what would make it real, and leave the call out.
+
+## The incident
+
+`@namzu/sdk` 14.0.0 gave `Project` a status and made spawn and both handoffs
+refuse an archived workspace. Two call sites in the CLI create sessions
+directly through the store, bypassing that gate. They look identical and are
+not:
+
+- The session store reads the project id back out of `.namzu/cli.json`, so from
+  the second run in a directory onward it attaches to a project it did not
+  create. The gate is real there and was added.
+- The subagent runtime builds a fresh store four lines earlier and its project
+  two lines earlier, neither outliving the call. A freshly created project is
+  always open, so the gate could never fire. It was left out, with a comment
+  naming what would make it real: a persistent store, or a project id arriving
+  from a caller.
+
+Establishing which case each site was in took one reading and changed the
+answer for one of them.
+
+## The sharper form
+
+The same rule catches a test that cannot fail. A test whose assertion holds
+under the bug it was written for is the same object: something that looks like
+a check and is not.
+
+## Related
+
+- [Mutate every test](mutation-check-every-test.md) — how you establish that a
+  check can fail, rather than arguing that it can.
+- [An optional dependency may degrade a feature, never a check](an-optional-dependency-may-not-degrade-a-check.md)
+  — a guard that cannot fail because its precondition was defaulted away.

--- a/docs/conventions/an-optional-dependency-may-not-degrade-a-check.md
+++ b/docs/conventions/an-optional-dependency-may-not-degrade-a-check.md
@@ -1,0 +1,47 @@
+---
+uid: namzu.conventions.an-optional-dependency-may-not-degrade-a-check
+title: An optional dependency may degrade a feature, never a check
+description: A call site reading an optional method with a default has decided what its absence means. For a feature that is fine; for a precondition it turns "I cannot establish this" into "this is satisfied".
+type: Convention
+diataxis: explanation
+owner: cogitave/namzu
+status: active
+timestamp: 2026-08-04T00:00:00Z
+lastReviewed: 2026-08-07
+resource: packages/sdk/src/manager/project/lifecycle.ts
+tags: [convention, api-design, verification]
+---
+
+# An optional dependency may degrade a feature, never a check
+
+Marking an interface method optional is right when the cost of requiring it
+falls on implementors: a host with its own store should not stop compiling
+because the SDK grew a method. But a call site that reads an optional method
+with a default has decided what its absence means. For a feature that is fine.
+For a precondition it converts "I cannot establish this" into "this is
+satisfied", which is the strongest possible wrong answer.
+
+Where a dependency the check needs is absent, refuse and name it. A caller who
+gets an error can implement the method or take another route; a caller who gets
+a false pass finds out later, from the damage.
+
+## The incident
+
+`@namzu/sdk` 14.0.0 shipped archival that refuses rather than cascading: a
+workspace holding a live session throws instead of closing over running work.
+`ProjectManager.archive` read the session list through an optional store method
+with `?? []` as the fallback. On a store not implementing it, the workspace
+closed over live sessions and the call returned success — the refusal the whole
+feature exists for was skippable by not implementing one method.
+
+Both halves were individually correct. Three store methods were made optional
+in the same change for exactly the right reason, and one method away in the
+same file `write()` already threw when its optional dependency was absent. Only
+the combination was wrong.
+
+## Related
+
+- [Refuse, do not silently degrade](refuse-do-not-degrade.md) — the general
+  form. This is its precondition case, where the degradation is a false pass.
+- [A check that cannot fail is worse than no check](a-check-that-cannot-fail.md)
+  — a defaulted precondition is one way a guard stops being able to fire.

--- a/docs/conventions/declared-but-undriven.md
+++ b/docs/conventions/declared-but-undriven.md
@@ -1,0 +1,72 @@
+---
+uid: namzu.conventions.declared-but-undriven
+title: A declaration nothing drives is a defect, not a roadmap
+description: A field, option or type that is declared, exported and read by no code path is not a feature pending. It is a lie the type system tells, and fourteen instances shipped in a single week.
+type: Convention
+diataxis: explanation
+owner: cogitave/namzu
+status: active
+timestamp: 2026-08-04T00:00:00Z
+lastReviewed: 2026-08-07
+resource: packages/sandbox/src/index.ts
+tags: [convention, api-design, types]
+---
+
+# A declaration nothing drives is a defect, not a roadmap
+
+Ratified 2026-08-04, from three sessions that each found the same shape.
+
+A field, option or type that is declared, threaded through the type system,
+exported publicly, and read by no code path is not "a feature not built yet".
+It is a **lie the type system tells**, and it costs more than the missing
+feature would: a caller sets it, gets no error, and believes the thing is on.
+
+## The rule
+
+Before shipping a declaration, name the code that reads it. If you cannot, do
+not ship it. If it is already shipped and nothing reads it, either drive it or
+remove it — and say which, in the changeset.
+
+An audit that finds these is a `config field → reader count` grep. Zero readers
+is the finding.
+
+## What it looked like, fourteen times in one week
+
+- `SandboxExecOptions.signal` — declared, documented with the exact failure it
+  prevents, honoured by **no backend**. So the failure its own docstring
+  described (a stop could only ever abandon the *wait*) was what always
+  happened.
+- `ThinkingConfig.display` — on the type, never serialized into the request.
+  And its values were wrong: `'full'` was not a value any driver accepted.
+- `runtimeToolOverrides` — honoured at two call sites, ignored at the third,
+  which was the one a host would most want.
+- `AgentManager.queueMessage` / `drainMessages` — a mid-run message queue the
+  loop never drained.
+- `ToolCatalogSurface` / `ToolsetPolicy.surfaces` — no producer, no reader,
+  shipped in two minors before removal.
+- `create_task` on an empty roster — mounted, unsatisfiable, advertised every
+  turn.
+- `PrepareStepResult.activeTools` — documented as the way to withhold a tool
+  from a surface where neither `prepareStep` nor `activeTools` exists.
+
+## Why "roadmap" is the wrong frame
+
+A roadmap item is absent. A declared-and-undriven field is *present and
+wrong*: it type-checks, autocompletes, appears in the docs, and survives review
+because reviewers read the declaration and assume the wiring. Every instance
+above passed review.
+
+## The tell
+
+The comment on the declaration usually describes the failure it prevents. When
+nothing drives it, that comment is a precise description of what your users are
+experiencing.
+
+## Related
+
+- [Refuse, do not silently degrade](refuse-do-not-degrade.md) — the same
+  failure seen from the caller's side.
+- [Mutate every test](mutation-check-every-test.md) — how these survive a
+  green suite.
+- [Reachability is its own property](reachability-is-its-own-property.md) —
+  the case where the reader exists and the road to it does not.

--- a/docs/conventions/fixture-must-match-production.md
+++ b/docs/conventions/fixture-must-match-production.md
@@ -1,0 +1,114 @@
+---
+uid: namzu.conventions.fixture-must-match-production
+title: A fixture unlike production tests a system that does not ship
+description: The assertion is right and the observation point is right, and the test still proves nothing, because the setup never enters the branch the defect lives in. A harness is a configuration.
+type: Convention
+diataxis: explanation
+owner: cogitave/namzu
+status: active
+timestamp: 2026-08-06T00:00:00Z
+lastReviewed: 2026-08-07
+tags: [convention, testing, verification]
+---
+
+# A fixture unlike production tests a system that does not ship
+
+Ratified 2026-08-06.
+
+The assertion is right and the observation point is right, and the test still
+proves nothing — because the setup never enters the branch the defect lives in.
+A harness is a **configuration**, and a configuration production never runs in
+describes a different system.
+
+The sharpest form is an optional subscriber. Code inside `for (const listener of
+set)` cannot throw when the set is empty, so a defect there is invisible to
+every test that attaches no listener — and visible on every production run,
+because production always attaches one.
+
+## The rule
+
+For every optional or defaulted thing in the fixture — a listener, a callback,
+an injected dependency, an ambient runtime — ask whether production runs with it
+on. If production always attaches it, the fixture attaches it.
+
+And ask the inverse: **can any real caller produce the state this fixture is
+in?** If not, everything standing on it is about a system that does not exist,
+and its greenness is not a fact about the product.
+
+Build collaborators the way the product builds them. A hand-assembled one is a
+second implementation whose divergence from the real one is exactly the space a
+defect hides in.
+
+## The one that shipped
+
+`sendMessage` handed a progress tee into the spawn, and the tee read
+`task.taskId` — the `const` that the very same `await` assigns. A child that
+emitted anything before the spawn resolved hit the temporal dead zone and killed
+its own launch with `Cannot access 'task' before initialization`.
+
+Two things kept it hidden, and both are this rule:
+
+- A single sequential launch usually resolves before the child speaks, so
+  ordering rarely bit. A **concurrent fan-out** is the production shape.
+- The throw only occurs when a progress listener is **attached**. With an empty
+  subscriber set the loop body never runs and the dead zone is never entered.
+  Production always has one — the delegation tool attaches it for the idle
+  bound. No unit test did.
+
+It was live from the release that introduced the idle bound until it was found
+by running the *published* package against the real service. Not by the
+2700-test suite, which was green throughout.
+
+Its regression test nearly repeated the defect: the first four cases attached no
+progress listener — including the one literally named *"survives a concurrent
+fan-out, which is how this was found"*, which therefore did not reproduce what it
+was named after. Attaching the listener took the mutation from 1 of 4 failing to
+3 of 4.
+
+## Four more, same shape
+
+- **The runner was holding the event loop open.** A run's own pending work did
+  not keep its process alive: a bare `drainQuery` in a plain process died at
+  `tool_review_requested` with `getActiveResourcesInfo() === []`, and the
+  identical run completed when an unrelated ref'd interval held the loop open.
+  Every test passed — including live-service ones — because the test runner *is*
+  that interval. The regression test has to spawn a child process; in-process it
+  is unwritable, and making it opt-in would have been the same trap again.
+- **Incomplete dependencies meant the work never happened.** A hand-built
+  `AgentManager` with partial deps never ran its children, so `allocations`
+  stayed empty — indistinguishable from a pass.
+- **A stub that could not survive being used.** A fake run manager of `{ id }`
+  broke `emitEvent`, which appends to the run store. Five unhandled rejections
+  fired after the assertions passed; the suite exited 1 while every summary line
+  read green.
+- **A fixture state no run can produce.** Eight task-listing tests seeded a
+  gateway with tasks the tool set had never launched — precisely the sibling-run
+  state that run-scoping later refuses. They broke when the scope landed, and
+  they were the finding, not an obstacle: they had been describing a gateway
+  state no run can reach. Rewritten to launch through the delegation tool first,
+  they now cover launch then list. Weakening the scope to keep them green would
+  have been fixing the test by reopening the hole.
+
+## The tell
+
+The defect is inside a subscriber loop, an `if (opts.x)`, a `catch`, or a branch
+guarded by an optional dependency. Anything default-off in a fixture and
+default-on in production is this rule waiting to happen.
+
+A second tell: the test constructs a collaborator with an object literal. Ask
+what the real one does that yours does not — and whether the difference is the
+branch you are trying to cover.
+
+A third: the property under test is about **concurrency or ordering**, and the
+fixture does one thing at a time.
+
+## Related
+
+- [A test can be sound and still be about the wrong thing](sound-about-the-wrong-thing.md)
+  — the observation is wrong there; the setup is wrong here.
+- [Mutate every test](mutation-check-every-test.md) — mutation is what exposes
+  it. Both fan-out cases above were caught by watching the mutation profile fail
+  to move.
+- [A declaration nothing drives is a defect](declared-but-undriven.md) — a
+  fixture that bypasses the surface a host constructs produces the same green
+  suite over the same dead wiring.

--- a/docs/conventions/index.md
+++ b/docs/conventions/index.md
@@ -1,0 +1,66 @@
+---
+okf_version: "0.2"
+---
+
+# Conventions
+
+Ratified rules about how code is written here, extracted when a session's
+decisions turn final. Each file is one rule with the evidence that produced it —
+a rule with no incident behind it is a preference, and preferences do not belong
+here.
+
+Read the rule that matches what you are about to change before you change it.
+
+## The rules
+
+### Declarations and reachability
+
+- [A declaration nothing drives is a defect, not a roadmap](declared-but-undriven.md)
+  — a field read by no code path is a lie the type system tells. Fourteen
+  instances in one week.
+- [Reachability is its own property, and it needs its own test](reachability-is-its-own-property.md)
+  — the behaviour is covered; the hop from the surface a host builds is not.
+- [Finding an emitter is not evidence that every path reaches it](one-site-is-not-every-site.md)
+  — the some-sites case, plus: how many shapes does this concept have?
+
+### Refusing rather than degrading
+
+- [Refuse, do not silently degrade](refuse-do-not-degrade.md) — a capability
+  that quietly does nothing is worse than one that errors.
+- [An optional dependency may degrade a feature, never a check](an-optional-dependency-may-not-degrade-a-check.md)
+  — a default fallback turned "I cannot establish this" into "this is
+  satisfied".
+
+### Tests that prove something
+
+- [Mutate every test](mutation-check-every-test.md) — and a unit test on a
+  helper never proves the caller invokes it.
+- [A test can be sound and still be about the wrong thing](sound-about-the-wrong-thing.md)
+  — right path, wrong observer, wrong moment. A live run is not exempt.
+- [A fixture unlike production tests a system that does not ship](fixture-must-match-production.md)
+  — the defect lives in a branch an empty listener set never enters.
+- [A check that cannot fail is worse than no check](a-check-that-cannot-fail.md)
+  — it teaches the next reader that the checks here are decoration.
+
+### Reading the evidence
+
+- [Verify the claim, including your own, including a comment's](verify-claims-including-your-own.md)
+  — including a report's, including your own from an hour ago.
+- [Never filter a verification down to something that can read green](never-filter-a-verification.md)
+  — the check ran and its answer was invisible. Three incidents in one day.
+
+## How to add one
+
+When a session's decisions turn final, promote the rules that apply beyond that
+session's own slice. A rule that is only about that session's code belongs in
+the code as a comment instead.
+
+Every file here carries front matter the documentation gate reads: `uid`,
+`title`, `description`, `type`, `diataxis`, `owner`, `status`, `timestamp` and
+`lastReviewed`, plus an optional `resource` naming the code the incident lives
+in. Where `resource` is set, the gate fails the build if that code has moved
+since the rule was last touched. Run it with `pnpm docs:check`.
+
+`verified` records who last re-established a rule against source, and when. It
+is absent on most of these, and that absence is accurate rather than an
+oversight — a rule carrying no `verified` key has been read but not re-checked.

--- a/docs/conventions/meta.json
+++ b/docs/conventions/meta.json
@@ -1,0 +1,21 @@
+{
+  "title": "Conventions",
+  "pages": [
+    "index",
+    "---Declarations & Reachability---",
+    "declared-but-undriven",
+    "reachability-is-its-own-property",
+    "one-site-is-not-every-site",
+    "---Refusing vs Degrading---",
+    "refuse-do-not-degrade",
+    "an-optional-dependency-may-not-degrade-a-check",
+    "---Tests That Prove Something---",
+    "mutation-check-every-test",
+    "sound-about-the-wrong-thing",
+    "fixture-must-match-production",
+    "a-check-that-cannot-fail",
+    "---Reading The Evidence---",
+    "verify-claims-including-your-own",
+    "never-filter-a-verification"
+  ]
+}

--- a/docs/conventions/mutation-check-every-test.md
+++ b/docs/conventions/mutation-check-every-test.md
@@ -1,0 +1,133 @@
+---
+uid: namzu.conventions.mutation-check-every-test
+title: Mutate every test, and never trust a helper test to prove its caller
+description: A passing test proves nothing until you have watched it fail. Break the thing it covers and confirm that that test, and not a neighbour, goes red — then read the whole run, not the summary line.
+type: Convention
+diataxis: explanation
+owner: cogitave/namzu
+status: active
+timestamp: 2026-08-04T00:00:00Z
+lastReviewed: 2026-08-07
+tags: [convention, testing, verification]
+---
+
+# Mutate every test, and never trust a helper test to prove its caller
+
+Ratified 2026-08-04 from three sessions; amended 2026-08-06 with
+"read the run, not the summary line".
+
+A passing test proves nothing until you have watched it fail. Break the thing
+it covers and confirm that *that* test, and not a neighbour, goes red.
+
+## The rule
+
+For every test that pins a behaviour:
+
+1. Mutate the source it covers back to the broken state.
+2. Confirm the intended test fails, and that tests asserting *preserved*
+   behaviour still pass. Both halves matter — a mutation that fails everything
+   says the tests are coupled, not that they are good.
+3. Restore, and confirm green.
+
+Record the mutation profile in the session log. "5 of 9 fail, and the 4 that
+pass are the preservation cases" is evidence; "tests pass" is not.
+
+## Six vacuous tests found this way in one session
+
+- Asserted `dangling.hasDangling` where the property is `isValid`.
+- A fallback-path test that never reached the fallback.
+- "Normal urgency appends nothing" — twice, the second attempt tautological
+  because `urgency ?? 'normal'` collapses the branches.
+- `disconnect()` on a never-connected client, emitting nothing either way.
+- Bookkeeping nothing read.
+- Human-in-the-loop tests that all drove the bare-config branch and never the
+  builder.
+
+## A unit test on a helper does not prove the caller invokes it
+
+This is the sharpest form of the rule, because both halves look green.
+
+- `attachSteering` had 9 passing unit tests. All 9 still pass with the loop
+  never calling it. Only the end-to-end file — a real run, with a tool that
+  steers from inside its own `execute` — fails when the wiring is reverted.
+- One driver's capability resolver had 27 passing tests. Reverting it to its
+  old passthrough failed **none** of them; 5 of the 9 request-body tests
+  failed instead.
+- Counting `assertThinkingUnsupported(` call sites in source proves nothing
+  about whether the guard fires. Each driver got a test that drives the real
+  `chatStream`.
+
+So: whenever a helper exists to be *called from somewhere*, one test must drive
+the somewhere.
+
+## Choose the mutation honestly
+
+A mutation that produces a type-invalid state is not a fair one. Replacing
+`if (override === 'disabled') continue` with `if (false) continue` left
+`register(tool, 'disabled')` — a value outside the availability union — and the
+catalog dropped the tool for the wrong reason, so the test passed by accident.
+The honest mutation was reverting to the pre-fix line.
+
+Conversely, a mutation that fails nothing can be correct: removing the lexical
+pre-check from `resolveWithinReal` broke no test because the canonical check
+catches traversal independently. That is defence-in-depth working. Two
+mutations were needed to say anything true about one function.
+
+## The harness itself can lie
+
+A mutation script reported all five write-file mutations as *not caught*. All
+five were caught — its failure-name regex did not survive an em-dash plus
+terminal colour codes, and the child process was not merging its error stream.
+It surfaced only because one result contradicted a failure watched by hand.
+
+A harness that reports false negatives certifies vacuous tests as sound. Make
+it print the summary line when it finds no failures, so "not caught" can be
+told apart from "could not read the output".
+
+## Read the run, not the summary line
+
+`N passed` is a subset of the result, not the result. Read the **exit code**,
+the **file count**, the **skip count**, and any **unhandled rejections**. Four
+false greens in one session came from reading the summary and stopping:
+
+- A fake run manager of `{ id }` broke `emitEvent`, which appends to the run
+  store. Five unhandled rejections fired *after* the assertions passed: the
+  suite exited 1 while every summary line read green. The exit code is now
+  checked directly rather than inferred from the summary.
+- Moving a host callback above the run manager's init produced 25 unhandled
+  rejections — `RunDiskStore not initialized` — and the run still reported
+  2763 passed.
+- The formatter split an inline type import across lines with a trailing comma.
+  The bundler rejected the file, it transformed to nothing, and the suite
+  reported `no tests` for it while the summary looked ordinary. Caught only by
+  the file count: 302 where 301 was expected. **A test file that fails to load
+  is not a failing test — it is an absent one.**
+- `156 passed | 35 skipped` was read as green. The 35 skips were the live
+  contract tests and no credential was set anywhere. Supplied, the suite ran
+  191 → 194 and every live file passed — and a live run then found a defect no
+  mock could reach.
+
+Record the shape of the run, not just its verdict: files, tests, exit code.
+
+## A test that cannot run must say so
+
+Symlink tests wrapped creation in try/catch and returned early on failure. On
+one platform that reported three tests as **passed** having exercised nothing.
+Use a capability probe and `it.skipIf`, so the reporter prints them skipped —
+and do not claim the behaviour works until a run that actually executed them is
+read.
+
+A skip is a result to look at, not a rounding error. Platform-gated with the
+reason written in the file is fine; a contract test skipped for want of a
+credential is a hole wearing a green summary.
+
+## Related
+
+- [A declaration nothing drives is a defect](declared-but-undriven.md)
+- [Never filter a verification down to something that can read green](never-filter-a-verification.md)
+  — the reading half of this rule, and its own incident.
+- [A test can be sound and still be about the wrong thing](sound-about-the-wrong-thing.md)
+  — mutation proves a test *can* fail; it does not prove it measures what
+  matters.
+- [A fixture unlike production tests a system that does not ship](fixture-must-match-production.md)
+  — the setup that makes a mutation profile refuse to move.

--- a/docs/conventions/never-filter-a-verification.md
+++ b/docs/conventions/never-filter-a-verification.md
@@ -1,0 +1,46 @@
+---
+uid: namzu.conventions.never-filter-a-verification
+title: Never filter a verification down to something that can read green
+description: Piping a check through a line filter can discard the diagnostic while keeping a summary line, so the check runs, its answer is invisible, and what you see reads as success.
+type: Convention
+diataxis: explanation
+owner: cogitave/namzu
+status: active
+timestamp: 2026-08-04T00:00:00Z
+lastReviewed: 2026-08-07
+resource: .github/workflows/ci.yml
+tags: [convention, verification, tooling]
+---
+
+# Never filter a verification down to something that can read green
+
+Piping a check through a line filter to keep the output short can discard the
+diagnostic while keeping a summary line — so the check runs, its answer is
+invisible, and what you see reads as success. A filter that can produce a
+confident green is worse than not running the check at all: not running it
+leaves you uncertain, and this leaves you wrong.
+
+Read the verdict the tool prints — its count of errors — not the lines your
+filter chose to keep. If the output is genuinely too long, filter on the
+verdict, never on a guess at what the diagnostic will look like.
+
+## The incidents, all in one day
+
+- A CLI change went red in CI on a lint rule. The author had run the linter
+  before committing, through a chain ending in a two-line tail and a search for
+  the test summary. The chain kept the summary and dropped the diagnostic.
+- A release failure was diagnosed as an expired publish credential on the
+  strength of a `404 Not Found - PUT` line surfaced by a filter matching
+  "error" and "404". The first error line, eliminated by that filter, was
+  `IDENTITY_TOKEN_READ_ERROR: error retrieving identity token` — a provenance
+  failure on the runner. The credential was fine. The owner said so, which is
+  the only reason the log was re-read.
+- The same session had already adopted this rule from the first incident, in
+  writing, and broke it in the next command.
+
+## Related
+
+- [Mutate every test](mutation-check-every-test.md) — its "read the run, not
+  the summary line" section is this rule applied to a test suite.
+- [A check that cannot fail is worse than no check](a-check-that-cannot-fail.md)
+  — a filter that cannot surface a failure turns a real check into that.

--- a/docs/conventions/one-site-is-not-every-site.md
+++ b/docs/conventions/one-site-is-not-every-site.md
@@ -1,0 +1,137 @@
+---
+uid: namzu.conventions.one-site-is-not-every-site
+title: Finding an emitter is not evidence that every path reaches it
+description: The mechanism is present, wired, tested and correct, and one of the paths into it does not use it. The check that finds a declaration nothing drives passes cleanly on this one.
+type: Convention
+diataxis: explanation
+owner: cogitave/namzu
+status: active
+timestamp: 2026-08-05T00:00:00Z
+lastReviewed: 2026-08-07
+resource: packages/sdk/src/types/hitl/index.ts
+tags: [convention, verification, testing]
+verified:
+  - by: process:conventions-migration
+    at: 2026-08-07T00:00:00Z
+---
+
+# Finding an emitter is not evidence that every path reaches it
+
+Ratified 2026-08-05; amended 2026-08-06 with the two-shapes-for-one-concept
+variant.
+
+> The question is *which callers arrive here*, not *does this exist*.
+
+The sibling rule catches a declaration **nothing** drives. This one catches a
+declaration driven from **one of its sites** — the mechanism is present, wired,
+tested and correct, and one of the paths into it does not use it.
+
+That variant is harder, because the check that finds the first one passes on the
+second. Grep for the reader, find a reader, conclude it is wired. It is wired.
+It is wired *there*.
+
+## The rule
+
+When you verify that a signal, option or hook is honoured, do not stop at the
+first honouring call site. Enumerate the paths that reach the behaviour and ask
+which of them arrive at that site. A signal emitted on one branch of a fork is
+absent on the other, and the absence looks exactly like the presence from where
+you were standing.
+
+The grep is not `emits X`. It is `who computes the thing X reports, and do all
+of them emit`.
+
+## What it looked like
+
+- **`compaction_completed`** — emitted from the structured working-state path
+  only. `applyReducer`, the path taken by any host with its own
+  `contextReducer` or `strategy: 'sliding-window'`, emitted nothing on success.
+  The docstring said the event existed because a host could not otherwise show
+  the user that context was dropped. For a large class of runs it still could
+  not. A switch case rendering it would have been correct, complete,
+  mutation-proven, and permanently silent.
+- **`--cwd`** — reached the session store and the skill search, not the agent
+  run. Three consumers, two wired. The agent globbed the launch directory and
+  reported the user's files missing.
+- **`thinking`** — settable on an agent config and forwarded by no ergonomic
+  entry point, because each hand-lists the run-config fields it passes.
+- **`activeTools`** — narrowed the request the model saw and not the dispatch
+  that executed, so a withheld tool ran when the model named it anyway.
+
+Each had the mechanism present and one path not using it. Each survived a full
+green suite, because every test exercised the path that worked.
+
+## A second axis: how many shapes does this concept have?
+
+The four above are one mechanism reached by several paths. There is a second
+geometry with the same signature, and it is not covered by asking about paths:
+one concept declared as **two types**, each populated by its own mapper that
+copies field by field.
+
+`PlanStep.agentId` was added so a human approving a plan could see which agent a
+step delegates to. It reached `PlanApprovalRequest` — what a host sees when it
+installs its own handler on `PlanManager` — and **not** `PlanApprovalData`,
+which is what every `resumeHandler` host receives. That type declared its own
+step shape, and both mappers copy field by field, so a new field on the source
+propagates to neither on its own.
+
+The change shipped and was tested, and left the busier of the two surfaces
+showing `toolName: 'create_task'` and nothing else — so the two delegated steps
+the field existed to tell apart stayed identical in every field the approver
+could read. The fix was correct, complete, mutation-proven, and landed on the
+quieter half.
+
+The repair is now in the tree, and the type carries the incident in its own
+docstring — see `resource` above. Read it there rather than trusting this
+paragraph.
+
+So the question is not only *which callers reach this emitter*. It is also:
+**how many shapes exist for this concept, and did the change reach all of
+them?**
+
+A **field-by-field mapper is the tell**. It is a place where adding a field to
+the source is guaranteed not to propagate, it is usually written once and never
+revisited, and it produces no error when it falls behind — the target type is
+still satisfied. Grep the concept as a **type**, not as a field.
+
+The mutation that proves it is cheap: removing the mapper line failed 2 of 2 on
+the other surface, a signal nothing else in the suite gave.
+
+## Why a green suite cannot see it
+
+Tests are written against the path the author had in mind. The emitting path is
+the one they were thinking about — that is *why* it emits. The other path has no
+test asserting the absence of a signal nobody knew was missing, and no test
+fails, because nothing is broken on the branch anyone looked at.
+
+The test that finds it is the one asserting the **contrast**: that success and
+failure are distinguishable, or that two entry points agree. One instance was
+found writing a test that a *successful* compaction reports no failure — it went
+red because success reported nothing at all.
+
+## The tell
+
+You are about to consume a signal, and you verified it exists by finding where
+it is produced. That is the moment. One emit site plus more than one code path
+into the behaviour is the shape.
+
+A second tell: the feature has two strategies, backends or modes, and you read
+the one named in the config you happened to be looking at.
+
+A third: the concept has more than one type declaration, and something maps
+between them field by field.
+
+## Related
+
+- [A declaration nothing drives is a defect](declared-but-undriven.md) — the
+  zero-site case; this is the some-sites case, and it hides better.
+- [Mutate every test](mutation-check-every-test.md) — mutation proves the test
+  catches a change on the path it covers, and says nothing about the path it
+  does not.
+- [Verify the claim, including your own](verify-claims-including-your-own.md)
+  — "emitted so a host can surface the loss" is such a claim. It was true of the
+  emit site and false of the feature.
+- [A test can be sound and still be about the wrong thing](sound-about-the-wrong-thing.md)
+  — the live run that "confirmed" `agentId` read it off the event stream, which
+  always carried it. Missing a shape and observing the wrong channel are how the
+  same defect survives twice.

--- a/docs/conventions/reachability-is-its-own-property.md
+++ b/docs/conventions/reachability-is-its-own-property.md
@@ -1,0 +1,132 @@
+---
+uid: namzu.conventions.reachability-is-its-own-property
+title: Reachability is its own property, and it needs its own test
+description: A knob can be declared on the config, honoured correctly by the machinery, tested at the layer that honours it, and still be unreachable from the surface a host actually constructs.
+type: Convention
+diataxis: explanation
+owner: cogitave/namzu
+status: active
+timestamp: 2026-08-06T00:00:00Z
+lastReviewed: 2026-08-07
+resource: packages/sdk/src/agents/__tests__/reachability.test.ts
+tags: [convention, testing, api-design]
+verified:
+  - by: process:conventions-migration
+    at: 2026-08-07T00:00:00Z
+---
+
+# Reachability is its own property, and it needs its own test
+
+Ratified 2026-08-06, from two sessions.
+
+Behaviour and reachability are two properties, and covering the first says
+nothing about the second. A knob can be declared on the config, honoured
+correctly by the machinery, tested at the layer that honours it, and still be
+unreachable from the surface a host actually constructs.
+
+The doctrine is already written in this repository, at the top of the test file
+named in `resource` above:
+
+> A feature a consumer cannot reach is a feature that does not exist for
+> them, so these assert reachability rather than behavior — the behavior
+> already has its own tests one layer down.
+
+That file exists because three config fields shipped inert in one session with
+their behaviour fully covered.
+
+## The rule
+
+**Behaviour tests belong one layer down.** They prove the mechanism is right.
+
+**A reachability test drives the front door** — the surface a host constructs,
+not the internal the behaviour test builds — and asserts a consequence that
+cannot occur without the hop.
+
+**Verify by deleting the hop.** Cut the forward, run typecheck and the suite. If
+both stay green, nothing tests the road and the knob is dead. This is a
+measurement, not an argument: `allowDelegation` was suspected and confirmed
+exactly this way — typecheck clean, 143 tests green, flag completely dead.
+
+## Three that shipped inert, one session
+
+- **`maxToolConcurrency`** — declared on `QueryParams`, honoured by the
+  executor, forwarded by `ReactiveAgent`, and absent from
+  `SupervisorAgentConfig`. The agent whose entire job is fan-out could not set
+  the fan-out gate; the agent that does not fan out could.
+- **`CreateTaskOptions.configOverrides`** — worse than unforwarded. It was
+  declared and then *overwritten*: `createTask` built its own overrides object
+  from the parent span and never read the field.
+- **The sibling policy** — `applySiblingPolicy` was complete and correct, and
+  only the hop from `SupervisorAgentConfig` was missing, so every host ran
+  `'continue'`. Its own tests passed because they constructed the gateway
+  directly, which is the fixture failure that lets this class ship.
+
+Also from the same class: `runAgent` dropped the `skills` it was given and had
+no `verificationGate` at all, both hidden behind an `as never` cast on the
+kernel seam — and the cast was not load-bearing.
+
+## The trap inside the reachability test
+
+The assertion has to be a consequence **of the hop**, not of the run having
+worked. A first draft asserted `status === 'completed'` and passed with the
+forwarding deleted, because the run completes either way. The corrected sibling
+asserts the cancellation itself — the thing that cannot happen unless the policy
+arrived.
+
+A second trap: if a regression makes the test **hang**, it is a bad signal. One
+sibling sat until the delegation timeout at 60s; a hang reads as flake, and
+flake gets retried rather than read. Given a deterministic gate and a 250ms
+safety release, the same regression fails in 302ms with
+`expected [] to include 'task_patient'`.
+
+## A remedy is a capability, and it is subject to this rule too
+
+A documented workaround is only real for the callers who can perform it. When
+writing *"if you want X, do Y"*, enumerate who hits X and confirm each of them
+can do Y.
+
+- **The invocation lock.** The docs prescribed "a host that wants parallelism
+  constructs a second instance". True, and unreachable from delegation, where
+  the definition owns the instance and the caller holds only an id. The fix was
+  the doc's own remedy made reachable — `Agent.forRun()`, returning a fresh
+  shell of the same class from the same metadata — not a different remedy.
+- **`PrepareStepResult.activeTools`** was documented as the way to withhold the
+  delegation tool from a surface on which neither `prepareStep` nor
+  `activeTools` exists.
+- **The plan-step bindings** named step ids that nothing had ever told the
+  caller. A binding whose caller cannot name the thing is a binding that does
+  not exist.
+
+## Run it before deleting, too
+
+The same check answers the opposite question, and it has come out both ways.
+
+- **`PlanManager`** was proposed for deletion as dead. It is exported from
+  `public-runtime.ts` and `drainQuery` hands it to hosts via
+  `onContextCreated`. "Zero callers in this package" is not "zero callers" —
+  the callers are hosts, outside the repository. The deletion would have removed
+  a working approval gate.
+- **`launchedTasks`** got the same check and failed it: a host *could* pass one,
+  but nothing ever wrote a host-supplied map, so passing one did nothing and
+  reading it back gave an empty map. Inert in both directions, so it went.
+
+"Is this dead?" was the wrong question both times. **"Which half of this is
+dead?"** was the right one: the launch signal was live and the accumulator that
+consumed it was not.
+
+## The tell
+
+A config type and the type it feeds have different field sets. Or: you can name
+the writer and you can name the reader, and you cannot name the road between
+them.
+
+## Related
+
+- [A declaration nothing drives is a defect](declared-but-undriven.md) — the
+  zero-reader case. Here the reader exists and is correct.
+- [Finding an emitter is not evidence that every path reaches it](one-site-is-not-every-site.md)
+  — the same geometry seen from the emitting end.
+- [A test can be sound and still be about the wrong thing](sound-about-the-wrong-thing.md)
+  — why `status === 'completed'` is not a reachability assertion.
+- [A fixture unlike production tests a system that does not ship](fixture-must-match-production.md)
+  — constructing the collaborator directly is how the missing hop stays green.

--- a/docs/conventions/refuse-do-not-degrade.md
+++ b/docs/conventions/refuse-do-not-degrade.md
@@ -1,0 +1,78 @@
+---
+uid: namzu.conventions.refuse-do-not-degrade
+title: Refuse, do not silently degrade
+description: A capability that quietly does nothing produces an answer that looks like an answer, leaving the caller no signal to tell a considered result from a request that was dropped on the floor.
+type: Convention
+diataxis: explanation
+owner: cogitave/namzu
+status: active
+timestamp: 2026-08-04T00:00:00Z
+lastReviewed: 2026-08-07
+resource: packages/providers/anthropic/src/thinking-capability.ts
+tags: [convention, error-handling, api-design]
+---
+
+# Refuse, do not silently degrade
+
+Ratified 2026-08-04, from two sessions.
+
+When a request cannot be honoured, say so. A capability that quietly does
+nothing produces an answer that looks like an answer, and the caller has no
+signal to distinguish "the model chose not to" from "nobody asked it to".
+
+## The rule
+
+If you cannot do what was asked:
+
+1. **Error, naming who refused and what to do instead.** In a multi-driver
+   setup, "which one refused" is the difference between a bug report about the
+   model and a one-line config fix.
+2. **Or omit the capability entirely**, so it is never offered.
+3. **Never accept and drop.**
+
+Turning something OFF is not a refusal — a config shared across backends saying
+`{ type: 'disabled' }` must not fail on the ones that were never going to do it
+anyway.
+
+## Degrading is worse than failing when the degradation is invisible
+
+Five drivers accepted `thinking` and dropped it. The caller got an ordinary
+completion with an empty `reasoning` array — indistinguishable from a model
+that reasoned and had nothing to show. One driver refused instead, with the
+reasoning written out beside it. The rule had been decided once and applied
+once while five siblings stayed silent, which is why it now lives in the SDK
+where a new driver inherits it.
+
+## Omission is a legitimate refusal, and sometimes the better one
+
+Two shapes, both correct, chosen by what the caller can act on:
+
+- **`create_task` on an empty roster is not mounted.** Mounting it with a
+  schema nothing satisfies reaches the same verdict the expensive way: the
+  model is shown a tool every turn and pays a turn to discover it cannot use
+  it. Not offering a capability is cheaper than denying it per call.
+- **A `disabled` thinking request on a model that cannot stop thinking omits
+  the field.** Throwing teaches nothing the driver's own rejection would not,
+  and it breaks a caller whose config spans models.
+
+## Do not fake a refusal you cannot perform
+
+Aborting a request is not cancelling the work. A remote sandbox backend that
+"honoured" `signal` by aborting the transport call would abandon the *wait*
+while the command kept running — the exact failure the option exists to
+prevent, wearing the appearance of a fix. Those backends ignore it and say so
+in the source, so the next reader does not "fix" it by wiring the transport's
+own signal through.
+
+## Refuse an ambiguity rather than guessing at it
+
+Two sources contributed one tool name and nothing ranked them. Warn-and-replace
+is a fine registry default and the wrong answer for a contract surface: the
+model keeps a tool whose behaviour depends on registration order. Refusing, and
+naming both escape hatches in the error, is the fail-safe reading.
+
+## Related
+
+- [A declaration nothing drives is a defect](declared-but-undriven.md)
+- [An optional dependency may degrade a feature, never a check](an-optional-dependency-may-not-degrade-a-check.md)
+  — the same rule where the thing being degraded is a precondition.

--- a/docs/conventions/sound-about-the-wrong-thing.md
+++ b/docs/conventions/sound-about-the-wrong-thing.md
@@ -1,0 +1,146 @@
+---
+uid: namzu.conventions.sound-about-the-wrong-thing
+title: A test can be sound and still be about the wrong thing
+description: A test can run, cover a real path, and go red under mutation, and still be evidence about a property nobody needed. The machinery is honest and the subject is wrong.
+type: Convention
+diataxis: explanation
+owner: cogitave/namzu
+status: active
+timestamp: 2026-08-06T00:00:00Z
+lastReviewed: 2026-08-07
+resource: packages/sdk/src/runtime/query/index.ts
+tags: [convention, testing, verification]
+---
+
+# A test can be sound and still be about the wrong thing
+
+Ratified 2026-08-06; amended the same session with "a live run is still an
+observation".
+
+A test can run, cover a real path, and go red under mutation, and still be
+evidence about a property nobody needed. The machinery is honest; the
+**subject** is wrong. The sibling rules catch a path that was never exercised.
+This one catches a path that was exercised perfectly while you were standing
+somewhere the difference does not show.
+
+It recurred six times in one session. One instance shipped, and one was made by
+a **live end-to-end run** — the remedy that is supposed to catch this class.
+
+## The rule
+
+Before writing the assertion, name three things:
+
+1. **The property** — what differs between the broken state and the fixed one.
+2. **The observer** — who has to be able to see that difference. A host? The
+   model? A later turn? The party you are protecting is rarely the object you
+   just edited.
+3. **The moment** — when the difference is visible, and when it is erased.
+
+Then read the property from where the observer stands, at a moment before it is
+erased.
+
+The check is one question: **would this assertion still hold with the fix
+deleted?** Answer it by deleting the fix, not by reasoning about it. If you can
+state what the test asserts without mentioning the defect, you have not written
+the test yet.
+
+## Five ways it went wrong in one session
+
+- **Read off the object under test instead of the consumer.** The plan
+  settlement tests read the outcome from `PlanManager` through
+  `onContextCreated` and proved the plan settled. `plan.completed` and
+  `plan.failed` were folded into a bare `break` in `wirePlanManager`, so no run
+  event was emitted and **no event consumer could see a settlement at all**.
+  The tests proved the state changed without ever asking whether anyone could
+  observe it. The unit suite structurally could not find this; a live
+  end-to-end run did — which is not the same as live runs being safe, as the
+  next section shows.
+- **Measured after the difference was erased.** The first probe for the
+  concurrent-fan-out budget bug measured the tracker *after settle* — and a
+  settled child refunds. The tracker looked healthy exactly when the transient
+  over-commitment was hidden.
+- **Measured the bookkeeping instead of the harm.** The second probe measured
+  the tracker rather than the allocations. The harm was never the ledger: it was
+  four children each believing they might spend half a pool that has one half.
+- **An assertion true under both states.** A completion-inbox case asserted
+  `progressed` was `[]` twice. That holds whether the progress tee is fixed or
+  broken. A test that cannot distinguish the two states is not evidence of
+  either.
+- **Attributed the protection to the wrong mechanism.** The permission gate
+  compiled the pattern before recording the tool names, and the comment claimed
+  that ordering is what stops a mistyped pattern widening "deny this tool when
+  its argument matches X" into "deny this tool". Reversing the two lines failed
+  nothing — the real protection is the missing-pattern check at the top of
+  `evaluateRule`, which returns before the name set is consulted. The test
+  passed for a reason other than the one it named. The comment was corrected,
+  a second test written against the real check, and the code left alone.
+
+That last one is the rule pointed at source rather than at tests: a comment
+claiming which line does the protecting is a claim to mutate.
+
+## A live run is still an observation
+
+The settlement case above was found by a live end-to-end run, which invites the
+conclusion *run it live and you are safe*. Later the same day that reading was
+disproved.
+
+`PlanStep.agentId` was checked by driving a real run through `resumeHandler` and
+watching the plan step report its agent. It did. But that reading came off the
+`plan_ready` run event, which carries whole `PlanStep`s and therefore **always
+had the field** — while `PlanApprovalData`, the payload the handler actually
+receives, did not. The run confirmed *the value exists somewhere*, which is not
+the question *does the approver get it*.
+
+Watching the event stream is not watching the approval channel.
+
+A live run is a **stronger fixture, not a different kind of evidence**. It
+removes the setup failures — the missing listener, the propped-up event loop,
+the hand-built collaborator — and removes none of the aiming ones. All three
+questions still apply to it, and the second is the one that bites:
+
+> **The channel you observe must be the channel under test.**
+
+When a value travels on more than one channel, reading it off the convenient one
+proves it was produced. It says nothing about the channel whose consumer you are
+protecting, and the convenient channel is convenient precisely because it
+carries everything.
+
+## How this differs from its nearest neighbour
+
+They fail in opposite halves of the same sentence.
+
+- [Finding an emitter is not evidence that every path reaches it](one-site-is-not-every-site.md)
+  asks **did the code run?** The mechanism is correct and one of the paths into
+  it does not use it. The fix is to enumerate the paths.
+- This rule asks **would I be able to tell?** The path ran, the defect was
+  present or absent as designed, and the assertion reads a quantity that is the
+  same either way — or reads it from a surface that is not the one that matters,
+  or at a moment when the difference has already been undone. The fix is to
+  relocate the observation, not to add a path.
+
+A test can satisfy one and fail the other. The plan settlement tests drove the
+right path through the right front door, and read the result off the wrong
+party.
+
+## The tell
+
+You wrote the assertion against the thing you just changed. That is the moment
+— the object you edited is the most convenient place to read from and almost
+never where the consumer stands.
+
+A second tell: the test's name describes a scenario and its body describes a
+state. "Survives a concurrent fan-out" and `expect(x).toEqual([])` are not the
+same claim, and the gap between them is where this hides.
+
+A third: you confirmed the value **exists** rather than that the consumer
+**received** it. "It is there" and "they get it" are different claims, and the
+first is far easier to satisfy — which is why it is the one you accidentally
+prove.
+
+## Related
+
+- [Mutate every test](mutation-check-every-test.md) — mutation proves the test
+  can fail. It does not prove that what it measures is what matters; three of
+  the instances above went red under *some* mutation.
+- [A fixture unlike production tests a system that does not ship](fixture-must-match-production.md)
+  — when the observation is right and the setup never reaches the defect.

--- a/docs/conventions/verify-claims-including-your-own.md
+++ b/docs/conventions/verify-claims-including-your-own.md
@@ -1,0 +1,96 @@
+---
+uid: namzu.conventions.verify-claims-including-your-own
+title: Verify the claim, including your own, including a comment's
+description: Re-establish every claim against source before acting on it — a reporter's finding, a comment already in the tree, and what you yourself concluded an hour ago are all claims of the same kind.
+type: Convention
+diataxis: explanation
+owner: cogitave/namzu
+status: active
+timestamp: 2026-08-04T00:00:00Z
+lastReviewed: 2026-08-07
+resource: packages/sdk/src/tools/builtins/ls.ts
+tags: [convention, verification, review]
+verified:
+  - by: process:conventions-migration
+    at: 2026-08-07T00:00:00Z
+---
+
+# Verify the claim, including your own, including a comment's
+
+Ratified 2026-08-04, from two sessions.
+
+Re-establish every claim against source before acting on it. This applies to a
+reporter's findings, to a comment already in the tree, and to what you yourself
+concluded an hour ago.
+
+## The rule
+
+Grade the evidence, then match the effort to the grade:
+
+- **MEASURED** — a command produced a number. Strongest, but the number came
+  from someone else's environment.
+- **PROBED** — something was executed against a fixture. Reproduce it here.
+- **READ** — source inspection only. Weakest. **Execute it rather than
+  re-reading it.**
+
+Every claim that has failed verification in this repository came from the READ
+tier, and executing is what caught them.
+
+## A reporter is often right and sometimes not
+
+Of one reporter's fifteen items, twelve held, one was wrong outright
+(`CHILD_PROMPT_MAX_CHARS` does not exist in this repository), and two were right
+about the symptom with the wrong mechanism. A later report of six items had five
+hold and one — a claim that a model family rejects the sampling parameters —
+supported by no reference page. **It was not implemented**, and the changeset
+says why: silently dropping sampling parameters that would have worked is its
+own defect.
+
+Acting on an unverified claim does not fail safe. It ships a second bug wearing
+the first one's justification.
+
+## Your own conclusion from an hour ago is a claim
+
+`z.never()` was shipped to close a fail-open roster. A verification pass then
+executed the repository's own schema renderer and found it emits `{"not":{}}`,
+which sits outside the keyword subset strict validators accept — and a rejected
+tool schema fails the whole request, not one tool. The conclusion survived; the
+mechanism was replaced.
+
+Citations are claims too: a Saltzer and Schroeder locator was wrong in three
+places, and the *principle* cited for one half was the wrong principle
+(complete mediation, not fail-safe defaults).
+
+## A comment's claim of universality is a claim to check
+
+`glob.ts` was fixed with a comment reading *"every sibling builtin already
+remembers this branch."* `ls.ts` did not. The comment was written in good faith
+by someone who had just fixed the neighbours.
+
+So: when a comment asserts that something holds everywhere, grep for the
+everywhere. Counting `context.sandbox` references across the builtins is what
+found it — every sibling had at least two and `ls.ts` had none.
+
+> **Illustrative, and deliberately not pinned.** Those per-file counts were a
+> snapshot taken while the defect was open. They have already moved: `ls.ts`
+> carries the branch now, and two siblings have grown further references since.
+> Re-run the count rather than trusting this paragraph — which is the rule this
+> document is about, turned on the document itself.
+
+## Read a peer's source to find what you cannot see in your own
+
+Reading another runtime's delimiter system revealed that this repository's own
+untrusted-content envelope was forgeable: content containing the closing tag
+closed the boundary early, and everything after read as the agent's own
+instructions. The label was the entire mitigation and the labelled party could
+delete it.
+
+That would not have been found by re-reading our code, because the belief that
+it was correct is what produced it.
+
+## Related
+
+- [Mutate every test](mutation-check-every-test.md)
+- [Refuse, do not silently degrade](refuse-do-not-degrade.md)
+- [Finding an emitter is not evidence that every path reaches it](one-site-is-not-every-site.md)
+  — where a universality claim is about code paths rather than files.

--- a/docs/meta.json
+++ b/docs/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Namzu",
-  "pages": ["index", "getting-started", "cli", "sdk", "providers", "computer-use"]
+  "pages": ["index", "getting-started", "cli", "sdk", "providers", "computer-use", "conventions"]
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "pnpm -r lint",
     "lint:fix": "pnpm -r lint:fix",
     "test": "pnpm -r test",
+    "docs:check": "node tools/check-docs.mjs",
     "sandbox:smoke": "pnpm --filter @namzu/sandbox test:smoke",
     "typecheck": "tsc --build",
     "namzu": "tsx packages/cli/src/bin.ts",

--- a/tools/check-docs.mjs
+++ b/tools/check-docs.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+// Fail the build when a document has drifted away from the thing it describes.
+//
+// Documentation in this repository follows the estate's documentation standard:
+// markdown with YAML front matter, one concept per file, Diataxis content
+// types. The front matter is the union of two contracts that the estate's own
+// records already carry in a single header -- the identity and ownership fields
+// of the documentation standard, and the portable knowledge-format fields. They
+// compose rather than compete: the knowledge format reserves no key it does not
+// define and requires consumers to preserve the rest.
+//
+// Five checks, all fatal:
+//
+//   FRONTMATTER   a doc in a migrated directory declares every required key,
+//                 and `description` is a real sentence rather than a stub.
+//   PROSE-STATUS  status belongs in front matter where a machine can read it. A
+//                 sentence saying "Status: PROPOSAL" is invisible to every gate.
+//   UID           `uid` is unique across the tree. Identity that collides is
+//                 not identity, and the cross-reference graph is built on it.
+//   RESOURCE      a doc's declared `resource:` path must exist. Documents
+//                 outlive the code they point at.
+//   DRIFT         if a doc's `resource:` has commits NEWER than the doc's own
+//                 last commit, the code moved and the doc did not. This is
+//                 causal, not a timer: a document whose subject nobody touched
+//                 is never nagged.
+//
+// DRIFT reads git history, so it REFUSES on a shallow clone rather than
+// returning a pass it cannot justify. A gate whose precondition is absent must
+// say "I cannot establish this", never "this is satisfied" -- see
+// `docs/conventions/an-optional-dependency-may-not-degrade-a-check.md`, which
+// is a rule this repository ratified after shipping exactly that defect.
+//
+// Scope is explicit and deliberately partial. `CONFORMING` lists the
+// directories migrated to the standard so far; the gate is authoritative inside
+// them and silent outside. Every run prints how many files are still outside,
+// because a migration whose remainder is invisible is a migration that stops.
+//
+// Usage: node tools/check-docs.mjs [rootDir]
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative, resolve } from 'node:path'
+
+/**
+ * Directories migrated to the documentation standard.
+ *
+ * Add a directory here in the same change that rewrites its pages, never
+ * before: an entry whose pages do not yet conform turns this gate red for
+ * everyone, and an entry added "ready for later" is a check that cannot fail.
+ */
+const CONFORMING = ['docs/conventions']
+
+/**
+ * Front-matter keys every conforming document declares.
+ *
+ * `uid`, `owner` and `lastReviewed` come from the documentation standard;
+ * `type`, `title`, `description`, `timestamp` and `status` from the portable
+ * knowledge format; `diataxis` carries the writing discipline. `type` and
+ * `diataxis` are separate on purpose -- `type` is what kind of thing the
+ * document IS (a Convention, an ADR, a Reference) and `diataxis` is how it is
+ * written. Collapsing them would restate one fact in two fields, which is the
+ * drift class the estate's knowledge-propagation standard exists to forbid.
+ *
+ * Deliberately NOT required: `products`, `roles` and `level`. The documentation
+ * standard lists them for the training-content pipeline, and no estate record
+ * outside that pipeline carries them. Requiring a key nothing reads would be
+ * the declared-but-undriven defect this repository names in its own rules.
+ */
+const REQUIRED_KEYS = [
+	'uid',
+	'title',
+	'description',
+	'type',
+	'diataxis',
+	'owner',
+	'status',
+	'timestamp',
+	'lastReviewed',
+]
+
+/** The documentation standard's bounds for `description`. */
+const DESCRIPTION_MIN = 75
+const DESCRIPTION_MAX = 300
+
+const PROPOSAL_STATES = new Set(['draft', 'proposal', 'proposed'])
+
+/** Prose that is really a status field wearing a disguise. */
+const PROSE_STATUS = /^\s*(?:\*\*)?status(?:\*\*)?\s*[:=]/i
+
+const root = resolve(process.argv[2] ?? join(import.meta.dirname, '..'))
+
+const git = (args) =>
+	execFileSync('git', args, {
+		cwd: root,
+		encoding: 'utf8',
+		stdio: ['ignore', 'pipe', 'ignore'],
+	}).trim()
+
+/** Unix timestamp of the newest commit touching `path`, or 0 when untracked. */
+function lastCommit(path) {
+	try {
+		return Number.parseInt(git(['log', '-1', '--format=%ct', '--', path]), 10) || 0
+	} catch {
+		return 0
+	}
+}
+
+/**
+ * Only the flat `key: value` subset is parsed -- deliberately, so a document
+ * that needs more structure fails loudly here rather than being half-understood.
+ */
+function parseFrontMatter(text) {
+	if (!text.startsWith('---')) return [{}, text]
+	const end = text.indexOf('\n---', 3)
+	if (end === -1) return [{}, text]
+	const meta = {}
+	for (const line of text.slice(3, end).split('\n')) {
+		// Indented lines are nested YAML (a `verified:` list, say). This parser
+		// reads the flat subset only, and a nested block's leaves are not keys.
+		if (!line.trim() || /^[#\s]/.test(line)) continue
+		const at = line.indexOf(':')
+		if (at > 0) meta[line.slice(0, at).trim().toLowerCase()] = line.slice(at + 1).trim()
+	}
+	return [meta, text.slice(end + 4)]
+}
+
+function* markdownUnder(dir) {
+	if (!existsSync(dir)) return
+	const entries = readdirSync(dir, { withFileTypes: true })
+	for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+		const full = join(dir, entry.name)
+		if (entry.isDirectory()) yield* markdownUnder(full)
+		else if (entry.name.endsWith('.md')) yield full
+	}
+}
+
+const rel = (path) => relative(root, path).split('\\').join('/')
+
+let problems = 0
+const fail = (...lines) => {
+	for (const l of lines) console.log(l)
+	problems += 1
+}
+
+// `index.md` and `log.md` are reserved listing filenames in the knowledge
+// format -- they describe a directory rather than a concept, so they carry no
+// concept front matter. `README.md` is the same role under a name the code
+// host renders.
+const isListing = (path) => /\/(index|log|README)\.md$/.test(path)
+
+// DRIFT cannot be established without history. Refuse rather than pass.
+let shallow = false
+try {
+	shallow = git(['rev-parse', '--is-shallow-repository']) === 'true'
+} catch {
+	// Not a git repository at all -- DRIFT is simply not applicable, and that
+	// is a different thing from history being truncated underneath us.
+}
+
+const uids = new Map()
+
+for (const dir of CONFORMING) {
+	for (const path of markdownUnder(join(root, dir))) {
+		const where = rel(path)
+		if (isListing(where)) continue
+
+		const text = readFileSync(path, 'utf8')
+		const [meta, body] = parseFrontMatter(text)
+
+		// Keys are parsed lowercased so that `Title:` and `title:` are one key.
+		// The required list keeps its canonical spelling for the message, so the
+		// membership test has to lower it too -- otherwise `lastReviewed` can
+		// never be found and the check reports every document as missing it.
+		const missing = REQUIRED_KEYS.filter((k) => !(k.toLowerCase() in meta))
+		if (missing.length) fail(`FRONTMATTER ${where}: missing ${missing.join(', ')}`)
+
+		const len = (meta.description ?? '').length
+		if (len && (len < DESCRIPTION_MIN || len > DESCRIPTION_MAX)) {
+			const bounds = `${DESCRIPTION_MIN}-${DESCRIPTION_MAX}`
+			fail(`FRONTMATTER ${where}: description is ${len} chars, must be ${bounds}`)
+		}
+
+		if (meta.uid) {
+			const owner = uids.get(meta.uid)
+			if (owner) fail(`UID ${where}: uid "${meta.uid}" already used by ${owner}`)
+			else uids.set(meta.uid, where)
+		}
+
+		// Only the head of the body: a status header lives at the top. Further
+		// down, "status = the StatusCode member" is prose ABOUT a field.
+		for (const line of body.split('\n').slice(0, 15)) {
+			if (PROSE_STATUS.test(line)) {
+				fail(
+					`PROSE-STATUS ${where}: ${line.trim().slice(0, 70)}`,
+					'             put it in front matter as `status:` where a gate can read it',
+				)
+				break
+			}
+		}
+
+		// A `resource:` may legitimately cite an external reference; only
+		// repository paths can be checked for existence or drift.
+		const resource = meta.resource
+		if (!resource || /^https?:\/\//i.test(resource)) continue
+		if (!existsSync(join(root, resource))) {
+			fail(`RESOURCE ${where}: declares resource: ${resource}, which does not exist`)
+			continue
+		}
+
+		if (shallow) continue
+		const docAt = lastCommit(where)
+		const resAt = lastCommit(resource)
+		if (docAt && resAt > docAt) {
+			const state = (meta.status ?? '').toLowerCase()
+			const what = PROPOSAL_STATES.has(state)
+				? 'a proposal whose code already shipped'
+				: 'the code moved, the doc did not'
+			fail(
+				`DRIFT ${where}: ${what}`,
+				`      ${resource} changed after this document was last touched`,
+			)
+		}
+	}
+}
+
+if (shallow) {
+	fail(
+		'DRIFT: refusing to report on a shallow clone -- `git log` cannot see whether',
+		'       a resource moved after its document, so a pass here would mean "I did',
+		'       not look", not "nothing drifted". Check out with fetch-depth: 0.',
+	)
+}
+
+// The remainder is debt, and it is printed every run so it stays visible.
+const conforming = new Set()
+for (const dir of CONFORMING) for (const p of markdownUnder(join(root, dir))) conforming.add(rel(p))
+let outside = 0
+for (const p of markdownUnder(join(root, 'docs'))) if (!conforming.has(rel(p))) outside += 1
+
+console.log(`docs gate: ${problems} problem(s) across ${conforming.size} conforming file(s)`)
+console.log(`           ${outside} file(s) under docs/ not yet migrated to the standard`)
+process.exit(problems ? 1 : 0)


### PR DESCRIPTION
First of three. This one establishes the shape and the gate; nothing legacy and
nothing from `docs.local/sessions/` moves here, and neither open question is
touched.

## What the standard actually is

"OKF" is the **Open Knowledge Format**, v0.2 — a portable spec for curated
knowledge as markdown with YAML front matter. It is not a Cogitave invention,
and the estate standard never names it, which is why it took establishing.

The two contracts do not compete, and the estate already proved it: both
`templates/base/docs/decisions/0001` and `standards/docs/decisions/0032` carry
`uid`, `title`, `description`, `type`, `diataxis`, `owner`, `lastReviewed`,
`timestamp` and `status` in a **single merged header**. The knowledge format
requires consumers to preserve keys it does not define, so the union is legal by
construction. `templates/base/tools/check-docs.mjs` is the executable form, and
`learn/docs/content-lifecycle.md` already records this repository as an OKF site
and says normalising is cheap. This PR is that normalisation.

One deliberate departure: `type` and `diataxis` are **not** collapsed. The
templates set both to the same value, which restates one fact in two fields —
the drift class the knowledge-propagation standard exists to forbid. Here `type`
is what kind of thing a document is (`Convention`) and `diataxis` is how it is
written (`explanation`).

## Why the conventions rather than the legacy tree

They are current, not historical: eleven actively cited rules, each with an
incident behind it. They also happen to be the only part of the old tree with
**zero** external-name violations, so they clear that blocker outright.

## The gate ships with the format

Eight checks, all fatal, and every one demonstrated able to fail rather than
argued to be:

| Mutation | Result |
|---|---|
| drop a required key | caught |
| description below the 75-char floor | caught |
| description above the 300-char ceiling | caught |
| `resource:` pointing nowhere | caught |
| `uid` colliding with a sibling | caught |
| status hidden in prose | caught |
| resource commits newer than its document | caught (DRIFT) |
| shallow clone | **refused**, not passed |

Tree clean before and after; 6/6 front-matter mutations, plus DRIFT and the
shallow refusal verified in a throwaway clone with real history.

DRIFT is causal, not a timer: a document whose subject nobody touched is never
nagged. That is the mechanism that would have caught the errors currently being
found by hand across `docs/cli/**`. It needs `git log`, so it **refuses on a
shallow clone** rather than returning a pass it cannot justify — which is this
repository's own `an-optional-dependency-may-not-degrade-a-check` applied to the
gate itself. Hence a separate `Docs` job with `fetch-depth: 0` rather than
widening the matrix's checkout.

Scope is partial and loudly so. The gate is authoritative inside `CONFORMING`
and silent outside it, and every run prints the unmigrated remainder — **65
files today** — because a migration whose remainder is invisible is a migration
that stops.

## Provenance

`docs.local/` was **never tracked** in git. `git log --all -- docs.local` is
empty, so `git mv` was never available and no history is being invented: these
enter as new files. The provenance that does exist is the per-entry commit
hashes inside the session logs the rules were extracted from, which stay on
local disk. This is stated plainly rather than papered over.

## Corrections found while re-checking against source

- The per-file `context.sandbox` counts in `verify-claims-including-your-own`
  were a snapshot taken while the defect was open and have **already moved** —
  `ls.ts` carries the branch now. That passage states the method and the
  conclusion instead of pinning a table, and says why. The rule, turned on its
  own document.
- The `PlanApprovalData` / `agentId` incident is repaired in the tree, and
  `types/hitl/index.ts` carries it in its own docstring, so the rule points
  there rather than restating it.

`verified:` is on three files only. Its absence elsewhere is accurate, not an
oversight: those rules were read in full but not re-established against source
in this pass. The actor is `process:conventions-migration` — an agent checked
them, and recording a human would be the false certificate this format exists to
prevent.

## Verification

- `node tools/check-docs.mjs` — 0 problems, exit 0, and red under all eight
  mutations above.
- `node scripts/audit-external-names.mjs` — clean, exit 0. This matters: the
  same scan over the rest of the old tree returns **87 violations across 9
  files**, which is why only the conventions move in this PR.
- `pnpm typecheck` / `lint` / `test` could not run in this worktree — it has no
  `node_modules` and installing needs approval. The diff touches no TypeScript,
  no package `src/`, and no package's `biome check src/` scope, so CI is the
  execution rather than my reasoning about it. Please read the Build & Test
  verdict rather than taking my word for the reach of the diff.

## Not in this PR

`AGENTS.md`, `CLAUDE.md`, the two husky hooks, seven skills, `.gitignore` and
the source comments citing `docs.local/` paths are the enforcement rewiring, and
they land next. Until then `AGENTS.md` still routes to `docs.local/conventions/`
and the two copies are identical in substance.

Still with the owner, untouched here: whether `docs/legacy/` gets an
external-name exemption, and who owns the site build.
