### PR TITLE
docs: working memory moves to .work/, and the gate follows it

### DIFF
--- a/.changeset/a-pointer-to-a-place-you-cannot-go.md
+++ b/.changeset/a-pointer-to-a-place-you-cannot-go.md
@@ -1,0 +1,31 @@
+---
+'@namzu/computer-use': patch
+'@namzu/sandbox': patch
+'@namzu/cli': patch
+'@namzu/sdk': patch
+---
+
+Remove references that pointed readers at a directory they can never open.
+
+Agent working memory in this repository is gitignored, and several published
+artifacts cited paths inside it. None of them resolved for anyone but the
+maintainer, and four cited session folders that no longer exist at all.
+
+What a consumer sees change:
+
+- `@namzu/sandbox` raised `Sandbox backend 'x' is not implemented yet. Track
+  progress in vendor/namzu/docs.local/sessions/ses_004-...` — a runtime error
+  instructing the reader to open a path that is not in the package, not in the
+  repository, and not on the internet. It now names what does ship instead.
+- `@namzu/computer-use`'s README linked to an adapter-pattern document under a
+  directory that does not exist in any checkout. It now links to the two
+  published pages that actually carry the adapter contract, the capability
+  protocol, and the platform command matrix.
+- `@namzu/cli`'s README linked to a session folder on the code host that
+  returns 404, to explain the doctor's protocol/runtime split. The split is now
+  explained in the sentence itself.
+- `@namzu/sdk` source comments cited design documents by path. They cite the
+  session by name instead, which is what the reference was ever worth.
+
+No API, type, or behaviour change. The `@namzu/sandbox` message text is the
+only runtime string affected, and nothing asserts on it.

--- a/.claude/skills/codex-check/SKILL.md
+++ b/.claude/skills/codex-check/SKILL.md
@@ -33,7 +33,7 @@ Runs an adversarial review pass with Codex to surface flaws, missed edges, conve
      - "Find what is broken in this plan."
      - "What edges does this miss?"
      - "What would break this implementation at scale / under concurrency / on partial failure?"
-     - "Where does this drift from the conventions in `docs.local/conventions/`?"
+     - "Where does this drift from the conventions in `docs/conventions/`?"
      - "What hidden assumption is this plan making that is not stated?"
      - "If you had to kill this design, what angle would you attack?"
    </prompts>
@@ -43,7 +43,7 @@ Runs an adversarial review pass with Codex to surface flaws, missed edges, conve
 4. Triage the response:
    - **Concrete critique** (named risk, specific edge, convention breach) → capture in the session under "Open questions" or "Risks identified".
    - **Generic praise** ("looks good", "well structured") → discard. Do not treat this as validation.
-   - **Convention drift flagged** → re-read the cited rule in `docs.local/conventions/`; if the drift is real, either align the plan or open a deviation discussion before continuing.
+   - **Convention drift flagged** → re-read the cited rule in `docs/conventions/`; if the drift is real, either align the plan or open a deviation discussion before continuing.
 
 5. Append to `progress.md`:
    ```md

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -48,7 +48,7 @@ Prepares and creates a git commit on this repository with the correct author ide
 
 4. Stage only the files that belong to this commit. Avoid `git add -A` or `git add .` — they can sweep in secrets, generated files, or unrelated edits.
 
-5. **Session progress gate — MANDATORY, not milestone-gated.** Read the index at `docs.local/sessions/README.md`; for **every** row whose Status is `draft` or `in-progress`, that session's `progress.md` MUST be touched (mtime newer than any staged file) **before** running `git commit`. The husky `pre-commit` hook (`.husky/pre-commit`) enforces this — if a session's `progress.md` is stale, the commit aborts.
+5. **Session progress gate — MANDATORY, not milestone-gated.** Read the index at `.work/sessions/README.md`; for **every** row whose Status is `draft` or `in-progress`, that session's `progress.md` MUST be touched (mtime newer than any staged file) **before** running `git commit`. The husky `pre-commit` hook (`.husky/pre-commit`) enforces this — if a session's `progress.md` is stale, the commit aborts.
 
    **What the agent writes (only when there is something to say).** The auto-baseline (`- <hash> <subject>` line) is appended by the husky `post-commit` hook (`.husky/post-commit`); the agent never types a hash. The agent's job is to write *supplements* under a `### YYYY-MM-DD HH:MM — Commit <N> about to land` sub-heading **before** the commit:
 
@@ -63,7 +63,7 @@ Prepares and creates a git commit on this repository with the correct author ide
 
    **Multi-session rule.** The `pre-commit` and `post-commit` hooks both walk every active session. The agent supplements only the sessions a given commit actually impacts; sessions with no supplement get only the auto-baseline (which by convention means "no impact on this session's scope").
 
-   **`docs.local/` is gitignored**, so progress.md never enters a commit. The discipline is the synchronous-update timing, not commit contents. The post-commit hook reads `git log -1 --format='%h %s'` and appends the baseline line to each in-progress session's `progress.md`; today's `## YYYY-MM-DD` heading is created if missing.
+   **`.work/` is gitignored**, so progress.md never enters a commit. The discipline is the synchronous-update timing, not commit contents. The post-commit hook reads `git log -1 --format='%h %s'` and appends the baseline line to each in-progress session's `progress.md`; today's `## YYYY-MM-DD` heading is created if missing.
 
    If no in-progress session exists, this step is a no-op.
 
@@ -74,7 +74,7 @@ Prepares and creates a git commit on this repository with the correct author ide
    - Diff introduces a **new public export** (new symbol in the root barrel, new file under `packages/*/src/`, new bucket in the public-surface split, new wire field, new CLI flag).
    - Diff is a **rename / relocation across feature folders** (e.g. `session/hierarchy/` → `types/session/` in ses_010, or an equivalent structural move).
    - Diff **deviates from `implementation-plan.md`** in a way the agent is about to flag as a `**Deviation:**` supplement in step 5.
