### PR TITLE
docs: remove two images that were never generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ diataxis: explanation
 
 <div align="center">
 
-<img src="docs/assets/hero.png" alt="Namzu — an agent kernel: a single supervised run, bounded and recorded" width="880">
-
 <h1>Namzu</h1>
 
 **An agent kernel for TypeScript.**
@@ -309,8 +307,6 @@ is a problem you hit at a specific hour of building an agent product, and each
 one is a thing you would otherwise stop and solve yourself. Every item names
 the file that implements it, because a README is a claim and the code is the
 evidence.
-
-<img src="docs/assets/kernel-boundary.png" alt="A single agent run held inside a boundary: budget, permission gate, and a written record" width="880">
 
 **Shrinking a conversation without corrupting it.**
 The window fills and something has to go, but you cannot simply drop the


### PR DESCRIPTION
docs: remove two images that were never generated

`README.md` carried `<img>` tags for `docs/assets/hero.png` and
`docs/assets/kernel-boundary.png`. `docs/assets/` does not exist and never has,
so both rendered as broken-image icons — on the repository landing page and
inside the published `@namzu/cli` and `@namzu/sdk` package pages, which is the
first thing anyone arriving at either of them saw.

They were left in place while the images were a pending deliverable. That is no
longer the case: the owner has decided to skip them, so a tag pointing at a file
nobody is going to produce is just a broken reference.

Deleted rather than commented out or pointed at a placeholder. A commented-out
tag is a broken reference that has stopped announcing itself, and a placeholder
image is a picture that says nothing occupying the spot where the reader was
promised one.

## What was checked before deleting

Nothing in the prose depends on a picture. `diagram`, `pictured`, `shown
above`, `figure` and their neighbours appear nowhere in the file, and both alt
texts were carrying their own meaning rather than captioning something the
sentences relied on. The surrounding text reads the same without them:

- The hero sat above `<h1>Namzu</h1>` inside the centred block, which still
  centres the title and the badges.
- The second sat between the "What is inside that is independently hard"
  introduction and its first item, both of which stand alone.

`grep -rn "docs/assets"` across the README, every package README and `docs/`
now returns nothing, so no other page is left pointing at the same missing
directory.

## Not abandoned

`ses_017`'s `image-prompts.md` stays where it is, and the five prompts still
describe exactly what would go here. Restoring this is a two-line change if the
images are ever generated: drop the files into `docs/assets/` and re-add the two
tags — the hero above the `<h1>` in the centred block, the other directly before
"Shrinking a conversation without corrupting it." That is recorded in the
session log so the next person does not read the prompts as dead.
