### PR TITLE
fix(install): name the directory the binary is actually in

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,28 @@ die() {
 
 have() { command -v "$1" >/dev/null 2>&1; }
 
+# The directory under `$1` that actually holds the binary, or nothing.
+#
+# Checked rather than computed. npm puts executables in `$prefix/bin` on unix
+# and in `$prefix` itself on Windows, and the shipped `namzu` is `namzu`,
+# `namzu.cmd` or `namzu.ps1` depending on the platform — so a single hard-coded
+# path is wrong somewhere. It was: the "not on PATH" message below named
+# `$NAMZU_PREFIX/bin` unconditionally, which is correct only on the fallback
+# branch, so a successful GLOBAL install that was not on PATH sent the operator
+# to an empty directory. That is the one place this script stopped verifying and
+# started guessing, and it fired exactly when someone needed it to be right.
+bin_dir_under() {
+	for candidate in "$1/bin" "$1"; do
+		for exe in namzu namzu.cmd namzu.ps1; do
+			if [ -e "$candidate/$exe" ]; then
+				printf '%s' "$candidate"
+				return 0
+			fi
+		done
+	done
+	return 1
+}
+
 # Major version of `node -v` output (`v20.11.1` -> `20`).
 node_major() {
 	"$1" -v 2>/dev/null | sed 's/^v//; s/\..*$//'
@@ -86,7 +108,11 @@ else
 	if npm install --global --prefix "$NAMZU_PREFIX" --no-fund --no-audit \
 		"${NAMZU_PKG}@${NAMZU_VERSION}" >/dev/null 2>&1; then
 		INSTALL_MODE=prefix
-		PATH="$NAMZU_PREFIX/bin:$PATH"
+		# Same reasoning as the failure path: locate it, do not compute it.
+		# Falling back to `$NAMZU_PREFIX/bin` keeps the old behaviour when the
+		# probe finds nothing, so the verification below still gets a chance to
+		# report honestly instead of this line silently exporting nothing.
+		PATH="$(bin_dir_under "$NAMZU_PREFIX" || printf '%s' "$NAMZU_PREFIX/bin"):$PATH"
 		export PATH
 	else
 		die "install failed both globally and into ${NAMZU_PREFIX}.
@@ -99,9 +125,33 @@ fi
 
 # The binary has to answer. Exiting 0 from the package manager says the files
 # landed, not that `namzu` resolves or runs.
-have namzu || die "installed, but 'namzu' is not on PATH.
-  The files are in ${NAMZU_PREFIX}/bin. Add it to your PATH:
-    export PATH=\"${NAMZU_PREFIX}/bin:\$PATH\""
+if ! have namzu; then
+	# Where it went depends on which branch ran, and the global branch's prefix
+	# is npm's to report rather than ours to assume.
+	if [ "$INSTALL_MODE" = prefix ]; then
+		NAMZU_ROOT="$NAMZU_PREFIX"
+	else
+		NAMZU_ROOT="$(npm prefix --global 2>/dev/null || true)"
+	fi
+
+	NAMZU_BIN=''
+	[ -n "$NAMZU_ROOT" ] && NAMZU_BIN="$(bin_dir_under "$NAMZU_ROOT" || true)"
+
+	if [ -n "$NAMZU_BIN" ]; then
+		die "installed, but 'namzu' is not on PATH.
+  The binary is in ${NAMZU_BIN}. Add it to your PATH:
+    export PATH=\"${NAMZU_BIN}:\$PATH\""
+	fi
+
+	# Nothing found. Say that, rather than naming a directory to cover the gap —
+	# sending someone to a path that does not hold the binary is the failure this
+	# branch exists to avoid, and doing it while sounding certain is worse than
+	# admitting the install landed somewhere this script cannot see.
+	die "installed, but 'namzu' is not on PATH and the binary could not be located.
+  npm reported its global prefix as: ${NAMZU_ROOT:-<npm did not answer>}
+  Find it and add its directory to your PATH:
+    npm ls --global --parseable ${NAMZU_PKG}"
+fi
 
 NAMZU_INSTALLED="$(namzu --version 2>/dev/null || true)"
 [ -n "$NAMZU_INSTALLED" ] || die "'namzu' is on PATH but did not answer --version.
@@ -110,11 +160,14 @@ NAMZU_INSTALLED="$(namzu --version 2>/dev/null || true)"
 say "namzu ${NAMZU_INSTALLED} installed."
 
 if [ "$INSTALL_MODE" = prefix ]; then
+	# The directory that was actually put on PATH above, so the line the operator
+	# copies into their profile is the line this run proved works.
+	NAMZU_BIN="$(bin_dir_under "$NAMZU_PREFIX" || printf '%s' "$NAMZU_PREFIX/bin")"
 	say ""
 	say "It went to ${NAMZU_PREFIX}, which is not on your PATH by default."
 	say "Add this to your shell profile:"
 	say ""
-	say "    export PATH=\"${NAMZU_PREFIX}/bin:\$PATH\""
+	say "    export PATH=\"${NAMZU_BIN}:\$PATH\""
 fi
 
 say ""

--- a/packages/cli/src/__tests__/__fixtures__/installer-not-on-path.sh
+++ b/packages/cli/src/__tests__/__fixtures__/installer-not-on-path.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Reproduce the reported defect end to end, with a stub npm and no network.
+#
+#   sh scenario.sh <path-to-install.sh>
+#
+# Simulates a SUCCESSFUL GLOBAL install whose bin directory is not on PATH,
+# which is the exact condition that produced the wrong instruction.
+set -eu
+
+INSTALLER="$1"
+W="$(mktemp -d)"
+trap 'rm -rf "$W"' EXIT
+
+mkdir -p "$W/fakebin"
+
+# Stub npm: installs into $W/prefix/bin, and reports $W/prefix as the global
+# prefix. Handles exactly the two invocations install.sh makes.
+cat > "$W/fakebin/npm" <<EOF
+#!/bin/sh
+case "\$1" in
+  install)
+    mkdir -p "$W/prefix/bin"
+    printf '#!/bin/sh\necho 9.9.9\n' > "$W/prefix/bin/namzu"
+    chmod +x "$W/prefix/bin/namzu"
+    exit 0 ;;
+  prefix)
+    printf '%s\n' "$W/prefix"
+    exit 0 ;;
+esac
+exit 1
+EOF
+chmod +x "$W/fakebin/npm"
+
+# The fallback location the old code hard-coded. Deliberately created and left
+# EMPTY, so naming it is visibly wrong rather than merely unproven.
+mkdir -p "$W/home/.namzu/bin"
+
+NODE_DIR="$(dirname "$(command -v node)")"
+
+set +e
+OUT="$(PATH="$W/fakebin:$NODE_DIR:/usr/bin:/bin" \
+       HOME="$W/home" \
+       NAMZU_PREFIX="$W/home/.namzu" \
+       sh "$INSTALLER" 2>&1)"
+STATUS=$?
+set -e
+
+echo "--- installer exit: $STATUS"
+echo "--- installer output:"
+echo "$OUT"
+echo "--- where the binary really is:"
+ls -1 "$W/prefix/bin" 2>/dev/null || echo "(nothing)"
+echo "--- what the fallback dir holds:"
+ls -1A "$W/home/.namzu/bin" 2>/dev/null || echo "(nothing)"
+
+# The assertion: the directory the message names must contain the binary.
+# Matches the current wording and the one it replaced, so a regression to the
+# old phrasing is reported as "named the wrong directory" rather than as "named
+# nothing" — the failure should name the defect, not the rename.
+NAMED="$(printf '%s' "$OUT" | sed -n 's/.*\(The binary is in\|The files are in\) \(.*\)\. Add it to your PATH.*/\2/p')"
+echo "--- directory the installer named: ${NAMED:-<none>}"
+
+if [ -z "$NAMED" ]; then
+	echo "RESULT: FAIL — the installer named no directory"
+	exit 1
+fi
+if [ -e "$NAMED/namzu" ]; then
+	echo "RESULT: PASS — named directory contains the binary"
+	exit 0
+fi
+echo "RESULT: FAIL — named directory does NOT contain the binary"
+exit 1

