### PR TITLE
feat(cli): a markdown file is a slash command

### DIFF
--- a/.changeset/a-file-becomes-a-command.md
+++ b/.changeset/a-file-becomes-a-command.md
@@ -1,0 +1,34 @@
+---
+'@namzu/cli': minor
+---
+
+A markdown file is now a slash command.
+
+```
+~/.namzu/commands/<name>.md      everywhere
+<cwd>/.namzu/commands/<name>.md  this project
+```
+
+`review.md` becomes `/review`, and the body is the prompt it sends. A project
+command shadows a user one of the same name — the same precedence skills use.
+Frontmatter is optional; only `description` is read, and it is what `/help` and
+the autocomplete dropdown show.
+
+**Arguments go through `$ARGUMENTS`.** `/review src/parse.ts` substitutes the
+path wherever the token appears. A template with no `$ARGUMENTS`, invoked with
+arguments, is **refused** — it names your file and the token to add. Running it
+would discard what you typed, and a command that silently ignores half its input
+is worse than one that stops. A template with no token and no arguments is a
+static prompt and runs normally.
+
+Refusing is the reversible direction. Relaxing it later, by appending arguments
+somewhere, breaks nobody; tightening an append into a refusal would break
+everyone who had come to rely on it.
+
+**A file that will not load is refused, not skipped.** It stays in `/help`
+marked `⚠` with the parse error, and the rest keep working. A file named after a
+built-in is listed the same way rather than silently ignored — built-ins always
+win, and its author needs to know why theirs never ran.
+
+Files are read when the session starts; `/model` or a restart picks up a new
+one.

--- a/docs/cli/tui.md
+++ b/docs/cli/tui.md
@@ -49,6 +49,8 @@ Type `/` followed by a command — an autocomplete dropdown filters as you type.
 
 Anything that isn't a slash command is sent to the agent as a message.
 
