### PR TITLE
feat(cli): an installer that verifies the thing it installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,29 @@ jobs:
       - name: External-name audit
         run: node scripts/audit-external-names.mjs
 
+      # The installer is the one path with no fallback: it runs before namzu
+      # exists, on whatever shell the machine has, and a syntax error in it is
+      # discovered by the person who has nothing installed yet. Both shells
+      # parse it without executing.
+      #
+      # What this catches is SYNTAX, and the bound is worth stating because it
+      # is narrower than it looks: `dash -n` does NOT reject every bashism.
+      # `[[ -n "$x" ]]` parses cleanly under it, because `[[` is read as an
+      # ordinary command word and only fails at run time. Measured, not
+      # assumed — the first version of this step claimed otherwise.
+      #
+      # So this gate proves the file parses, not that it is free of bashisms.
+      # Catching those needs a linter that is not guaranteed on this runner,
+      # and a conditional check that skips when its tool is absent would turn
+      # "I cannot establish this" into "this is satisfied" — the failure
+      # `docs/conventions/an-optional-dependency-may-not-degrade-a-check.md`
+      # exists to prevent. Reviewing the diff is the control for bashisms.
+      - name: Installer parses as POSIX sh
+        if: matrix.node-version == 24
+        run: |
+          sh -n install.sh
+          dash -n install.sh
+
       # Behaviour regression gate. The harness exists so that a change to a
       # tool description, the deferred-tool top-k, or the compaction
       # threshold ships with a signal behind it — and that signal could not

--- a/README.md
+++ b/README.md
@@ -265,8 +265,20 @@ to the slots you asked for, so it never means more than it checked.
 ### The terminal agent
 
 ```bash
+# Install it
+curl -fsSL https://raw.githubusercontent.com/cogitave/namzu/main/install.sh | sh
+
+# Or, if you would rather not pipe a script into a shell
+npm install -g @namzu/cli
+
+# Or run it once without installing
 npx @namzu/cli
 ```
+
+The installer checks for Node 20+, installs the package, and then verifies the
+binary answers before claiming success. If your global prefix is not writable
+it retries into `~/.namzu` and tells you the one line to add to your profile —
+it never re-runs itself with elevated privileges.
 
 Bare `namzu` opens an interactive terminal agent. The same binary is
 scriptable: `namzu run` for a single headless prompt, `namzu run-stream` for

--- a/docs/conventions/never-filter-a-verification.md
+++ b/docs/conventions/never-filter-a-verification.md
@@ -38,6 +38,32 @@ verdict, never on a guess at what the diagnostic will look like.
 - The same session had already adopted this rule from the first incident, in
   writing, and broke it in the next command.
 