--- a/packages/cli/src/__tests__/installer-names-a-real-directory.test.ts
+++ b/packages/cli/src/__tests__/installer-names-a-real-directory.test.ts
@@ -1,0 +1,82 @@
+/**
+ * When `install.sh` cannot find `namzu` on PATH, the directory it names holds
+ * the binary.
+ *
+ * The installer's whole argument is that it verifies rather than assumes — it
+ * refuses to trust the package manager's exit code and checks that the binary
+ * answers. One place did the opposite: the "not on PATH" message hard-coded
+ * `$NAMZU_PREFIX/bin`, which is correct only on the FALLBACK branch, while the
+ * check runs after both. So a successful GLOBAL install that was not on PATH
+ * sent the operator to a directory holding zero files while the four files sat
+ * somewhere else.
+ *
+ * It fires for exactly the person the message exists for: anyone whose npm
+ * global bin is not already on PATH, which is the normal state under a version
+ * manager and common on Windows. The install worked, the instruction was wrong,
+ * and the reasonable conclusion is that the installer is broken.
+ *
+ * Asserting the exit code, or that the words "not on PATH" appear, passes with
+ * the defect present. The assertion has to be that the named directory CONTAINS
+ * the binary, which is the only claim the message actually makes.
+ *
+ * ## Why the scenario is a shell script rather than inline here
+ *
+ * It builds a stub `npm`, a PATH, and two directories, then reads the message
+ * back — all of it POSIX-shaped. Driving that from Node means marshalling
+ * Windows paths into a `sh` script and a `:`-separated PATH whose entries
+ * contain drive-letter colons, which is how the first version of this test
+ * failed with no output at all. The fixture runs in the environment it is
+ * about; this file runs the fixture.
+ *
+ * Verified in both directions before landing: exit 1 against the installer as
+ * it was, exit 0 against the fix.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..', '..', '..')
+const INSTALLER = join(REPO_ROOT, 'install.sh')
+const SCENARIO = join(import.meta.dirname, '__fixtures__', 'installer-not-on-path.sh')
+
+/**
+ * `sh` is required, not optional.
+ *
+ * Probed so the reporter says "skipped" on a machine without it rather than
+ * "passed" — a test that reports green having run nothing is the failure this
+ * repository keeps finding. CI is Linux and always takes the real path, so the
+ * check always runs where it decides anything.
+ */
+function hasSh(): boolean {
+	try {
+		execFileSync('sh', ['-c', 'exit 0'], { stdio: 'ignore' })
+		return true
+	} catch {
+		return false
+	}
+}
+
+describe.skipIf(!hasSh())('install.sh, when the binary is not on PATH', () => {
+	it('names a directory that actually contains the binary', () => {
+		// The fixture simulates a SUCCESSFUL GLOBAL install whose bin directory
+		// is not on PATH, with a stub npm — no network, no touching the real
+		// global prefix. It exits non-zero when the named directory does not
+		// hold `namzu`, and prints both locations when it does not.
+		let output = ''
+		let status = 0
+		try {
+			output = execFileSync('sh', [SCENARIO, INSTALLER], {
+				encoding: 'utf8',
+				stdio: ['ignore', 'pipe', 'pipe'],
+			})
+		} catch (err) {
+			const e = err as { status?: number; stdout?: string; stderr?: string }
+			status = e.status ?? -1
+			output = `${e.stdout ?? ''}${e.stderr ?? ''}`
+		}
+
+		expect(status, output).toBe(0)
+		expect(output).toContain('RESULT: PASS')
+	})
+})


