### PR TITLE
docs(sdk): a retraction two pages cited while contradicting

### DIFF
--- a/docs/sdk/runtime/identities.md
+++ b/docs/sdk/runtime/identities.md
@@ -1,7 +1,7 @@
 ---
 title: Run Identities
 description: Required IDs for agent runs in @namzu/sdk, how to generate them, and how to decide when to reuse or rotate them.
-last_updated: 2026-04-21
+last_updated: 2026-08-07
 status: current
 related_packages: ["@namzu/sdk"]
 ---
@@ -18,7 +18,7 @@ For `ReactiveAgent.run()` and the kernel spawn path, four fields matter most:
 | --- | --- | --- |
 | `tenantId` | Isolation boundary between organizations, users, or workspaces | Reused across all work for the same tenant |
 | `projectId` | Long-lived folder-bound goal scope | Reused across many threads, sessions, and runs |
-| `threadId` | Topic- or objective-level container; A2A-connection surface | Reused across many sessions for one line-of-work |
+| `threadId` | Topic- or objective-level grouping key | Reused across many sessions for one line-of-work |
 | `sessionId` | One immediate working session inside a thread | Reused across one interactive session or task burst |
 
 If any of these is missing, the runtime throws before starting the run.
@@ -29,7 +29,7 @@ These IDs drive real behavior:
 
 - `tenantId` protects isolation boundaries
 - `projectId` gives the runtime a durable project scope, bound to a folder in local mode
-- `threadId` is the scope an A2A connection attaches to (see [A2A Threading](../sessions/a2a-threading.md))
+- `threadId` groups many sessions under one line-of-work. It is **not** what an A2A connection attaches to — that is `projectId` (see [A2A Context](../sessions/a2a-threading.md))
 - `sessionId` groups immediate run activity under one active session
 
 Without them, state and persistence would collapse into anonymous runs, which breaks the hierarchy-aware architecture.