+## It recurred, in a shape the rule did not spell out
+
+2026-08-07. An agent ran `node tools/check-docs.mjs 2>&1 | tail -4; echo $?`
+and read `0`. The gate had found a problem and exited `1`. The zero belonged to
+`tail`.
+
+This is the same failure through a different door. The earlier incidents lost
+the **diagnostic** to a filter; this one lost the **exit code**, because in a
+pipeline `$?` is the last command's status and a filter always succeeds. The
+output even printed the problem — it was the verdict that got replaced.
+
+So the rule's "read the verdict the tool prints" needs its companion: when the
+verdict you are reading is an exit code, the pipeline has already thrown it
+away. Run the check unpiped, or capture its status before anything else touches
+it:
+
+```sh
+node tools/check-docs.mjs > /dev/null 2>&1; echo $?   # the gate's own status
+node tools/check-docs.mjs | tail -4; echo $?          # tail's status, always 0
+```
+
+Caught the same day by an agent that had read this page that morning, which is
+the second time this file records someone adopting the rule and then breaking
+it. That is not irony, it is the measurement: the habit is easy to hold in
+principle and hard to hold in the next command.
+
 ## Related
 
 - [Mutate every test](mutation-check-every-test.md) — its "read the run, not

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+# Install the namzu terminal agent.
+#
+#   curl -fsSL https://raw.githubusercontent.com/cogitave/namzu/main/install.sh | sh
+#
+# The repository URL is the one advertised, because it is the one that serves
+# this file. A short vanity URL is a nicer thing to type and would be a claim
+# about hosting nobody has set up; when it exists, it can be added here.
+#
+# POSIX sh on purpose: this runs before namzu exists, on whatever shell the
+# machine has, and a bashism here is a failure on the one path that has no
+# fallback. Verified with `sh -n` in CI.
+#
+# What it does, in order, refusing rather than guessing at every step:
+#
+#   1. Finds a Node runtime and checks it is new enough.
+#   2. Installs @namzu/cli globally.
+#   3. If the global prefix is not writable, retries into a user-owned prefix
+#      instead of asking for a privilege escalation the caller did not offer.
+#   4. Verifies the binary actually answers before claiming success.
+#
+# Step 4 is the point. An installer that ends at "the package manager exited 0"
+# reports success for a binary that is not on PATH, which is the failure mode
+# this script exists to remove.
+
+set -eu
+
+NAMZU_PKG="@namzu/cli"
+NAMZU_MIN_NODE=20
+# Pin with: NAMZU_VERSION=2.0.0 sh install.sh
+NAMZU_VERSION="${NAMZU_VERSION:-latest}"
+# Where a fallback install lands when the global prefix is not writable.
+NAMZU_PREFIX="${NAMZU_PREFIX:-$HOME/.namzu}"
+
+say() { printf '%s\n' "$*"; }
+err() { printf 'install: %s\n' "$*" >&2; }
+
+die() {
+	err "$*"
+	exit 1
+}
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# Major version of `node -v` output (`v20.11.1` -> `20`).
+node_major() {
+	"$1" -v 2>/dev/null | sed 's/^v//; s/\..*$//'
+}
+
+# ---------------------------------------------------------------- node
+
+have node || die "no Node runtime on PATH.
+  namzu runs on Node ${NAMZU_MIN_NODE} or newer. Install it, then run this again."
+
+NODE_MAJOR="$(node_major node)"
+case "$NODE_MAJOR" in
+'' | *[!0-9]*)
+	die "could not read a version from 'node -v'.
+  Got: $(node -v 2>&1 || echo '<no output>')"
+	;;
+esac
+
+if [ "$NODE_MAJOR" -lt "$NAMZU_MIN_NODE" ]; then
+	die "Node $(node -v) is too old.
+  namzu needs Node ${NAMZU_MIN_NODE} or newer."
+fi
+
+have npm || die "found Node but no npm on PATH.
+  npm ships with Node; a PATH that has one and not the other is usually a
+  partial install. Reinstall Node, then run this again."
+
+say "namzu: Node $(node -v), installing ${NAMZU_PKG}@${NAMZU_VERSION}"
+
+# ---------------------------------------------------------------- install
+
+# `--global` first. It is what most machines want and what puts `namzu` on PATH
+# without touching the caller's shell profile.
+if npm install --global --no-fund --no-audit "${NAMZU_PKG}@${NAMZU_VERSION}" >/dev/null 2>&1; then
+	INSTALL_MODE=global
+else
+	# The common cause is an unwritable global prefix. Retry into a user-owned
+	# one rather than re-running under sudo: a curl-to-shell script that
+	# escalates privilege on failure is a script nobody should pipe into sh.
+	say "namzu: global install failed, retrying into ${NAMZU_PREFIX}"
+	mkdir -p "$NAMZU_PREFIX"
+	if npm install --global --prefix "$NAMZU_PREFIX" --no-fund --no-audit \
+		"${NAMZU_PKG}@${NAMZU_VERSION}" >/dev/null 2>&1; then
+		INSTALL_MODE=prefix
+		PATH="$NAMZU_PREFIX/bin:$PATH"
+		export PATH
+	else
+		die "install failed both globally and into ${NAMZU_PREFIX}.
+  Re-run the install by hand to see why:
+    npm install --global ${NAMZU_PKG}@${NAMZU_VERSION}"
+	fi
+fi
+
+# ---------------------------------------------------------------- verify
+
+# The binary has to answer. Exiting 0 from the package manager says the files
+# landed, not that `namzu` resolves or runs.
+have namzu || die "installed, but 'namzu' is not on PATH.
+  The files are in ${NAMZU_PREFIX}/bin. Add it to your PATH:
+    export PATH=\"${NAMZU_PREFIX}/bin:\$PATH\""
+
+NAMZU_INSTALLED="$(namzu --version 2>/dev/null || true)"
+[ -n "$NAMZU_INSTALLED" ] || die "'namzu' is on PATH but did not answer --version.
+  Run 'namzu doctor' to see what it says about itself."
+
+say "namzu ${NAMZU_INSTALLED} installed."
+
+if [ "$INSTALL_MODE" = prefix ]; then
+	say ""
+	say "It went to ${NAMZU_PREFIX}, which is not on your PATH by default."
+	say "Add this to your shell profile:"
+	say ""
+	say "    export PATH=\"${NAMZU_PREFIX}/bin:\$PATH\""
+fi
+
+say ""
+say "Next: run 'namzu doctor' to check credentials and sandboxing,"
+say "or just 'namzu' to open the terminal agent."