### PR DESCRIPTION
fix(install): name the directory the binary is actually in

The installer's argument is that it verifies rather than assumes: it refuses to
trust the package manager's exit code and checks that the binary answers. One
line did the opposite, and it was the line an operator reads at the worst
moment.

The "not on PATH" message hard-coded `${NAMZU_PREFIX}/bin`. That is correct on
the FALLBACK branch and nowhere else, while the check runs after both — so a
**successful global install** that was not on PATH sent the operator to an empty
directory while the files sat in npm's global prefix.

It fires for exactly the person the message exists for: anyone whose npm global
bin is not already on PATH, which is the normal state under a version manager
and common on Windows. The install worked, the instruction was wrong, and the
reasonable conclusion is that the installer is broken when it is not.

## Report what happened, do not compute it

`bin_dir_under()` probes `$root/bin` then `$root` for `namzu`, `namzu.cmd` or
`namzu.ps1`. Both halves of that matter: npm puts executables in `$prefix/bin`
on unix and in `$prefix` itself on Windows, and the shipped name differs too, so
any single hard-coded path is wrong somewhere.

The global branch asks `npm prefix --global` rather than assuming, since that
prefix is npm's to report.

When nothing is found it says so and points at `npm ls --global --parseable`
instead of naming a directory to cover the gap. Sending someone to a path that
does not hold the binary is the failure this branch exists to avoid; doing it
while sounding certain is worse than admitting the install landed somewhere the
script cannot see.

The fallback branch's `PATH` export and the trailing success message carried the
same assumption and now use the same probe, so the line an operator copies into
their profile is the line this run proved works.

## A test that fails on the bug

`installer-names-a-real-directory.test.ts` runs a committed fixture that builds
a **stub npm** — no network, no touching the real global prefix — simulates a
successful global install whose bin directory is off PATH, and asserts that the
directory the message names **contains the binary**.

That assertion is the whole point. Checking the exit code, or that the words
"not on PATH" appear, passes with the defect present.

Verified in both directions before landing: exit 1 against the installer as it
was on `main`, exit 0 against the fix, and the vitest wrapper goes red when
`install.sh` is reverted underneath it.

The scenario is a shell fixture rather than inline Node on purpose. The first
version marshalled Windows paths into a `sh` script and a `:`-separated PATH
whose entries contain drive-letter colons; it failed with no output at all. The
fixture runs in the environment it is about, and this test runs the fixture.

## Untested, and recorded as untested

**The fallback branch is unverified.** Neither the owner's live run nor this
fixture takes it — both exercise the global path. The `~/.namzu` messages on
that branch may well be right and there is no evidence either way, so they
should be read as untried rather than as working.
