### PR TITLE
docs: what the folder page was missing, and a blind spot in the gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,8 +56,12 @@ This file is a **router**, not a rulebook. Detail lives in the folders below; re
     Skill: `update-docs`.
   </published_docs>
 
-  <legacy path="docs/legacy/">
-    Superseded design notes and frozen session records, moved rather than rewritten. Carries the minimum front matter the gate requires and **no `verified:` key**, which marks it unverified — nobody has re-checked it against the code, and nobody is going to. Read it as history, never as a current claim.
+  <legacy path="(deliberately does not exist)">
+    **There is no `docs/legacy/`, and its absence is a decision.** Frozen sessions and superseded design notes stay whole and untracked in `.work/`.
+
+    The plan was to group them under `docs/legacy/`. Measuring them ended it: the owner ruled that no third-party brand name appears in tracked prose, and under that ruling not one frozen session can move without leaving files behind. In every case the blocked files are the `README.md` and the `progress.md` — the ones that give the rest its meaning. Moving the remainder would produce anonymous fragments in a bin, which is the outcome the exercise existed to avoid.
+
+    An empty `docs/legacy/` would be worse than none: a directory that exists to hold the old material, holding nothing, reads as "there is no old material" rather than "the old material could not come". So do not create it. The naming ruling is the owner's to revisit, and this follows from it.
   </legacy>
 
   <runtime_state path=".namzu/">

--- a/docs/sdk/directory/agent-as-a-directory.md
+++ b/docs/sdk/directory/agent-as-a-directory.md
@@ -97,6 +97,41 @@ A manifest loaded this way cannot be derived into run options.
 `deriveRunOptions` throws rather than producing an agent with no capabilities
 and no indication why.
 
+### An import that runs long is not an import that stopped
+
+Each module gets `moduleTimeoutMs` (default 10s), and that deadline bounds
+**the loader, not the module**. `import()` cannot be cancelled, so a file whose
+outcome is `'abandoned'` is still executing: it may still finish, and its
+top-level side effects may land after `loadDirectory` has already returned. The
+runtime then caches the module, so a second load in the same process can see the
+same file succeed instantly.
+
+That is why `'abandoned'` is a distinct outcome from `'failed'`. "We stopped
+waiting" and "it did not work" send a reader to different places.
+
+### A diagnostic's `cause` is not sanitised
+
+The loader never reads file *contents* into a diagnostic. But `cause` carries
+whatever the runtime reported or the authored module threw, and is exactly as
+trustworthy as that module — `throw new Error(secret)` puts that secret there.
+Treat `cause` as untrusted when you log or surface it.
+
+### Loading only part of a folder
+
+`include` narrows the load to the slots you name, and `ALL_SLOTS` is the full
+list. It is an allow-list, and the type makes an empty array unrepresentable on
+purpose: an allow-list that admits everything when empty is a fail-open shape,
+so here an empty list would scan nothing.
+
+Remember that `ok` is scoped to what you included.
+
+### When the runtime cannot import the project
+
+`importModule` replaces the import for a project whose syntax the runtime's own
+type stripping cannot read — enums, decorators, path aliases. The host passes
+its own importer, which keeps a bundler dependency out of this tree. It is
+ignored under `modules: 'skip'`, where nothing is imported at all.
+
 ## Nothing is silently dropped
 
 Every refusal comes back as a diagnostic naming its file and reason, at
@@ -154,6 +189,15 @@ const instructions = assembleSystemPrompt(persona)
 A folder under `agents/` is a delegate with the same shape. Use
 `deriveSupervisorOptions` instead of `deriveRunOptions` for that case; it throws
 if the project declares no delegates, since there is nothing to coordinate.
+
+It returns `{ config, delegates }`, and **the delegates come back as plans, not
+registrations**. Registering them mutates your `AgentManager`, and a function
+that quietly mutates an object it was handed for reference is the surprise this
+package exists to avoid — so you do it, in one loop you can see.
+
+The `AgentManager` is yours and is never built here. A manager owns running
+processes, budgets and cancellation; handing back options carrying one this
+package constructed would make a loader into a runner.
 
 A delegate may name its own model — a cheap one for a narrow job is the common
 case — and inherits the supervisor's only when it does not. Inheriting