-   - Diff **ships a new convention** or touches `docs.local/conventions/`.
+   - Diff **ships a new convention** or touches `docs/conventions/`.
 
    If none of these apply, the baseline per-commit progress supplement (step 5) is enough — no Codex call.
 

--- a/.claude/skills/freeze-session/SKILL.md
+++ b/.claude/skills/freeze-session/SKILL.md
@@ -5,7 +5,7 @@ description: Use this skill when a session's decisions are final and either the 
 
 # Freeze Session
 
-Marks a session as the final record of its decisions, extracts any stable rules that emerged into `docs.local/conventions/`, and, if the session's decisions changed the public surface, triggers `update-docs`.
+Marks a session as the final record of its decisions, extracts any stable rules that emerged into `docs/conventions/`, and, if the session's decisions changed the public surface, triggers `update-docs`.
 
 ## When to trigger
 
@@ -60,13 +60,28 @@ Marks a session as the final record of its decisions, extracts any stable rules 
    - Cross-cutting — applies to future work, not just this session's slice.
    - Unambiguous — a reviewer can tell whether a change complies or deviates.
 
-4. For each stable rule, extract into `docs.local/conventions/`:
+4. For each stable rule, extract into `docs/conventions/` — **tracked, published, and gated**, so it is written to the documentation standard rather than as a free-form note:
 
    <extraction>
-     - Open `docs.local/conventions/README.md`, pick the next slug.
-     - Create `docs.local/conventions/<slug>.md` using the template in that README.
-     - Fill the sections: generic rule, project implementation, rationale (with back-link to this session), examples (complies / violates).
-     - Add the row to the conventions catalogue table.
+     - Read `docs/conventions/index.md` for the catalogue and pick a slug that names the rule, not the session.
+     - Create `docs/conventions/<slug>.md` with the front matter the gate requires:
+       `uid` (`namzu.conventions.<slug>`), `title`, `description` (75-300 chars),
+       `type: Convention`, `diataxis: explanation`, `owner: cogitave/namzu`,
+       `status: active`, `timestamp` (ratification date, ISO 8601),
+       `lastReviewed`.
+     - Optional and worth setting: `resource:` naming the code the incident
+       lives in. The gate then fails the build when that code moves and the
+       rule does not. Omit it rather than inventing one when the incident has
+       no single home.
+     - **Do not set `verified:` unless you personally re-established the rule
+       against source in this pass.** Its absence honestly reads as unverified;
+       a false one is a certificate nobody can trust.
+     - Write the rule and the incident that produced it. A rule with no
+       incident behind it is a preference and does not belong here.
+     - Add it to `docs/conventions/index.md` under the right heading, and to
+       `docs/conventions/meta.json`.
+     - Run `pnpm docs:check` — it is a required CI gate, and it will tell you
+       exactly which key is missing.
    </extraction>
 
 5. If the session's decisions changed anything documented in `docs/` (public API, CLI behavior, wire shape), invoke the `update-docs` skill for each affected page.
