### PR TITLE
test(cli): a budget sized for what the tests actually do

### DIFF
--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,53 @@
+import { defineConfig } from 'vitest/config'
+
+/**
+ * This suite is integration-shaped, and vitest's default 5000ms `testTimeout`
+ * is a unit-test default. That mismatch is the whole content of this file.
+ *
+ * Every other package here carries a `vitest.config.ts`; the CLI, whose tests
+ * drive real command handlers and real sessions across the widest module graph
+ * in the repository, carried none and inherited the defaults.
+ *
+ * ## What that cost, measured
+ *
+ * Four tests boot the CLI + SDK graph with a dynamic `import()` inside the test
+ * body, so the module load is billed to the per-test budget. Under the full
+ * 44-file parallel run on Windows they land at:
+ *
+ *   headless-trust-gate      refuses, and does not open a session in it   5217ms
+ *   deferred-tool-discovery  the session offers it and a sub-agent does not 5387ms
+ *   mcp-servers-reach-…      is in the tool roster the session hands the model 5163ms
+ *   permission-rules-reach-… reaches the gate of the turn that enforces it 5139ms
+ *
+ * All four straddle the 5000ms line. That is why the failure COUNT varied
+ * between runs of the same commit — the suite was not flaky in the usual sense,
+ * it was four tests sitting within 400ms of a cliff, and how many fell depended
+ * on how the workers happened to contend.
+ *
+ * The follow-on damage made it read as two more unrelated defects. A test vitest
+ * abandons at the timeout keeps running: its handles were still open on the temp
+ * directory when `afterEach` removed it, which surfaced as `EBUSY: resource busy
+ * or locked, rmdir`, and the aborted test's successor then asserted against state
+ * its predecessor never finished writing (`expected undefined to deeply equal`).
+ * Both vanish when nothing is abandoned; neither was a Windows filesystem bug.
+ *
+ * ## Why widening the budget is the fix rather than a cover-up
+ *
+ * The 5 seconds are spent in vite transforming TypeScript source. A shipped CLI
+ * runs compiled `dist/`, so production never pays this cost and there is no
+ * product defect behind these numbers. Nothing under `src/` needed to change.
+ *
+ * 15s is ~3x the measured worst case: enough headroom for a more loaded machine,
+ * and still short enough to fail a genuine hang rather than let CI sit on it. It
+ * stays below the deliberate 20s/40s budgets in `integrations/mcp/connect.test.ts`,
+ * so those keep reading as "longer on purpose" rather than merging into the floor.
+ *
+ * CI runs ubuntu-latest only, where the transform is fast enough that all four
+ * pass. This was therefore invisible to the gate and visible only to a
+ * contributor on Windows.
+ */
+export default defineConfig({
+	test: {
+		testTimeout: 15_000,
+	},
+})


### PR DESCRIPTION
Three CLI tests failed on Windows and nobody owned them. They were called pre-existing and load-sensitive, and the evidence for that was a failure **count** that changed between runs of the same commit — which points at the harness, but only as a hypothesis. It stayed open until measured.

## What the measurement says

The hypothesis was wrong in its mechanism and right in its conclusion.

Four tests dynamic-`import()` the CLI + SDK graph **inside the test body**, so vite's transform of that graph is billed to the per-test budget. Under the full 44-file parallel run they land at:

| test | duration |
|---|---|
| `headless-trust-gate` › refuses, and does not open a session in it | 5217ms |
| `deferred-tool-discovery` › the session offers it and a sub-agent does not | 5387ms |
| `mcp-servers-reach-the-session` › is in the tool roster the session hands the model | 5163ms |
| `permission-rules-reach-the-turn` › reaches the gate of the turn that has to enforce it | 5139ms |

Against vitest's default `testTimeout` of **5000ms**.

Nothing is racing anything. Four tests sit within 400ms of a cliff, and how many fall depends on how the workers happen to contend — which is precisely a count that varies across identical commits. It also means the fourth test, which has never been reported failing, is one bad moment away from it.

## Two symptoms that looked like separate defects

Both are downstream of the first. A test vitest abandons at the timeout keeps running:

- its handles were still open on the temp directory when `afterEach` removed it → `EBUSY: resource busy or locked, rmdir`
- the aborted test's successor then asserted against state its predecessor never finished writing → `expected undefined to deeply equal [...]`

Both vanish when nothing is abandoned. Neither was a Windows filesystem bug.

## Harness defect, not a product defect — and that is checkable

The five seconds are spent in **vite transforming TypeScript source**. A shipped CLI runs compiled `dist/`, so production never pays this cost. Nothing under `src/` needed to change.

## The fix

`packages/cli` was the only package in the workspace with **no `vitest.config.ts`**, so it inherited a unit-test default for a suite that drives real command handlers across the widest module graph in the repo. It gets one.

`15s` is ~3x the measured worst case — enough headroom for a more loaded machine, still short enough to fail a genuine hang. It stays below the deliberate 20s/40s budgets in `integrations/mcp/connect.test.ts`, so those keep reading as "longer on purpose" rather than merging into the floor.

## Verification

Mutation-checked rather than trusted to a green run: at `testTimeout: 1` the suite fails with `Test timed out in 1ms`, proving the config is actually read and not passing on a quiet machine. Restored, the full suite is **44 files, 417 passed, 4 skipped, 0 failed, no EBUSY**.

`pnpm typecheck`, `pnpm lint`, `pnpm test` all green; `audit-external-names.mjs` and `tools/check-docs.mjs` both clean.

## No changeset

`@namzu/cli` ships `files: ["dist", "README.md"]`. This file is not published and no consumer-visible behaviour changes, so there is no bump intent to declare.

## Note on the gate

CI runs `ubuntu-latest` only, where the transform is fast enough that all four pass. That is why this was invisible to CI and visible only to a contributor on Windows.