--- a/tools/check-docs.mjs
+++ b/tools/check-docs.mjs
@@ -156,6 +156,18 @@ const fail = (...lines) => {
 // format -- they describe a directory rather than a concept, so they carry no
 // concept front matter. `README.md` is the same role under a name the code
 // host renders.
+//
+// THIS IS A BLIND SPOT WITH A NAME, so know it is here: a directory whose only
+// page is called `README.md` can sit in `CONFORMING` while nothing in it is
+// ever read. It would report as migrated and be checked by nobody -- decoration
+// in the one place decoration is most dangerous, since the gate's whole value
+// is that "conforming" means something. A near-miss, not a hypothetical: a page
+// was very nearly authored under that name, and the author found it only by
+// mutating `resource:` and watching the gate stay green.
+//
+// The guard is below: an entry that contributes zero checked files fails. That
+// keeps the skip correct for genuine listings while making an empty entry
+// impossible to add by accident.
 const isListing = (path) => /\/(index|log|README)\.md$/.test(path)
 
 // DRIFT cannot be established without history. Refuse rather than pass.
@@ -169,10 +181,15 @@ try {
 
 const uids = new Map()
 
+/** Files this run actually opened and checked, per `CONFORMING` entry. */
+const checkedPerEntry = new Map()
+
 for (const dir of CONFORMING) {
+	checkedPerEntry.set(dir, 0)
 	for (const path of markdownUnder(join(root, dir))) {
 		const where = rel(path)
 		if (isListing(where)) continue
+		checkedPerEntry.set(dir, checkedPerEntry.get(dir) + 1)
 
 		const text = readFileSync(path, 'utf8')
 		const [meta, body] = parseFrontMatter(text)
@@ -241,12 +258,35 @@ if (shallow) {
 	)
 }
 
+// An entry that checked nothing is the failure mode named beside `isListing`:
+// it declares a directory migrated while the gate reads none of it.
+for (const [dir, count] of checkedPerEntry) {
+	if (count === 0) {
+		fail(
+			`EMPTY ${dir}: listed in CONFORMING, but no file in it was checked.`,
+			'      Every page under it is a reserved listing name (index/log/README),',
+			'      so the entry claims the directory is migrated and verifies nothing.',
+			'      Rename the page to its concept, or drop the entry.',
+		)
+	}
+}
+
 // The remainder is debt, and it is printed every run so it stays visible.
 const conforming = new Set()
 for (const dir of CONFORMING) for (const p of markdownUnder(join(root, dir))) conforming.add(rel(p))
 let outside = 0
 for (const p of markdownUnder(join(root, 'docs'))) if (!conforming.has(rel(p))) outside += 1
 
-console.log(`docs gate: ${problems} problem(s) across ${conforming.size} conforming file(s)`)
+// Checked and skipped are reported separately on purpose. A listing inside a
+// conforming directory is in scope and deliberately not read, so one combined
+// number would overstate what this run actually verified.
+let checked = 0
+for (const n of checkedPerEntry.values()) checked += n
+const listings = conforming.size - checked
+
+console.log(`docs gate: ${problems} problem(s) across ${checked} checked file(s)`)
+if (listings > 0) {
+	console.log(`           ${listings} listing(s) skipped by name (index/log/README)`)
+}
 console.log(`           ${outside} file(s) under docs/ not yet migrated to the standard`)
 process.exit(problems ? 1 : 0)


### PR DESCRIPTION
Fallout from #213 landing the folder page that #216 was also writing. **#216 is
closed**, with the comparison in its closing comment rather than a silent
abandon — #213 is the better page, and in one place mine was outright wrong
(it said `skills/` holds files; `load.ts` delegates to `loadSkill` precisely
because `Skill.dirPath` is required and a flat `skills/*.md` renders a path that
does not exist). This PR keeps only what #216 had that the merged page does not.

## Six additions to the folder page

- **`'abandoned'` is not `'failed'`.** `import()` cannot be cancelled, so a
  module that outran `moduleTimeoutMs` is still executing: it may still finish,
  its top-level side effects may land after `loadDirectory` returned, and the
  runtime then caches it so a second load can see it succeed instantly.
- **`cause` is not sanitised.** The loader never reads file contents into a
  diagnostic, but `cause` carries whatever the module threw and is exactly as
  trustworthy as that module.
- **`moduleTimeoutMs` bounds the loader, not the module.**
- **`importModule`** — the exit for a project whose syntax the runtime's own
  type stripping cannot read.
- **`include` / `ALL_SLOTS`** — an allow-list whose empty case is
  unrepresentable on purpose, because an allow-list that admits everything when
  empty is a fail-open shape.
- **`deriveSupervisorOptions` returns delegate *plans*, not registrations**,
  because registering mutates the host's `AgentManager` — which is the host's
  and is never built here.

## A blind spot in the docs gate

Found by the other agent, not by me, and worth stating plainly: `isListing`
skips every `README.md`, so a directory whose only page carried that name could
sit in `CONFORMING`, **report as migrated, and be read by nothing.** They nearly
shipped exactly that, and caught it only by mutating `resource:` and watching
the gate stay green.

That is decoration in the one place decoration is most dangerous — the gate's
entire value is that "conforming" means something.

The skip is correct for genuine listings, so removing it is the wrong fix. Two
changes instead:

- **An entry contributing zero checked files now fails**, with a message saying
  what happened and what to do. Verified it fires: a directory containing only a
  `README.md`, added to `CONFORMING`, turns the gate red.
- **The summary line stops conflating checked with in-scope.** It now reports
  files actually checked and skipped listings separately, because one combined
  number overstated what the run had verified. Today: 12 checked, 1 listing
  skipped, 65 unmigrated.

The comment above `isListing` names the trap, so the next person does not find
it by luck.

## `docs/legacy/` recorded as deliberately absent

The routing block I added in #206 promised a tree that will now never exist — a
declaration nothing drives, in the file that defines the rule against them. It
is replaced by the reason: under the owner's naming ruling not one frozen
session can move without leaving its `README.md` and `progress.md` behind, and
an empty directory would read as "there is no old material" rather than "the old
material could not come".

Worth surfacing because it is a conflict between two owner instructions rather
than a technical outcome: **the naming ruling emptied the "group everything old
under `docs/legacy/`" instruction.** The ruling is the stronger and more recent
so it wins, but the other instruction is unsatisfiable as written rather than
merely deferred.

## Deliberately not included

- **`verified:` on the folder page.** I re-established most of it against source
  while writing #216, but not the persona section, and `verified:` is a
  whole-document claim. An absent key correctly reads as unverified.
- **Single-file `CONFORMING` entries.** #216 added them so a new page could be
  gated among unmigrated siblings; #213 solved the same problem with a
  subdirectory, which is the better pattern. Keeping the capability with no
  caller would be the declared-but-undriven defect this repo publishes a rule
  about.

## Verification

- `node tools/check-docs.mjs` — 0 problems, exit 0; and red under the new EMPTY
  guard when a README-only directory is listed.
- `node scripts/audit-external-names.mjs` — clean, exit 0.
- No TypeScript touched: markdown and the stdlib-only gate script only.
