### PR TITLE
docs: record the owner's ruling in the file that enforces it

### DIFF
--- a/scripts/audit-external-names.mjs
+++ b/scripts/audit-external-names.mjs
@@ -300,12 +300,17 @@ const all = []
 // analysis has to say what it compared against.
 //
 // That exemption is a property of being UNTRACKED, not of the directory's
-// name, and it is the reason those documents stay untracked. When the
-// documentation tree moved to `docs/`, nine of them were measured against
-// this rule and produced 87 findings between them; the ruling was that no
-// third-party name enters tracked prose, so they were parked in `.work/`
-// rather than published, redacted, or exempted. Adding a path exemption
-// here would reverse that decision silently — do not.
+// name. When the documentation tree moved to `docs/`, nine of those documents
+// were measured against this rule and produced 87 findings between them, so
+// they stayed in `.work/` rather than moving with the rest.
+//
+// Whether they should EVER enter tracked prose is an open question with the
+// owner, not a settled one, and it is commercial rather than technical: the
+// choice is between publishing competitor names in a repository whose whole
+// rule is that they do not appear, redacting documents whose value is the
+// comparison, and leaving them untracked. Until that is decided, adding a
+// path exemption here would settle it silently and in the least visible
+// place available — so do not. Bring the question up instead.
 for (const entry of await readdir(ROOT, { withFileTypes: true })) {
 	if (!entry.isFile() || !entry.name.endsWith('.md')) continue
 	all.push(...findings(await readFile(join(ROOT, entry.name), 'utf-8'), entry.name))

--- a/scripts/audit-external-names.mjs
+++ b/scripts/audit-external-names.mjs
@@ -304,13 +304,12 @@ const all = []
 // were measured against this rule and produced 87 findings between them, so
 // they stayed in `.work/` rather than moving with the rest.
 //
-// Whether they should EVER enter tracked prose is an open question with the
-// owner, not a settled one, and it is commercial rather than technical: the
-// choice is between publishing competitor names in a repository whose whole
-// rule is that they do not appear, redacting documents whose value is the
-// comparison, and leaving them untracked. Until that is decided, adding a
-// path exemption here would settle it silently and in the least visible
-// place available — so do not. Bring the question up instead.
+// Whether they could instead move into `docs/` under a path exemption was put
+// to the owner, who ruled that no third-party brand name appears in tracked
+// prose. That ruling is settled, and it is the owner's to revisit — not a
+// default, not a convention, and not something to reopen from inside this
+// file. Adding a path exemption here would reverse an owner decision in the
+// least visible place available. Do not; raise it instead.
 for (const entry of await readdir(ROOT, { withFileTypes: true })) {
 	if (!entry.isFile() || !entry.name.endsWith('.md')) continue
 	all.push(...findings(await readFile(join(ROOT, entry.name), 'utf-8'), entry.name))


### PR DESCRIPTION
Two commits, and the second reverses the first's conclusion while keeping its
improvements. That is deliberate — see below.

## What this ends up saying

The external-name audit's comment records why the nine parked documents stay in
`.work/` rather than moving into `docs/` with the rest of the documentation
tree. It now states:

- **The measured facts.** Nine documents were checked against the rule and
  produced 87 findings between them, so they stayed where they were.
- **The ruling, and whose it is.** Moving them under a path exemption was put to
  the owner, who ruled that no third-party brand name appears in tracked prose.
  That ruling is settled and the owner's to revisit.
- **What to do about it.** Adding a path exemption in this file would reverse an
  owner decision in the least visible place available. Raise it instead.

It does **not** paraphrase the owner's reasoning. Stating the rule and that it
was given is enough to obey it; summarising why someone decided something is
how a record acquires claims nobody made.

## Why two commits instead of one clean one

The first commit removed the ruling, on my conclusion that no such ruling
existed and that I had inferred one from a coordination message. I was wrong —
the ruling is real, it came from the owner, and the original comment was right
to record it. What actually happened is that I was told the question was open,
told later that it was decided, and weighted the earlier statement when
re-reading during a rebase.

The second commit restores it. I stacked rather than squashed on purpose: **a
pull request about not asserting things the record does not support is the last
place to quietly rewrite the record.** The history should show that this went
wrong in both directions, because the useful lesson is not "the ruling exists"
but that a settled decision and an open question look identical in a source
comment unless the comment says which it is.

Both errors are the same defect pointed opposite ways, and the second was worse:
"undecided" invites a reader to decide it, and it had already been decided.

## The process change worth taking from it

When a ruling matters enough to write into an enforcement file, confirm it is
current *before* it lands rather than after. A comment in a gate is not
documentation of a decision — it is the thing a future engineer will treat as
the decision, in the exact file where they would go to change it.

## Verification

Comment only, no behaviour change.

- `node scripts/audit-external-names.mjs` — clean, exit 0.
- `node tools/check-docs.mjs` — 0 problems, exit 0.
- English-only checked mechanically: the edited file contains no non-ASCII
  characters beyond the em-dash already used throughout it, and no brand name.
