### PR TITLE
feat(cli): three questions the terminal agent could not answer

### DIFF
--- a/.changeset/three-questions-the-tui-could-not-answer.md
+++ b/.changeset/three-questions-the-tui-could-not-answer.md
@@ -1,0 +1,29 @@
+---
+'@namzu/cli': minor
+---
+
+Three new slash commands in the terminal agent: `/cost`, `/permissions` and
+`/agents`.
+
+- **`/cost`** — tokens and spend for this run, exact rather than the status
+  bar's abbreviation. It states that the figure is cumulative spend and not
+  context fill, because those are different quantities and reading one as the
+  other is a mistake this codebase has already made once.
+- **`/permissions`** — whether an unreviewed tool call is asked about or
+  approved automatically, plus the `allow`/`deny` rules from your
+  `namzu.config.json`. It also states the precedence, which is the part people
+  get wrong in the dangerous direction: a rule decides first, so the bypass flag
+  can never reopen what a `deny` closed.
+- **`/agents`** — the delegates this session can dispatch to, or a plain answer
+  that there are none.
+
+Nothing new is computed. Every figure these print was already produced by the
+kernel and thrown away at the edge: usage arrives on the run's own event stream,
+the permission rules were compiled before the session opened, and the delegate
+roster is decided when the subagent runtime is built. They were reaching the
+status bar in abbreviated form, or nowhere at all.
+
+`AgentSession` gains a readonly `agentIds` field so the roster can be reported
+rather than rebuilt to find out. It is internal — `@namzu/cli`'s library entry
+exports the doctor API, the shell and the config loader, and has never exported
+`AgentSession` — so this is additive for consumers.

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -294,6 +294,14 @@ export function App({ ctx }: AppProps) {
 		availableTools: session?.toolNames ?? [],
 		providerSummary: session?.providerSummary ?? null,
 		modelSummary: session?.modelSummary ?? null,
+		// The same state the status bar reads, unformatted. `/cost` prints exact
+		// figures where the bar abbreviates to fit.
+		usage,
+		permissions: {
+			skipPermissions: ctx.skipPermissions === true,
+			rules: ctx.rules ?? [],
+		},
+		agentIds: session?.agentIds ?? [],
 	}
 
 	// `/resume`: open the picker with this folder's recent conversations.

--- a/packages/cli/src/tui/__fixtures__/agent-session.ts
+++ b/packages/cli/src/tui/__fixtures__/agent-session.ts
@@ -45,6 +45,7 @@ export function fakeAgentSession(overrides: Partial<AgentSession> = {}): AgentSe
 		skippedInstructionFiles: [],
 		mcpConnected: [],
 		mcpFailed: [],
