### PR TITLE
test(cli): one place that knows what an AgentSession is

### DIFF
--- a/packages/cli/src/__tests__/headless-trust-gate.test.ts
+++ b/packages/cli/src/__tests__/headless-trust-gate.test.ts
@@ -55,22 +55,13 @@ vi.mock('../tui/agent.js', () => ({
 	createAgentSession: vi.fn(
 		async (_prefs: unknown, _detected: unknown, opts?: { cwd?: string }) => {
 			sessionsCreated.push(opts?.cwd ?? '')
-			return {
-				hasProvider: true,
-				providerSummary: 'mock',
-				modelSummary: 'mock-model',
-				toolNames: [],
-				instructionFiles: [] as readonly string[],
-				skippedInstructionFiles: [] as readonly { path: string; reason: string }[],
-				mcpConnected: [] as readonly { name: string; toolCount: number }[],
-				mcpFailed: [] as readonly { name: string; reason: string }[],
-				close: async () => {},
-				errorHint: null,
-				send: () =>
-					(async function* () {
-						yield { kind: 'done', stopReason: 'end_turn' }
-					})(),
-			}
+			// Imported here rather than at the top: this file mocks the whole of
+			// `../tui/agent.js`, and a dynamic import inside the lazily-called
+			// factory keeps the fixture clear of the hoisting that mock factories
+			// are subject to. The fixture itself imports only types from the
+			// mocked module, so nothing of it survives to run.
+			const { fakeAgentSession } = await import('../tui/__fixtures__/agent-session.js')
+			return fakeAgentSession()
 		},
 	),
 }))

--- a/packages/cli/src/commands/__tests__/run-exit-code.test.ts
+++ b/packages/cli/src/commands/__tests__/run-exit-code.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import { fakeAgentSession } from '../../tui/__fixtures__/agent-session.js'
+import type { AgentSession } from '../../tui/agent.js'
 import { runCommand } from '../run.js'
 import type { CommandContext } from '../types.js'
 
