### PR TITLE
refactor(sdk)!: one frontmatter key holds one kind of thing

### DIFF
--- a/.changeset/one-reader-for-the-fence.md
+++ b/.changeset/one-reader-for-the-fence.md
@@ -2,17 +2,30 @@
 '@namzu/sdk': minor
 ---
 
-Added `parseFrontmatter`, the one reader for a markdown file's `---` block, and
-its `ParsedFrontmatter` result type.
+Added `parseFrontmatter`, the one reader for a markdown file's `---` block, with
+its `ParsedFrontmatter` result and `FrontmatterValue` types.
 
 ```ts
 import { parseFrontmatter } from '@namzu/sdk'
 
-const { data, blocks, body } = parseFrontmatter(raw, `command at "${path}"`)
-// data:   { description: 'Open a pull request', 'argument-hint': '<branch>' }
-// blocks: { metadata: { author: 'someone' } }   ← one level of nesting
-// body:   everything after the closing fence, trimmed
+const { values, body } = parseFrontmatter(raw, `command at "${path}"`)
+// values: {
+//   description:     { kind: 'scalar',  value: 'Open a pull request' },
+//   'argument-hint': { kind: 'scalar',  value: '<branch>' },
+//   metadata:        { kind: 'mapping', entries: { author: 'someone' } },
+// }
+// body: everything after the closing fence, trimmed
+
+const description = values.description
+if (description?.kind !== 'scalar') throw new Error('description must be a scalar')
 ```
+
+**One entry per key, discriminated on `kind`.** A key is a scalar or a
+one-level block, never both — no YAML file can express both, so the type does
+not let you represent it and the parser refuses a file that tries (a value
+*and* indented lines under the same key). Two parallel maps would have made
+every caller invent a precedence for a case that cannot arrive, and quietly
+punished the ones who did not.
 
 **Why you would want it.** If you read your own markdown — command files,
 prompt templates, anything with frontmatter — you were writing a second reader.
@@ -47,9 +60,7 @@ release; covered by tests.
 **It does not know what your fields mean.** It returns the parsed map and
 validates no field names — a skill's vocabulary and a command's are different,
 and widening one to cover the other is how a skill-shaped API comes to mean
-something it does not. `data` holds top-level scalars, `blocks` holds one level
-of indented keys grouped under the key above them. Your own validation stays
-yours.
+something it does not. Your own validation stays yours.
 
 **Nothing about `loadSkill`, `discoverSkills`, `SkillRegistry` or
 `resolveSkillChain` changes**, with one disclosed exception below. They are now
@@ -60,6 +71,12 @@ children, `metadata:` with a value *and* children, children under a
 non-`metadata` key, duplicate keys, and indented lines before any key — and
 compared on returned metadata, body, token estimate, and thrown message. 52
 cases, no structural difference.
+
+**A third exception, from the shape above.** A `SKILL.md` whose key carried both
+a value and an indented block — `metadata: something` with `author: …` beneath
+it — used to load, with the value silently discarded. It is now refused, naming
+the key. The discarded half is why: the file said two things and the loader only
+ever honoured one, so the author had no way to see which.
 
 **A second exception, and it is a fix.** A file using lone-`CR` line endings
 (classic Mac, pre-2001) used to be read as one single line, which collapsed the

--- a/.github/scripts/public-surface-baseline.json
+++ b/.github/scripts/public-surface-baseline.json
@@ -886,6 +886,7 @@
     "FileReadTracker",
     "FileSlot",
     "FilesystemMigrationError",
+    "FrontmatterValue",
     "GENAI",
     "GateDecision",
     "GateEvaluationResult",

--- a/docs/sdk/prompting/README.md
+++ b/docs/sdk/prompting/README.md
@@ -215,13 +215,28 @@ writing a second one:
 ```ts
 import { parseFrontmatter } from '@namzu/sdk'
 
-const { data, blocks, body } = parseFrontmatter(raw, `command at "${path}"`)
-// data:   { description: 'Open a pull request', 'argument-hint': '<branch>' }
-// blocks: { metadata: { author: 'someone' } }   ← one level of nesting
-// body:   everything after the closing fence, trimmed
+const { values, body } = parseFrontmatter(raw, `command at "${path}"`)
+// values: {
+//   description:     { kind: 'scalar',  value: 'Open a pull request' },
+//   'argument-hint': { kind: 'scalar',  value: '<branch>' },
+//   metadata:        { kind: 'mapping', entries: { author: 'someone' } },
+// }
+// body: everything after the closing fence, trimmed
+
+const description = values.description
+if (description?.kind !== 'scalar') {
+  throw new Error('a command needs a scalar description')
+}
 ```
 
