### PR TITLE
chore(sdk)!: remove a progress channel that never had a producer

### DIFF
--- a/.changeset/an-event-that-never-fired.md
+++ b/.changeset/an-event-that-never-fired.md
@@ -1,0 +1,53 @@
+---
+'@namzu/sdk': major
+---
+
+Removed the task-progress reporting channel, which never had a producer: the
+`progress_updated` variant of `AgentLifecycleEvent`, the `AgentTask.progress`
+field, and the `AgentTaskProgress` type.
+
+**What breaks.**
+
+- `AgentLifecycleEvent` no longer includes
+  `{ type: 'progress_updated'; taskId: TaskId; progress: AgentTaskProgress }`.
+  A listener with a `case 'progress_updated':` branch is now a type error, and
+  an exhaustive `switch` over the union will fail to compile until that branch
+  is deleted.
+- `AgentTask.progress` is gone. Reading `task.progress` is now a type error.
+- `AgentTaskProgress` is no longer exported. An annotation naming it will not
+  resolve.
+
+**What to do instead: delete the code that touched them. Nothing replaces it.**
+All three were one channel and nothing in the SDK ever drove any part of it —
+no emit site for the event, no write to the field. A `case 'progress_updated':`
+branch has never executed, and `task.progress` has been `undefined` on every
+task that has ever existed. If you were waiting on progress to arrive, you were
+waiting on something that could not come; this release stops advertising it, it
+does not change what your code observes at runtime.
+
+Both declarations carried `@deprecated No producer. Removed in the next major.`
+in a shipped release, so this is that deprecation being honoured on schedule
+rather than a surprise removal.
+
+If you need per-task progress, the live surface is the run event stream —
+`tool_progress` carries a tool's own progress messages, and the activity store
+(`activity.progress`) carries structured activity updates. Neither is affected
+by this change.
+
+**Why removal rather than building the producer.** Emitting it would be a new
+feature. Unlike the other producerless events in this codebase, this one has no
+half-built machinery waiting on it — no wire mapper case, no reporter case, no
+test fixture. There is nothing to finish, only a declaration to stop making.
+
+**Scope note, because a much wider removal was proposed and rejected.** This
+release was drafted against an audit finding of 23 "declared but nothing reads
+it" items. Most did not survive verification and are deliberately **not**
+removed: `memoizeAsync`, `toWireRunStatus`, `startBidiRun`,
+`createMockBidiProvider`, `createRunReporter`, `parseWorktreeList`,
+`compressShellOutputFull`, `bodySaysContextOverflow`,
+`classifyProviderHttpStatus`, `resolveSkillChain`, the `SkillChain` and
+`SkillLoadResult` fields, and `InvocationState.metadata` / `.services` /
+`.parentChain`. Several have callers inside this package, two are the entry
+points of the documented duplex runtime, and `InvocationState` is delivered
+intact to `ToolContext.invocationState` for a host's own tools to read. If you
+use any of them, this upgrade does not touch them.

--- a/.github/scripts/public-surface-baseline.json
+++ b/.github/scripts/public-surface-baseline.json
@@ -641,7 +641,6 @@
     "AgentTask",
     "AgentTaskBudget",
     "AgentTaskContext",
-    "AgentTaskProgress",
     "AgentTaskResult",
     "AgentTaskState",
     "AgentToolOptions",

--- a/packages/sdk/src/types/agent/lifecycle-event.ts
+++ b/packages/sdk/src/types/agent/lifecycle-event.ts
@@ -1,6 +1,5 @@
 import type { TaskId } from '../ids/index.js'
 import type { BaseAgentResult } from './base.js'
-import type { AgentTaskProgress } from './task.js'
 
 export type AgentLifecycleEvent =
 	| {
@@ -11,14 +10,6 @@ export type AgentLifecycleEvent =
 			depth: number
 	  }
 	| { type: 'running'; taskId: TaskId }
-	/**
-	 * **Never emitted.** Nothing constructs this variant, so a host that
-	 * switches on it has written a branch that cannot run — and a host that
-	 * relies on progress arriving will wait for an event that never comes.
-	 *
-	 * @deprecated No producer. Removed in the next major.
-	 */
-	| { type: 'progress_updated'; taskId: TaskId; progress: AgentTaskProgress }
 	| { type: 'completed'; taskId: TaskId; result: BaseAgentResult }
 	| { type: 'failed'; taskId: TaskId; error: string }
 	| { type: 'canceled'; taskId: TaskId }

--- a/packages/sdk/src/types/agent/task.ts
+++ b/packages/sdk/src/types/agent/task.ts
@@ -1,6 +1,5 @@
 import type { ActorRef } from '../../types/session/actor.js'
 import type { WorkspaceBackendKind } from '../../types/workspace/ref.js'
-import type { TokenUsage } from '../common/index.js'
 import type { ResumeHandler } from '../hitl/index.js'
 import type { RunId, SessionId, TaskId, TenantId } from '../ids/index.js'
 import type { Message } from '../message/index.js'