@@ -14,20 +16,10 @@ import type { CommandContext } from '../types.js'
  * deploy` went ahead on the empty file.
  */
 
-const sessionStub = {
-	hasProvider: true,
-	providerSummary: 'mock',
-	modelSummary: 'mock-model',
-	// A real session always carries this, empty or not. A stub that omits a
-	// field production always sets is a fixture that tests a system which does
-	// not ship.
-	instructionFiles: [] as readonly string[],
-	skippedInstructionFiles: [] as readonly { path: string; reason: string }[],
-	mcpConnected: [] as readonly { name: string; toolCount: number }[],
-	mcpFailed: [] as readonly { name: string; reason: string }[],
-	close: async () => {},
-	send: undefined as unknown,
-}
+// Typed as the real interface via the shared fixture, so a field added to
+// `AgentSession` fails in the fixture rather than silently leaving this stub
+// missing something production always sets.
+const sessionStub = fakeAgentSession()
 
 // These tests are about exit codes for a run that STARTED. Standing in a
 // trusted folder is the ordinary production state and is what they need; the
@@ -62,10 +54,13 @@ function contextCapturing(): { ctx: CommandContext; printed: string[]; errors: s
 }
 
 function streaming(events: unknown[]): void {
-	sessionStub.send = () =>
+	// Cast at the seam on purpose: these tests feed event shapes the union does
+	// not admit, because the defect under test is how the command reacts to a
+	// stream it did not expect.
+	sessionStub.send = (() =>
 		(async function* () {
 			for (const e of events) yield e
-		})()
+		})()) as AgentSession['send']
 }
 
 async function runWith(events: unknown[]): Promise<{

--- a/packages/cli/src/commands/__tests__/run-flags.test.ts
+++ b/packages/cli/src/commands/__tests__/run-flags.test.ts
@@ -15,6 +15,8 @@ import { Readable } from 'node:stream'
 import { describe, expect, it, vi } from 'vitest'
 
 import { EXIT_USAGE } from '../../exit-codes.js'
+import { fakeAgentSession } from '../../tui/__fixtures__/agent-session.js'
+import type { AgentEvent } from '../../tui/agent.js'
 import { composePrompt, runCommand } from '../run.js'
 import type { CommandContext } from '../types.js'
 
@@ -62,27 +64,25 @@ vi.mock('../../tui/agent.js', () => ({
 			seen.cwd = opts?.cwd
 			seen.provider = prefs.provider
 			seen.model = prefs.model
-			return {
-				hasProvider: true,
-				providerSummary: 'mock',
-				modelSummary: 'mock-model',
-				toolNames: [],
-				// Present because a real session always sets these — a stub missing a
-				// field production always has is a fixture for a system that does
-				// not ship.
+			// Only what this file is about is spelled out: the instruction files
+			// it drives assertions from, and a `send` that records the prompt.
+			return fakeAgentSession({
 				instructionFiles: instructions.loaded,
 				skippedInstructionFiles: instructions.skipped,
-				mcpConnected: [] as readonly { name: string; toolCount: number }[],
-				mcpFailed: [] as readonly { name: string; reason: string }[],
-				close: async () => {},
-				errorHint: null,
-				send: (messages: Array<{ content: string }>) => {
-					seen.prompt = messages[0]?.content ?? null
+				send: (messages) => {
+					// `Message.content` is a union, not a string: a tool result carries
+					// blocks. The hand-written stub this replaced declared it as
+					// `{ content: string }`, which type-checked only because it was
+					// describing a message shape that does not exist. The prompt this
+					// file asserts on is a user message, so anything else is `null`
+					// rather than coerced into a string nobody sent.
+					const first = messages[0]?.content
+					seen.prompt = typeof first === 'string' ? first : null
 					return (async function* () {
-						yield { kind: 'done', stopReason: 'end_turn' }
+						yield { kind: 'done', stopReason: 'end_turn' } as AgentEvent
 					})()
 				},
-			}
+			})
 		},
 	),
 }))

--- a/packages/cli/src/commands/__tests__/run-stream-flags.test.ts
+++ b/packages/cli/src/commands/__tests__/run-stream-flags.test.ts
@@ -4,6 +4,7 @@ import { join, resolve } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { openSessions } from '../../integrations/sessions/store.js'
+import { fakeAgentSession } from '../../tui/__fixtures__/agent-session.js'
 import { parseRunFlags } from '../run-flags.js'
 import { historyCommand, runStreamCommand, skillsJSONCommand } from '../run-stream.js'
 import type { CommandContext } from '../types.js'
@@ -46,22 +47,14 @@ vi.mock('../../tui/agent.js', () => ({
 			opts?: { cwd?: string; rules?: unknown[]; permissionMode?: string },
 		) => {
 			sessionOptions.push(opts)
-			return {
-				hasProvider: true,
+			// This file asserts on the OPTIONS the session was constructed with,
+			// captured above, so the session itself only has to exist. `send`
+			// yields nothing on purpose: these runs are not driven to a result.
+			return fakeAgentSession({
 				providerSummary: 'stub',
 				modelSummary: 'stub',
-				toolNames: [],
-				// Present because a real session always sets these: a stub missing a
-				// field production always has is a fixture for a system that does not
-				// ship.
-				instructionFiles: [] as readonly string[],
-				skippedInstructionFiles: [] as readonly { path: string; reason: string }[],
-				mcpConnected: [] as readonly { name: string; toolCount: number }[],
-				mcpFailed: [] as readonly { name: string; reason: string }[],
-				close: async () => {},
-				errorHint: null,
 				send: async function* () {},
-			}
+			})
 		},
 	),
 }))

--- a/packages/cli/src/tui/__fixtures__/agent-session.ts
+++ b/packages/cli/src/tui/__fixtures__/agent-session.ts
@@ -1,0 +1,55 @@
+/**
+ * One place that knows the shape of an `AgentSession`.
+ *
+ * Four test files each built this stub by hand, so every field added to
+ * `AgentSession` broke four unrelated suites at once and the fix was to paste
+ * the same default into each of them. The interface is the thing under test in
+ * none of those files — they stub it to get past it — so the duplication bought
+ * nothing and charged rent.
+ *
+ * The return type is `AgentSession`, deliberately and not `Partial` or a
+ * structural literal: a new REQUIRED field on the interface must fail
+ * type-checking HERE, once, with the compiler naming the field. A fixture typed
+ * loosely enough to absorb the change would hide exactly the event it exists to
+ * surface.
+ *
+ * Defaults describe a session that came up cleanly — a provider, no failures,
+ * nothing skipped — because that is the uninteresting case every caller wants
+ * as a baseline. Anything a test actually cares about it passes in, and the
+ * override is then the only unusual thing in the file, which is what a reader
+ * should see. A fixture whose defaults do not resemble a real session tests a
+ * system that does not ship
+ * (`docs/conventions/fixture-must-match-production.md`).
+ */
+
+import type { Message } from '@namzu/sdk'
+
+import type { AgentEvent, AgentSession, SendOptions } from '../agent.js'
+
+/**
+ * A session that yields one `done` and nothing else.
+ *
+ * `send` is the field most callers replace. The default is the shortest
+ * well-formed turn rather than an empty iterable, because a consumer that
+ * waits for `done` hangs on the latter — a stub that never terminates is a
+ * timeout with extra steps, and this package has already paid for one of those.
+ */
+export function fakeAgentSession(overrides: Partial<AgentSession> = {}): AgentSession {
+	return {
+		hasProvider: true,
+		providerSummary: 'mock',
+		modelSummary: 'mock-model',
+		toolNames: [],
+		errorHint: null,
+		instructionFiles: [],
+		skippedInstructionFiles: [],
+		mcpConnected: [],
+		mcpFailed: [],
+		send: (_messages: readonly Message[], _opts?: SendOptions): AsyncIterable<AgentEvent> =>
+			(async function* () {
+				yield { kind: 'done', stopReason: 'end_turn' } as AgentEvent
+			})(),
+		close: async () => {},
+		...overrides,
+	}
+}


### PR DESCRIPTION
test(cli): one place that knows what an AgentSession is

Four test files each built an `AgentSession` stub by hand, ten fields apiece.
The interface is what none of them is testing — they stub it to get past it — so
every field added to `AgentSession` broke four unrelated suites at once, and the
fix each time was to paste the same default into four places.

`fakeAgentSession(overrides)` is that default, once.

## Why the return type is `AgentSession` and not `Partial`

The fixture is typed as the real interface deliberately. A new REQUIRED field
must fail type-checking HERE, with the compiler naming it, because that failure
is the notification. A fixture typed loosely enough to absorb the change would
hide the one event it exists to surface, and the stubs would go on describing a
session that no longer exists.

Mutation-checked rather than argued. Adding `readonly mutationProbe: string` to
`AgentSession` produces errors in exactly three places:

    src/tui/__fixtures__/agent-session.ts(38,2)   the fixture
    src/tui/agent.ts(510,2)                       a real constructor
    src/tui/agent.ts(1238,2)                      the other real constructor

Zero test files. Before this change the same mutation hit four of them.
Production still fails loudly, which is the half that must not be softened.

## A lie the old stubs were telling

`run-flags` declared `send: (messages: Array<{ content: string }>)`. The real
`Message.content` is a union — a tool result carries blocks, not a string. The
stub type-checked only because it described a message shape that does not
exist, and the assertion behind it read `messages[0]?.content ?? null` as though
a string were the only possibility. Typed against the real interface it stops
compiling, and the test now takes the prompt when it is a string and `null`
otherwise rather than coercing something nobody sent.

## Details worth keeping

`headless-trust-gate` mocks the whole of `../tui/agent.js`, so it imports the
fixture dynamically inside the lazily-called mock factory rather than at the
top. The fixture imports only types from that module, so nothing of it survives
to run, but the dynamic import keeps it clear of mock hoisting entirely.

`send` defaults to yielding one `done` rather than an empty iterable: a consumer
that waits for `done` hangs on the latter, and a stub that never terminates is a
timeout with extra steps. `run-stream-flags` overrides it back to empty, on
purpose and now visibly, because those runs are never driven to a result.

Defaults describe a session that came up cleanly, so whatever a test overrides
is the only unusual thing in the file — which is what a reader should see.

No behaviour change; no changeset. Test support only.
