### PR TITLE
fix(cli): one reader for one file shape

### DIFF
--- a/.changeset/one-reader-for-one-file-shape.md
+++ b/.changeset/one-reader-for-one-file-shape.md
@@ -1,0 +1,28 @@
+---
+'@namzu/cli': minor
+---
+
+A `SKILL.md` written on Windows now works.
+
+The skill reader carried its own frontmatter regex, `/^---\n…\n---\n?/`, which
+is LF-only. A file saved with CRLF line endings — the Windows default — matched
+nothing, so the entire file was treated as body and the skill was listed under
+its directory name with `(no description)`. It never failed; it described the
+skill wrongly, which is why it survived this long.
+
+It now reads through `parseFrontmatter` from `@namzu/sdk`, so LF, CRLF and a
+lone CR all parse identically, a BOM is handled, and frontmatter keys can no
+longer reach `Object.prototype`.
+
+**One behaviour changed on purpose.** Frontmatter you *leave out* is still fine
+and still documented: a file with no `---` fence is all body. Frontmatter you
+*open and get wrong* is now refused instead of being treated as absent. The old
+answer put the unreadable YAML into the body, where it reached the model
+verbatim under a skill named after its own directory.
+
+A refused skill does not take the roster with it. It stays in `/skills` marked
+`⚠` with the parse error, so a file you can see on disk is accounted for, and
+`/skill <name>` declines to activate it rather than injecting nothing.
+
+If you have a `SKILL.md` whose frontmatter never parsed, you will now be told —
+that is the change, and the skill was not working before either.

--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -1,7 +1,7 @@
 ---
 title: Skills
 description: Author SKILL.md capability docs, discover them, and activate one for the session with /skill.
-last_updated: 2026-05-25
+last_updated: 2026-08-07
 status: current
 related_packages: ["@namzu/cli"]
 ---
