### PR TITLE
fix(build): stop publishing tests to the registry

### DIFF
--- a/.changeset/tarballs-carrying-their-own-tests.md
+++ b/.changeset/tarballs-carrying-their-own-tests.md
@@ -1,0 +1,40 @@
+---
+'@namzu/cli': patch
+'@namzu/sdk': patch
+'@namzu/computer-use': patch
+'@namzu/files': patch
+'@namzu/sandbox': patch
+'@namzu/telemetry': patch
+'@namzu/anthropic': patch
+'@namzu/bedrock': patch
+'@namzu/http': patch
+'@namzu/lmstudio': patch
+'@namzu/ollama': patch
+'@namzu/openai': patch
+'@namzu/openrouter': patch
+---
+
+Published tarballs no longer contain test files.
+
+`files: ["dist", "src", ...]` reads as "the build output and the sources" and
+means "everything the compiler emitted and everything in the tree", so every
+compiled test, its declaration, and both source maps shipped to the registry —
+and for the twelve packages that also ship `src`, the raw test sources went with
+them.
+
+Measured on the versions currently published:
+
+| package | files | of which tests | unpacked |
+| --- | --- | --- | --- |
+| `@namzu/sdk` | 3879 → 2239 | 1640 (42%) | 12.73 MB → 6.81 MB |
+| `@namzu/cli` | 462 → 282 | 180 (39%) | 1.21 MB → 0.73 MB |
+
+Nothing you can import changes. Every package restricts `exports` to `"."`, so
+Node refused a deep subpath into those files already — they were weight in the
+tarball and nothing else. Hence `patch`: there is no consumer-visible surface
+here, only less to download.
+
+The exclusions are at the packaging layer, not the compiler. Adding `exclude`
+to `tsconfig.json` would have kept tests out of `dist` and also dropped them
+from `tsc --noEmit`, silently ending type-checking of the entire test suite —
+trading a packaging defect for a much worse one.