+You can add your own — see [Your own slash commands](#your-own-slash-commands).
+
 ### What `/cost` is counting
 
 `/cost` reports **cumulative spend for the run** — every token across every
@@ -64,6 +66,56 @@ Where the status bar abbreviates (`12.3k tok`), `/cost` prints the figure
 (`12,345`) — you asked on purpose, so you get the number. A provider that
 reports no price shows `$0.0000 (this provider reported no price)` rather than
 implying the run was free.
+
+## Your own slash commands
+
+A markdown file becomes a command. The body is the prompt it sends.
+
+```
+~/.namzu/commands/<name>.md      available in every project
+<cwd>/.namzu/commands/<name>.md  this project only
+```
+
+`review.md` becomes `/review`. A project command shadows a user command of the
+same name, the same precedence [skills](./skills.md) use. Frontmatter is
+optional and only `description` is read — it is what `/help` and the
+autocomplete dropdown show.
+
+```markdown
+---
+description: Review a file for unchecked errors
+---
+
+Read $ARGUMENTS and list every place an error is swallowed or ignored.
+Quote the line. Do not suggest fixes yet.
+```
+
+### Arguments
+
+`$ARGUMENTS` is replaced by whatever followed the command, so
+`/review src/parse.ts` sends the template with the path substituted. Every
+occurrence is replaced; with no arguments it becomes empty.
+
+**A template with no `$ARGUMENTS`, invoked with arguments, is refused.** It
+names the file and tells you to add the token. This is deliberate: running it
+would discard what you typed, and a command that silently ignores half its
+input is worse than one that stops. A template with no `$ARGUMENTS` and no
+arguments is a static prompt and runs normally.
+
+The refusal is the reversible choice. Relaxing it later — appending the
+arguments somewhere — breaks nobody, while going the other way would break
+everyone who had come to rely on the looser behaviour.
+
+### When a file will not load
+
+A command whose frontmatter cannot be parsed is refused, not skipped. It still
+appears in `/help` marked `⚠` with the parse error, so a file you can see on
+disk is accounted for, and the other commands keep working. A file named after a
+built-in — `help.md` — is likewise listed with its reason rather than silently
+ignored; built-ins always win.
+
+Files are read when the session starts. After adding one, `/model` or a restart
+picks it up.
 
 ### What `/init` does, and what it will not do
 

--- a/packages/cli/src/__tests__/a-command-file-reaches-the-turn.test.ts
+++ b/packages/cli/src/__tests__/a-command-file-reaches-the-turn.test.ts
@@ -1,0 +1,136 @@
+/**
+ * A `.md` file on disk becomes a prompt the model is actually sent.
+ *
+ * The loader returning a well-formed object proves nothing about whether the
+ * text ever leaves the CLI. This is genuinely new code rather than a call into
+ * existing machinery — `discoverSkills` finds directories containing a
+ * `SKILL.md` and returns `[]` for a folder of loose `.md` files — so the road
+ * from the file to the provider is new too, and reachability is its own
+ * property (`docs/conventions/reachability-is-its-own-property.md`).
+ *
+ * So this drives the real dispatch and the real session, and asserts on what
+ * `query()` was handed. The chain has four links and a unit test sits on one
+ * side of every break:
+ *
+ *   file on disk → discoverUserCommands → runSlash → prompt action → query()
+ *
+ * The assertion is the command's TEMPLATE text arriving in the message the
+ * kernel is given. Asserting that `runSlash` returned `{kind:'prompt'}` would
+ * pass with the App never sending it.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SLASH_COMMANDS, type SlashContext, runSlash } from '../tui/slashCommands.js'
+import { discoverUserCommands } from '../user-commands/store.js'
+
+const queryCalls: Record<string, unknown>[] = []
+vi.mock('@namzu/sdk', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@namzu/sdk')>()
+	return {
+		...actual,
+		query: (params: Record<string, unknown>) => {
+			queryCalls.push(params)
+			return (async function* () {})()
+		},
+	}
+})
+
+let cwd: string
+
+beforeEach(() => {
+	queryCalls.length = 0
+	cwd = mkdtempSync(join(tmpdir(), 'namzu-cmd-reach-'))
+})
+
+afterEach(() => {
+	rmSync(cwd, { recursive: true, force: true })
+})
+
+function writeCommand(name: string, body: string): void {
+	const dir = join(cwd, '.namzu', 'commands')
+	mkdirSync(dir, { recursive: true })
+	writeFileSync(join(dir, name), body)
+}
+
+function context(userCommands: SlashContext['userCommands']): SlashContext {
+	return {
+		availableTools: [],
+		providerSummary: 'mock (mock)',
+		modelSummary: 'mock-model',
+		usage: null,
+		permissions: { skipPermissions: false, rules: [] },
+		agentIds: [],
+		instructionFiles: [],
+		userCommands,
+	}
+}
+
+describe('a command file the operator wrote', () => {
+	it('reaches the model as the prompt for a turn', async () => {
+		writeCommand('audit.md', 'Audit $ARGUMENTS for unchecked errors.')
+
+		// Real discovery, from the real directory layout.
+		const commands = discoverUserCommands({
+			home: cwd,
+			cwd,
+			reserved: SLASH_COMMANDS.map((c) => c.name),
+		})
+		expect(
+			commands.map((c) => c.name),
+			'the file was not discovered',
+		).toEqual(['audit'])
+
+		// Real dispatch.
+		const action = runSlash('/audit src/parse.ts', context(commands))
+		expect(action?.kind, 'dispatch did not turn it into a turn').toBe('prompt')
+		const text = action?.kind === 'prompt' ? action.text : ''
+		expect(text).toBe('Audit src/parse.ts for unchecked errors.')
+
+		// Real session, mocked provider. This is the link the earlier assertions
+		// cannot cover: that the composed text is what the kernel is given.
+		const { createAgentSession } = await import('../tui/agent.js')
+		const session = await createAgentSession(
+			{ version: 2, provider: 'anthropic', subagents: { active: [] } } as never,
+			[
+				{
+					entry: {
+						id: 'anthropic',
+						label: 'Anthropic',
+						defaultModel: 'claude-sonnet-4-5',
+						requiresApiKey: true,
+						envVars: ['ANTHROPIC_API_KEY'],
+					},
+					source: 'env',
+					apiKey: 'sk-ant-not-a-real-key',
+					alternatives: [],
+				} as never,
+			],
+			{ cwd },
+		)
+		for await (const _ of session.send([{ role: 'user', content: text, timestamp: 0 }])) {
+			// drain
+		}
+
+		expect(queryCalls.length, 'the turn never reached query()').toBe(1)
+		const messages = queryCalls[0]?.messages as ReadonlyArray<{ content: unknown }> | undefined
+		const sent = messages?.map((m) => (typeof m.content === 'string' ? m.content : '')).join('\n')
+		expect(sent, 'the file’s text is not in what the model was sent').toContain(
+			'Audit src/parse.ts for unchecked errors.',
+		)
+	})
+
+	it('does not reach the model when the file cannot be read', async () => {
+		// Refusing has to stop the turn, not merely annotate it. A broken command
+		// that still sends something would be worse than one that sends nothing.
+		writeCommand('broken.md', '---\nunclosed frontmatter')
+		const commands = discoverUserCommands({ home: cwd, cwd })
+
+		const action = runSlash('/broken', context(commands))
+		expect(action?.kind).toBe('message')
+		expect(queryCalls.length).toBe(0)
+	})
+})

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -61,7 +61,8 @@ import {
 	probeAgentSession,
 } from './agent.js'
 import { ResumePicker } from './ResumePicker.js'
-import { type SlashContext, runSlash } from './slashCommands.js'
+import { type UserCommand, discoverUserCommands } from '../user-commands/store.js'
+import { SLASH_COMMANDS, type SlashContext, runSlash } from './slashCommands.js'
 import { theme } from './theme.js'
 import type { TranscriptMessage, TuiContext } from './types.js'
 
@@ -91,6 +92,11 @@ export function App({ ctx }: AppProps) {
 	const [activeSkills, setActiveSkills] = useState<ReadonlyArray<{ name: string; body: string }>>(
 		[],
 	)
+	// Read when the session comes up rather than on every keystroke: the
+	// autocomplete dropdown consults this on each character, and a `readdirSync`
+	// per keypress is a cost nobody asked for. A file added mid-session is
+	// picked up by `/model` (which re-hydrates) or a restart.
+	const [userCommands, setUserCommands] = useState<readonly UserCommand[]>([])
 	const [usage, setUsage] = useState<{ totalTokens: number; costUsd: number } | null>(null)
 	// Context fill, straight from the kernel and held apart from `usage` —
 	// they are different quantities and conflating them is what made the
@@ -207,6 +213,15 @@ export function App({ ctx }: AppProps) {
 			void previousSessionRef.current?.close()
 			previousSessionRef.current = s
 			setSession(s)
+			setUserCommands(
+				discoverUserCommands({
+					cwd: ctx.cwd,
+					// Builtins are reserved: a `help.md` must not take over `/help`.
+					// Passing the names here is what lets the loader tell its author
+					// the file is shadowed instead of leaving it silently unused.
+					reserved: SLASH_COMMANDS.map((c) => c.name),
+				}),
+			)
 			setCurrentProvider(prefs.provider)
 			if (s.hasProvider) {
 				setPhase('ready')
@@ -303,6 +318,7 @@ export function App({ ctx }: AppProps) {
 		},
 		agentIds: session?.agentIds ?? [],
 		instructionFiles: session?.instructionFiles ?? [],
+		userCommands,
 	}
 
 	// `/resume`: open the picker with this folder's recent conversations.
@@ -868,6 +884,7 @@ export function App({ ctx }: AppProps) {
 								<Composer
 									disabled={phase !== 'ready' || state === 'awaiting-permission'}
 									onSubmit={handleSubmit}
+									userCommands={userCommands}
 									history={history}
 								/>
 							</ComposerFrame>

--- a/packages/cli/src/tui/Composer.tsx
+++ b/packages/cli/src/tui/Composer.tsx
@@ -13,6 +13,7 @@ import { Box, Text, useInput } from 'ink'
 import { useCallback, useState } from 'react'
 
 import { readClipboardImage } from '../integrations/clipboard/image.js'
+import type { UserCommand } from '../user-commands/store.js'
 import { matchSlashCommands } from './slashCommands.js'
 import { theme } from './theme.js'
 
@@ -20,13 +21,20 @@ export interface ComposerProps {
 	readonly disabled?: boolean
 	readonly onSubmit: (value: string, images?: readonly ImageAttachment[]) => void
 	readonly history: readonly string[]
+	/** Operator-defined commands, offered in the dropdown alongside builtins. */
+	readonly userCommands?: readonly UserCommand[]
 }
 
 const MAX_SUGGESTIONS = 6
 // A single keypress longer than this (with no newline) is treated as a paste.
 const PASTE_THRESHOLD = 80
 