@@ -23,6 +23,20 @@ Call out risky patterns explicitly and suggest concrete fixes.
 ```
 
 `name` and `description` are optional — if `name` is absent, the directory name is used; the frontmatter block itself is optional (a file with no frontmatter is all body).
+
+**Frontmatter you open must parse.** Leaving it out entirely is supported, as
+above. Opening a `---` fence and then writing something the reader cannot
+understand is not: the skill is refused and listed with the reason, rather than
+loaded as if it had no metadata. That distinction is new, and it exists because
+the old behaviour put the unreadable frontmatter into the body — where it
+reached the model verbatim, under a skill named after its own directory.
+
+A refused skill does not hide the others. It appears in `/skills` marked `⚠`
+with the parse error, so the file you can see on disk is accounted for.
+
+Line endings do not matter. LF, CRLF and a lone CR all parse — a `SKILL.md`
+written on Windows used to lose its frontmatter silently and show up under its
+directory name with `(no description)`.
 
 ## Discovery
 

--- a/docs/conventions/never-filter-a-verification.md
+++ b/docs/conventions/never-filter-a-verification.md
@@ -64,6 +64,38 @@ the second time this file records someone adopting the rule and then breaking
 it. That is not irony, it is the measurement: the habit is easy to hold in
 principle and hard to hold in the next command.
 
+It then happened to a third person, on a different tool, the same day: a live
+run of the CLI was measured through `| tail -3` and reported `exit 0` for a
+command that exits `77`, which nearly went in as "the trust gate is broken".
+
+Three people, three tools, one shape — **the thing that reports success is not
+the thing you ran.**
+
+## The variant that hides best
+
+A filter eating the diagnostic leaves a gap you might notice. `$?` after a
+pipeline leaves nothing to notice: it is a number, confidently about the wrong
+process. It has now bitten twice, and it is the least visible of the three.
+
+```sh
+node tools/check-docs.mjs > /dev/null 2>&1; echo $?   # the gate's own status
+node tools/check-docs.mjs | tail -4; echo $?          # tail's status, always 0
+```
+
+## An exit code you did not read the cause of is not evidence
+
+The same rule pointed at a tool rather than a filter. Two from one session:
+
+- A mutation reported `exit 1` and was recorded as the test failing. It was
+  `vitest is not recognized` — a bad invocation. **A false kill reads exactly
+  like a real one.**
+- A mutation applied with `sed` inserted a literal newline, broke the file, and
+  vitest reported `no tests`. Also `exit 1`, also not the assertion firing.
+
+Both were caught by re-running through the real command and reading *why* it
+failed. A mutation that "passes" tells you nothing until you have seen the
+assertion in the failure output.
+
 ## Related
 
 - [Mutate every test](mutation-check-every-test.md) — its "read the run, not

--- a/packages/cli/src/skills/store.test.ts
+++ b/packages/cli/src/skills/store.test.ts
@@ -41,9 +41,40 @@ describe('parseSkillMarkdown', () => {
 		expect(parsed.body).toBe('just a body')
 	})
 
-	it('tolerates malformed frontmatter', () => {
-		const parsed = parseSkillMarkdown('---\n: : bad yaml :\n---\nbody here')
-		expect(parsed.body).toBe('body here')
+	// The defect this adoption exists to close. The old reader's regex was
+	// `/^---\n…\n---\n?/` — LF only — so a SKILL.md saved on Windows matched
+	// nothing, the whole file became body, and the skill was listed under its
+	// directory name with "(no description)". It did not fail; it described the
+	// skill wrongly.
+	it('reads CRLF frontmatter, which the previous reader silently ignored', () => {
+		const parsed = parseSkillMarkdown(
+			'---\r\nname: Pirate\r\ndescription: talk like a pirate\r\n---\r\nArr matey.',
+		)
+		expect(parsed.name).toBe('Pirate')
+		expect(parsed.description).toBe('talk like a pirate')
+		expect(parsed.body).toBe('Arr matey.')
+	})
+
+	it('refuses frontmatter it cannot read, rather than calling it absent', () => {
+		// An author who opened a fence and got the contents wrong is not the
+		// same as an author who wrote no frontmatter. Answering the first with
+		// "no metadata, carry on" put the broken YAML into the body and from
+		// there into the system prompt.
+		expect(() => parseSkillMarkdown('---\nname: x\nbody with no closing fence')).toThrow()
+	})
+
+	it('names the source in the refusal, so the operator knows which file', () => {
+		expect(() => parseSkillMarkdown('---\nunclosed', '/skills/broken/SKILL.md')).toThrow(
+			/\/skills\/broken\/SKILL\.md/,
+		)
+	})
+
+	it('still treats a file with no fence as all body, which is documented', () => {
+		// `docs/cli/skills.md` promises this, and the refusal above must not
+		// have taken it with it.
+		const parsed = parseSkillMarkdown('# Just a heading\n\nand prose.')
+		expect(parsed.name).toBeUndefined()
+		expect(parsed.body).toBe('# Just a heading\n\nand prose.')
 	})
 })
 

--- a/packages/cli/src/skills/store.ts
+++ b/packages/cli/src/skills/store.ts
@@ -15,7 +15,7 @@
 import { readFileSync, readdirSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import { parse as parseYaml } from 'yaml'
+import { parseFrontmatter } from '@namzu/sdk'
 
 export type SkillSource = 'user' | 'project'
 
@@ -24,6 +24,16 @@ export interface SkillInfo {
 	readonly description: string
 	readonly path: string
 	readonly source: SkillSource
+	/**
+	 * Why this skill cannot be used, when it cannot.
+	 *
+	 * A `SKILL.md` whose frontmatter does not parse is REFUSED rather than
+	 * loaded with the metadata missing, but refusing it must not take the rest
+	 * of the roster with it: one unreadable file in `~/.namzu/skills` would
+	 * otherwise leave the operator with no skills and no reason. So it stays in
+	 * the list, named, carrying the reason it is unusable.
+	 */
+	readonly problem?: string
 }
 
 export function userSkillsDir(home: string = homedir()): string {
@@ -41,25 +51,47 @@ interface ParsedSkill {
 }
 
 /**
- * Split `SKILL.md` into frontmatter (name/description) + body. Tolerant:
- * a file with no frontmatter is all body.
+ * Split `SKILL.md` into frontmatter (name/description) + body.
+ *
+ * Reads through the kernel's `parseFrontmatter`, which is the point: this file
+ * used to carry its own regex, `/^---\n…\n---\n?/`, and that regex is LF-only.
+ * A `SKILL.md` saved on Windows has CRLF line endings, so the match failed, the
+ * whole file was treated as body, and the skill was listed under its directory
+ * name with `(no description)`. It did not fail — it described the skill
+ * wrongly, which is the shape that survives review.
+ *
+ * ## Absent frontmatter is fine; broken frontmatter is not
+ *
+ * These were the same case here and are not the same thing. A file with no
+ * frontmatter is a documented, supported shape (`docs/cli/skills.md`): the body
+ * is the skill. A file that opens a fence and then fails to parse is an author
+ * who tried to write metadata and got it wrong, and answering that with "no
+ * metadata, carry on" put the broken YAML into the body — and from there
+ * verbatim into the system prompt.
+ *
+ * So the fence decides. No fence, no parser: body only, exactly as documented.
+ * A fence present hands the file to the kernel reader, which throws rather than
+ * returning a partial result. The absence test mirrors the reader's own
+ * (`raw.trimStart().startsWith('---')`) so the two cannot disagree about what
+ * counts as having frontmatter — two readers disagreeing on that is the defect
+ * this consolidation exists to remove.
+ *
+ * @param source A label for the error message, e.g. the file's path.
+ * @throws When a fence is present and the frontmatter cannot be read.
  */
-export function parseSkillMarkdown(raw: string): ParsedSkill {
-	const match = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/)
-	if (!match) return { body: raw.trim() }
-	const [, frontmatter, body] = match
-	let name: string | undefined
-	let description: string | undefined
-	try {
-		const meta = parseYaml(frontmatter ?? '') as Record<string, unknown> | null
-		if (meta && typeof meta === 'object') {
-			if (typeof meta.name === 'string') name = meta.name
-			if (typeof meta.description === 'string') description = meta.description
-		}
-	} catch {
-		// Malformed frontmatter → treat as no metadata; body still usable.
-	}
-	return { name, description, body: (body ?? '').trim() }
+export function parseSkillMarkdown(raw: string, source = 'SKILL.md'): ParsedSkill {
+	if (!raw.trimStart().startsWith('---')) return { body: raw.trim() }
+
+	const { values, body } = parseFrontmatter(raw, source)
+
+	// A non-scalar `name` or `description` is dropped rather than rendered:
+	// there is no sensible string for a block of indented pairs, and the
+	// fallbacks below (directory name, "(no description)") are the honest
+	// answer for a key that did not carry one.
+	const name = values.name?.kind === 'scalar' ? values.name.value : undefined
+	const description = values.description?.kind === 'scalar' ? values.description.value : undefined
+
+	return { name, description, body }
 }
 
 function readSkillsFrom(dir: string, source: SkillSource): SkillInfo[] {
@@ -80,7 +112,22 @@ function readSkillsFrom(dir: string, source: SkillSource): SkillInfo[] {
 		} catch {
 			continue
 		}
-		const parsed = parseSkillMarkdown(raw)
+		let parsed: ParsedSkill
+		try {
+			parsed = parseSkillMarkdown(raw, path)
+		} catch (err) {
+			// Refused, but still listed. One unreadable file must not empty the
+			// roster and leave the operator without a reason — the whole point of
+			// refusing instead of degrading is that somebody gets told.
+			skills.push({
+				name: dirName,
+				description: '(could not be read)',
+				path,
+				source,
+				problem: err instanceof Error ? err.message : String(err),
+			})
+			continue
+		}
 		skills.push({
 			name: parsed.name ?? dirName,
 			description: parsed.description ?? '(no description)',
@@ -106,7 +153,8 @@ export function discoverSkills(opts: { home?: string; cwd?: string } = {}): Skil
 
 /** Read a skill's markdown body (frontmatter stripped). */
 export function loadSkillBody(info: SkillInfo): string {
-	return parseSkillMarkdown(readFileSync(info.path, 'utf8')).body
+	if (info.problem) throw new Error(info.problem)
+	return parseSkillMarkdown(readFileSync(info.path, 'utf8'), info.path).body
 }
 
 /** Compose the active-skills system block, or null when none are active. */

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -618,8 +618,13 @@ export function App({ ctx }: AppProps) {
 							return
 						}
 						const activeNames = new Set(activeSkills.map((s) => s.name))
-						const lines = skills.map(
-							(s) => `${activeNames.has(s.name) ? '● ' : '○ '}${s.name} — ${s.description}`,
+						const lines = skills.map((s) =>
+							// A refused skill is shown with its reason rather than hidden.
+							// Dropping it silently would leave someone wondering where a
+							// file they can see on disk went.
+							s.problem
+								? `⚠ ${s.name} — ${s.problem}`
+								: `${activeNames.has(s.name) ? '● ' : '○ '}${s.name} — ${s.description}`,
 						)
 						pushMessage('system', `Skills (● active):\n  ${lines.join('\n  ')}`)
 						return


### PR DESCRIPTION
fix(cli): one reader for one file shape

The skill reader carried its own frontmatter regex. `parseFrontmatter` from the
kernel replaces it, and that replacement *is* the Windows fix rather than a step
toward one.

`/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/` is LF-only. A `SKILL.md` saved with CRLF
matched nothing, so the whole file became body and the skill was listed under
its directory name with `(no description)`. It never failed. It described the
skill wrongly, which is the shape that survives review.

## Absent frontmatter and broken frontmatter were the same case, and are not

This is the part that needed deciding rather than porting.

`docs/cli/skills.md` documents frontmatter as optional: a file with no fence is
all body. That contract is good and it stands. What the old reader did was
answer *malformed* frontmatter the same way — a regex miss became "no metadata,
carry on" — so an author who opened a fence and got the contents wrong had their
broken YAML moved into the body, and from there into the system prompt verbatim,
under a skill named after its own directory.

So the fence decides:

- **No `---` fence** → body only, no parser call. Exactly as documented.
- **A fence** → the kernel reader, which throws rather than returning a partial
  result.

The absence test mirrors the reader's own — `raw.trimStart().startsWith('---')`
— on purpose. Two readers disagreeing about what counts as *having* frontmatter
is precisely the class of defect this consolidation exists to remove, and it
would have been careless to introduce a fresh instance of it in the change that
removes one.

## Refusing must not empty the roster

`SkillInfo` gains `problem?`. A skill whose frontmatter will not parse stays in
the list under `⚠` with the parse error, and `loadSkillBody` declines to
activate it. One unreadable file in `~/.namzu/skills` silently leaving the
operator with no skills and no reason would have swapped one quiet failure for
another.

## Verification

Mutation-proved by restoring the LF-only regex: three tests fail, the CRLF one
with `expected undefined to be 'Pirate'` — the reported defect exactly. The
"no fence is all body" test correctly survives, which is what confirms the
documented contract is pinned separately from the bug.

Two false signals of my own, both caught rather than believed:

- The first type-check failed with `Property 'values' does not exist on type
  'ParsedFrontmatter'`. The CLI resolves `@namzu/sdk` to `dist/`, and `dist` was
  stale. Rebuilt, rather than doubting a freshly published API.
- The first mutation used `sed` with an escaped newline that landed as a
  **literal** newline, breaking the file. Vitest reported `no tests` and exit 1,
  which reads exactly like a caught mutation and is a syntax error. Same family
  as the `vitest is not recognized` false kill earlier today.

Both are now recorded in `docs/conventions/never-filter-a-verification.md`,
along with the `$?`-after-a-pipeline variant that has bitten three people on
three tools today. That page was due one line and got the section the evidence
earned; it rides here rather than in a PR of its own.

`yaml` stays a dependency — `config/load.ts` and `output/yaml.ts` still use it.

Free with the adoption: lone-CR and BOM parse, the body keeps its own line
endings, and a `__proto__` key can no longer write through to
`Object.prototype` and poison skills loaded later in the same process.
