### PR TITLE
docs: the name audit has two exemptions, and the README claimed one

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,9 +477,11 @@ every source folder is explicitly classified for test presence; a
 separate process, because an in-process test cannot prove a run survives on
 its own event-loop footprint; a **consumer-install check** that catches
 peer-range drift before a publish rather than at the registry; package-manifest
-validation; and an audit that refuses third-party product names in prose and
-identifiers, exempting only the paths whose job is to speak somebody else's
-protocol.
+validation; and an audit that refuses a list of third-party product names in
+prose and identifiers, exempting the paths and the published vocabulary whose
+job is to speak somebody else's protocol — a driver package has to name the
+service it drives, and a page telling an operator what namzu connects to has
+to name it too.
 
 ## Next
 


### PR DESCRIPTION
The honesty section said the name audit refuses third-party product names `exempting only the paths whose job is to speak somebody else's protocol`.

There are **two** exemptions, not one. `scripts/audit-external-names.mjs` exempts wire-value **paths** — a driver package, a model-id table, an error classifier — and separately exempts a **vocabulary** in published markdown: the services namzu ships a driver for may be named in prose, on the script's own stated grounds that a catalogue refusing to say what it connects to is useless to whoever is deciding whether to install it.

A reader who took the sentence literally, then grepped and found a service named in a docs page, would conclude the gate is weaker than advertised. It is not weaker — the sentence was narrower than the mechanism.

Imprecise rather than false, and small. Worth fixing anyway: it is a claim about a gate, sitting on the page whose whole argument is that claims should be checkable. The replacement also says what the exemptions are **for**, which is the part a reader can actually use.

Found while verifying a peer's report about a *different* page — by re-reading my own merged prose rather than the file the report was about. Second time this session that checking someone else's finding surfaced one of mine.

`audit-external-names` 0 · `lint` 0 · `tools/check-docs.mjs` 0.