--- a/.github/scripts/check-publish-metadata.mjs
+++ b/.github/scripts/check-publish-metadata.mjs
@@ -45,13 +45,26 @@ const isTestPath = (p) =>
  * Checking the config would have agreed with itself and found nothing.
  */
 function packedPaths(dir) {
-	// `shell: true` for Windows, where the executable is `npm.cmd`. Without it
-	// every call throws and a caller that swallows the error reports a clean
-	// run over packages it never opened.
+	// Windows needs a shell here and nothing else does.
+	//
+	// npm is `npm.cmd` on Windows, and since the CVE-2024-27980 mitigation Node
+	// refuses to spawn a `.cmd` without one — `execFileSync('npm.cmd', …)`
+	// fails with `spawnSync npm.cmd EINVAL`. Under a shell the arguments are
+	// concatenated rather than escaped, which also earns a DEP0190, so it is
+	// scoped to the platform that requires it instead of applied everywhere.
+	// CI runs Linux and takes the no-shell path.
+	//
+	// The arguments are fixed literals. Anyone adding an interpolated one here
+	// has a command injection on Windows rather than a warning, which is why
+	// this is a comment and not just a flag.
+	//
+	// Getting this wrong is silent in the worst way: the first draft of this
+	// check caught the spawn error and continued, reporting fourteen packages
+	// clean while packing none of them.
 	const out = execFileSync('npm', ['pack', '--dry-run', '--json'], {
 		cwd: dir,
 		encoding: 'utf8',
-		shell: true,
+		shell: process.platform === 'win32',
 		stdio: ['ignore', 'pipe', 'pipe'],
 	})
 	return JSON.parse(out)[0].files.map((f) => f.path)

--- a/.github/scripts/check-publish-metadata.mjs
+++ b/.github/scripts/check-publish-metadata.mjs
@@ -14,10 +14,48 @@
  * code path that costs the most to retry.
  */
 
+import { execFileSync } from 'node:child_process'
 import { readFileSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 
 const EXPECTED_REPO = 'https://github.com/cogitave/namzu'
+
+/**
+ * A path in a tarball that is test material rather than shipped code.
+ *
+ * Deliberately broader than the exclusion patterns in any one manifest. The
+ * manifests exclude what we knew to name; this recognises what a test looks
+ * like, so a new convention that the patterns miss fails here instead of
+ * shipping.
+ */
+const isTestPath = (p) =>
+	/(^|\/)__tests__\//.test(p) ||
+	/(^|\/)__fixtures__\//.test(p) ||
+	/\.test\.[a-z.]+$/.test(p) ||
+	/\.proc-test\.[a-z.]+$/.test(p) ||
+	/(^|\/)test-setup\./.test(p)
+
+/**
+ * What `npm publish` would actually put on the registry.
+ *
+ * The manifest's `files` array is a claim; this is the artifact. They come
+ * apart easily — `files: ["dist"]` reads as "the build output" and means
+ * "everything the compiler emitted", which is how `@namzu/cli@2.0.0` and
+ * `@namzu/sdk` shipped with 39% and 42% of their files being compiled tests.
+ * Checking the config would have agreed with itself and found nothing.
+ */
+function packedPaths(dir) {
+	// `shell: true` for Windows, where the executable is `npm.cmd`. Without it
+	// every call throws and a caller that swallows the error reports a clean
+	// run over packages it never opened.
+	const out = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+		cwd: dir,
+		encoding: 'utf8',
+		shell: true,
+		stdio: ['ignore', 'pipe', 'pipe'],
+	})
+	return JSON.parse(out)[0].files.map((f) => f.path)
+}
 
 /** Every `packages/**\/package.json`, one level deep and under `providers/`. */
 function packageDirs() {
@@ -65,6 +103,39 @@ for (const dir of packageDirs()) {
 	// the same omission one step less costly, and the same fix.
 	for (const field of ['license', 'description']) {
 		if (!manifest[field]) problems.push(`${manifest.name} (${dir}) has no \`${field}\`.`)
+	}
+
+	// The tarball carries no test material.
+	//
+	// A pack failure is a FAILURE, never a skip. The first draft of this check
+	// caught the error and continued, and reported every package clean while
+	// packing none of them — a verification that could not fail is worse than
+	// no verification, because it leaves you confident instead of uncertain.
+	let packed
+	try {
+		packed = packedPaths(dir)
+	} catch (err) {
+		problems.push(
+			`${manifest.name} (${dir}) could not be packed, so its contents are unknown: ${err.message.split('\n')[0]}`,
+		)
+		continue
+	}
+
+	const tests = packed.filter(isTestPath)
+	if (tests.length > 0) {
+		problems.push(
+			`${manifest.name} (${dir}) would publish ${tests.length} test file(s), e.g. ${tests[0]}. Add \`!<root>/**/*.test.*\` and the sibling patterns to \`files\`.`,
+		)
+	}
+
+	// An empty tarball also contains no tests. Assert the entry point survived,
+	// so an over-broad exclusion cannot pass this by shipping nothing. Only
+	// when the package declares a `main` — `@namzu/evals` has none and exposes
+	// `./kernel/*`, and inventing one for it would fail it for lacking a file
+	// it never claimed.
+	const main = manifest.main?.replace(/^\.\//, '')
+	if (main !== undefined && !packed.includes(main)) {
+		problems.push(`${manifest.name} (${dir}) would publish without its \`main\` (${main}).`)
 	}
 }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,11 @@
 	},
 	"files": [
 		"dist",
+		"!dist/**/*.test.*",
+		"!dist/**/*.proc-test.*",
+		"!dist/**/__tests__",
+		"!dist/**/__fixtures__",
+		"!dist/**/test-setup.*",
 		"README.md"
 	],
 	"scripts": {

--- a/packages/computer-use/package.json
+++ b/packages/computer-use/package.json
@@ -23,7 +23,17 @@
   },
   "files": [
     "dist",
+    "!dist/**/*.test.*",
+    "!dist/**/*.proc-test.*",
+    "!dist/**/__tests__",
+    "!dist/**/__fixtures__",
+    "!dist/**/test-setup.*",
     "src",
+    "!src/**/*.test.*",
+    "!src/**/*.proc-test.*",
+    "!src/**/__tests__",
+    "!src/**/__fixtures__",
+    "!src/**/test-setup.*",
     "LICENSE.md",
     "README.md",
     "CHANGELOG.md"

--- a/packages/files/package.json
+++ b/packages/files/package.json
@@ -40,7 +40,12 @@
 		}
 	},
 	"files": [
-		"dist"
+		"dist",
+		"!dist/**/*.test.*",
+		"!dist/**/*.proc-test.*",
+		"!dist/**/__tests__",
+		"!dist/**/__fixtures__",
+		"!dist/**/test-setup.*"
 	],
 	"scripts": {
 		"build": "tsc -p tsconfig.json",

--- a/packages/providers/anthropic/package.json
+++ b/packages/providers/anthropic/package.json
@@ -23,7 +23,17 @@
   },
   "files": [
     "dist",
+    "!dist/**/*.test.*",
+    "!dist/**/*.proc-test.*",
+    "!dist/**/__tests__",
+    "!dist/**/__fixtures__",
+    "!dist/**/test-setup.*",
     "src",
+    "!src/**/*.test.*",
+    "!src/**/*.proc-test.*",
+    "!src/**/__tests__",
+    "!src/**/__fixtures__",
+    "!src/**/test-setup.*",
     "LICENSE.md",
     "README.md",
     "CHANGELOG.md"

--- a/packages/providers/bedrock/package.json
+++ b/packages/providers/bedrock/package.json
@@ -23,7 +23,17 @@
   },
   "files": [
     "dist",
+    "!dist/**/*.test.*",
+    "!dist/**/*.proc-test.*",
+    "!dist/**/__tests__",
+    "!dist/**/__fixtures__",
+    "!dist/**/test-setup.*",
     "src",
+    "!src/**/*.test.*",
+    "!src/**/*.proc-test.*",
+    "!src/**/__tests__",
+    "!src/**/__fixtures__",
+    "!src/**/test-setup.*",
     "LICENSE.md",
     "README.md",
     "CHANGELOG.md"

--- a/packages/providers/http/package.json
+++ b/packages/providers/http/package.json
@@ -23,7 +23,17 @@
   },
   "files": [
     "dist",
+    "!dist/**/*.test.*",
+    "!dist/**/*.proc-test.*",
+    "!dist/**/__tests__",
+    "!dist/**/__fixtures__",
+    "!dist/**/test-setup.*",
     "src",
+    "!src/**/*.test.*",
+    "!src/**/*.proc-test.*",
+    "!src/**/__tests__",
+    "!src/**/__fixtures__",
+    "!src/**/test-setup.*",
     "LICENSE.md",
     "README.md",
     "CHANGELOG.md"

--- a/packages/providers/lmstudio/package.json
+++ b/packages/providers/lmstudio/package.json
@@ -23,7 +23,17 @@
   },
   "files": [
     "dist",
+    "!dist/**/*.test.*",
+    "!dist/**/*.proc-test.*",
+    "!dist/**/__tests__",
+    "!dist/**/__fixtures__",
+    "!dist/**/test-setup.*",
     "src",
+    "!src/**/*.test.*",
+    "!src/**/*.proc-test.*",
+    "!src/**/__tests__",
+    "!src/**/__fixtures__",
+    "!src/**/test-setup.*",
     "LICENSE.md",
     "README.md",
     "CHANGELOG.md"

--- a/packages/providers/ollama/package.json
+++ b/packages/providers/ollama/package.json
@@ -23,7 +23,17 @@
   },
   "files": [
     "dist",
+    "!dist/**/*.test.*",
+    "!dist/**/*.proc-test.*",
+    "!dist/**/__tests__",
+    "!dist/**/__fixtures__",
+    "!dist/**/test-setup.*",
     "src",
+    "!src/**/*.test.*",
+    "!src/**/*.proc-test.*",
+    "!src/**/__tests__",
+    "!src/**/__fixtures__",
+    "!src/**/test-setup.*",
     "LICENSE.md",
     "README.md",
     "CHANGELOG.md"

--- a/packages/providers/openai/package.json
+++ b/packages/providers/openai/package.json
@@ -23,7 +23,17 @@
   },
   "files": [
     "dist",
+    "!dist/**/*.test.*",
+    "!dist/**/*.proc-test.*",
+    "!dist/**/__tests__",
+    "!dist/**/__fixtures__",
+    "!dist/**/test-setup.*",
     "src",
+    "!src/**/*.test.*",
+    "!src/**/*.proc-test.*",
+    "!src/**/__tests__",
+    "!src/**/__fixtures__",
+    "!src/**/test-setup.*",
     "LICENSE.md",
     "README.md",
     "CHANGELOG.md"

--- a/packages/providers/openrouter/package.json
+++ b/packages/providers/openrouter/package.json
@@ -23,7 +23,17 @@
   },
   "files": [
     "dist",
+    "!dist/**/*.test.*",
+    "!dist/**/*.proc-test.*",
+    "!dist/**/__tests__",
+    "!dist/**/__fixtures__",
+    "!dist/**/test-setup.*",
     "src",
+    "!src/**/*.test.*",
+    "!src/**/*.proc-test.*",
+    "!src/**/__tests__",
+    "!src/**/__fixtures__",
+    "!src/**/test-setup.*",
     "LICENSE.md",
     "README.md",
     "CHANGELOG.md"

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -23,7 +23,17 @@
   },
   "files": [
     "dist",
+    "!dist/**/*.test.*",
+    "!dist/**/*.proc-test.*",
+    "!dist/**/__tests__",
+    "!dist/**/__fixtures__",
+    "!dist/**/test-setup.*",
     "src",
+    "!src/**/*.test.*",
+    "!src/**/*.proc-test.*",
+    "!src/**/__tests__",
+    "!src/**/__fixtures__",
+    "!src/**/test-setup.*",
     "LICENSE.md",
     "README.md",
     "CHANGELOG.md"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -24,7 +24,17 @@
 	},
 	"files": [
 		"dist",
+		"!dist/**/*.test.*",
+		"!dist/**/*.proc-test.*",
+		"!dist/**/__tests__",
+		"!dist/**/__fixtures__",
+		"!dist/**/test-setup.*",
 		"src",
+		"!src/**/*.test.*",
+		"!src/**/*.proc-test.*",
+		"!src/**/__tests__",
+		"!src/**/__fixtures__",
+		"!src/**/test-setup.*",
 		"LICENSE.md",
 		"README.md",
 		"CHANGELOG.md"

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -34,7 +34,17 @@
 	},
 	"files": [
 		"dist",
+		"!dist/**/*.test.*",
+		"!dist/**/*.proc-test.*",
+		"!dist/**/__tests__",
+		"!dist/**/__fixtures__",
+		"!dist/**/test-setup.*",
 		"src",
+		"!src/**/*.test.*",
+		"!src/**/*.proc-test.*",
+		"!src/**/__tests__",
+		"!src/**/__fixtures__",
+		"!src/**/test-setup.*",
 		"LICENSE.md",
 		"README.md",
 		"CHANGELOG.md"


### PR DESCRIPTION
fix(build): stop publishing tests to the registry

`@namzu/cli@2.0.0` is on the registry with 180 test files in it. It is not the
only one, and it is not a CLI defect — the shape was copied. Twelve of the
fourteen publishable packages ship `files: ["dist", "src", ...]`, which reads as
"the build output and the sources" and means "everything the compiler emitted
and everything in the tree". So every compiled test, its declaration and both
source maps went out, and for the twelve that ship `src`, the raw test sources
went with them.

Established by packing, not by reading the config:

    @namzu/sdk   3879 files → 2239   1640 were tests (42%)   12.73 MB → 6.81 MB
    @namzu/cli    462 files →  282    180 were tests (39%)    1.21 MB → 0.73 MB

Thirteen manifests gain negated `files` patterns. `@namzu/evals` needed none —
it ships `kernel/` and has no tests in it.

## Why the fix is not in tsconfig

`exclude` in `tsconfig.json` would keep tests out of `dist` and would also drop
them from `tsc --noEmit`, silently ending type-checking of the entire test
suite. That is not hypothetical: the type-check currently reports errors inside
`.test.ts` files, which is how a stub declaring `content: string` for a union
type was caught two commits ago. Trading a packaging defect for a much worse one
is not a fix, so the exclusions live at the packaging layer where the defect is.

All five patterns are load-bearing, checked one at a time rather than assumed:
`*.test.*` misses `run-survives-its-own-park.proc-test.js` and `test-setup.js`,
which contain no `.test.` segment; `__fixtures__` is needed for
`agent-session.js`; and `__tests__` is needed for `_fixtures.d.ts`, which
matches neither of the other two.

## The gate

`check-publish-metadata.mjs` already exists because a field nothing checked
422'd a release after its siblings had published. This is the same shape one
step earlier, so it goes in the same place: the gate now packs every publishable
package and fails on any test path, plus asserts the declared `main` survived —
because an over-broad exclusion that ships nothing also contains no tests.

It recognises what a test looks like rather than re-reading the manifest's own
patterns, so a new naming convention the patterns miss fails the gate instead of
shipping.

## Two false-confidence incidents, mine, both caught before this landed

**The verification reported ALL CLEAN over fourteen packages it never opened.**
`npm pack` failed for every one — on Windows the executable is `npm.cmd` and the
call needed `shell: true` — and the script caught the error and `continue`d
without counting it. Exit 0, fourteen ticks, nothing established. A check that
cannot fail is worse than no check, because it leaves you confident rather than
uncertain. A pack failure is now fatal in both the script and the gate.

**The first gate mutation was not caught, and it was the mutation that was
wrong.** Deleting `!dist/**/__tests__` from the CLI manifest changed nothing,
because `*.test.*` already covers those files. Recording that as a broken gate
would have been the wrong conclusion from a real observation; re-testing each
pattern separately is what produced the load-bearing list above. The gate does
catch a real regression — removing the SDK's `__tests__` exclusion fails it with
the four `_fixtures` files named.

`patch` for all thirteen. Every package restricts `exports` to `"."`, so Node
refused a deep subpath into those files already: they were weight and nothing
else, and no consumer-visible surface changes.