@@ -106,12 +105,6 @@ export interface AgentTask {
 	context: AgentTaskContext
 	state: AgentTaskState
 	result?: BaseAgentResult
-	/**
-	 * **Never populated.** Nothing in the SDK writes task progress.
-	 *
-	 * @deprecated No producer. Removed in the next major.
-	 */
-	progress?: AgentTaskProgress
 
 	/**
 	 * Tokens reserved from the shared pool when this child was spawned.
@@ -132,12 +125,6 @@ export interface AgentTask {
 	evictAfter?: number
 
 	runEventListener?: RunEventListener
-}
-
-export interface AgentTaskProgress {
-	toolUseCount: number
-	usage: TokenUsage
-	recentActivities: string[]
 }
 
 /**


### PR DESCRIPTION
Drafted against an audit finding of 23 "declared but nothing reads it" items,
asked for as one `major`. **One of the 23 is removed. The other 22 are refuted,
with a reader named for each.** The short list is the finding.

## What is removed

`AgentTask.progress`, the `progress_updated` lifecycle variant, and the
`AgentTaskProgress` type they share — one reporting channel with no producer.
Both declarations already carried `@deprecated No producer. Removed in the next
major.`, so this is that deprecation being honoured on schedule.

`AgentLifecycleManager` emits five variants from five sites — `pending` (232),
`running` (745), `completed` (929), `failed` (962), `canceled` (1038). The
sixth had none.

**Mutation profile**, because "typecheck still passes" only means something if
the typechecker can see this union at all:

| mutation | result |
|---|---|
| remove `progress_updated` (undriven) | `tsc --build` **exit 0**, no errors |
| remove `canceled` (driven) | **exit 2**, `lifecycle.ts(1038,15): TS2322` at its emit site |

That asymmetry is the evidence. Restored after; green again.

## Why the other 22 stay

**The brief's criterion does not discriminate.** I scanned all 1217 names under
the public-surface gate for "no reference outside its own file and the
barrels". **191 match** — including `InMemoryStore`, `PipelineAgent`,
`SkillRegistry`, `mergePersonas`, `withSessionContext`, `ApiError`, and every
A2A wire schema. `@namzu/sdk` is published with a single `.` export;
`public-runtime.ts` *is* the product, so "no in-repo importer" is the ordinary
condition of 16% of its surface.

The repo already ratified this caution in
`docs/conventions/reachability-is-its-own-property.md`: *"'Zero callers in this
package' is not 'zero callers' — the callers are hosts, outside the repository.
The deletion would have removed a working approval gate."*

**The audit says so too.** Its Theme G, covering exactly the nine exports,
reads *"and here the finding is mostly wrong"*, and item 9 defers them to
*"decide keep/remove when a major is already in flight, not before"*. Item 8
asks for **tests**, not deletion. The brief converted that deferral into a
delete list — and omitted item 15, `progress_updated`, which is the one thing
actually ready to go.

**Four are simply false — these have callers in this package:**

| symbol | reader |
|---|---|
| `bodySaysContextOverflow` | `provider/errors.ts` 275, 278, 390, 399 |
| `classifyProviderHttpStatus` | `provider/errors.ts` 398, 435 |
| `compressShellOutputFull` | `compressShellOutput`, `shell-compress.ts:147` |
| `parseWorktreeList` | `GitWorktreeDriver.inspect`, `git-worktree.ts:160` |

The first two are worse than a false positive: `CHANGELOG.md:3174` records a
changeset that **deliberately restored** them after a merge dropped them —
*"They exist for a driver outside this repo"* — and the public-surface gate
exists because of that incident. Deleting them re-commits the defect it repaired.

**Two are a shipped feature:** `startBidiRun` and `createMockBidiProvider` are
the entry points of the duplex runtime, with a published page
(`docs/sdk/runtime/duplex.md`) and a nine-case suite.

**`resolveSkillChain` + all three `SkillChain` fields** appear in a runnable
documented example that prints `chain.inherited`, `chain.own`, `chain.resolved`.

**`InvocationState.metadata` / `.services` / `.parentChain`** — the brief called
`parentChain` "the trap". The road is unbroken and every hop is real:

```
AgentConfig.invocationState      types/agent/base.ts:118
 -> ReactiveAgent.ts:135  -> QueryParams  -> runtime/query/index.ts:675
 -> tooling.ts:50         -> executor.ts:443
 -> ToolContext.invocationState                types/tool/index.ts:100
```

A host writes them, `deriveChildState` propagates them, and the host's own tool
reads them back. Live in both directions — the ratified test.

## Adversarial pass

Commissioned before merging and **read before merging**. It confirmed the
conclusion ("survives with modifications"; its KEEP list matches mine symbol for
symbol) and landed two critiques on my own work, both verified at source and
both adopted:

1. **My first cut was a half-removal.** I had claimed `AgentTaskProgress`
   survives because `AgentTask.progress` is live. It is not — that field carries
   the identical *"Never populated"* deprecation, and `CHANGELOG.md:1637` names
   the pair as one channel. Widened to the whole cluster.
2. **My census wording was loose** — `hashToolResult` is in the 191 because its
   caller sits in the same file. Corrected; it cuts in favour of the conclusion.

## Found on the way, not fixed here

- **The public-surface gate is blind to shape.** It caught one of my three
  removals — `AgentTaskProgress`, a name — and saw neither the union member nor
  the interface field, because it compares name arrays. Its own header says the
  declared view was added after "a public type removal went by unremarked"; a
  narrowed union and a dropped field are the same class of break and still pass.
- **`SkillRegistry.load` returns two lies on its cached branch**:
  `tokenEstimate: 0` where the loader computes a real count, and it collapses
  `'assets'` to `'full'`. The audit spotted the first. That is a repair, not a
  deletion.
- **`InvocationState` still needs its front-door reachability test** (audit item
  10) — the existing tests drive `deriveChildState` directly, which the
  reachability convention explicitly says is not that test.

## Verification

`pnpm typecheck` exit 0 · `pnpm test` exit 0, 430 test files, 5 skipped
(unchanged from baseline) · `pnpm lint` exit 0, 7 pre-existing warnings, none in
touched files · docs gate 0 problems · external-name audit clean ·
public-surface baseline regenerated in the same commit, 1217 → 1216 declared,
runtime unchanged at 529.

No page under `docs/` mentions any removed identifier, so there is no docs debt.
The `resource:` drift gate did not fire: no document points at either file.