-export function Composer({ disabled = false, onSubmit, history }: ComposerProps) {
+export function Composer({
+	disabled = false,
+	onSubmit,
+	history,
+	userCommands = [],
+}: ComposerProps) {
 	const [value, setValue] = useState<string>('')
 	const [historyIndex, setHistoryIndex] = useState<number>(-1)
 	const [selected, setSelected] = useState<number>(0)
@@ -37,7 +45,7 @@ export function Composer({ disabled = false, onSubmit, history }: ComposerProps)
 	// vision attachments on submit.
 	const [images, setImages] = useState<readonly ImageAttachment[]>([])
 
-	const suggestions = matchSlashCommands(value).slice(0, MAX_SUGGESTIONS)
+	const suggestions = matchSlashCommands(value, userCommands).slice(0, MAX_SUGGESTIONS)
 	const showSuggestions = suggestions.length > 0
 	const selIdx = Math.min(selected, Math.max(0, suggestions.length - 1))
 

--- a/packages/cli/src/tui/slashCommands.test.ts
+++ b/packages/cli/src/tui/slashCommands.test.ts
@@ -25,6 +25,7 @@ function context(over: Partial<SlashContext> = {}): SlashContext {
 		permissions: { skipPermissions: false, rules: [] },
 		agentIds: [],
 		instructionFiles: [],
+		userCommands: [],
 		...over,
 	}
 }

--- a/packages/cli/src/tui/slashCommands.ts
+++ b/packages/cli/src/tui/slashCommands.ts
@@ -16,6 +16,8 @@
 
 import type { VerificationRule } from '@namzu/sdk'
 
+import { type UserCommand, expandCommand } from '../user-commands/store.js'
+
 export type SlashAction =
 	| { kind: 'message'; role: 'system'; content: string }
 	| { kind: 'exit' }
@@ -71,6 +73,13 @@ export interface SlashContext {
 	 * reports this; nothing new is discovered to answer it.
 	 */
 	readonly instructionFiles: readonly string[]
+	/**
+	 * Commands the operator defined as `.md` files.
+	 *
+	 * Consulted only after the builtins, so a file cannot take a name the TUI
+	 * already answers to. Empty is the normal case.
+	 */
+	readonly userCommands: readonly UserCommand[]
 }
 
 export interface SlashCommand {
@@ -90,11 +99,24 @@ export interface ParsedSlash {
  * once a space is typed (the user has moved on to arguments) or the value
  * isn't a slash command, so the dropdown only shows while picking a name.
  */
-export function matchSlashCommands(value: string): SlashCommand[] {
+export function matchSlashCommands(
+	value: string,
+	userCommands: readonly UserCommand[] = [],
+): SlashCommand[] {
 	const m = /^\/([\w-]*)$/.exec(value)
 	if (!m) return []
 	const prefix = (m[1] ?? '').toLowerCase()
-	return SLASH_COMMANDS.filter((c) => c.name.startsWith(prefix))
+
+	// A command the dropdown does not offer is one nobody discovers. Refused
+	// ones are offered too, carrying their reason as the description — running
+	// it prints the problem, which is how its author finds out.
+	const own: SlashCommand[] = userCommands.map((c) => ({
+		name: c.name,
+		description: c.problem ? `⚠ ${c.problem}` : c.description,
+		action: () => ({ kind: 'none' }) as const,
+	}))
+
+	return [...SLASH_COMMANDS, ...own].filter((c) => c.name.startsWith(prefix))
 }
 
 /** Returns null when the line is not a slash command. */
@@ -110,11 +132,26 @@ export const SLASH_COMMANDS: readonly SlashCommand[] = [
 	{
 		name: 'help',
 		description: 'Show available slash commands.',
-		action: () => ({
-			kind: 'message',
-			role: 'system',
-			content: SLASH_COMMANDS.map((c) => `/${c.name.padEnd(10)} ${c.description}`).join('\n'),
-		}),
+		action: (ctx) => {
+			const builtin = SLASH_COMMANDS.map((c) => `/${c.name.padEnd(12)} ${c.description}`)
+			// Listed separately and always, including the refused ones with their
+			// reason. A command file that exists and does not work is exactly what
+			// its author needs to see here — leaving it out of `/help` is how it
+			// stays broken.
+			const own = ctx.userCommands.map((c) =>
+				c.problem
+					? `/${c.name.padEnd(12)} ⚠ ${c.problem}`
+					: `/${c.name.padEnd(12)} ${c.description}`,
+			)
+			return {
+				kind: 'message',
+				role: 'system',
+				content:
+					own.length > 0
+						? `${builtin.join('\n')}\n\nYour commands:\n${own.join('\n')}`
+						: builtin.join('\n'),
+			}
+		},
 	},
 	{
 		name: 'clear',
@@ -360,13 +397,25 @@ export function renderAgents(agentIds: readonly string[]): string {
 export function runSlash(line: string, ctx: SlashContext): SlashAction | null {
 	const parsed = parseSlash(line)
 	if (!parsed) return null
+
+	// Builtins first, always. A file appearing on disk must not take over a name
+	// the TUI already answers to — `discoverUserCommands` marks those files with
+	// a `problem` so their author is told, rather than leaving them to wonder
+	// why the file never ran.
 	const cmd = SLASH_COMMANDS.find((c) => c.name === parsed.name)
-	if (!cmd) {
-		return {
-			kind: 'message',
-			role: 'system',
-			content: `Unknown command: /${parsed.name}. Try /help.`,
-		}
+	if (cmd) return cmd.action(ctx, parsed.args)
+
+	const user = ctx.userCommands.find((c) => c.name === parsed.name)
+	if (user) {
+		const expanded = expandCommand(user, parsed.args.join(' '))
+		return expanded.ok
+			? { kind: 'prompt', text: expanded.prompt }
+			: { kind: 'message', role: 'system', content: expanded.reason }
 	}
-	return cmd.action(ctx, parsed.args)
+
+	return {
+		kind: 'message',
+		role: 'system',
+		content: `Unknown command: /${parsed.name}. Try /help.`,
+	}
 }

--- a/packages/cli/src/user-commands/store.test.ts
+++ b/packages/cli/src/user-commands/store.test.ts
@@ -1,0 +1,141 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { discoverUserCommands, expandCommand } from './store.js'
+
+let home: string
+let cwd: string
+
+beforeEach(() => {
+	home = mkdtempSync(join(tmpdir(), 'namzu-uc-home-'))
+	cwd = mkdtempSync(join(tmpdir(), 'namzu-uc-proj-'))
+})
+
+afterEach(() => {
+	rmSync(home, { recursive: true, force: true })
+	rmSync(cwd, { recursive: true, force: true })
+})
+
+function write(root: string, name: string, body: string): void {
+	const dir = join(root, '.namzu', 'commands')
+	mkdirSync(dir, { recursive: true })
+	writeFileSync(join(dir, name), body)
+}
+
+describe('discoverUserCommands', () => {
+	it('is empty when nothing is defined, which is the normal case', () => {
+		expect(discoverUserCommands({ home, cwd })).toEqual([])
+	})
+
+	it('reads a bare template with no frontmatter', () => {
+		write(cwd, 'review.md', 'Review the diff for correctness.')
+		const [cmd] = discoverUserCommands({ home, cwd })
+		expect(cmd?.name).toBe('review')
+		expect(cmd?.template).toBe('Review the diff for correctness.')
+		expect(cmd?.problem).toBeUndefined()
+	})
+
+	it('takes the description from frontmatter, CRLF included', () => {
+		// Same reader as skills, so the Windows line-ending fix comes with it
+		// rather than needing to be remembered here.
+		write(cwd, 'ship.md', '---\r\ndescription: Cut a release\r\n---\r\nDo the release.')
+		const [cmd] = discoverUserCommands({ home, cwd })
+		expect(cmd?.description).toBe('Cut a release')
+		expect(cmd?.template).toBe('Do the release.')
+	})
+
+	it('lets a project command shadow a user one', () => {
+		write(home, 'review.md', 'user version')
+		write(cwd, 'review.md', 'project version')
+		const found = discoverUserCommands({ home, cwd })
+		expect(found).toHaveLength(1)
+		expect(found[0]?.template).toBe('project version')
+		expect(found[0]?.source).toBe('project')
+	})
+
+	it('refuses a broken file without losing the others', () => {
+		// The `SkillInfo.problem` pattern: one bad file must not empty the list,
+		// and its author has to be told why it never ran.
+		write(cwd, 'good.md', 'fine')
+		write(cwd, 'broken.md', '---\nunclosed frontmatter')
+		const found = discoverUserCommands({ home, cwd })
+
+		expect(found.map((c) => c.name)).toEqual(['broken', 'good'])
+		expect(found.find((c) => c.name === 'good')?.problem).toBeUndefined()
+		expect(found.find((c) => c.name === 'broken')?.problem).toMatch(/unclosed/i)
+	})
+
+	it('names the file in the refusal', () => {
+		write(cwd, 'broken.md', '---\nunclosed')
+		const found = discoverUserCommands({ home, cwd })
+		expect(found[0]?.problem).toContain('broken.md')
+	})
+
+	it('will not let a file take a built-in name', () => {
+		// A builtin someone relies on disappearing because a file appeared is the
+		// worst kind of surprise; ignoring the file silently is the second worst.
+		write(cwd, 'help.md', 'not the real help')
+		const [cmd] = discoverUserCommands({ home, cwd, reserved: ['help'] })
+		expect(cmd?.problem).toContain('built-in')
+	})
+
+	it('ignores files that are not markdown', () => {
+		write(cwd, 'notes.txt', 'not a command')
+		expect(discoverUserCommands({ home, cwd })).toEqual([])
+	})
+})
+
+describe('expandCommand', () => {
+	const cmd = (template: string) =>
+		({
+			name: 'demo',
+			description: '',
+			template,
+			path: '/p/demo.md',
+			source: 'project',
+		}) as const
+
+	it('substitutes $ARGUMENTS', () => {
+		const r = expandCommand(cmd('Review $ARGUMENTS please'), 'src/foo.ts')
+		expect(r.ok && r.prompt).toBe('Review src/foo.ts please')
+	})
+
+	it('substitutes every occurrence', () => {
+		const r = expandCommand(cmd('$ARGUMENTS then $ARGUMENTS'), 'x')
+		expect(r.ok && r.prompt).toBe('x then x')
+	})
+
+	it('substitutes empty when no arguments were given', () => {
+		const r = expandCommand(cmd('Review $ARGUMENTS'), '')
+		expect(r.ok && r.prompt).toBe('Review ')
+	})
+
+	it('runs a static template with no arguments', () => {
+		const r = expandCommand(cmd('Summarise the diff.'), '')
+		expect(r.ok && r.prompt).toBe('Summarise the diff.')
+	})
+
+	it('REFUSES arguments a template cannot receive, rather than dropping them', () => {
+		// The contract decision. Silently discarding what the operator typed is
+		// the failure mode this whole file is written against; appending them
+		// somewhere would be guessing where the author wanted them.
+		const r = expandCommand(cmd('Summarise the diff.'), 'src/foo.ts')
+		expect(r.ok).toBe(false)
+		expect(!r.ok && r.reason).toContain('takes no arguments')
+	})
+
+	it('names the file and the exact fix when it refuses', () => {
+		const r = expandCommand(cmd('static'), 'oops')
+		expect(!r.ok && r.reason).toContain('$ARGUMENTS')
+		expect(!r.ok && r.reason).toContain('/p/demo.md')
+	})
+
+	it('refuses a command that could not be read', () => {
+		const broken = { ...cmd(''), problem: 'bad frontmatter' }
+		const r = expandCommand(broken, '')
+		expect(r.ok).toBe(false)
+		expect(!r.ok && r.reason).toBe('bad frontmatter')
+	})
+})

--- a/packages/cli/src/user-commands/store.ts
+++ b/packages/cli/src/user-commands/store.ts
@@ -1,0 +1,188 @@
+/**
+ * User-defined slash commands — one `.md` file per command.
+ *
+ * A command is a markdown file whose body is a prompt template:
+ *
+ *   ~/.namzu/commands/<name>.md    available everywhere
+ *   <cwd>/.namzu/commands/<name>.md   this project only
+ *
+ * The name is the filename without `.md`, so `review.md` is `/review`. A
+ * project command shadows a user command of the same name, which is the same
+ * precedence skills use.
+ *
+ * ## Why this is not `discoverSkills`
+ *
+ * The kernel's `discoverSkills` finds DIRECTORIES containing a `SKILL.md`, and
+ * returns `[]` for a folder of loose `.md` files — silently, because an empty
+ * roster is a legitimate answer to "no skills here". A command is one file, so
+ * that loader cannot serve this layout and would report nothing rather than
+ * fail. What IS reused is the part worth sharing: `parseFrontmatter`, so there
+ * is exactly one definition of what a `---` block means anywhere in the repo.
+ *
+ * ## Arguments
+ *
+ * `$ARGUMENTS` in the template is replaced by whatever followed the command.
+ * A template WITHOUT it, invoked WITH arguments, is refused rather than run —
+ * see `expandCommand`. Dropping them silently is the failure this file is
+ * written to avoid, and appending them somewhere the author did not ask for
+ * would be guessing where they belong.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { parseFrontmatter } from '@namzu/sdk'
+
+export type UserCommandSource = 'user' | 'project'
+
+export interface UserCommand {
+	/** Invoked as `/<name>`. The filename without `.md`. */
+	readonly name: string
+	readonly description: string
+	/** The prompt template. Empty when the file could not be read. */
+	readonly template: string
+	readonly path: string
+	readonly source: UserCommandSource
+	/**
+	 * Why this command cannot be used, when it cannot.
+	 *
+	 * Same contract as `SkillInfo.problem`: a file that will not parse is
+	 * refused, but it stays listed with its reason so one bad file does not
+	 * quietly remove the rest — and so a file the operator can see on disk is
+	 * accounted for rather than missing.
+	 */
+	readonly problem?: string
+}
+
+/** The token a template uses to receive what followed the command. */
+export const ARGUMENTS_TOKEN = '$ARGUMENTS'
+
+export function userCommandsDir(home: string = homedir()): string {
+	return join(home, '.namzu', 'commands')
+}
+
+export function projectCommandsDir(cwd: string = process.cwd()): string {
+	return join(cwd, '.namzu', 'commands')
+}
+
+function readCommandsFrom(dir: string, source: UserCommandSource): UserCommand[] {
+	let files: string[]
+	try {
+		files = readdirSync(dir, { withFileTypes: true })
+			.filter((e) => e.isFile() && e.name.endsWith('.md'))
+			.map((e) => e.name)
+	} catch {
+		// No directory is not an error: most projects define no commands.
+		return []
+	}
+
+	const out: UserCommand[] = []
+	for (const file of files) {
+		const path = join(dir, file)
+		const name = file.slice(0, -'.md'.length)
+		let raw: string
+		try {
+			raw = readFileSync(path, 'utf8')
+		} catch {
+			continue
+		}
+
+		// Same fence-decides rule as the skill reader: a file with no `---` is
+		// all body, which is the common case for a command, and a file that
+		// opens one must parse. The absence test mirrors the kernel reader's own
+		// so the two cannot disagree about what counts as having frontmatter.
+		try {
+			if (!raw.trimStart().startsWith('---')) {
+				out.push({ name, description: '(no description)', template: raw.trim(), path, source })
+				continue
+			}
+			const { values, body } = parseFrontmatter(raw, path)
+			const description =
+				values.description?.kind === 'scalar' ? values.description.value : '(no description)'
+			out.push({ name, description, template: body, path, source })
+		} catch (err) {
+			out.push({
+				name,
+				description: '(could not be read)',
+				template: '',
+				path,
+				source,
+				problem: err instanceof Error ? err.message : String(err),
+			})
+		}
+	}
+	return out
+}
+
+/**
+ * Every user-defined command, project shadowing user on a name clash.
+ *
+ * `reserved` names are dropped with a `problem` rather than allowed to win:
+ * a file called `help.md` must not replace `/help`, because a builtin someone
+ * relies on disappearing when a file appears is the worst kind of surprise —
+ * and silently ignoring the file would leave its author with no idea why it
+ * never ran.
+ */
+export function discoverUserCommands(
+	opts: { home?: string; cwd?: string; reserved?: readonly string[] } = {},
+): UserCommand[] {
+	const reserved = new Set(opts.reserved ?? [])
+	const user = readCommandsFrom(userCommandsDir(opts.home), 'user')
+	const project = readCommandsFrom(projectCommandsDir(opts.cwd), 'project')
+
+	const byName = new Map<string, UserCommand>()
+	for (const c of user) byName.set(c.name, c)
+	for (const c of project) byName.set(c.name, c) // project wins
+
+	return [...byName.values()]
+		.map((c) =>
+			reserved.has(c.name)
+				? { ...c, problem: `"/${c.name}" is a built-in command, so this file is not used.` }
+				: c,
+		)
+		.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+export type ExpandResult =
+	| { readonly ok: true; readonly prompt: string }
+	| { readonly ok: false; readonly reason: string }
+
+/**
+ * Fill a command's template with the arguments it was invoked with.
+ *
+ * Three cases, and the third is the decision worth defending:
+ *
+ * 1. Template has `$ARGUMENTS` → substituted, with `''` when none were given.
+ * 2. No `$ARGUMENTS`, no arguments → the template is a static prompt. Fine.
+ * 3. No `$ARGUMENTS`, arguments given → **refused**, naming the file and the
+ *    fix.
+ *
+ * The third could have appended them under a heading instead, and that is
+ * friendlier in the moment. It was rejected because it guesses where the author
+ * wanted them and because the author never finds out their template ignores
+ * arguments. Refusing is one-time friction that teaches the contract.
+ *
+ * It is also the reversible direction: relaxing a refusal into an append later
+ * breaks nobody, while tightening an append into a refusal breaks everyone who
+ * had come to rely on it. Where a contract is hard to change, pick the one that
+ * can still be changed.
+ */
+export function expandCommand(command: UserCommand, args: string): ExpandResult {
+	if (command.problem) return { ok: false, reason: command.problem }
+
+	const trimmed = args.trim()
+	if (command.template.includes(ARGUMENTS_TOKEN)) {
+		return { ok: true, prompt: command.template.split(ARGUMENTS_TOKEN).join(trimmed) }
+	}
+	if (trimmed.length === 0) return { ok: true, prompt: command.template }
+
+	return {
+		ok: false,
+		reason: [
+			`/${command.name} takes no arguments, but you gave: ${trimmed}`,
+			'',
+			`Add ${ARGUMENTS_TOKEN} where they belong in ${command.path}, and they will be`,
+			'substituted there. Running it now would silently discard them.',
+		].join('\n'),
+	}
+}


### PR DESCRIPTION
feat(cli): a markdown file is a slash command

```
~/.namzu/commands/<name>.md      everywhere
<cwd>/.namzu/commands/<name>.md  this project
```

`review.md` becomes `/review`, and the body is the prompt it sends. Project
shadows user on a name clash, the same precedence skills use. Frontmatter is
optional; only `description` is read, and it is what `/help` and the
autocomplete dropdown show.

This is new code rather than a call into existing machinery, and the reason is
worth stating: `discoverSkills` finds DIRECTORIES containing a `SKILL.md` and
returns `[]` for a folder of loose `.md` files — silently, because an empty
roster is a legitimate answer to "no skills here". What is reused is the part
worth sharing, `parseFrontmatter` and the fence-decides rule, so there is still
exactly one definition of what a `---` block means.

## The argument contract, and why this one

`$ARGUMENTS` is substituted with whatever followed the command. A template with
**no** `$ARGUMENTS`, invoked **with** arguments, is refused — naming the file
and the token to add. A template with neither is a static prompt and runs.

The alternative was appending the arguments under a heading, which is friendlier
in the moment. Two things decided against it: it guesses where the author wanted
them, and the author never finds out their template ignores arguments.

The argument that settled it is reversibility. Relaxing a refusal into an append
later breaks nobody; tightening an append into a refusal breaks everyone who had
come to rely on it. This is the part hardest to change later, so it takes the
form that can still be changed.

Documented in `docs/cli/tui.md` in this PR, including that reasoning — a
convention nobody wrote down is worse than no convention.

## Refusing without going dark

`SkillInfo.problem` carried across. A command whose frontmatter will not parse
stays in `/help` under `⚠` with the parse error, and the others keep working;
one bad file emptying the list would swap a quiet failure for a louder one
rather than fixing it. A file named after a built-in is listed the same way —
built-ins always win, and silently ignoring `help.md` would leave its author
with no idea why it never ran.

## The reachability test

`a-command-file-reaches-the-turn.test.ts` drives real discovery, real
`runSlash`, and a real `createAgentSession` with a mocked provider, then asserts
the file's **text** appears in what `query()` was handed. Asserting that
`runSlash` returned `{kind: 'prompt'}` would pass with the App never sending it,
and the chain has four links with a unit test sitting on one side of every
break.

Two mutations: unwiring the user-command branch in `runSlash` kills it at the
dispatch link; disabling substitution kills four tests including the
query-level one.

## Two details

Discovery runs per session, not per keystroke — the autocomplete dropdown
consults this on every character, and a `readdirSync` per keypress is a cost
nobody asked for. A file added mid-session is picked up by `/model` or a
restart, which the docs say.

The transcript keeps `/review src/parse.ts` while the model receives the
expanded template. That is not a new liberty: `expandFileMentions` already keeps
the readable `@path` token visible while inlining the file contents, so this
follows ratified behaviour rather than inventing a hidden mutation.
