### PR TITLE
test(sdk): a premise asserted before the conclusion that needs it

### DIFF
--- a/packages/sdk/src/store/session/__tests__/a-workspace-can-be-configured.test.ts
+++ b/packages/sdk/src/store/session/__tests__/a-workspace-can-be-configured.test.ts
@@ -145,8 +145,25 @@ describe.each(IMPLEMENTATIONS)('a workspace carries its own limits (%s)', (_name
 		const created = []
 		for (const name of ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']) {
 			created.push(await store.createProject({ tenantId: TENANT, name }, TENANT))
-			await new Promise((resolve) => setTimeout(resolve, 2))
+			// Long enough to clear a coarse clock, not only a millisecond one.
+			// `Date.now()` advances in ~15.6ms steps on Windows by default, and
+			// virtualised CI hosts coalesce timers too — a 2ms gap left several
+			// records sharing a timestamp there, so the tie-break decided the
+			// order and this assertion failed as if the sort were wrong.
+			await new Promise((resolve) => setTimeout(resolve, 20))
 		}
+
+		// The premise, asserted before the conclusion that depends on it.
+		//
+		// This test means "older records come first", which is only a question
+		// if the records have distinct ages. When the clock does not advance,
+		// the correct behaviour is the tie-break — so the failure would be a
+		// true statement about a test whose premise had quietly evaporated,
+		// reported as "these two ids are swapped". Checking it here makes the
+		// message name the real cause.
+		const stamps = created.map((p) => p.createdAt.getTime())
+		const strictlyIncreasing = stamps.every((t, i) => i === 0 || t > (stamps[i - 1] ?? 0))
+		expect({ strictlyIncreasing, stamps }).toEqual({ strictlyIncreasing: true, stamps })
 
 		const listed = await store.listProjects?.(TENANT)
 


### PR DESCRIPTION
A flake another agent hit in CI, in a test I wrote this morning.

`a-workspace-can-be-configured.test.ts` spaced its records by **2ms** to make "oldest first" a question about age. That does not clear a coarse clock — `Date.now()` advances in ~15.6ms steps on Windows by default, and virtualised CI hosts coalesce timers. Records shared a timestamp, the tie-break `(createdAt, id)` correctly decided their order, and the assertion failed reporting *two ids swapped*.

Which was **true, and about the wrong thing**: the sort was right, the test's premise had evaporated. A failure message that blames the code for honouring its own contract is worse than no message.

## What changed

- The gap is **20ms**, past the coarsest clock granularity in play.
- The timestamps are asserted **strictly increasing before** the order is asserted. If the clock ever fails to advance again, the failure names that instead of the sort.

## Verification

Mutation: dropping the sort still fails this test and the tie-break test beside it. Lint 0. Test-only — no consumer-visible change, so no changeset.