+		agentIds: [],
 		send: (_messages: readonly Message[], _opts?: SendOptions): AsyncIterable<AgentEvent> =>
 			(async function* () {
 				yield { kind: 'done', stopReason: 'end_turn' } as AgentEvent

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -220,6 +220,16 @@ export interface AgentSession {
 	 * the task. An empty tool list is not a signal; a named failure is.
 	 */
 	readonly mcpFailed: readonly FailedMcpServer[]
+	/**
+	 * Delegates this session can dispatch to. Empty when the subagent runtime
+	 * did not come up, which is non-fatal and leaves the session doing its own
+	 * work.
+	 *
+	 * Reported because the roster was decided here and then discarded, so no
+	 * surface could answer "what can this thing delegate to" without rebuilding
+	 * the runtime to find out.
+	 */
+	readonly agentIds: readonly string[]
 	send(messages: readonly Message[], opts?: SendOptions): AsyncIterable<AgentEvent>
 	/**
 	 * Release what the session holds — today, the external tool servers.
@@ -451,6 +461,11 @@ export async function createAgentSession(
 	// drains it onto the `Agent` result as a `├─/└─` tree. Scoped per `Agent`
 	// call (cleared when one starts).
 	const childSteps: string[] = []
+	// Stays empty when the runtime below throws, which is the honest answer: the
+	// catch is non-fatal and the session then genuinely has no delegate to
+	// dispatch to. A roster reported from the request rather than the result
+	// would name agents that are not there.
+	let allowedAgentIds: readonly string[] = []
 	try {
 		const sub = await createSubagentRuntime({
 			cwd,
@@ -486,6 +501,7 @@ export async function createAgentSession(
 		})
 		registry.register([sub.agentTool])
 		subagentGateway = sub.gateway
+		allowedAgentIds = sub.allowedAgentIds
 	} catch {
 		// Sub-agents unavailable this session — non-fatal.
 	}
@@ -511,6 +527,7 @@ export async function createAgentSession(
 		providerSummary: entry.label,
 		modelSummary: model,
 		toolNames: activeToolNames,
+		agentIds: allowedAgentIds,
 		instructionFiles: projectInstructions.files.map((f) => f.path),
 		skippedInstructionFiles: projectInstructions.skipped,
 		mcpConnected: mcp.connected,
@@ -1239,6 +1256,9 @@ function emptySession(errorHint: string): AgentSession {
 		providerSummary: null,
 		modelSummary: null,
 		toolNames: [],
+		// No provider, so no runtime was built and there is nothing to delegate
+		// to — the same reason `toolNames` is empty.
+		agentIds: [],
 		// Nothing was injected, because no turn will run. Reporting files here
 		// would claim instructions are in force on a session that has no prompt.
 		instructionFiles: [],

--- a/packages/cli/src/tui/slashCommands.test.ts
+++ b/packages/cli/src/tui/slashCommands.test.ts
@@ -8,17 +8,32 @@ import {
 	runSlash,
 } from './slashCommands.js'
 
-const ctx: SlashContext = {
-	availableTools: [],
-	providerSummary: null,
-	modelSummary: null,
+/**
+ * A context with nothing interesting in it, plus whatever this test is about.
+ *
+ * Built through a helper rather than as literals so that a field added to
+ * `SlashContext` lands in one place — the same reason `__fixtures__/agent-session.ts`
+ * exists, and this file had two literals that would each have had to grow.
+ */
+function context(over: Partial<SlashContext> = {}): SlashContext {
+	return {
+		availableTools: [],
+		providerSummary: null,
+		modelSummary: null,
+		usage: null,
+		permissions: { skipPermissions: false, rules: [] },
+		agentIds: [],
+		...over,
+	}
 }
 
-const ctxWithTools: SlashContext = {
+const ctx: SlashContext = context()
+
+const ctxWithTools: SlashContext = context({
 	availableTools: ['Bash', 'Read', 'Edit'],
 	providerSummary: 'anthropic-personal (anthropic)',
 	modelSummary: 'claude-opus-4-7',
-}
+})
 
 describe('matchSlashCommands', () => {
 	it('returns all commands for a bare slash', () => {
@@ -134,5 +149,130 @@ describe('runSlash', () => {
 
 	it('/model re-opens the picker (repick action)', () => {
 		expect(runSlash('/model', ctxWithTools)).toEqual({ kind: 'repick' })
+	})
+})
+
+describe('/cost', () => {
+	it('says so plainly before any turn has reported usage', () => {
+		const r = runSlash('/cost', context({ usage: null }))
+		expect(r?.kind).toBe('message')
+		if (r?.kind === 'message') expect(r.content).toContain('No usage reported yet')
+	})
+
+	it('prints exact figures rather than the status bar abbreviation', () => {
+		const r = runSlash('/cost', context({ usage: { totalTokens: 12_345, costUsd: 0.0731 } }))
+		expect(r?.kind).toBe('message')
+		if (r?.kind === 'message') {
+			// `12,345`, not `12.3k` — someone who asked wants the number.
+			expect(r.content).toContain('12,345')
+			expect(r.content).toContain('$0.0731')
+		}
+	})
+
+	it('names a zero price as unreported rather than as free', () => {
+		const r = runSlash('/cost', context({ usage: { totalTokens: 900, costUsd: 0 } }))
+		if (r?.kind === 'message') expect(r.content).toContain('reported no price')
+	})
+
+	it('says the number is spend and not context fill', () => {
+		// The two were conflated once, in the gauge. A command that prints one
+		// without naming which it is invites the same misreading back.
+		const r = runSlash('/cost', context({ usage: { totalTokens: 10, costUsd: 1 } }))
+		if (r?.kind === 'message') {
+			expect(r.content).toContain('Cumulative')
+			expect(r.content).toContain('how full')
+		}
+	})
+})
+
+describe('/permissions', () => {
+	it('reports that unreviewed calls are asked about by default', () => {
+		const r = runSlash('/permissions', context())
+		if (r?.kind === 'message') expect(r.content).toContain('you are asked')
+	})
+
+	it('names the flag when approval is automatic', () => {
+		const r = runSlash(
+			'/permissions',
+			context({ permissions: { skipPermissions: true, rules: [] } }),
+		)
+		if (r?.kind === 'message') {
+			expect(r.content).toContain('approved automatically')
+			expect(r.content).toContain('--dangerously-skip-permissions')
+		}
+	})
+
+	it('lists configured rules with their verb', () => {
+		const r = runSlash(
+			'/permissions',
+			context({
+				permissions: {
+					skipPermissions: false,
+					rules: [
+						{ type: 'deny_by_name', toolNames: ['bash'] },
+						{ type: 'allow_by_name', toolNames: ['read', 'glob'] },
+					],
+				},
+			}),
+		)
+		if (r?.kind === 'message') {
+			expect(r.content).toContain('deny')
+			expect(r.content).toContain('bash')
+			expect(r.content).toContain('allow')
+			expect(r.content).toContain('read, glob')
+		}
+	})
+
+	it('states that a rule outranks the approval setting', () => {
+		// The precedence people get wrong, and wrong in the dangerous direction:
+		// assuming the bypass flag lifts a `deny` they wrote. It does not.
+		const r = runSlash(
+			'/permissions',
+			context({ permissions: { skipPermissions: true, rules: [] } }),
+		)
+		if (r?.kind === 'message') expect(r.content).toContain('never reopen what a')
+	})
+})
+
+describe('/agents', () => {
+	it('answers honestly when nothing is mounted', () => {
+		const r = runSlash('/agents', context({ agentIds: [] }))
+		if (r?.kind === 'message') {
+			expect(r.content).toContain('No delegates')
+			expect(r.content).toContain('does the work itself')
+		}
+	})
+
+	it('lists the roster it was given', () => {
+		const r = runSlash('/agents', context({ agentIds: ['general-purpose', 'reviewer'] }))
+		if (r?.kind === 'message') {
+			expect(r.content).toContain('general-purpose')
+			expect(r.content).toContain('reviewer')
+			expect(r.content).toContain('2')
+		}
+	})
+})
+
+describe('the new commands are reachable', () => {
+	it('/help lists them, so they are discoverable without docs', () => {
+		const r = runSlash('/help', ctx)
+		expect(r?.kind).toBe('message')
+		if (r?.kind === 'message') {
+			// Anchored on the whole name, not a prefix. `toContain('/agents')` was
+			// the first version and it survived renaming the command to
+			// `/agentsXX`, because that contains it — the same substring trap that
+			// let a deleted command keep passing a `--help` assertion in
+			// `cli.test.ts`. `/help` pads the name, so a real entry is the name
+			// followed by whitespace.
+			expect(r.content).toMatch(/\/cost\s/)
+			expect(r.content).toMatch(/\/permissions\s/)
+			expect(r.content).toMatch(/\/agents\s/)
+		}
+	})
+
+	it('autocomplete offers them', () => {
+		expect(matchSlashCommands('/co').map((c) => c.name)).toContain('cost')
+		expect(matchSlashCommands('/ag').map((c) => c.name)).toContain('agents')
+		expect(matchSlashCommands('/per').map((c) => c.name)).toContain('permissions')
 	})
 })

--- a/packages/cli/src/tui/slashCommands.ts
+++ b/packages/cli/src/tui/slashCommands.ts
@@ -4,7 +4,17 @@
  * A command's `action` returns either a `system` message to push onto the
  * transcript, an `exit` signal, or `void` (no transcript change). The
  * caller (App) maps results onto state.
+ *
+ * `/cost`, `/permissions` and `/agents` are RENDERERS. Every number and rule
+ * they print was already computed — the kernel emits usage on its own event,
+ * the permission rules were compiled before the session opened, and the
+ * delegate roster is decided when the subagent runtime is built. None of them
+ * asks the model, recomputes anything, or reaches past what the session
+ * already carries. A command that had to compute its own answer would be a
+ * second source for a fact the kernel already owns, and the two would drift.
  */
+
+import type { VerificationRule } from '@namzu/sdk'
 
 export type SlashAction =
 	| { kind: 'message'; role: 'system'; content: string }
@@ -22,6 +32,26 @@ export interface SlashContext {
 	readonly availableTools: readonly string[]
 	readonly providerSummary: string | null
 	readonly modelSummary: string | null
+	/**
+	 * CUMULATIVE run spend, or `null` before the first turn reports any.
+	 *
+	 * The same numbers the status bar abbreviates. Kept as the kernel's own
+	 * quantity rather than a formatted string so `/cost` can print exact
+	 * figures — an abbreviation is right for a bar that must fit and wrong for
+	 * a question someone asked on purpose.
+	 */
+	readonly usage: { readonly totalTokens: number; readonly costUsd: number } | null
+	/** What the operator's config and flags decided about tool approval. */
+	readonly permissions: {
+		/** `--yolo` / `--dangerously-skip-permissions`. */
+		readonly skipPermissions: boolean
+		readonly rules: readonly VerificationRule[]
+	}
+	/**
+	 * Delegate ids this session can dispatch to, empty when the delegation tool
+	 * is not mounted.
+	 */
+	readonly agentIds: readonly string[]
 }
 
 export interface SlashCommand {
@@ -146,7 +176,102 @@ export const SLASH_COMMANDS: readonly SlashCommand[] = [
 		description: 'Re-open the provider picker to switch the primary provider.',
 		action: () => ({ kind: 'repick' }),
 	},
+	{
+		name: 'cost',
+		description: 'Show tokens and spend for this run.',
+		action: (ctx) => ({ kind: 'message', role: 'system', content: renderCost(ctx.usage) }),
+	},
+	{
+		name: 'permissions',
+		description: 'Show how tool calls get approved, and any rules in force.',
+		action: (ctx) => ({
+			kind: 'message',
+			role: 'system',
+			content: renderPermissions(ctx.permissions),
+		}),
+	},
+	{
+		name: 'agents',
+		description: 'List the delegates this session can dispatch to.',
+		action: (ctx) => ({ kind: 'message', role: 'system', content: renderAgents(ctx.agentIds) }),
+	},
 ]
+
+/**
+ * Spend, stated as spend.
+ *
+ * `totalTokens` is cumulative and monotone; it is NOT how full the context is,
+ * and the two were conflated once already — the gauge divided cumulative spend
+ * by a guessed window, so it climbed with turn count and read FULL on a
+ * conversation with room to spare. This command prints the spend and says which
+ * quantity it is, so that nobody reads it as the other one.
+ */
+export function renderCost(usage: SlashContext['usage']): string {
+	if (usage === null) {
+		return 'No usage reported yet. The kernel emits it as a turn runs, so this fills in after the first exchange.'
+	}
+	const cost =
+		usage.costUsd > 0 ? `$${usage.costUsd.toFixed(4)}` : '$0.0000 (this provider reported no price)'
+	return [
+		`Tokens: ${usage.totalTokens.toLocaleString('en-US')}`,
+		`Cost:   ${cost}`,
+		'',
+		'Cumulative for this run, across every turn. Not a measure of how full',
+		'the context is — that is a different quantity and it goes down when the',
+		'conversation is compacted, while this only ever grows.',
+	].join('\n')
+}
+
+/** What decides a tool call, in the order it actually decides it. */
+export function renderPermissions(permissions: SlashContext['permissions']): string {
+	const lines: string[] = []
+
+	lines.push(
+		permissions.skipPermissions
+			? 'Unreviewed calls: approved automatically (--dangerously-skip-permissions).'
+			: 'Unreviewed calls: you are asked before they run.',
+	)
+
+	if (permissions.rules.length === 0) {
+		lines.push('')
+		lines.push('No rules configured. Add a [permissions] table to namzu.config.json')
+		lines.push('to allow or deny tools by name without being asked each time.')
+	} else {
+		lines.push('')
+		lines.push(`Rules (${permissions.rules.length}), from your config:`)
+		for (const rule of permissions.rules) lines.push(`  ${describeRule(rule)}`)
+	}
+
+	lines.push('')
+	// Stated because the precedence is the part people get wrong, and getting it
+	// wrong in this direction is the dangerous one: assuming the flag lifts a
+	// `deny` they wrote.
+	lines.push('A rule decides first. The approval setting above only reaches calls')
+	lines.push('no rule covered, so it can never reopen what a `deny` closed.')
+
+	return lines.join('\n')
+}
+
+function describeRule(rule: VerificationRule): string {
+	if (rule.type === 'deny_by_name') return `deny   ${rule.toolNames.join(', ')}`
+	if (rule.type === 'allow_by_name') return `allow  ${rule.toolNames.join(', ')}`
+	return rule.type
+}
+
+/** The delegate roster, and an honest answer when there is none. */
+export function renderAgents(agentIds: readonly string[]): string {
+	if (agentIds.length === 0) {
+		return 'No delegates. This session has no delegation tool mounted, so it does the work itself.'
+	}
+	return [
+		`Delegates (${agentIds.length}):`,
+		...agentIds.map((id) => `  ${id}`),
+		'',
+		'The agent dispatches to these itself when a task suits one. It may also',
+		'define a specialist for a single task, which is not listed here because',
+		'it does not exist until the agent asks for it.',
+	].join('\n')
+}
 
 export function runSlash(line: string, ctx: SlashContext): SlashAction | null {
 	const parsed = parseSlash(line)


### PR DESCRIPTION
feat(cli): three questions the terminal agent could not answer

`/cost`, `/permissions` and `/agents`.

All three are RENDERERS, and that is the point rather than a limitation. Every
figure they print was already produced by the kernel and then thrown away at the
edge:

- usage arrives on the run's own event stream and is already set into App state
  (`App.tsx:94`, `:440`) — the status bar abbreviates it to fit, and nothing
  could show the actual number;
- the permission rules were compiled before the session opened and are already
  on `TuiContext`;
- the delegate roster is decided by `createSubagentRuntime` and was discarded on
  the next line.

None of them asks the model, recomputes anything, or reaches past what the
session already carries. A command that computed its own answer would be a
second source for a fact the kernel owns, and the two would drift.

## What each says, and why it says it that way

**`/cost`** prints exact figures — `12,345`, not `12.3k`. An abbreviation is
right for a bar that must fit and wrong for a question someone asked on purpose.
It also states that the number is cumulative spend and NOT context fill. Those
are different quantities, and reading one as the other is a mistake already made
here once: the gauge divided cumulative spend by a guessed window, so it climbed
with turn count and read FULL on a conversation with room to spare. A zero price
is reported as unreported rather than as free.

**`/permissions`** shows whether an unreviewed call is asked about or approved
automatically, then the `allow`/`deny` rules from the config. It ends by stating
the precedence, because that is what people get wrong and they get it wrong in
the dangerous direction — assuming the bypass flag lifts a `deny` they wrote. A
rule decides first, so the approval setting only ever reaches calls no rule
covered.

**`/agents`** lists the roster, or says plainly that there is none and the
session does its own work. It does not claim the specialists the agent can
define for a single task, because those do not exist until it asks.

## The one piece of plumbing

`AgentSession` gains a readonly `agentIds`. The roster was computed and dropped,
so no surface could answer "what can this delegate to" without rebuilding the
runtime to find out. It stays empty when the subagent runtime throws — that
catch is non-fatal, and a roster reported from the request rather than the
result would name agents that are not there.

Adding it was cheap because the fixture merged one commit ago absorbed it: the
typecheck named exactly three sites — the fixture and the two real constructors
— and zero test files.

`@namzu/cli`'s library entry exports the doctor API, the shell and the config
loader, and has never exported `AgentSession`, so this is internal. `minor`.

## Verification

Twelve tests, mutation-checked, and the second mutation found a defect in one of
my own:

- `renderCost` forced to ignore its input kills 3 `/cost` tests, while the "no
  usage yet" test correctly survives.
- Renaming the registered command `agents` to `agentsXX` — a reachability check,
  since a renderer that works and is not wired is worth nothing — killed the
  behaviour tests but **not** the `/help` one. It asserted
  `toContain('/agents')`, and `/agentsXX` contains that as a substring. That is
  precisely the trap `cli.test.ts` already records, where a deleted command kept
  passing a `--help` assertion. Anchored on the padded name, the same mutation
  now kills four tests instead of three.

Worth recording separately: a mutation run first reported exit 1 that turned out
to be `vitest is not recognized` from a bad invocation, not a failing test. A
false kill reads exactly like a real one, so the run was repeated through the
real command before the result was believed.
