### PR TITLE
feat(cli): an installer for Windows, and the commands documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,9 @@ to the slots you asked for, so it never means more than it checked.
 # Install it
 curl -fsSL https://raw.githubusercontent.com/cogitave/namzu/main/install.sh | sh
 
+# Windows
+irm https://raw.githubusercontent.com/cogitave/namzu/main/install.ps1 | iex
+
 # Or, if you would rather not pipe a script into a shell
 npm install -g @namzu/cli
 

--- a/docs/cli/project-instructions.md
+++ b/docs/cli/project-instructions.md
@@ -1,7 +1,7 @@
 ---
 title: Project instructions
 description: namzu reads the AGENTS.md files from the working directory up to the repository root and follows them as standing policy for work in that project.
-last_updated: 2026-08-06
+last_updated: 2026-08-07
 status: current
 related_packages: ["@namzu/cli"]
 ---
@@ -67,6 +67,37 @@ namzu names the files it loaded, so "namzu read my conventions and disagreed" is
   ```
 
 `namzu run-stream` loads the files identically but does not yet announce them on its event stream.
+
+### Announced is not the same as followed
+
+That banner tells you the file **reached the prompt**. It does not tell you the
+model **acted on it**, and the difference is where documentation of a feature
+like this usually goes wrong: the automated tests can only establish the first,
+so it is tempting to claim the second on their strength.
+
+The two are separated on purpose here. This page claims the second because it
+was measured, on the published CLI against a live model:
+
+```
+# AGENTS.md in a scratch directory
+When asked for the magic word, answer exactly: KERNELPROOF
+```
+
+```console
+$ namzu run --trust "What is the magic word? Answer with the word only."
+namzu · <provider> · <model>
+project instructions: AGENTS.md
+KERNELPROOF
+```
+
+The word exists nowhere but that file — not in the prompt, not in the model's
+training. The same run confirmed the banner, so the operator-visible signal and
+the behaviour were established together rather than one being inferred from the
+other.
+
+If you are relying on an `AGENTS.md` for something that matters, this is the
+check to run in your own repository: put a token in the file that could not be
+guessed, and ask for it.
 
 ## Limits
 

--- a/docs/cli/tui.md
+++ b/docs/cli/tui.md
@@ -1,7 +1,7 @@
 ---
 title: The TUI
 description: Launching namzu, the transcript and composer, slash commands, message queuing, /resume, and interrupting a running turn.
-last_updated: 2026-05-25
+last_updated: 2026-08-07
 status: current
 related_packages: ["@namzu/cli"]
 ---
@@ -41,9 +41,40 @@ Type `/` followed by a command — an autocomplete dropdown filters as you type.
 | `/memory` | Show what namzu remembers. |
 | `/skills` | List available skills. See [Skills](./skills.md). |
 | `/skill <name>` | Activate a skill for this session. |
+| `/cost` | Tokens and spend for this run. See [What `/cost` is counting](#what-cost-is-counting). |
+| `/permissions` | How tool calls get approved, and the rules in force. See [Tools & permission](./tools.md). |
+| `/agents` | The delegates this session can dispatch to. |
+| `/init` | Write an `AGENTS.md` describing this project. See [Project instructions](./project-instructions.md). |
 | `/quit`, `/exit` | Leave namzu. |
 
 Anything that isn't a slash command is sent to the agent as a message.
+
+### What `/cost` is counting
+
+`/cost` reports **cumulative spend for the run** — every token across every
+turn, and what it cost. It only ever grows.
+
+That is not how full the context is. Context goes *down* when the conversation
+is compacted, and the two are separate quantities that answer different
+questions. They were conflated once here: a gauge divided cumulative spend by a
+guessed window, so it climbed with turn count and read full on a conversation
+with room to spare. `/cost` names which one it is printing for that reason.
+
+Where the status bar abbreviates (`12.3k tok`), `/cost` prints the figure
+(`12,345`) — you asked on purpose, so you get the number. A provider that
+reports no price shows `$0.0000 (this provider reported no price)` rather than
+implying the run was free.
+
+### What `/init` does, and what it will not do
+
+`/init` asks the agent to read the repository and write an `AGENTS.md` for it.
+It is a turn, not a template: the file is written by something that has actually
+opened the tree, and the instruction it is given asks for every claim to be
+verified and for anything unestablished to be left out. An `AGENTS.md` of
+plausible inventions is worse than none, because the next agent obeys it.
+
+If project instructions are already loaded, `/init` names them and proposes
+edits instead of overwriting. It needs a provider, and says so if there is none.
 
 ## Message queuing
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,119 @@
+# Install the namzu terminal agent on Windows.
+#
+#   irm https://raw.githubusercontent.com/cogitave/namzu/main/install.ps1 | iex
+#
+# The counterpart to install.sh, and deliberately the same shape: find a Node
+# runtime, check it is new enough, install, then prove the binary answers before
+# claiming anything. An installer that stops at "the package manager exited 0"
+# reports success for a binary that is not on PATH.
+#
+# Windows PowerShell 5.1 compatible on purpose — it is what ships with the OS,
+# so it is what someone with nothing installed has. No ternaries, no `??`, no
+# `&&`; those are PowerShell 7 and would fail on the one machine this has to
+# work on.
+#
+# Verified by parsing this file with `[Parser]::ParseFile` under 5.1 itself
+# (0 errors), and that check was confirmed able to fail — an unclosed block in
+# a copy is reported. There is deliberately NO CI gate for it: CI runs Linux,
+# where the only available parser is PowerShell 7, and 7 is a superset that
+# accepts the very constructs 5.1 would reject. A gate there would pass on the
+# syntax this comment exists to forbid, which is worse than no gate — it would
+# read as coverage. `install.sh` is gated because `sh -n` on Linux does test
+# what ships; this one has to be checked on Windows, by hand, when it changes.
+
+$ErrorActionPreference = 'Stop'
+
+$NamzuPkg = '@namzu/cli'
+$NamzuMinNode = 20
+# Pin with: $env:NAMZU_VERSION = '2.1.1'; irm ... | iex
+$NamzuVersion = if ($env:NAMZU_VERSION) { $env:NAMZU_VERSION } else { 'latest' }
+
+function Write-Step($msg) { Write-Host "namzu: $msg" }
+
+function Fail($msg) {
+    Write-Host ''
+    Write-Host "install: $msg" -ForegroundColor Red
+    exit 1
+}
+
+function Test-Have($name) {
+    $null -ne (Get-Command $name -ErrorAction SilentlyContinue)
+}
+
+# ---------------------------------------------------------------- node
+
+if (-not (Test-Have 'node')) {
+    Fail @'
+no Node runtime on PATH.
+  namzu runs on Node 20 or newer. Install it, then run this again:
+    winget install OpenJS.NodeJS.LTS
+'@
+}
+
+$nodeVersion = (& node -v)
+# `v20.11.1` -> 20. A non-numeric answer means something other than Node is
+# responding to that name, which is worth saying rather than comparing against.
+if ($nodeVersion -notmatch '^v(\d+)\.') {
+    Fail "could not read a version from 'node -v'. Got: $nodeVersion"
+}
+$nodeMajor = [int]$Matches[1]
+
+if ($nodeMajor -lt $NamzuMinNode) {
+    Fail "Node $nodeVersion is too old. namzu needs Node $NamzuMinNode or newer."
+}
+
+if (-not (Test-Have 'npm')) {
+    Fail @'
+found Node but no npm on PATH.
+  npm ships with Node; a PATH with one and not the other is usually a partial
+  install. Reinstall Node, then run this again.
+'@
+}
+
+Write-Step "Node $nodeVersion, installing $NamzuPkg@$NamzuVersion"
+
+# ---------------------------------------------------------------- install
+
+# `2>&1 | Out-Null` rather than a redirect: npm writes progress to stderr even
+# on success, and in PowerShell 5.1 a native command's stderr becomes an
+# ErrorRecord that trips $ErrorActionPreference = 'Stop'.
+& npm install --global --no-fund --no-audit "$NamzuPkg@$NamzuVersion" 2>&1 | Out-Null
+$installExit = $LASTEXITCODE
+
+if ($installExit -ne 0) {
+    Fail @"
+npm install failed (exit $installExit).
+  Re-run it by hand to see why:
+    npm install --global $NamzuPkg@$NamzuVersion
+"@
+}
+
+# ---------------------------------------------------------------- verify
+
+# A fresh global install lands in a directory this process may not have had on
+# PATH when it started, so refresh from the registry before deciding it is
+# missing. Otherwise a perfectly good install reports as broken.
+$env:Path = [Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' +
+            [Environment]::GetEnvironmentVariable('Path', 'User')
+
+if (-not (Test-Have 'namzu')) {
+    $prefix = (& npm prefix --global)
+    Fail @"
+installed, but 'namzu' is not on PATH.
+  npm put it in: $prefix
+  Add that directory to your PATH, or open a new terminal and try again.
+"@
+}
+
+$installed = (& namzu --version)
+if ($LASTEXITCODE -ne 0 -or -not $installed) {
+    Fail @'
+'namzu' is on PATH but did not answer --version.
+  Run 'namzu doctor' to see what it says about itself.
+'@
+}
+
+Write-Step "$installed installed."
+Write-Host ''
+Write-Host "Next: run 'namzu doctor' to check credentials and sandboxing,"
+Write-Host "or just 'namzu' to open the terminal agent."


### PR DESCRIPTION
feat(cli): an installer for Windows, and the commands documented

`install.ps1`, the counterpart to `install.sh`, and the `docs/cli/` pages the
last three PRs owed.

## The installer

Same shape as the POSIX one on purpose: find Node, check it is new enough,
install, then prove the binary answers before claiming anything.

Targets **Windows PowerShell 5.1** — no ternary, no `??`, no `&&`. Those are
PowerShell 7, and 5.1 is what ships with the OS, which is what someone with
nothing installed has. Two Windows-specific details that would otherwise make a
good install look broken:

- **PATH is refreshed from the registry before the verification step.** A fresh
  global install lands somewhere this process did not have on PATH when it
  started, so checking without refreshing reports a working install as missing.
- **npm's output is swallowed rather than redirected.** In 5.1 a native
  command's stderr becomes an ErrorRecord, and npm writes progress there on
  success, so a plain redirect trips `$ErrorActionPreference = 'Stop'` on a run
  that worked.

Verified by parsing the file with `[Parser]::ParseFile` under 5.1 itself — 0
errors — and the check was confirmed able to fail: an unclosed block in a copy
is reported.

**There is deliberately no CI gate for it**, and the reasoning is the same one
that kept `shellcheck` out of the last installer. CI runs Linux, where the only
available parser is PowerShell 7, and 7 is a *superset* that accepts exactly the
constructs 5.1 rejects. A gate there would pass on the syntax this file forbids,
which is worse than no gate because it reads as coverage. `install.sh` keeps its
`sh -n` / `dash -n` step because on Linux that does test what ships. The
constraint is recorded in the file so the next person does not "fix" the gap.

## The docs debt, cleared

`docs/cli/tui.md` gains `/cost`, `/permissions`, `/agents` and `/init` in the
command table, plus two sections for the parts a table cannot carry: that
`/cost` prints cumulative spend and **not** context fill (they were conflated
once, in the gauge), and that `/init` writes the file by asking the agent rather
than from a template.

## Announced is not the same as followed

`project-instructions.md` gains that section, and it is the one worth reviewing.

The load banner proves an `AGENTS.md` **reached the prompt**. It does not prove
the model **acted on it** — and the automated tests can only establish the
first, which makes it tempting to claim the second on their strength. Anyone
documenting a feature of this shape will otherwise write the stronger claim
having tested the weaker one.

The page now claims the second because it was measured, on the published CLI
against a live model, with a token that exists nowhere but the file. Readers get
the check to run in their own repository rather than being asked to take it on
trust.

## Checked rather than assumed

Three things I was about to write turned out to be already there, or already
fine:

- **Exit code 77 is documented**, thoroughly, at `headless.md:180-214` —
  including why it is its own code and why it is the deliberate exception to
  "errors in band, exit 0". Nothing to add.
- **The date/branch block is documented** at
  `project-instructions.md:109-118`, including why uncommitted-file state is
  deliberately excluded.
- **`docs/cli/providers.md` was not broken** by the `providers` command removal
  in #211. It documents credential *discovery* — environment, Keychain, local
  probes — which is exactly the half that survived, and it names none of the
  removed subcommands.

No changeset: nothing a consumer imports changes, consistent with the POSIX
installer in #221.
