### PR TITLE
feat(cli): /init asks the agent to describe the project

### DIFF
--- a/.changeset/init-asks-the-agent.md
+++ b/.changeset/init-asks-the-agent.md
@@ -1,0 +1,24 @@
+---
+'@namzu/cli': minor
+---
+
+New `/init` slash command: writes an `AGENTS.md` describing the current project
+to future agents.
+
+It works by asking the agent, not by generating a template. The kernel already
+reads the tree and writes files, so `/init` composes an instruction and drives an
+ordinary turn — a CLI-side generator would produce a directory listing with
+headings on it, and would become a second way to inspect a repository that then
+disagreed with the one the model uses.
+
+The instruction it sends is the substance. It asks for every claim to be verified
+against the tree and for omission over invention, in those words, because an
+`AGENTS.md` full of plausible-looking conventions is worse than no file at all:
+the next agent obeys it.
+
+It knows what is already there. When project instructions are loaded, `/init`
+names them and asks for proposed edits rather than a rewrite; when there are
+none, it asks for a new file at the repository root. The session already reports
+which instruction files are in force, so nothing is discovered to answer this.
+
+Without a provider it says so and stops, since there is no agent to ask.

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -302,6 +302,7 @@ export function App({ ctx }: AppProps) {
 			rules: ctx.rules ?? [],
 		},
 		agentIds: session?.agentIds ?? [],
+		instructionFiles: session?.instructionFiles ?? [],
 	}
 
 	// `/resume`: open the picker with this folder's recent conversations.
@@ -563,6 +564,11 @@ export function App({ ctx }: AppProps) {
 	const handleSubmit = useCallback(
 		(value: string, images?: readonly ImageAttachment[]) => {
 			setHistory((prev) => [...prev, value])
+			// What actually gets sent. A `prompt` action replaces it with text the
+			// command composed, and then takes the ordinary send path below —
+			// including the queue — so a command-driven turn is not a second way
+			// to run one.
+			let outgoing = value
 			const slash = runSlash(value, slashCtx)
 			if (slash) {
 				switch (slash.kind) {
@@ -642,6 +648,12 @@ export function App({ ctx }: AppProps) {
 					case 'resume':
 						void doResume()
 						return
+					case 'prompt':
+						// Deliberately does NOT return: the composed text falls
+						// through to the same queue-or-send below that a typed
+						// message takes.
+						outgoing = slash.text
+						break
 					case 'none':
 						return
 				}
@@ -649,10 +661,10 @@ export function App({ ctx }: AppProps) {
 			// A turn is in flight → queue the message; it auto-sends when idle.
 			// (Queued messages are text-only; pasted images aren't carried.)
 			if (state !== 'idle') {
-				setQueued((q) => [...q, value])
+				setQueued((q) => [...q, outgoing])
 				return
 			}
-			void runTurn(value, images)
+			void runTurn(outgoing, images)
 		},
 		[activeSkills, doResume, exit, pushMessage, runTurn, slashCtx, state],
 	)

--- a/packages/cli/src/tui/slashCommands.test.ts
+++ b/packages/cli/src/tui/slashCommands.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
 	SLASH_COMMANDS,
 	type SlashContext,
+	initPrompt,
 	matchSlashCommands,
 	parseSlash,
 	runSlash,
@@ -23,6 +24,7 @@ function context(over: Partial<SlashContext> = {}): SlashContext {
 		usage: null,
 		permissions: { skipPermissions: false, rules: [] },
 		agentIds: [],
+		instructionFiles: [],
 		...over,
 	}
 }
@@ -250,6 +252,44 @@ describe('/agents', () => {
 			expect(r.content).toContain('reviewer')
 			expect(r.content).toContain('2')
 		}
+	})
+})
+
+describe('/init', () => {
+	it('refuses without a provider, because it works by asking the agent', () => {
+		const r = runSlash('/init', context({ providerSummary: null }))
+		expect(r?.kind).toBe('message')
+		if (r?.kind === 'message') expect(r.content).toContain('needs a provider')
+	})
+
+	it('drives a turn rather than printing at the user', () => {
+		// The whole design: the kernel reads the tree and writes the file, so
+		// this must be a prompt and not a CLI-side generator.
+		const r = runSlash('/init', context({ providerSummary: 'mock (mock)' }))
+		expect(r?.kind).toBe('prompt')
+	})
+
+	it('tells the agent to verify claims and omit what it cannot establish', () => {
+		// An AGENTS.md of plausible inventions is worse than none, because the
+		// next agent obeys it. If this instruction goes missing the command
+		// still "works" and quietly gets worse, so it is pinned.
+		const p = initPrompt([])
+		expect(p).toContain('Verify every claim against the tree')
+		expect(p).toContain('leave it out')
+	})
+
+	it('asks for a new file when the project has no instructions', () => {
+		const p = initPrompt([])
+		expect(p).toContain('no AGENTS.md yet')
+		expect(p).not.toContain('Do not overwrite')
+	})
+
+	it('refuses to overwrite instructions that already exist, and names them', () => {
+		const p = initPrompt(['/repo/AGENTS.md', '/repo/pkg/AGENTS.md'])
+		expect(p).toContain('Do not overwrite')
+		expect(p).toContain('/repo/AGENTS.md')
+		expect(p).toContain('/repo/pkg/AGENTS.md')
+		expect(p).not.toContain('no AGENTS.md yet')
 	})
 })
 