@@ -130,14 +130,20 @@ const result = await agent.run(
 )
 ```
 
-## 7. Why Thread, Not Just Project
+## 7. What Thread Is For
 
-A Thread layer is not universal, and its absence is easy to miss: a runtime without one collapses Project and Thread into a single identity. Namzu separates them because the **Thread is where A2A connections attach**:
+A Thread layer is not universal: a runtime without one collapses Project and Thread into a single identity.
 
-- **Project** is folder-bound. Shared as a folder or workspace URL.
-- **Thread** is path-independent. Shared as a topic surface that external agents can join without seeing every Thread in the Project.
+This section used to say Namzu separates them because "the Thread is where A2A connections attach", and cited [A2A Context](../sessions/a2a-threading.md) as the rationale. **That page retracts exactly that claim.** The A2A bridge binds to `project_id` in both directions and has never referenced a Thread — pinned by `bridge/a2a/__tests__/project-is-the-a2a-context.test.ts`. A page cannot cite as its authority a document that contradicts it, so the justification is withdrawn rather than reworded.
 
-See [A2A Threading](../sessions/a2a-threading.md) for the full rationale. If your application has no A2A component today, a "default" Thread per Project works fine as a formality — but the layer is there when you need it.
+What remains true is smaller and worth stating plainly:
+
+- **Project** is folder-bound, and it is the A2A sharing boundary. A peer holding a `contextId` holds a Project.
+- **Thread** is a path-independent grouping key over sessions. It owns no message stream, no status, no participant set and no directory of its own.
+
+So use `threadId` when you want to group sessions by topic or objective and query them back. Do not reach for it as an isolation or sharing boundary — it is not one. If one peer should see part of a workspace and not the rest, give it a separate Project.
+
+The layer's future is under discussion; see section 4 of [A2A Context](../sessions/a2a-threading.md). Nothing has been deprecated, and a "default" thread per project remains fine.
 
 ## 8. Common Mistakes
 
@@ -146,7 +152,8 @@ See [A2A Threading](../sessions/a2a-threading.md) for the full rationale. If you
 | generating a new `projectId` on every single message | breaks long-lived project grouping |
 | reusing one `sessionId` forever | collapses separate active sessions into one lineage |
 | using one `tenantId` for every user or customer | removes meaningful isolation boundaries |
-| treating `threadId` as disposable or optional | loses the topic-level continuity that A2A and hand-off rely on |
+| treating `threadId` as disposable or optional | loses the topic-level grouping you would otherwise query back |
+| expecting `threadId` to scope what an A2A peer can see | it does not — `projectId` is the A2A boundary |
 | hardcoding raw strings without validation | makes ID drift and debugging harder |
 
 ## 9. App-Level Recommendation
@@ -163,7 +170,7 @@ Only use generator helpers when you do not already have a durable identity model
 ## Related
 
 - [SDK Quickstart](../quickstart.md)
-- [A2A Threading](../sessions/a2a-threading.md)
+- [A2A Context](../sessions/a2a-threading.md)
 - [Run Configuration](./configuration.md)
 - [Provider Registry](../provider-integration/registry.md)
 - [ID Utilities Source](https://github.com/cogitave/namzu/blob/main/packages/sdk/src/utils/id.ts)

--- a/docs/sdk/sessions/README.md
+++ b/docs/sdk/sessions/README.md
@@ -1,7 +1,7 @@
 ---
 title: Sessions, Threads, Workspaces, and Retention
 description: Understand the project-thread-session-subsession-run hierarchy, session stores, workspaces, handoff, and archival surfaces exposed by @namzu/sdk.
-last_updated: 2026-04-21
+last_updated: 2026-08-07
 status: current
 related_packages: ["@namzu/sdk"]
 ---
@@ -25,7 +25,7 @@ Each level solves a different problem:
 | Entity | Role |
 | --- | --- |
 | `Project` | Folder-bound long-lived scope for shared limits, knowledge bases, memory, and retention policy. Shared between collaborators. |
-| `Thread` | Topic- or objective-level container inside a Project. Path-independent. The layer that A2A connections attach to. See [A2A Threading](./a2a-threading.md). |
+| `Thread` | Topic- or objective-level grouping key inside a Project. Path-independent. Owns no message stream, status or policy of its own. Not the A2A boundary — see [A2A Context](./a2a-threading.md). |
 | `Session` | Active work unit owned by one actor at a time, under a Thread. |
 | `SubSession` | A Session spawned by another Session's agent via delegation. Structurally just a Session with `parentSessionId` set. |
 | `Run` | One atomic agent invocation under a Session — bounded iterations, terminal status. |
@@ -34,7 +34,7 @@ Three identity rules are important:
 
 - `tenantId` is the isolation boundary
 - `projectId` is the long-lived goal scope (folder-bound in local mode)
-- `threadId` is the topic-level A2A-connection surface
+- `threadId` is the topic-level grouping key over sessions (the A2A boundary is `projectId`)
 - `sessionId` is the concrete execution or collaboration unit
 
 ## 2. Start with a Session Store
@@ -195,12 +195,12 @@ The design intent is important:
 | treating `sessionId` as a disposable run ID | sessions are durable lifecycle objects, not just one provider call |
 | deleting a session that still has attached sub-sessions | the store rejects this; callers must clean up children first |
 | assuming tenant isolation is implied by file paths | tenant checks are explicit and enforced in the store contracts |
-| skipping the Thread layer and creating Sessions directly under a Project | Threads are where A2A connections attach; skipping them gives up enterprise-sharing semantics |
+| expecting the Thread layer to scope what an A2A peer can see | it does not; `projectId` is the A2A boundary, and a peer holding a context holds the whole Project |
 | binding workspace lifetime directly to every session by default | the SDK keeps workspace provisioning explicit and separate |
 
 ## Related
 
-- [A2A Threading](./a2a-threading.md) — how enterprise project sharing and thread-level A2A connection work together
+- [A2A Context](./a2a-threading.md) — the A2A `contextId` is a Project, and what that means for what a peer can reach
 - [Run Identities](../runtime/identities.md)
 - [Agents and Orchestration](../agents/README.md)
 - [Low-Level Runtime](../runtime/low-level.md)

--- a/docs/sdk/sessions/a2a-threading.md
+++ b/docs/sdk/sessions/a2a-threading.md
@@ -1,7 +1,7 @@
 ---
 title: A2A Context
 description: A2A's contextId is a Project. What this page used to say, why it was wrong, and what to do instead.
-last_updated: 2026-08-06
+last_updated: 2026-08-07
 status: current
 related_packages: ["@namzu/sdk"]
 ---
@@ -42,20 +42,35 @@ Archival is namzu's context-expiry policy, and it is surfaced as an explicit rej
 
 > **Being fixed separately, and worth knowing now.** Archival stops new sessions and does not stop runs already under way: `runtime/query` never consults the session store, so nothing marks a session active and the archival guard reads a field nobody maintains. Until that lands, read "archived" as "no new work admitted", not as "everything has stopped".
 
-## 4. Thread is being removed
+## 4. Thread's removal is proposed, not underway
 
-The Thread layer is scheduled for removal. It owns no message stream, no derived status, no participant set, no policy, and no segment of the on-disk layout (`projects/{prj}/sessions/{ses}/runs/{run}`) — and its one stated justification is the A2A claim this page has just retracted.
+**Thread is live. Nothing about it has been removed or deprecated.** `runAgent`
+mints a `thd_` id on every run it is not given one for
+(`agents/runAgent.ts:193`), `ThreadId` is an exported branded type, and no
+declaration on the Thread surface carries an `@deprecated` tag. If you are
+reading this to find out what shipped, the answer is: the layer is exactly where
+it was.
 
-| If you were using | Use instead |
+What follows is a **proposal** and the argument for it, recorded here so the next
+reader does not have to reconstruct it. It is not a migration in progress and
+nothing has been staged.
+
+The case for removing it: the layer owns no message stream, no derived status, no participant set, no policy, and no segment of the on-disk layout (`projects/{prj}/sessions/{ses}/runs/{run}`) — and its one stated justification is the A2A claim this page has just retracted.
+
+If it were carried out, the replacements would be these. Read the right-hand
+column as "what to prefer in new code", not as "what you must migrate to" —
+nothing on the left has been withdrawn:
+
+| Rather than building new work on | Prefer |
 | --- | --- |
 | `ThreadId` as an A2A attach point | `ProjectId` — which is what the bridge already used |
 | `ThreadManager.archive` for context expiry | Project-scoped archival |
 | `listSessions(threadId, …)` | `listSessionsByProject`, plus a `threadId` filter |
 | `Thread` as a grouping label | `Session.threadId`, which survives as an optional **queryable** grouping key |
 
-`ThreadId` itself is not going away. It stays as an optional branded key on `Session` with a filter on listing — grouping without an entity, which is the shape other harnesses use for the same job. What goes is the container, the store, the manager, and the lifecycle.
+Under the proposal `ThreadId` itself would not go away. It would stay as an optional branded key on `Session` with a filter on listing — grouping without an entity, which is the shape other harnesses use for the same job. What would go is the container, the store, the manager, and the lifecycle.
 
-The removal is staged: deprecations with named replacements first, the removal in the next major. Nothing here requires action today beyond not building anything new on `Thread`.
+Were it adopted, it would be staged: deprecations with named replacements first, the removal in a later major. **None of that has begun** — there is no deprecation on any Thread declaration today. Nothing here requires action beyond not building anything new on `Thread`.
 
 ## Related
 


### PR DESCRIPTION
docs(sdk): a retraction two pages cited while contradicting

`sessions/a2a-threading.md` retracts the claim that A2A attaches at the Thread
level. Two other pages assert that same claim and link to the retraction as
their authority for it.

## The false claim, and where it was

Established at source before editing. `bridge/a2a/task.ts:60` emits
`contextId: run.project_id ?? undefined` and `:103` reads it back as
`projectId: params.contextId`. Both directions bind the Project. `ThreadId`
occurs exactly once anywhere in the bridge — in
`bridge/a2a/__tests__/project-is-the-a2a-context.test.ts:14`, in a comment
asserting that it appears nowhere.

- `runtime/identities.md` §7 was titled "Why Thread, Not Just Project" and said
  Namzu separates them "because the **Thread is where A2A connections attach**",
  then pointed at the retraction "for the full rationale". The section's whole
  justification was the retracted sentence. It also carried the claim in the ID
  table (`A2A-connection surface`), in §2, and in the mistakes table.
- `sessions/README.md` called Thread "the layer that A2A connections attach to"
  in the entity table, repeated it in the identity rules, and listed "skipping
  the Thread layer" as a mistake that "gives up enterprise-sharing semantics".

Rewritten against the code rather than softened: `projectId` is the A2A
boundary, `threadId` is a grouping key over sessions and not an isolation or
sharing boundary. The mistakes tables now carry the inverse warning, because the
belief this page created is one a reader will arrive with.

## The second defect: intent written as state

Section 4 was headed "Thread is being removed" and said "The removal is staged:
deprecations with named replacements first, the removal in the next major."

None of that has happened, and the page gave a reader no way to tell:

- `runAgent.ts:193` mints `generateThreadId()` on every run not given one.
- `ThreadId` is a live exported branded type, `` `thd_${string}` ``.
- **No declaration on the Thread surface carries an `@deprecated` tag.** The
  first stage the page describes as already underway has not started.

So the section now says what it is — a proposal, with the argument recorded so
the next reader need not reconstruct it — and states up front that Thread is
live and nothing has been deprecated. The migration table's header changed from
"If you were using / Use instead", which reads as a completed deprecation, to
"Rather than building new work on / Prefer".

A plan stated as a fact is how a reader ends up migrating off something that
never moved. The distinction is the whole point of the edit.

No code changed. Frontmatter `last_updated` bumped on all three pages.