-Three things about it are deliberate:
+Every key is one entry, and `kind` says whether it is a scalar or a one-level
+block. That is a union rather than two parallel maps because **a key cannot be
+both** — no YAML file can say it — and a shape that could represent it would
+force every caller to invent a precedence for a case that never arrives. A file
+that tries (a value *and* indented lines under one key) is refused rather than
+half-read.
+
+Three more things about it are deliberate:
 
 - **It refuses rather than degrades.** Absent frontmatter, an unclosed fence, or
   YAML it does not implement — a block scalar (`>`/`|`), a flow sequence

--- a/packages/sdk/src/public-types.ts
+++ b/packages/sdk/src/public-types.ts
@@ -99,7 +99,7 @@ export type {
 export type { AdvisoryCallContext, AdvisoryExecutionResult } from './advisory/index.js'
 
 export type { ModelPricing } from './utils/cost.js'
-export type { ParsedFrontmatter } from './utils/frontmatter.js'
+export type { FrontmatterValue, ParsedFrontmatter } from './utils/frontmatter.js'
 export type { Logger } from './utils/logger.js'
 export type { ShellCompressOptions, ShellCompressResult } from './utils/shell-compress.js'
 

--- a/packages/sdk/src/skills/loader.ts
+++ b/packages/sdk/src/skills/loader.ts
@@ -29,46 +29,68 @@ function sourceLabel(dirPath: string): string {
  * skill requires is this function's. A command file goes through the same
  * reader and validates an entirely different set of keys.
  */
+/**
+ * Read one key, narrowed to the shape this field is declared to have.
+ *
+ * `Object.hasOwn`, not a bare `values[key]`: a plain property read walks the
+ * prototype chain, so a `Object.prototype.description` poisoned by anything
+ * else in the process would be picked up here as though the file had declared
+ * it. The parser can no longer create that poison; this is the other end of
+ * the same guarantee.
+ */
+function scalarAt(values: ParsedFrontmatter['values'], key: string): string | undefined {
+	if (!Object.hasOwn(values, key)) return undefined
+	const found = values[key]
+	return found?.kind === 'scalar' ? found.value : undefined
+}
+
+function mappingAt(
+	values: ParsedFrontmatter['values'],
+	key: string,
+): Readonly<Record<string, string>> | undefined {
+	if (!Object.hasOwn(values, key)) return undefined
+	const found = values[key]
+	return found?.kind === 'mapping' ? found.entries : undefined
+}
+
 function toSkillMetadata(parsed: ParsedFrontmatter, dirPath: string): SkillMetadata {
 	const source = sourceLabel(dirPath)
-	const { data, blocks } = parsed
+	const { values } = parsed
 
-	if (!data.name) {
+	const name = scalarAt(values, 'name')
+	const description = scalarAt(values, 'description')
+
+	if (!name) {
 		throw new Error(`${source} missing required field: name`)
 	}
-	if (!data.description) {
+	if (!description) {
 		throw new Error(`${source} missing required field: description`)
 	}
 
-	validateSkillName(data.name, dirPath)
-	validateDescription(data.description, dirPath)
+	validateSkillName(name, dirPath)
+	validateDescription(description, dirPath)
 
-	const skillMetadata: SkillMetadata = {
-		name: data.name,
-		description: data.description,
+	const skillMetadata: SkillMetadata = { name, description }
+
+	const license = scalarAt(values, 'license')
+	if (license) {
+		skillMetadata.license = license
 	}
 
-	if (data.license) {
-		skillMetadata.license = data.license
-	}
-
-	if (data.compatibility) {
-		if (data.compatibility.length > 500) {
+	const compatibility = scalarAt(values, 'compatibility')
+	if (compatibility) {
+		if (compatibility.length > 500) {
 			throw new Error(`${source}: compatibility exceeds 500 characters`)
 		}
-		skillMetadata.compatibility = data.compatibility
+		skillMetadata.compatibility = compatibility
 	}
 
-	if (data['allowed-tools']) {
-		skillMetadata.allowedTools = data['allowed-tools']
+	const allowedTools = scalarAt(values, 'allowed-tools')
+	if (allowedTools) {
+		skillMetadata.allowedTools = allowedTools
 	}
 
-	// `Object.hasOwn`, not `blocks.metadata`: a bare property read walks the
-	// prototype chain, so a poisoned `Object.prototype.metadata` anywhere in
-	// the process would be picked up here as though the file had declared it.
-	// The parser no longer creates that poison, and this is the other end of
-	// the same guarantee.
-	const extra = Object.hasOwn(blocks, 'metadata') ? blocks.metadata : undefined
+	const extra = mappingAt(values, 'metadata')
 	if (extra && Object.keys(extra).length > 0) {
 		skillMetadata.metadata = { ...extra }
 	}

--- a/packages/sdk/src/utils/__tests__/frontmatter.test.ts
+++ b/packages/sdk/src/utils/__tests__/frontmatter.test.ts
@@ -30,18 +30,28 @@ const LINES = [
 
 const SOURCE = 'test.md'
 
+/** The scalar keys, flattened, so a whole-map comparison stays readable. */
+function scalars(raw: string): Record<string, string> {
+	const { values } = parseFrontmatter(raw, SOURCE)
+	return Object.fromEntries(
+		Object.entries(values).flatMap(([k, v]) =>
+			v.kind === 'scalar' ? [[k, v.value] as const] : [],
+		),
+	)
+}
+
 describe('line endings', () => {
 	it('parses CRLF identically to LF', () => {
-		const lf = parseFrontmatter(LINES.join('\n'), SOURCE)
-		const crlf = parseFrontmatter(LINES.join('\r\n'), SOURCE)
+		const lf = scalars(LINES.join('\n'))
+		const crlf = scalars(LINES.join('\r\n'))
 
-		expect(lf.data).toEqual({ name: 'a-skill', description: 'Does a useful thing' })
+		expect(lf).toEqual({ name: 'a-skill', description: 'Does a useful thing' })
 		// The whole point: the same keys, not merely "some keys".
-		expect(crlf.data).toEqual(lf.data)
+		expect(crlf).toEqual(lf)
 	})
 
 	it('does not leave a carriage return inside a CRLF value', () => {
-		const { data } = parseFrontmatter(LINES.join('\r\n'), SOURCE)
+		const data = scalars(LINES.join('\r\n'))
 		// A trailing \r survives naive splitting and reaches the system prompt.
 		expect(data.description).toBe('Does a useful thing')
 		expect(data.description).not.toMatch(/\r/)
@@ -59,7 +69,10 @@ describe('line endings', () => {
 		const raw = ['---', 'name: x', 'metadata:', '  author: someone', '---', '', 'Body.'].join(
 			'\r\n',
 		)
-		expect(parseFrontmatter(raw, SOURCE).blocks.metadata).toEqual({ author: 'someone' })
+		expect(parseFrontmatter(raw, SOURCE).values.metadata).toEqual({
+			kind: 'mapping',
+			entries: { author: 'someone' },
+		})
 	})
 
 	it('splits a lone-CR file into lines rather than one long key', () => {
@@ -68,7 +81,7 @@ describe('line endings', () => {
 		// escaped it only because the collapse also removes the `description`
 		// key, so the required-field check refused the file first. A caller
 		// that validates nothing would have taken the mangled name.
-		const { data } = parseFrontmatter(LINES.join('\r'), SOURCE)
+		const data = scalars(LINES.join('\r'))
 		expect(data).toEqual({ name: 'a-skill', description: 'Does a useful thing' })
 		expect(data.name).not.toMatch(/description/)
 	})
@@ -81,7 +94,7 @@ describe('line endings', () => {
 	it('parses a file that opens with a byte-order mark', () => {
 		// An editor on Windows writes one, and `---` is then not at index 0.
 		const raw = `﻿${LINES.join('\r\n')}`
-		expect(parseFrontmatter(raw, SOURCE).data.name).toBe('a-skill')
+		expect(scalars(raw).name).toBe('a-skill')
 	})
 })
 
@@ -112,6 +125,29 @@ describe('refusing rather than degrading', () => {
 		const raw = ['---', 'name: x', 'opts: {a: b}', '---'].join('\n')
 		expect(() => parseFrontmatter(raw, SOURCE)).toThrow(/flow mapping/)
 	})
+
+	it('refuses a key that is both a scalar and a block', () => {
+		// No YAML file can mean this, so the result type cannot express it.
+		// Picking a precedence instead would silently drop half of what the
+		// author wrote.
+		const raw = ['---', 'name: x', 'metadata: inline', '  author: someone', '---'].join('\n')
+		expect(() => parseFrontmatter(raw, SOURCE)).toThrow(
+			/"metadata" has both a value and an indented block/,
+		)
+	})
+
+	it('refuses the same conflict when the block comes from a later duplicate key', () => {
+		const raw = [
+			'---',
+			'name: x',
+			'metadata: inline',
+			'other: y',
+			'metadata:',
+			'  a: 1',
+			'---',
+		].join('\n')
+		expect(() => parseFrontmatter(raw, SOURCE)).toThrow(/has both a value and an indented block/)
+	})
 })
 
 describe('keys from an untrusted file cannot reach the prototype chain', () => {
@@ -137,19 +173,19 @@ describe('keys from an untrusted file cannot reach the prototype chain', () => {
 
 	it('reports such a key as ordinary own data instead', () => {
 		const raw = ['---', 'name: x', '__proto__:', '  polluted: yes', '---'].join('\n')
-		const { blocks } = parseFrontmatter(raw, SOURCE)
+		const { values } = parseFrontmatter(raw, SOURCE)
 
 		// The file really did declare it, so reporting it is honest; what must
 		// not happen is the write landing on the prototype.
-		expect(Object.hasOwn(blocks, '__proto__')).toBe(true)
+		expect(Object.hasOwn(values, '__proto__')).toBe(true)
 		expect(({} as Record<string, unknown>).polluted).toBeUndefined()
 	})
 
 	it('does not let a `constructor` scalar shadow anything structural', () => {
 		const raw = ['---', 'name: x', 'constructor: hijacked', '---'].join('\n')
-		const { data } = parseFrontmatter(raw, SOURCE)
-		expect(data.constructor).toBe('hijacked')
-		expect(Object.hasOwn(data, 'constructor')).toBe(true)
+		const { values } = parseFrontmatter(raw, SOURCE)
+		expect(values.constructor).toEqual({ kind: 'scalar', value: 'hijacked' })
+		expect(Object.hasOwn(values, 'constructor')).toBe(true)
 	})
 })
 
@@ -164,8 +200,8 @@ describe('the closing fence', () => {
 			'Body text.',
 		].join('\n')
 
-		const { data, body } = parseFrontmatter(raw, SOURCE)
-		expect(data.description).toContain('CSV')
+		expect(scalars(raw).description).toContain('CSV')
+		const { body } = parseFrontmatter(raw, SOURCE)
 		expect(body).toBe('Body text.')
 		// A leak here is a leak into the system prompt.
 		expect(body).not.toContain('description:')
@@ -188,35 +224,49 @@ describe('vocabulary belongs to the caller', () => {
 			'Prompt template.',
 		].join('\n')
 
-		const { data, body } = parseFrontmatter(raw, SOURCE)
-		expect(data).toEqual({
-			description: 'Open a pull request',
-			'argument-hint': '<branch>',
+		const { values, body } = parseFrontmatter(raw, SOURCE)
+		expect(values).toEqual({
+			description: { kind: 'scalar', value: 'Open a pull request' },
+			'argument-hint': { kind: 'scalar', value: '<branch>' },
 		})
 		expect(body).toBe('Prompt template.')
 	})
 
 	it('validates no field names of its own — `name` is not required', () => {
 		const raw = ['---', 'description: no name here', '---'].join('\n')
-		expect(parseFrontmatter(raw, SOURCE).data).toEqual({ description: 'no name here' })
+		expect(scalars(raw)).toEqual({ description: 'no name here' })
 	})
 
 	it('groups an indented block under any key, not only `metadata`', () => {
 		const raw = ['---', 'name: x', 'inputs:', '  branch: main', '  force: "yes"', '---'].join('\n')
-		const { data, blocks } = parseFrontmatter(raw, SOURCE)
-		expect(data).toEqual({ name: 'x' })
-		expect(blocks.inputs).toEqual({ branch: 'main', force: 'yes' })
+		const { values } = parseFrontmatter(raw, SOURCE)
+		expect(values).toEqual({
+			name: { kind: 'scalar', value: 'x' },
+			inputs: { kind: 'mapping', entries: { branch: 'main', force: 'yes' } },
+		})
+	})
+
+	it('makes the scalar-or-mapping choice narrowable rather than guessable', () => {
+		const raw = ['---', 'flat: v', 'nested:', '  a: b', '---'].join('\n')
+		const { values } = parseFrontmatter(raw, SOURCE)
+
+		const flat = values.flat
+		const nested = values.nested
+		// The union is the point: one lookup, one discriminant, no key that
+		// could be in two places at once.
+		expect(flat?.kind === 'scalar' && flat.value).toBe('v')
+		expect(nested?.kind === 'mapping' && nested.entries).toEqual({ a: 'b' })
 	})
 })
 
 describe('scalars', () => {
 	it('keeps a quoted value containing a colon', () => {
 		const raw = ['---', 'url: "Reads a URL: http://example.com"', '---'].join('\n')
-		expect(parseFrontmatter(raw, SOURCE).data.url).toBe('Reads a URL: http://example.com')
+		expect(scalars(raw).url).toBe('Reads a URL: http://example.com')
 	})
 
 	it('skips comments and blank lines', () => {
 		const raw = ['---', '# a comment', '', 'name: x', '---'].join('\n')
-		expect(parseFrontmatter(raw, SOURCE).data).toEqual({ name: 'x' })
+		expect(scalars(raw)).toEqual({ name: 'x' })
 	})
 })

--- a/packages/sdk/src/utils/frontmatter.ts
+++ b/packages/sdk/src/utils/frontmatter.ts
@@ -96,22 +96,36 @@ const UNSUPPORTED_YAML = [
 	{ pattern: /^\{.*\}$/, what: 'a flow mapping (`{a: b}`)' },
 ] as const
 
+/**
+ * What one frontmatter key holds: a scalar, or a block of indented pairs.
+ *
+ * A discriminated union rather than two parallel maps, because the source
+ * format cannot express both at once. The first shape of this type had
+ * `data: Record<string, string>` beside `blocks: Record<string, Record<…>>`,
+ * which let one key sit in both — a state no YAML file can produce. Every
+ * caller would then have had to decide a precedence for a case that cannot
+ * arrive, and the ones who did not would be carrying a latent bug against a
+ * shape that told them the case existed. Removing the state beats documenting
+ * it.
+ */
+export type FrontmatterValue =
+	| { readonly kind: 'scalar'; readonly value: string }
+	| { readonly kind: 'mapping'; readonly entries: Readonly<Record<string, string>> }
+
 export interface ParsedFrontmatter {
 	/**
-	 * Top-level `key: value` scalars. A key whose value is empty is omitted —
-	 * it is a block header, not a value.
-	 */
-	readonly data: Readonly<Record<string, string>>
-
-	/**
-	 * Indented `key: value` lines, grouped under the top-level key that
-	 * precedes them. One level only; this reader does not nest further.
+	 * Every top-level key, in the order the file declared it.
 	 *
-	 * Kept separate from {@link data} rather than folded into it as a union so
-	 * that a key carrying both a scalar and a block keeps both, and so a caller
-	 * reading `data.x` never has to narrow a string against a record.
+	 * A key whose value is empty and which has no indented lines under it is
+	 * absent: it declared nothing. Narrow on `kind` to read it —
+	 *
+	 * ```ts
+	 * const d = values.description
+	 * if (d?.kind !== 'scalar') throw new Error('description must be a scalar')
+	 * use(d.value)
+	 * ```
 	 */
-	readonly blocks: Readonly<Record<string, Readonly<Record<string, string>>>>
+	readonly values: Readonly<Record<string, FrontmatterValue>>
 
 	/** Everything after the closing fence, trimmed. */
 	readonly body: string
@@ -187,11 +201,26 @@ export function parseFrontmatter(raw: string, source: string): ParsedFrontmatter
 		if (value) data.set(key, value)
 	}
 
-	return {
-		data: Object.fromEntries(data),
-		blocks: Object.fromEntries([...blocks].map(([k, v]) => [k, Object.fromEntries(v)])),
-		body,
+	// A key cannot be a scalar and a mapping at once — no YAML file can say
+	// that — so refusing here is what makes the illegal state unrepresentable
+	// in the returned type rather than merely undocumented. The alternative,
+	// picking a precedence, would silently drop half of what the author wrote.
+	for (const key of blocks.keys()) {
+		if (!data.has(key)) continue
+		throw new Error(
+			`${source}: "${key}" has both a value and an indented block. A key is one or the other — remove the value, or un-indent the lines beneath it.`,
+		)
 	}
+
+	const values = new Map<string, FrontmatterValue>()
+	for (const [key, value] of data) {
+		values.set(key, { kind: 'scalar', value })
+	}
+	for (const [key, entries] of blocks) {
+		values.set(key, { kind: 'mapping', entries: Object.fromEntries(entries) })
+	}
+
+	return { values: Object.fromEntries(values), body }
 }
 
 function normalizeScalar(value: string): string {


### PR DESCRIPTION
`ParsedFrontmatter` shipped in #233 with `data` and `blocks` as parallel maps,
so **one key could sit in both**. No YAML file can say that. A type that can
represent a state its own input cannot produce forces every caller to invent a
precedence for a case that never arrives, and quietly punishes the ones who do
not.

**The release PR is held for this**, on a cost asymmetry: `ParsedFrontmatter`
has never been published, so changing it now costs this PR. Changing it after
publication costs a `major` plus a migration note for every consumer — and the
first consumer adopts it the moment it reaches npm, after which reshaping means
changing their code too.

## The shape

```ts
export type FrontmatterValue =
  | { readonly kind: 'scalar'; readonly value: string }
  | { readonly kind: 'mapping'; readonly entries: Readonly<Record<string, string>> }

export interface ParsedFrontmatter {
  readonly values: Readonly<Record<string, FrontmatterValue>>
  readonly body: string
}
```

**Two halves, because the type alone is not enough.**

1. The type can no longer represent the state — one entry per key,
   discriminated on `kind`.
2. The parser **refuses the input that produced it**. A key carrying a value
   *and* an indented block now throws, naming the key.

Picking a precedence instead would have moved the ambiguity out of the type and
into a silent drop — the same defect wearing a different hat. Under the old
reader that file loaded and the scalar was discarded with nothing said, which is
exactly what `refuse-do-not-degrade` exists to stop.

**No helper accessors exported.** Narrowing on `kind` is idiomatic, and the
asymmetry that motivated this whole change argues for the smaller surface:
adding an export later is a `minor`, removing one is a `major`.

## Differential, bucketed

35 shapes × 3 line endings = 105 cases, compared against the pre-refactor loader
on returned skill, token estimate and thrown message. 41 differences, **and no
unexpected bucket**:

| count | bucket |
|---|---|
| 4 | **NEW: scalar+block refusal** |
| 31 | lone-CR (ruled previously) |
| 6 | prose (ruled previously) |

Bucketing rather than eyeballing is the point — it turns "I looked at the diffs"
into a result that fails loudly if something lands outside the categories I
claimed.

## Verification

`pnpm typecheck` 0 · full suite 0, 431 files, 5 skipped · lint 0 (the four
changed files clean; 7 pre-existing warnings elsewhere untouched) · docs gate 0 ·
external-name audit clean.

Baseline regenerated and **checked by name, not count** — adds
`FrontmatterValue` to the declared array; 1218 → 1219, runtime unchanged at 530.

`docs/sdk/prompting/README.md` §5b updated in the same change, since it carried
the old shape as a worked example — a doc showing `data`/`blocks` after this
lands would be teaching an API that no longer exists.

## Note on the branch

Cherry-picked onto current `main` rather than rebased: the previous branch's
commits are already in `main` via #233's squash, so a rebase replayed them
against themselves and conflicted. One commit, clean apply.
