### PR TITLE
docs: the front page named a command that was just removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,8 +271,9 @@ npx @namzu/cli
 Bare `namzu` opens an interactive terminal agent. The same binary is
 scriptable: `namzu run` for a single headless prompt, `namzu run-stream` for
 newline-delimited events a host UI can consume, `namzu history`,
-`namzu providers`, `namzu doctor`, and `namzu eval`. Run `namzu --help` for
-the current list.
+`namzu doctor`, `namzu skills`, and `namzu eval`, plus `namzu providers-json`
+and `namzu skills-json` for a host UI that wants the rosters as JSON. Run
+`namzu --help` for the current list.
 
 Three things it does on the way in are worth knowing, because they are the
 difference between a toy and something you point at a real repository:


### PR DESCRIPTION
docs: the front page named a command that was just removed

#211 deleted `namzu providers`. The root README went on listing it among the
scriptable commands, so the npm and repository landing page was telling readers
to run something that now errors.

Mine, and worth recording how it got through. The removal PR grepped `docs/`
and both READMEs for `providers add`, `providers ls` and `providers.json` and
found nothing — which was true, and not the same question. The stale reference
was the bare command name in a prose sentence, and nothing I searched for would
have matched it. A removal has to grep for the command name itself, not only for
the subcommands and files that made it recognisable.

Corrected against the registered set rather than by deletion: `doctor`, `eval`,
`history`, `run`, `run-stream`, `serve`, `skills`, `skills-json` and
`providers-json`. `providers-json` survives #211 and is a different command, so
it is named explicitly alongside `skills-json` rather than dropped — which is
where a reader looking for the removed one will now land.