@@ -81,7 +96,7 @@ Marks a session as the final record of its decisions, extracts any stable rules 
    - This session is now historical record.
    ```
 
-7. Update `docs.local/sessions/README.md` index row: status → `frozen`, fill the "Frozen" column with today's date.
+7. Update `.work/sessions/README.md` index row: status → `frozen`, fill the "Frozen" column with today's date.
 
 8. If this session supersedes a prior frozen session, cross-link both ways:
    - In this session's README: `Supersedes: ses_<old>/ (<brief reason>)`.

--- a/.claude/skills/read-conventions/SKILL.md
+++ b/.claude/skills/read-conventions/SKILL.md
@@ -5,7 +5,7 @@ description: Use this skill before making any non-trivial code change, architect
 
 # Read Conventions
 
-Loads the relevant project rules from `docs.local/conventions/` before a non-trivial change, so the change aligns with decisions already ratified in prior sessions.
+Loads the relevant project rules from `docs/conventions/` before a non-trivial change, so the change aligns with decisions already ratified in prior sessions.
 
 ## When to trigger
 
@@ -20,7 +20,9 @@ Loads the relevant project rules from `docs.local/conventions/` before a non-tri
 ## Steps
 
 <procedure>
-1. Read `docs.local/conventions/README.md` to see the catalogue of ratified rules. **If the file is missing**, this is not a hard error — `docs.local/` is gitignored and lives only on the author machine, so a fresh `git clone` may not have a catalogue yet (per `ses_002-workflow-discipline` design.md §9.4). Treat missing as "single-machine deployment, no catalogue yet" and report `no ratified rules apply yet`. Do not fabricate or guess rules.
+1. Read `docs/conventions/index.md` to see the catalogue of ratified rules. **The catalogue is tracked**, so every clone has it. If it is missing, that is a real defect — say so and stop; do not report "no rules apply", and do not fabricate or guess rules.
+
+   This inverts the skill's previous instruction. The catalogue used to live in gitignored working memory, where absence genuinely meant "not bootstrapped on this machine". It is now part of the repository, and absence means something is wrong.
 
 2. Map the change's surface to the catalogue. Examples:
    <mapping>
@@ -32,7 +34,7 @@ Loads the relevant project rules from `docs.local/conventions/` before a non-tri
      - Changing CLI command → CLI-conventions / commit-convention rules.
    </mapping>
 
-3. Read each relevant rule file fully, not just its generic rule line. The `🔧 Project Implementation` section is where compliance lives.
+3. Read each relevant rule file fully, not just its one-line summary in the catalogue. The incident a rule carries is what tells you whether your case is the one it covers.
 
 4. Check the change against each rule:
    - **Complies** → proceed.
@@ -44,4 +46,4 @@ Loads the relevant project rules from `docs.local/conventions/` before a non-tri
 
 - List of rule files consulted.
 - One-line compliance note per rule: `complies` / `ambiguous — see session ses_NNN` / `deviation — session ses_NNN opened`.
-- Empty or missing catalogue is a valid result while `docs.local/conventions/` is still growing or has not been bootstrapped on the local machine; in that case report "no ratified rules apply yet".
+- A catalogue with no rule matching the change's surface is a valid result — report "no ratified rule covers this". A *missing* catalogue is not: `docs/conventions/index.md` is tracked, so its absence is a defect to report rather than a state to work around.

--- a/.claude/skills/resume-session/SKILL.md
+++ b/.claude/skills/resume-session/SKILL.md
@@ -5,7 +5,7 @@ description: Use this skill whenever the user resumes existing design, architect
 
 # Resume Session
 
-Locates the most relevant in-flight session under `docs.local/sessions/` and loads its context so work can continue without loss of prior decisions. The `progress.md` log inside the session is the primary source for "where did we leave off".
+Locates the most relevant in-flight session under `.work/sessions/` and loads its context so work can continue without loss of prior decisions. The `progress.md` log inside the session is the primary source for "where did we leave off".
 
 ## When to trigger
 
@@ -19,7 +19,7 @@ Locates the most relevant in-flight session under `docs.local/sessions/` and loa
 ## Steps
 
 <procedure>
-1. Read `docs.local/sessions/README.md` — this is the index of all sessions with status and slug.
+1. Read `.work/sessions/README.md` — this is the index of all sessions with status and slug.
 
 2. Filter candidates by status and topic:
    - Status `draft` or `in-progress` → active work.

--- a/.claude/skills/start-session/SKILL.md
+++ b/.claude/skills/start-session/SKILL.md
@@ -5,7 +5,7 @@ description: Use this skill whenever the user begins new non-trivial design, arc
 
 # Start Session
 
-Opens a new working-memory folder under `docs.local/sessions/` to capture scope, decisions, plans, progress, and open questions for a focused piece of work. Sessions are the agent's durable memory across turns, across agents, and across `/clear`.
+Opens a new working-memory folder under `.work/sessions/` to capture scope, decisions, plans, progress, and open questions for a focused piece of work. Sessions are the agent's durable memory across turns, across agents, and across `/clear`.
 
 ## When to trigger
 
@@ -25,7 +25,7 @@ Opens a new working-memory folder under `docs.local/sessions/` to capture scope,
 ## Steps
 
 <procedure>
-1. Read `docs.local/sessions/README.md` to find the next sequential ID and re-read the current conventions (status values, freeze rule, layout).
+1. Read `.work/sessions/README.md` to find the next sequential ID and re-read the current conventions (status values, freeze rule, layout).
 
 2. Pick a slug:
    - 2–4 lowercase words, hyphenated.
@@ -33,7 +33,7 @@ Opens a new working-memory folder under `docs.local/sessions/` to capture scope,
 
 3. Create the folder:
    ```
-   docs.local/sessions/ses_<NNN>-<slug>/
+   .work/sessions/ses_<NNN>-<slug>/
    ```
 
 4. Scaffold the standard files inside it:
@@ -64,7 +64,7 @@ Opens a new working-memory folder under `docs.local/sessions/` to capture scope,
      Decisions pending user input. Create when unresolved questions exist.
    </file>
 
-5. Update `docs.local/sessions/README.md` index table with the new row: ID, slug, status, opened date.
+5. Update `.work/sessions/README.md` index table with the new row: ID, slug, status, opened date.
 
 6. Write the first `progress.md` entry:
    ```md

--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -5,7 +5,7 @@ description: Use this skill whenever a code change alters anything documented in
 
 # Update Docs
 
-Keeps `docs/` (published to `docs.namzu.ai`) in sync with code. This skill finds the affected pages via frontmatter tags, updates content accurately, and bumps the `last_updated` field so reviewers can tell a page is current.
+Keeps `docs/` in sync with code. This skill finds the affected pages via frontmatter tags, updates content accurately, and refreshes the page's review date so reviewers can tell a page is current.
 
 ## When to trigger
 
@@ -19,14 +19,31 @@ Keeps `docs/` (published to `docs.namzu.ai`) in sync with code. This skill finds
 
 <not_triggers>
 - Internal refactors with no public-surface change.
-- Session-internal notes in `docs.local/` (that is working memory, not published docs).
+- Session-internal notes in `.work/` (that is working memory, not published docs).
 - README snippets inside individual packages (unless they describe the public API).
 </not_triggers>
 
 ## Frontmatter contract
 
 <frontmatter>
-Every page in `docs/` carries a YAML frontmatter block:
+**Two frontmatter shapes coexist in `docs/` right now. Match the page you are
+editing; do not convert one to the other as a side effect.**
+
+1. **The documentation standard** — `uid`, `title`, `description`, `type`,
+   `diataxis`, `owner`, `status`, `timestamp`, `lastReviewed`, plus optional
+   `resource:` and `verified:`. Machine-checked by `pnpm docs:check` for the
+   directories in its `CONFORMING` array (`docs/conventions/` today). New pages
+   are written this way. There is no `last_updated` here — `lastReviewed` is the
+   equivalent, and `verified:` is the stronger claim: set it only when you have
+   re-established the page against source yourself.
+
+2. **The original shape**, below, still carried by the pages not yet migrated.
+   Bump `last_updated` on these as described.
+
+The rest of this section describes shape 2. Migrating a page from 2 to 1 is a
+deliberate change with its own commit, not something to do in passing.
+
+Every unmigrated page in `docs/` carries a YAML frontmatter block:
 
 ```yaml
 ---
@@ -111,7 +128,7 @@ There is no `surface` field. Page topic is implied by directory placement (`docs
 - Code is the source of truth. If the doc and the code disagree, the doc is wrong until proven otherwise.
 - Never update `last_updated` without actually changing content. The field must mean "the content on this page was verified and current on this date".
 - Never delete a public-surface doc without a redirect or a `superseded_by:` link. Readers following an external link should land somewhere useful.