--- a/packages/cli/src/tui/slashCommands.ts
+++ b/packages/cli/src/tui/slashCommands.ts
@@ -26,6 +26,15 @@ export type SlashAction =
 	| { kind: 'list-skills' }
 	| { kind: 'load-skill'; name: string }
 	| { kind: 'resume' }
+	/**
+	 * Drive a turn with text the command composed rather than the user typed.
+	 *
+	 * The kernel already does the work — reading the tree, writing the file —
+	 * so a command that needs the agent asks it, instead of the CLI growing a
+	 * second way to inspect a repository that would then disagree with the one
+	 * the model uses.
+	 */
+	| { kind: 'prompt'; text: string }
 	| { kind: 'none' }
 
 export interface SlashContext {
@@ -52,6 +61,16 @@ export interface SlashContext {
 	 * is not mounted.
 	 */
 	readonly agentIds: readonly string[]
+	/**
+	 * Absolute paths of the project-instruction files already in this session's
+	 * system prompt.
+	 *
+	 * `/init` reads it to tell "this project has never been described" from
+	 * "one exists and you are about to be asked to rewrite it", which are
+	 * different requests and want different prompts. The session already
+	 * reports this; nothing new is discovered to answer it.
+	 */
+	readonly instructionFiles: readonly string[]
 }
 
 export interface SlashCommand {
@@ -195,7 +214,72 @@ export const SLASH_COMMANDS: readonly SlashCommand[] = [
 		description: 'List the delegates this session can dispatch to.',
 		action: (ctx) => ({ kind: 'message', role: 'system', content: renderAgents(ctx.agentIds) }),
 	},
+	{
+		name: 'init',
+		description: 'Write an AGENTS.md describing this project to future agents.',
+		action: (ctx) => {
+			if (!ctx.providerSummary) {
+				return {
+					kind: 'message',
+					role: 'system',
+					content:
+						'/init asks the agent to read this repository and write the file, so it needs a provider. Run /model to pick one.',
+				}
+			}
+			return { kind: 'prompt', text: initPrompt(ctx.instructionFiles) }
+		},
+	},
 ]
+
+/**
+ * The instruction `/init` sends as a turn.
+ *
+ * Written as a prompt rather than a template the CLI fills in, because the
+ * useful half of this file is what a reader could not guess from the tree —
+ * the commands that actually work here, the layout that is deliberate — and
+ * only something that has read the repository can say that. A CLI-side
+ * generator would produce a directory listing with headings on it.
+ *
+ * The instruction it opens with is the one that matters: an `AGENTS.md` full of
+ * invented conventions is worse than none, because the next agent obeys it. So
+ * the prompt asks for verification against the tree and for omission over
+ * invention, in those words.
+ */
+export function initPrompt(instructionFiles: readonly string[]): string {
+	const existing =
+		instructionFiles.length > 0
+			? [
+					'',
+					'This project ALREADY has project instructions, loaded from:',
+					...instructionFiles.map((f) => `  ${f}`),
+					'',
+					'Do not overwrite them. Read them first, then propose specific edits —',
+					'what is now wrong, what is missing — and make only the changes I agree to.',
+				].join('\n')
+			: ['', 'This project has no AGENTS.md yet. Create one at the repository root.'].join('\n')
+
+	return [
+		'Write the project instructions that a coding agent joining this repository would need.',
+		'',
+		'Verify every claim against the tree before you write it. Do not describe a',
+		'command you have not found, a layout you have not opened, or a convention you',
+		'have inferred from one file. If you cannot establish something, leave it out —',
+		'an AGENTS.md full of plausible inventions is worse than a short true one,',
+		'because the next agent will follow it.',
+		existing,
+		'',
+		'Cover what a newcomer cannot get from the file listing:',
+		'  - what this project is, in a sentence or two',
+		'  - the build, test and lint commands that actually work here (check the',
+		'    package manifest or task runner rather than assuming the usual ones)',
+		'  - the layout, and any part of it that is deliberate rather than incidental',
+		'  - conventions the code visibly holds to, with the evidence that shows it',
+		'  - anything that would let someone break the project without noticing',
+		'',
+		'Keep it short enough to be read in full. Every line costs context on every',
+		'future run, so a sentence that says nothing is not free.',
+	].join('\n')
+}
 
 /**
  * Spend, stated as spend.


### PR DESCRIPTION
feat(cli): /init asks the agent to describe the project

`/init` writes an `AGENTS.md` for the current repository. It does it by asking
the agent, not by filling in a template.

That is the whole design decision. The kernel already reads trees and writes
files, so `/init` composes an instruction and drives an ordinary turn. A
CLI-side generator would produce a directory listing with headings on it, and
worse, it would be a second way to inspect a repository — one that would drift
from the one the model actually uses.

Mechanically it is a new `SlashAction` kind, `{ kind: 'prompt'; text }`, which
falls through to the same queue-or-send path a typed message takes. A
command-driven turn is not a second way to run one.

## The prompt is the substance

It asks for every claim to be verified against the tree, and for omission over
invention, in those words:

> If you cannot establish something, leave it out — an AGENTS.md full of
> plausible inventions is worse than a short true one, because the next agent
> will follow it.

That instruction is pinned by a test. Losing it would leave a command that still
"works" and quietly gets worse, which is the failure mode a test exists for.

It also asks for the build/test/lint commands that actually work *here*, checked
against the manifest rather than assumed, and it says that every line costs
context on every future run — a file nobody can afford to read in full is a file
nobody reads.

## It knows what is already there

When project instructions are loaded it names them and asks for proposed edits
rather than a rewrite; when there are none it asks for a new file at the root.
Those are different requests and deserve different prompts.

`session.instructionFiles` already reports this, so nothing is discovered to
answer it — the same shape as `/cost` and `/agents`. `SlashContext` gains the
field, and the test `context()` helper absorbed it in one place, which is the
second time that helper has paid for itself.

Without a provider it says so and stops. There is no agent to ask.

## A flake found while verifying, and deliberately not fixed here

The full suite failed once on
`integrations/sessions/__tests__/archived-workspace.test.ts` with
`ENOTEMPTY: directory not empty, rmdir` on a Windows temp directory.

Established rather than assumed, because "an unrelated test failed" is exactly
the claim worth checking: it passes isolated on clean `main`, passes isolated
with this change, and the full-suite re-run is 403 passed / 0 failed.
Intermittent, and not caused by this.

It is the same family as the `EBUSY` from the test-timeout work but a different
code, and this one is **not** downstream of a timeout — nothing timed out in
that run, so the cleanup is racing something else. It deserves its own change;
folding it in here would put two unrelated concerns in one PR.
