### PR TITLE
docs: there is no documentation site, so stop saying there is

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,17 +483,19 @@ protocol.
 
 ## Next
 
-- [`docs/`](./docs/) — the published documentation, including
+- [`docs/`](./docs/) — the longer-form documentation, including
   [getting started](./docs/getting-started.md), the
   [SDK guide](./docs/sdk/), the [CLI guide](./docs/cli/) and
-  [driver notes](./docs/providers/).
+  [driver notes](./docs/providers/). Read it here in the repository: there is
+  no documentation site yet.
 - [`packages/sdk/README.md`](./packages/sdk/README.md) — the kernel's
   subsystem map.
 - `AGENTS.md` — the working contract any coding agent in this repository
   follows.
 
-Some pages under `docs/` predate recent kernel changes. Where a page and the
-code disagree, the code is correct; please open an issue.
+Some pages under `docs/` predate recent kernel changes, and an audit of them is
+partly done rather than finished. Where a page and the code disagree, the code
+is correct; please open an issue.
 
 ## Status
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,16 @@
 ---
 title: Namzu Documentation
-description: Entry point for the published Namzu docs covering the SDK, computer-use package, and provider packages.
-last_updated: 2026-04-18
+description: Entry point for the Namzu documentation covering the SDK, computer-use package, and provider packages.
+last_updated: 2026-08-07
 status: current
 related_packages: ["@namzu/sdk", "@namzu/computer-use", "@namzu/openai", "@namzu/anthropic", "@namzu/bedrock", "@namzu/openrouter", "@namzu/http", "@namzu/ollama", "@namzu/lmstudio"]
 ---
 
 # Namzu Documentation
 
-This directory is the publishable documentation surface for Namzu. It is written for direct use on `docs.namzu.ai`, covers only packages that are currently shipped, and intentionally excludes local-only or ignored workspace content.
+This directory is the publishable documentation surface for Namzu. It covers only packages that are currently shipped, and intentionally excludes local-only or ignored workspace content.
+
+**There is no documentation site today.** Nothing in this repository builds or deploys these pages — no generator, no site config, no deploy workflow — so this directory is read in the repository, and the `meta.json` ordering files are inert until something is stood up to read them.
 
 ## 1. Start Here
 


### PR DESCRIPTION
Two pages claimed a documentation site that does not exist. One of them was
mine.

## The claim

- `docs/README.md:11` — pages are *"written for direct use on
  `docs.namzu.ai`"*
- `README.md:486` — `docs/` is *"the published documentation"*

## Verified before changing a word

- No generator config of any kind: no `source.config.ts`, `mkdocs.yml`,
  `docusaurus.config.js`, `docs/package.json`.
- No `packages/docs`.
- Three workflows — `ci`, `release`, `sandbox-smoke` — none of which builds or
  deploys a page.
- `docs.namzu.ai` occurs in prose about the project and nowhere else.
- The `meta.json` ordering files are inert; nothing in the repository parses
  them.

A claim about the world with no artifact behind it, on the two pages a reader
reaches first. That is the defect class this repository refuses on principle.

## The root README line was mine

Written four changes ago, in the same pass where I was auditing exactly this
kind of unbacked deployment claim out of other people's prose. Worth saying
plainly rather than fixing quietly.

## What both now say

The pages are read in the repository, and the ordering files stay inert until
something is stood up to read them.

Also tempered the caveat under `Next`: it said some pages predate recent kernel
changes, and now also says the audit of them is **partly done rather than
finished** — several areas were never reached, and letting "no findings" read
as "clean" would be the same defect in a quieter register.

## Deliberately not in this PR

`AGENTS.md:52` carries the stronger form of the same claim — "published to
`docs.namzu.ai`". It is policy rather than documentation, it is already being
edited in #206, and it is not this change's to rewrite. Raised with that PR's
author instead.

## Checks

`audit-external-names` 0 · `lint` 0 · `tools/check-docs.mjs` 0 (the edited file
is among the 65 not yet migrated to the standard, so the new frontmatter shape
does not apply to it yet).

Confirmed #206's file list does not include `docs/README.md` — no collision.