-- Do not edit `docs.local/` from this skill — that is working memory, separate from published docs.
+- Do not edit `.work/` from this skill — that is working memory, separate from published docs.
 </discipline>
 
 ## Output

--- a/.github/scripts/check-sdk-test-presence.mjs
+++ b/.github/scripts/check-sdk-test-presence.mjs
@@ -24,9 +24,8 @@
  * check lives in `check-sdk-module-coverage.mjs`.
  *
  * Convention: "enumerate what counts, don't infer." Mirrors
- * `.github/scripts/verify-public-surface.mjs`. See
- * `docs.local/conventions/public-surface-buckets.md` for the same pattern
- * applied to the public API.
+ * `.github/scripts/verify-public-surface.mjs`, which applies the same
+ * pattern to the public API.
  *
  * Non-bypassable by design (ses_006 Q7); there is no env-var escape hatch.
  */

--- a/.github/scripts/verify-public-surface.mjs
+++ b/.github/scripts/verify-public-surface.mjs
@@ -26,8 +26,7 @@
  * missing in a major while this gate reported no problem.
  *
  * Baseline captured at the tip of commit f8cb129 (the final commit of
- * ses_010-sdk-type-layering, pre-ses_011). See
- * `docs.local/sessions/ses_011-sdk-public-surface/design.md#4.5`.
+ * ses_010-sdk-type-layering, pre-ses_011).
  *
  * Extension: if a commit intentionally changes the public surface, regenerate
  * the baseline in that same commit:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,15 @@ dist/
 *.tsbuildinfo
 .DS_Store
 coverage/
+
+# Agent working memory: live session logs, and comparative analyses that name
+# other systems in order to compare against them. Deliberately untracked —
+# `scripts/audit-external-names.mjs` forbids a third-party product name in
+# tracked prose, and naming what was compared IS the work in those documents,
+# so they are parked here rather than published or rewritten into uselessness.
+# `docs.local/` is the name this had before the documentation migration; it
+# stays ignored until every checkout has been renamed.
+.work/
 docs.local/
 
 # Runtime state

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # Post-commit progress baseline (ses_002-workflow-discipline).
 #
-# For every in-progress session under docs.local/sessions/, append the
+# For every in-progress session under .work/sessions/, append the
 # just-completed commit's hash + subject to progress.md as the auto-
 # baseline line. Today's `## YYYY-MM-DD` heading is created if missing.
 #
@@ -12,8 +12,18 @@
 
 set -e
 