### PR DESCRIPTION
feat(cli): an installer that verifies the thing it installed

namzu was npm-only. `npm install -g @namzu/cli` is a fine instruction for
someone who already has a Node toolchain and knows they want one; it is a poor
front door for someone who has just read the README.

`install.sh` is the front door. POSIX `sh`, not bash — this is the one path
with no fallback, running before namzu exists on whatever shell the machine
has, so a bashism here fails for the person least equipped to debug it. Parsed
by both `sh -n` and `dash -n` in CI.

## What it refuses rather than guesses

- **No Node, or Node older than 20** — names the floor and stops, rather than
  letting the package manager fail with its own message about a peer range.
- **Node present but no npm** — a PATH with one and not the other is usually a
  partial install, and saying so is more useful than "command not found".
- **An unwritable global prefix** — retries into `~/.namzu` and prints the one
  line to add to a profile. It does **not** re-run itself under sudo. A script
  people are invited to pipe into a shell should not escalate privilege when it
  hits a permission error.

## The step that is the point

It verifies the binary answers before claiming success. An installer that ends
at "the package manager exited 0" reports success for a binary that is not on
PATH, which is the failure this exists to remove.

The verification is `namzu --version`, and the choice matters: `--version` is
handled by commander (`cli.ts:69`, short-circuited at `:170`) before any
command handler runs. A headless one-shot would have been the obvious thing to
verify with and would have been wrong — `namzu run` now refuses a working
directory nobody has trusted and exits 77 (`commands/run.ts:199`), so
`curl | sh && namzu run "hi"` fails by design, and the installer would have
gone red for a reason that is not the installer.

## Two claims of my own that were false, and are not in the diff

The CI comment first said `dash -n` catches bashisms. Measured: it does not.
`[[ -n "$x" ]]` parses clean under dash and exits 0, because `[[` is read as an
ordinary command word and only fails at run time. The comment now states the
real bound — this gate proves the file parses, nothing more — and records why a
conditional `shellcheck` was refused rather than added: a check that skips when
its tool is absent turns "I cannot establish this" into "this is satisfied",
which is the failure `an-optional-dependency-may-not-degrade-a-check` exists to
prevent.

The script also advertised `https://namzu.ai/install.sh`, which I had not
verified serves anything. It now advertises the raw repository URL, which is
the one that will actually serve this file. A vanity URL can be added when it
exists rather than promised now.

## Not in scope here

`.ps1` for Windows, and the slash-command surface, are separate iterations.
This is the installer only.