-INDEX="docs.local/sessions/README.md"
-[ -f "$INDEX" ] || exit 0
+# Same two-location resolution as the pre-commit gate, and for the same
+# reason: the baseline append must not silently stop happening because the
+# directory was renamed. See .husky/pre-commit for the full rationale.
+if [ -f ".work/sessions/README.md" ]; then
+  INDEX=".work/sessions/README.md"
+elif [ -f "docs.local/sessions/README.md" ]; then
+  INDEX="docs.local/sessions/README.md"
+else
+  exit 0
+fi
+
+WORK=$(dirname "$(dirname "$INDEX")")
 
 sessions=$(awk -F'|' '
   /^\| ses_/ {
@@ -33,7 +43,7 @@ subject=$(git log -1 --format='%s')
 today=$(date "+%Y-%m-%d")
 
 for sess in $sessions; do
-  pfile="docs.local/sessions/${sess}/progress.md"
+  pfile="${WORK}/sessions/${sess}/progress.md"
   [ -f "$pfile" ] || continue
 
   if ! grep -q "^## ${today}$" "$pfile"; then

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # Pre-commit progress gate (ses_002-workflow-discipline).
 #
-# For every in-progress session under docs.local/sessions/, verify that
+# For every in-progress session under .work/sessions/, verify that
 # progress.md has been updated at least as recently as the most recent
 # staged file. If not, fail with a pointer to the commit skill Step 5.
 #
@@ -11,15 +11,30 @@
 # but is forbidden by AGENTS.md <workflow_safety> without explicit user
 # permission.
 #
-# docs.local/ is gitignored, so progress.md never enters a commit. The
+# .work/ is gitignored, so progress.md never enters a commit. The
 # discipline is the synchronous-update timing, not the commit contents.
 
 set -e
 
-INDEX="docs.local/sessions/README.md"
+# Resolve the working-memory root. `.work/` is the location; `docs.local/`
+# is the name it had before the documentation migration and is still
+# honoured, deliberately, so that the gate NEVER lapses while a checkout is
+# mid-rename. A hook that quietly stopped gating because its path moved is
+# the exact failure this hook exists to prevent, one level up.
+#
+# Drop the fallback once no checkout carries the old directory.
+if [ -f ".work/sessions/README.md" ]; then
+  INDEX=".work/sessions/README.md"
+elif [ -f "docs.local/sessions/README.md" ]; then
+  INDEX="docs.local/sessions/README.md"
+  echo "note: working memory is still at docs.local/. Rename it to .work/ —" >&2
+  echo "      the gate is running against the old path meanwhile." >&2
+else
+  # Neither location exists → there are genuinely no sessions to gate.
+  exit 0
+fi
 
-# No index → no sessions to gate.
-[ -f "$INDEX" ] || exit 0
+WORK=$(dirname "$(dirname "$INDEX")")
 
 # Extract in-progress + draft sessions from the index table.
 # Rows look like:  | ses_001 | hierarchy-redesign | in-progress | 2026-04-18 | — |
@@ -62,7 +77,7 @@ done
 
 failed=""
 for sess in $sessions; do
-  pfile="docs.local/sessions/${sess}/progress.md"
+  pfile="${WORK}/sessions/${sess}/progress.md"
   if [ ! -f "$pfile" ]; then
     echo "✗ pre-commit: session ${sess} is active in ${INDEX} but ${pfile} is missing." >&2
     failed=1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,28 +36,46 @@ Use `pnpm --filter <pkg>` to scope commands to a single package.
 This file is a **router**, not a rulebook. Detail lives in the folders below; read their `README.md` before drilling deeper.
 
 <routing>
-  <working_memory path="docs.local/sessions/">
-    Durable agent memory. Every non-trivial piece of design, decision, or refactor work opens a session folder here (`ses_<NNN>-<slug>/`). Sessions capture scope, decisions, plans, and open questions. When a new agent takes over, it starts here to see what's in flight.
+  <working_memory path=".work/sessions/">
+    Durable agent memory, and **gitignored**. Every non-trivial piece of design, decision, or refactor work opens a session folder here (`ses_<NNN>-<slug>/`). Sessions capture scope, decisions, plans, and open questions. When a new agent takes over, it starts here to see what's in flight.
+
+    It stays untracked on purpose. A session log compares this kernel against other systems by name, and `scripts/audit-external-names.mjs` forbids a third-party product name in tracked prose — so this material can be neither published nor rewritten without destroying what it is for. `.work/parked/` holds superseded analyses of the same kind.
 
     Skills: `start-session`, `resume-session`, `freeze-session`.
   </working_memory>
 
-  <code_rules path="docs.local/conventions/">
-    Ratified, stable rules about how code is written. Grows organically as sessions freeze and emit stable rules. Read its `README.md` for the catalog before a non-trivial change.
+  <code_rules path="docs/conventions/">
+    Ratified, stable rules about how code is written, and **tracked** — these are live rules, not history. Grows as sessions freeze and emit stable rules. Read its `index.md` for the catalog before a non-trivial change.
 
     Skill: `read-conventions`.
   </code_rules>
 
   <published_docs path="docs/">
-    User-facing documentation published to `docs.namzu.ai`. Pages carry YAML frontmatter (`related_packages`, `surface`, `status`, `last_updated`) so the right page can be found from a code change. Do not edit during internal decision work; update only when a design lands and the public surface actually changes.
+    User-facing documentation. Pages carry YAML frontmatter the docs gate reads — see the standard below. Do not edit during internal decision work; update only when a design lands and the public surface actually changes.
 
     Skill: `update-docs`.
   </published_docs>
+
+  <legacy path="docs/legacy/">
+    Superseded design notes and frozen session records, moved rather than rewritten. Carries the minimum front matter the gate requires and **no `verified:` key**, which marks it unverified — nobody has re-checked it against the code, and nobody is going to. Read it as history, never as a current claim.
+  </legacy>
 
   <runtime_state path=".namzu/">
     The repo's own dogfooding runtime state (threads, sessions, runs). Do not edit by hand.
   </runtime_state>
 </routing>
+
+## Documentation standard
+
+`docs/` follows the estate documentation standard: markdown with YAML front matter, one concept per file, Diataxis content types. Required keys, all machine-checked by `pnpm docs:check` (`tools/check-docs.mjs`):
+
+`uid`, `title`, `description` (75-300 chars), `type`, `diataxis`, `owner`, `status`, `timestamp`, `lastReviewed`.
+
+`type` is what kind of thing the document is; `diataxis` is how it is written. They are separate on purpose — collapsing them would restate one fact in two fields.
+
+Optional and load-bearing: `resource:` names the code the document describes, and the gate **fails the build** when that code has commits newer than the document. `verified:` records who last re-established the document against source; **omit it rather than guess**, because an absent key honestly reads as unverified and a false one does not.
+
+The gate is authoritative only inside the directories listed in its `CONFORMING` array and prints the unmigrated remainder on every run. Add a directory there in the same change that brings its pages up to the standard, never before.
 
 ## Working flow
 
@@ -65,10 +83,10 @@ This file is a **router**, not a rulebook. Detail lives in the folders below; re
 1. Starting or continuing any non-trivial work → open or resume a session.
 2. Before a non-trivial change → read the relevant conventions.
 3. After drafting a plan → run an adversarial second-opinion check (see `codex-check` skill).
-4. **Every commit while an in-progress session exists** → `progress.md` entry is written **synchronously with the commit**, not as a follow-up. `docs.local/` is gitignored, so the entry does not enter the commit itself — it lives on local disk, and the discipline is that the working-tree update happens before `git commit` runs. This is non-negotiable — the log is what makes a fresh agent able to pick up after `/clear`, and a six-commit gap has happened before. An entry is one line minimum: `- <hash> <subject> — what/why` (hash filled post-commit); add a `**Deviation:**` line if the commit diverges from the ratified plan. See skill: `commit`.
+4. **Every commit while an in-progress session exists** → `progress.md` entry is written **synchronously with the commit**, not as a follow-up. `.work/` is gitignored, so the entry does not enter the commit itself — it lives on local disk, and the discipline is that the working-tree update happens before `git commit` runs. This is non-negotiable — the log is what makes a fresh agent able to pick up after `/clear`, and a six-commit gap has happened before. An entry is one line minimum: `- <hash> <subject> — what/why` (hash filled post-commit); add a `**Deviation:**` line if the commit diverges from the ratified plan. See skill: `commit`.
 5. After implementation → `pnpm typecheck && pnpm lint && pnpm test` must all pass.
 6. Commit touches public surface (exported types, wire schema, CLI flags, API routes)? → **queue a `**Docs debt:**` line in the touching commit's `progress.md` entry**; the debt is cleared by running the `update-docs` skill before `freeze-session`. Queuing is mandatory per commit; actually writing `docs/` pages can batch at freeze time.
-7. Decisions turning final → freeze the session; extract stable rules into `conventions/`.
+7. Decisions turning final → freeze the session; extract stable rules into `docs/conventions/`, written to the documentation standard above.
 </flow>
 
 ## Hard rules
@@ -98,7 +116,7 @@ A changeset body is read by a stranger deciding whether to take the upgrade. Nam
 <workflow_safety>
 - Never push without explicit user approval.
 - Never run destructive ops (`git reset --hard`, `git push --force`, `rm -rf`, `npm unpublish`) without explicit approval.
-- Never skip hooks (`--no-verify`, `--no-gpg-sign`) unless the user explicitly asks. The husky `pre-commit` hook (`.husky/pre-commit`) machine-enforces the per-commit progress gate: every active session in `docs.local/sessions/README.md` must have a `progress.md` mtime newer than the staged files. Bypass with `--no-verify` is forbidden by this rule, not by the hook itself.
+- Never skip hooks (`--no-verify`, `--no-gpg-sign`) unless the user explicitly asks. The husky `pre-commit` hook (`.husky/pre-commit`) machine-enforces the per-commit progress gate: every active session in `.work/sessions/README.md` must have a `progress.md` mtime newer than the staged files. Bypass with `--no-verify` is forbidden by this rule, not by the hook itself.
 - File-scoped operations (lint, unit tests) may run freely. Risky operations (installs, pushes, infrastructure changes) require approval.
 </workflow_safety>
 

--- a/docs/conventions/declared-but-undriven.md
+++ b/docs/conventions/declared-but-undriven.md
@@ -8,8 +8,11 @@ owner: cogitave/namzu
 status: active
 timestamp: 2026-08-04T00:00:00Z
 lastReviewed: 2026-08-07
-resource: packages/sandbox/src/index.ts
+resource: packages/sdk/src/sandbox/__tests__/exec-cancellation.test.ts
 tags: [convention, api-design, types]
+verified:
+  - by: process:conventions-migration
+    at: 2026-08-07T00:00:00Z
 ---
 
 # A declaration nothing drives is a defect, not a roadmap
@@ -35,7 +38,12 @@ is the finding.
 - `SandboxExecOptions.signal` — declared, documented with the exact failure it
   prevents, honoured by **no backend**. So the failure its own docstring
   described (a stop could only ever abandon the *wait*) was what always
-  happened.
+  happened. **Repaired**, and the repair is what `resource` above points at:
+  a regression test that drives the real provider, because a stub asserting
+  "the signal was passed along" would have passed against the broken code. The
+  backends that still cannot honour it now say so in source rather than
+  forwarding a signal that would abort the *wait* and leave the process
+  running — see [Refuse, do not silently degrade](refuse-do-not-degrade.md).
 - `ThinkingConfig.display` — on the type, never serialized into the request.
   And its values were wrong: `'full'` was not a value any driver accepted.
 - `runtimeToolOverrides` — honoured at two call sites, ignored at the third,

--- a/docs/sdk/runtime/replay.md
+++ b/docs/sdk/runtime/replay.md
@@ -226,6 +226,6 @@ Not in v1; deferred with a dedicated follow-up:
 
 ## 10. References
 
-- [`ses_005-deterministic-replay`](https://github.com/bahadirarda/namzu/tree/main/docs.local/sessions/ses_005-deterministic-replay) — design record, ratified decisions, implementation plan. Internal; linked here for context on what was cut from v1 and why.
+- `ses_005-deterministic-replay` — the design record behind this feature, including what was cut from v1 and why. It is agent working memory, gitignored and never published, so this names it rather than linking to it.
 - `projectEmergencyToCheckpoint` — exported helper if you want to project emergency dumps yourself rather than letting `prepareReplayState` do it.
 - `CheckpointManager.listEntries()` — the lower-level method that `listCheckpoints` wraps, useful if you already hold a `CheckpointManager` for the run.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -72,7 +72,7 @@ process.exit(report.exit)
 
 ## Architecture
 
-The doctor's protocol types (`DoctorCheck`, `DoctorCheckResult`, `DoctorReport`, `DoctorStatus`) live in `@namzu/sdk` so kernel components (providers, vaults, sandboxes) can implement `doctorCheck?()` hooks against them. The runtime (registry, runner, output formatting, exit codes) lives here in `@namzu/cli` because it's operator-facing concerns. This is the [`ses_007-probe-and-doctor`](https://github.com/cogitave/namzu/tree/main/docs.local/sessions/ses_007-probe-and-doctor) split.
+The doctor's protocol types (`DoctorCheck`, `DoctorCheckResult`, `DoctorReport`, `DoctorStatus`) live in `@namzu/sdk` so kernel components (providers, vaults, sandboxes) can implement `doctorCheck?()` hooks against them. The runtime (registry, runner, output formatting, exit codes) lives here in `@namzu/cli` because it's operator-facing concerns. This is the protocol/runtime split: the kernel owns the contract, the operator surface owns the presentation.
 
 ## License
 

--- a/packages/cli/src/commands/stubs.ts
+++ b/packages/cli/src/commands/stubs.ts
@@ -3,7 +3,7 @@
  *
  * Each stub corresponds to a milestone in the M0→M7 plan and exits 0 after
  * printing a structured marker. The implementations themselves land in
- * their respective milestone sessions (see docs.local/sessions/).
+ * their respective milestone sessions (agent working memory, gitignored).
  */
 
 import type { CommandDef, CommandHandler } from './types.js'

--- a/packages/cli/src/doctor/registry.test.ts
+++ b/packages/cli/src/doctor/registry.test.ts
@@ -1,5 +1,5 @@
 /**
- * Ratified §9 of docs.local/sessions/ses_007-probe-and-doctor/design.md.
+ * Ratified in ses_007-probe-and-doctor §9 (agent working memory, gitignored).
  * D4 = registerDoctorCheck + plugin auto-discovery + standalone-CLI /
  * embedded-runDoctor split. D5 = sysexits exit codes (0/1/2/70).
  */

--- a/packages/computer-use/README.md
+++ b/packages/computer-use/README.md
@@ -96,7 +96,7 @@ If the user installs a missing CLI mid-session, reconstruct the host (capabiliti
 
 ## Design
 
-See [`docs.local/architecture/patterns/namzu-computer-use/subprocess-adapter-pattern.md`](../../docs.local/architecture/patterns/namzu-computer-use/subprocess-adapter-pattern.md) for adapter contract, capability protocol, and platform command matrix.
+See [Platform support](https://github.com/cogitave/namzu/blob/main/docs/computer-use/platform-support.md) and [Host lifecycle](https://github.com/cogitave/namzu/blob/main/docs/computer-use/host-lifecycle.md) for the adapter contract, the capability protocol, and the platform command matrix.
 
 ADR: [`docs/architecture/decisions/adr-computer-use-subprocess.md`](../../docs/architecture/decisions/adr-computer-use-subprocess.md) explains why subprocess over Rust+napi-rs.
 

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -661,7 +661,7 @@ export class SandboxBackendNotImplementedError extends Error {
 
 	constructor(public readonly backend: string) {
 		super(
-			`Sandbox backend '${backend}' is not implemented yet. Track progress in vendor/namzu/docs.local/sessions/ses_004-native-agentic-runtime-and-sandbox.`,
+			`Sandbox backend '${backend}' is not implemented yet. See the backends listed in @namzu/sandbox for what ships today.`,
 		)
 	}
 }

--- a/packages/sdk/coverage-config.json
+++ b/packages/sdk/coverage-config.json
@@ -1,5 +1,5 @@
 {
-	"$comment": "Coverage gate config for @namzu/sdk. Consumed by .github/scripts/check-sdk-module-coverage.mjs and check-sdk-test-presence.mjs. Managed by ses_006-test-coverage-sprint; see docs.local/sessions/ses_006-test-coverage-sprint/design.md for rules.",
+	"$comment": "Coverage gate config for @namzu/sdk. Consumed by .github/scripts/check-sdk-module-coverage.mjs and check-sdk-test-presence.mjs. The bucket rules were ratified in ses_006-test-coverage-sprint.",
 	"modules": {
 		"required": [
 			"advisory",

--- a/packages/sdk/src/public-runtime.ts
+++ b/packages/sdk/src/public-runtime.ts
@@ -2,8 +2,8 @@
 //
 // Every runtime value a consumer might need: classes (agents, managers,
 // stores, registries), functions (helpers, ID generators, runtime entry
-// points), zod schemas, constants, error classes. See §4.2 of
-// `docs.local/sessions/ses_011-sdk-public-surface/design.md`.
+// points), zod schemas, constants, error classes. The three-bucket taxonomy
+// was ratified in ses_011-sdk-public-surface §4.2.
 //
 // Rule: no type-only exports here (types live in public-types.ts). No tool
 // definitions or builders (tools live in public-tools.ts).

--- a/packages/sdk/src/public-tools.ts
+++ b/packages/sdk/src/public-tools.ts
@@ -7,7 +7,7 @@
 // Generic RAG runtime (vector stores, retrievers, embeddings, knowledge
 // base) lives in `public-runtime.ts`; only `createRAGTool` belongs here.
 //
-// See §4.3 of `docs.local/sessions/ses_011-sdk-public-surface/design.md`.
+// Ratified in ses_011-sdk-public-surface §4.3.
 
 // ─── Tool definition primitive ───────────────────────────────────────────
 

--- a/packages/sdk/src/public-types.ts
+++ b/packages/sdk/src/public-types.ts
@@ -8,8 +8,8 @@
 // (classes, functions, constants, zod schemas, errors) live in
 // `public-runtime.ts`. Tool builders live in `public-tools.ts`.
 //
-// See `docs.local/sessions/ses_011-sdk-public-surface/design.md` for the
-// three-bucket taxonomy and migration rationale.
+// The three-bucket taxonomy and its migration rationale were ratified in
+// ses_011-sdk-public-surface.
 
 // ─── per-domain shape surfaces ────────────────────────────────────────────
 

--- a/packages/sdk/src/types/thread/entity.ts
+++ b/packages/sdk/src/types/thread/entity.ts
@@ -51,7 +51,7 @@ export type ThreadStatus = 'open' | 'archived'
  *
  * ## Design reference
  *
- * Session design §4 (`docs.local/sessions/ses_001-hierarchy-redesign/design.md`):
+ * Session design §4 (ratified in ses_001-hierarchy-redesign):
  *   - Container only. No own message stream, no own Run stream. Messages
  *     live in Sessions (Phase 0 decision B.1).
  *   - `title` is a user-facing label. **Titles are NOT unique within a

--- a/scripts/audit-external-names.mjs
+++ b/scripts/audit-external-names.mjs
@@ -295,9 +295,17 @@ const all = []
 
 // The repository's own top-level pages are the most public prose there is,
 // and they were the one surface no walk reached. Top level only, and
-// deliberately not a recursive walk from the root: `docs.local/` is
-// gitignored working memory where naming another system is the WORK — a
-// fit-gap report has to say what it compared against.
+// deliberately not a recursive walk from the root: `.work/` is gitignored
+// working memory where naming another system is the WORK — a comparative
+// analysis has to say what it compared against.
+//
+// That exemption is a property of being UNTRACKED, not of the directory's
+// name, and it is the reason those documents stay untracked. When the
+// documentation tree moved to `docs/`, nine of them were measured against
+// this rule and produced 87 findings between them; the ruling was that no
+// third-party name enters tracked prose, so they were parked in `.work/`
+// rather than published, redacted, or exempted. Adding a path exemption
+// here would reverse that decision silently — do not.
 for (const entry of await readdir(ROOT, { withFileTypes: true })) {
 	if (!entry.isFile() || !entry.name.endsWith('.md')) continue
 	all.push(...findings(await readFile(join(ROOT, entry.name), 'utf-8'), entry.name))

--- a/tools/check-docs.mjs
+++ b/tools/check-docs.mjs
@@ -24,6 +24,16 @@
 //                 causal, not a timer: a document whose subject nobody touched
 //                 is never nagged.
 //
+// Choosing a `resource:` is the part that decides whether DRIFT is signal or
+// noise. Point it at the narrowest artifact whose change would actually
+// invalidate the document — a regression test that exists BECAUSE of the
+// incident is usually the best answer, since it changes when the behaviour
+// does and not otherwise. A barrel or an index file is the worst: it churns
+// for unrelated reasons and trains everyone to wave the failure through.
+// This gate's first real firing was exactly that mistake, on its own author.
+// Where no single artifact owns the claim, omit `resource:` rather than
+// inventing one; the field is optional and a wrong pointer is worse than none.
+//
 // DRIFT reads git history, so it REFUSES on a shallow clone rather than
 // returning a pass it cannot justify. A gate whose precondition is absent must
 // say "I cannot establish this", never "this is satisfied" -- see


### PR DESCRIPTION
Second of three. The enforcement rewiring: every wire into the old
working-memory directory moves with it, and the per-commit progress discipline
comes out the other side enforced rather than merely renamed.

## `docs.local/` becomes `.work/`, and stays untracked

The old name claimed to be a documentation tree while being gitignored working
memory. That is the confusion this migration exists to unwind.

Its staying untracked is now a **decision with a reason attached**, not an
accident of history. A session log compares this kernel against other systems
by name, and `scripts/audit-external-names.mjs` forbids a third-party product
name in tracked prose. Nine of those documents produced **87 findings** between
them. They can be neither published nor redacted without destroying the thing
they are for, so they are parked. The audit script's own comment now records
this, and records that adding a path exemption there would silently reverse it.

## The progress gate never lapses

Both hooks resolve `.work/` first and fall back to `docs.local/` with a rename
warning, so a checkout that has not been renamed yet is **still gated** rather
than silently ungated. There is no flag day and no window where the discipline
is off — which matters, because other agents are writing to those session logs
right now.

Six scenarios exercised end to end against a throwaway repository:

| Scenario | Result |
|---|---|
| neither location present | exit 0 — genuinely no sessions to gate |
| legacy only, progress stale | **fails**, and warns about the rename |
| legacy only, progress refreshed | passes, still warns |
| new location present, progress stale | **fails**, no warning |
| new location, progress refreshed | passes |
| post-commit append | lands in `.work/`, legacy copy untouched |

A hook that quietly stopped gating because its path moved would be the exact
failure the hook exists to prevent, one level up. Drop the fallback once no
checkout carries the old directory.

## The conventions are tracked now, so one skill was wrong rather than stale

`read-conventions` told agents that a missing catalogue is *not* an error —
"`docs.local/` is gitignored and lives only on the author machine, so a fresh
clone may not have a catalogue yet". That was correct while the catalogue was
gitignored. It is now **tracked**, so absence means a defect, and the skill says
so and stops instead of reporting "no rules apply". This is an inverted
instruction, not a path swap.

`freeze-session` gained the front matter a new rule must carry, a pointer to
`pnpm docs:check`, and the instruction **not to invent a `verified:` key**.
`update-docs` now states plainly that two front-matter shapes coexist in `docs/`
and that converting one to the other is a deliberate change with its own commit,
never a side effect of editing a page.

## Eleven references pointed at nothing

Every reference into working memory was checked rather than mechanically
rewritten. Four named session folders that **no longer exist at all**
(`ses_001`, `ses_004`, `ses_005`, `ses_007`), and one named a convention file
that has never existed. Three were in published artifacts:

- **`@namzu/sandbox`** raised a runtime error telling an operator to "track
  progress in `vendor/namzu/docs.local/sessions/ses_004-...`" — a path not in
  the package, not in the repository, and not on the internet.
- **`@namzu/computer-use`**'s README linked to an adapter-pattern document under
  a directory present in no checkout.
- **`@namzu/cli`**'s README linked to a session folder on the code host that
  returns 404.

These are corrected, not repointed — repointing a dead link only moves it. Where
a session id still carries meaning it is kept as a name without a path claim.
`docs/sdk/runtime/replay.md` also linked under the wrong org.

A `patch` changeset covers the four publishable packages; the sandbox message is
the only runtime string affected and nothing asserts on it.

## Also

AGENTS.md stops describing pages as carrying a `surface` frontmatter field. It
appears on **none** of the 65 pages and never has — a declaration nothing
drives, which is a rule this repository now publishes. Caught by `readme-author`.
`update-docs` had it right all along.

## Verification

- Hook behaviour: the six scenarios above, in a throwaway git repository with
  real staging and real mtimes.
- `node scripts/audit-external-names.mjs` — clean, exit 0.
- `node tools/check-docs.mjs` — 0 problems, exit 0.
- `pnpm typecheck` / `lint` / `test` still cannot run in this worktree (no
  `node_modules`, install needs approval). This PR **does** touch TypeScript,
  unlike the last one — comments in four `@namzu/sdk` files, two `@namzu/cli`
  files, and one string literal in `@namzu/sandbox`. I grepped for assertions on
  that string and found none, but that is my reasoning; **please read the Build
  & Test verdict**, which is the actual execution.

## Not in this PR

The legacy park (`docs/legacy/` for the zero-violation material, `.work/parked/`
for the nine) is next, and it is a move rather than a migration. The physical
rename of `docs.local/` → `.work/` on a working checkout is a local `mv` that
has to be done when no agent is mid-write; the hooks tolerate either order,
which is why this can merge first.
