### PR TITLE
fix(cli): a command works where you would run it

### DIFF
--- a/.changeset/a-command-works-where-you-run-it.md
+++ b/.changeset/a-command-works-where-you-run-it.md
@@ -1,0 +1,29 @@
+---
+'@namzu/cli': minor
+---
+
+Your own slash commands now work in `namzu run` and `namzu run-stream`, not only
+in the terminal agent.
+
+Before this, `namzu run "/review src/parse.ts"` sent that string to the model as
+prose. The model tried to make sense of it and answered about something else, at
+exit 0 — the command had not failed, it had quietly done something different.
+Running one from a script is most of the reason to write one, so this was the
+larger half of the feature missing rather than a boundary.
+
+**A leading `/` still does not make something a command.** `namzu run
+"/usr/local/bin is missing"` is an ordinary prompt and is sent as written. What
+makes it a command is the first word naming one your project declares: a file in
+`.namzu/commands/` is an explicit declaration, and a word that merely starts with
+a slash is not. Prompts that begin with a slash keep working.
+
+Built-in commands are interactive and do nothing headless. A prompt that is
+exactly one — `namzu run "/help"` — is refused with a message instead of being
+sent, because nobody means that literally. `namzu run "/clear the cache in
+redis"` passes through untouched; the extra words are what distinguish a request
+from an invocation.
+
+A command that cannot run — arguments a template has no `$ARGUMENTS` to receive,
+or frontmatter that will not parse — exits non-zero with the reason and sends
+nothing. A script continuing on a misfired command is the outcome worth
+preventing.

--- a/docs/cli/headless.md
+++ b/docs/cli/headless.md
@@ -1,7 +1,7 @@
 ---
 title: Headless runs
 description: namzu run and namzu run-stream — one prompt, no terminal. Shared options, the working directory, exit codes, and the NDJSON event stream.
-last_updated: 2026-08-06
+last_updated: 2026-08-07
 status: current
 related_packages: ["@namzu/cli"]
 ---
@@ -186,7 +186,7 @@ error.
 | `0` | The model answered and the run finished normally. |
 | `1` | The run failed, or stopped early — a token budget, a timeout, the iteration cap, a cancellation, or a refused answer. Any partial output is still printed, and the reason goes to stderr. |
 | `2` | No prompt was supplied. |
-| `64` | An argument is wrong (unknown option, bad `--cwd`). |
+| `64` | An argument is wrong (unknown option, bad `--cwd`), or a slash command was named and could not run — see [Your own slash commands](./tui.md#they-work-in-scripts-too). |
 | `77` | The folder has not been trusted, and **nothing ran**. Fixed by a decision, not by a different invocation — see [The folder has to be trusted](#the-folder-has-to-be-trusted). |
 
 A stopped run exits 1 even though it produced text, so

--- a/docs/cli/tui.md
+++ b/docs/cli/tui.md
@@ -117,6 +117,31 @@ ignored; built-ins always win.
 Files are read when the session starts. After adding one, `/model` or a restart
 picks it up.
 
+### They work in scripts too
+
+`namzu run` and `namzu run-stream` expand your commands the same way, which is
+most of the reason to write one:
+
+```bash
+namzu run "/review src/parse.ts"
+```
+
+**A leading `/` is not enough to make something a command.** `namzu run
+"/usr/local/bin is missing"` is an ordinary prompt and is sent as written. What
+makes it a command is the first word naming one your project actually declares —
+a file in `.namzu/commands/` is an explicit declaration, while a word that
+happens to start with a slash is not.
+
+Built-in commands are interactive and do nothing headless. `namzu run "/help"`
+is refused with a message rather than sent, because nobody means that string
+literally. But `namzu run "/clear the cache in redis"` is a request and passes
+through untouched — the extra words are what tell the two apart.
+
+A command that refuses — arguments it cannot receive, or frontmatter that will
+not parse — exits non-zero and prints the reason. It is never sent as prose:
+the run failing is the point, since a script that continues on a misfired
+command is the thing worth preventing.
+
 ### What `/init` does, and what it will not do
 
 `/init` asks the agent to read the repository and write an `AGENTS.md` for it.

--- a/packages/cli/src/__tests__/a-command-works-headless.test.ts
+++ b/packages/cli/src/__tests__/a-command-works-headless.test.ts
@@ -1,0 +1,161 @@
+/**
+ * A command the operator defined works in `namzu run`, not only in the TUI.
+ *
+ * Reported from a real run of the published CLI: a project with
+ * `.namzu/commands/ozet.md`, then `namzu run --trust "/ozet hedef.js"`. The
+ * model received the literal string, could not make sense of it, and offered to
+ * create a file called `ozet hedef.js`. Exit 0, confident output, nothing to do
+ * with the command.
+ *
+ * The loader had exactly one call site — the TUI's `App.tsx` — and that was
+ * never a decision. It was where the work happened to be done. A boundary
+ * nobody chose, announced by nothing, is worse than either answer.
+ *
+ * ## What is asserted, and what is deliberately not
+ *
+ * The rule is NOT "a leading slash is a command". `namzu run "/usr/local/bin is
+ * missing"` and `namzu run "/clear the cache in redis"` are ordinary prompts,
+ * and breaking a working prompt to fix a broken one is not a trade worth
+ * making. The rule is "the first token names a command this project declares" —
+ * a file the operator wrote is an explicit declaration; a built-in's name is a
+ * common English word nobody declared.
+ *
+ * So the pass-through cases are pinned as hard as the expansion is. Without
+ * them this file would pass with an implementation that hijacks every slash.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { runCommand } from '../commands/run.js'
+import type { CommandContext } from '../commands/types.js'
+
+// Trusted, because this file is about prompt expansion. The gate that refuses
+// an untrusted folder has its own test.
+vi.mock('../integrations/trust/store.js', () => ({
+	isTrusted: () => true,
+	trustDir: () => {},
+}))
+
+/** What the model was actually sent. */
+const sent: string[] = []
+
+vi.mock('../tui/agent.js', () => ({
+	probeAgentSession: vi.fn(async () => ({
+		preferences: { version: 2, provider: 'mock', subagents: { active: [] } },
+		needsRepickReason: null,
+		detected: [],
+	})),
+	createAgentSession: vi.fn(async () => {
+		const { fakeAgentSession: make } = await import('../tui/__fixtures__/agent-session.js')
+		return make({
+			send: (messages) => {
+				for (const m of messages) {
+					if (typeof m.content === 'string') sent.push(m.content)
+				}
+				return (async function* () {
+					yield { kind: 'delta', text: 'ok' }
+					yield { kind: 'done', stopReason: 'end_turn' }
+				})() as never
+			},
+		})
+	}),
+}))
+
+let cwd: string
+
+beforeEach(() => {
+	sent.length = 0
+	cwd = mkdtempSync(join(tmpdir(), 'namzu-headless-cmd-'))
+})
+
+afterEach(() => {
+	rmSync(cwd, { recursive: true, force: true })
+})
+
+function writeCommand(name: string, body: string): void {
+	const dir = join(cwd, '.namzu', 'commands')
+	mkdirSync(dir, { recursive: true })
+	writeFileSync(join(dir, name), body)
+}
+
+function context(): { ctx: CommandContext; errors: string[] } {
+	const errors: string[] = []
+	const ctx = {
+		formatter: {
+			name: 'text' as const,
+			print: () => {},
+			info: () => {},
+			error: (e: unknown) => errors.push(String((e as { message?: string })?.message ?? e)),
+		},
+		config: {},
+	} as unknown as CommandContext
+	return { ctx, errors }
+}
+
+async function run(prompt: string): Promise<{ code: number; errors: string[] }> {
+	const { ctx, errors } = context()
+	const code = (await runCommand.handler({
+		rawArgs: ['--cwd', cwd, '--trust', prompt],
+		ctx,
+	} as never)) as number
+	return { code, errors }
+}
+
+describe('a command file in a headless run', () => {
+	it('is expanded, with its arguments substituted', () => {
+		writeCommand('ozet.md', 'Summarise $ARGUMENTS in three bullets.')
+		return run('/ozet hedef.js').then(({ code }) => {
+			expect(code).toBe(0)
+			// The reported defect: this used to be the literal `/ozet hedef.js`.
+			expect(sent.join('\n')).toContain('Summarise hedef.js in three bullets.')
+			expect(sent.join('\n')).not.toContain('/ozet')
+		})
+	})
+
+	it('is refused, not silently sent, when its arguments cannot land', async () => {
+		writeCommand('static.md', 'Summarise the diff.')
+		const { code, errors } = await run('/static extra words')
+		expect(code).not.toBe(0)
+		expect(errors.join('\n')).toContain('takes no arguments')
+		expect(sent).toHaveLength(0)
+	})
+
+	it('is refused when the file cannot be read', async () => {
+		writeCommand('broken.md', '---\nunclosed frontmatter')
+		const { code, errors } = await run('/broken')
+		expect(code).not.toBe(0)
+		expect(errors.join('\n')).toMatch(/unclosed/i)
+		expect(sent).toHaveLength(0)
+	})
+})
+
+describe('a leading slash that is not a command', () => {
+	it('passes through as ordinary prose', async () => {
+		// The case that makes "every slash is a command" wrong. Nothing declares
+		// `/usr`, so this is a sentence.
+		const { code } = await run('/usr/local/bin is missing, what should I check?')
+		expect(code).toBe(0)
+		expect(sent.join('\n')).toContain('/usr/local/bin is missing')
+	})
+
+	it('passes through even when it starts with a built-in name plus words', async () => {
+		// `/clear the cache in redis` is a request, not an invocation of `/clear`.
+		// A built-in's name is a common word that nobody declared, so matching on
+		// it would break working prompts.
+		const { code } = await run('/clear the cache in redis')
+		expect(code).toBe(0)
+		expect(sent.join('\n')).toContain('/clear the cache in redis')
+	})
+
+	it('refuses a bare built-in, which nobody means literally', async () => {
+		// `namzu run "/help"` is not a sentence. Answering it by letting the model
+		// improvise on the string is the same silent misfire as the original bug.
+		const { code, errors } = await run('/help')
+		expect(code).not.toBe(0)
+		expect(errors.join('\n')).toContain('interactive')
+		expect(sent).toHaveLength(0)
+	})
+})

--- a/packages/cli/src/commands/run-stream.ts
+++ b/packages/cli/src/commands/run-stream.ts
@@ -40,6 +40,8 @@ import {
 import { decideHeadlessTrust } from '../permissions/headless-trust.js'
 import { resolvePermissionMode } from '../permissions/mode.js'
 import { compilePermissions } from '../permissions/rules.js'
+import { SLASH_COMMANDS } from '../tui/slashCommands.js'
+import { expandHeadlessCommand } from '../user-commands/store.js'
 import {
 	loadSkillsContext,
 	parseRunFlags,
@@ -124,6 +126,16 @@ export const runStreamCommand: CommandDef = {
 		const resolved = resolveWorkingDirectory(flags.cwd)
 		if ('error' in resolved) return fail(resolved.error)
 		const cwd = resolved.cwd
+
+		// The same expansion `run` does. A host UI sending `/ozet x` on behalf of
+		// someone who defined that command should get the command, not the model
+		// improvising on the literal text.
+		const expansion = expandHeadlessCommand(prompt, {
+			cwd,
+			builtins: SLASH_COMMANDS.map((c) => c.name),
+		})
+		if (expansion.kind === 'refused') return fail(expansion.reason)
+		const finalPrompt = expansion.kind === 'expanded' ? expansion.prompt : prompt
 
 		// Before the session store is opened, before anything is read or run in
 		// that directory.
@@ -225,7 +237,11 @@ export const runStreamCommand: CommandDef = {
 		// turn's extra system context (the same channel the TUI's /skill uses).
 		const extraSystem = await loadSkillsContext(cwd, flags.skills)
 
-		const userMessage: Message = { role: 'user', content: prompt, timestamp: Date.now() } as Message
+		const userMessage: Message = {
+			role: 'user',
+			content: finalPrompt,
+			timestamp: Date.now(),
+		} as Message
 		const messages: Message[] = [...prior, userMessage]
 
 		let assistantText = ''

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -27,6 +27,8 @@ import { openSessions } from '../integrations/sessions/store.js'
 import { decideHeadlessTrust } from '../permissions/headless-trust.js'
 import { resolvePermissionMode } from '../permissions/mode.js'
 import { compilePermissions } from '../permissions/rules.js'
+import { SLASH_COMMANDS } from '../tui/slashCommands.js'
+import { expandHeadlessCommand } from '../user-commands/store.js'
 import { resolveResume } from './resume.js'
 import {
 	loadSkillsContext,
@@ -193,6 +195,25 @@ export const runCommand: CommandDef = {
 			return EXIT_USAGE
 		}
 
+		// A command the operator defined is expanded here too, not only in the
+		// TUI. Most of the reason to write one is to run it from a script, and
+		// sending `/ozet hedef.js` to the model as prose gave a confident answer
+		// about something else at exit 0.
+		//
+		// After the cwd is resolved, because the project's commands live under
+		// it; before the trust gate, because expanding a template only reads
+		// `.namzu/commands` and a refusal here should not need the folder to be
+		// trusted first.
+		const expansion = expandHeadlessCommand(prompt, {
+			cwd: resolved.cwd,
+			builtins: SLASH_COMMANDS.map((c) => c.name),
+		})
+		if (expansion.kind === 'refused') {
+			ctx.formatter.error({ message: expansion.reason })
+			return EXIT_USAGE
+		}
+		const finalPrompt = expansion.kind === 'expanded' ? expansion.prompt : prompt
+
 		// Before anything is read, run or constructed in that directory. The
 		// order is the gate: a check that happens after the session is built has
 		// already opened stores and walked the tree it was meant to protect.
@@ -320,7 +341,7 @@ export const runCommand: CommandDef = {
 		let failed: string | null = null
 		let stopReason: StopReason | undefined
 		for await (const event of session.send(
-			[...prior, { role: 'user', content: prompt, timestamp: Date.now() }],
+			[...prior, { role: 'user', content: finalPrompt, timestamp: Date.now() }],
 			extraSystem ? { extraSystem } : undefined,
 		)) {
 			if (event.kind === 'delta') text += event.text

--- a/packages/cli/src/user-commands/store.ts
+++ b/packages/cli/src/user-commands/store.ts
@@ -143,6 +143,72 @@ export function discoverUserCommands(
 		.sort((a, b) => a.name.localeCompare(b.name))
 }
 
+export type HeadlessExpansion =
+	/** Not a command. Send it as written. */
+	| { readonly kind: 'unchanged'; readonly prompt: string }
+	| { readonly kind: 'expanded'; readonly prompt: string; readonly name: string }
+	| { readonly kind: 'refused'; readonly reason: string }
+
+/**
+ * Resolve a headless prompt that may name one of the operator's own commands.
+ *
+ * `namzu run "/ozet hedef.js"` used to send that string to the model verbatim.
+ * The model, reasonably, tried to make sense of it — offering to create a file
+ * called `ozet hedef.js`. The run exited 0 with confident output that had
+ * nothing to do with the command. It did not fail; it quietly did something
+ * else, which is the shape worth removing.
+ *
+ * ## Why a leading `/` is not enough to call it a command
+ *
+ * `namzu run "/usr/local/bin is missing"` and `namzu run "/clear the cache in
+ * redis"` are ordinary prompts. Treating every leading slash as a command would
+ * break them, and breaking a working prompt to fix a broken one is not a trade
+ * worth making. So the test is not the slash — it is whether the first token
+ * names a command **this project actually declares**.
+ *
+ * That asymmetry is the whole rule. A file in `.namzu/commands/` is an explicit
+ * declaration by the operator, so matching it is high-confidence. A built-in's
+ * name is a common English word that nobody declared, so matching it is not.
+ *
+ * The one exception is a prompt that is EXACTLY a built-in and nothing else:
+ * `namzu run "/help"` is not a sentence anybody means literally, and answering
+ * it with a model improvising on the string is the same silent misfire. With
+ * arguments — `/clear the cache` — it stays prose, because there the words
+ * carry a meaning the command name does not.
+ */
+export function expandHeadlessCommand(
+	prompt: string,
+	opts: { home?: string; cwd?: string; builtins?: readonly string[] } = {},
+): HeadlessExpansion {
+	const trimmed = prompt.trim()
+	if (!trimmed.startsWith('/')) return { kind: 'unchanged', prompt }
+
+	const [token, ...rest] = trimmed.slice(1).split(/\s+/)
+	const name = token ?? ''
+	if (!name) return { kind: 'unchanged', prompt }
+
+	const builtins = new Set(opts.builtins ?? [])
+	if (rest.length === 0 && builtins.has(name)) {
+		return {
+			kind: 'refused',
+			reason: `/${name} is an interactive command and does nothing in \`namzu run\`. Run \`namzu\` for the terminal agent, or pass a prompt instead.`,
+		}
+	}
+
+	const commands = discoverUserCommands({
+		...(opts.home !== undefined ? { home: opts.home } : {}),
+		...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
+		reserved: [...builtins],
+	})
+	const found = commands.find((c) => c.name === name)
+	if (!found) return { kind: 'unchanged', prompt }
+
+	const expanded = expandCommand(found, rest.join(' '))
+	return expanded.ok
+		? { kind: 'expanded', prompt: expanded.prompt, name }
+		: { kind: 'refused', reason: expanded.reason }
+}
+
 export type ExpandResult =
 	| { readonly ok: true; readonly prompt: string }
 	| { readonly ok: false; readonly reason: string }


### PR DESCRIPTION
fix(cli): a command works where you would run it

`namzu run "/ozet hedef.js"` sent that string to the model as prose. The model
tried to make sense of it, offered to create a file called `ozet hedef.js`, and
the run exited 0 with confident output about something else.

**It was a defect, not a scope decision, and it is worth being exact about
that.** `discoverUserCommands` had one call site: the TUI's `App.tsx`. I wired
it where I was working and never considered headless. The documentation lives in
`docs/cli/tui.md` because that is where the code went, not because a boundary
was reasoned about. A boundary nobody chose, announced by nothing, is worse than
either answer would have been.

So: commands expand in `run` and `run-stream` both. A host UI sending `/ozet x`
on someone's behalf hits the identical gap.

## The rule is not "a leading slash is a command"

That is the part that needed care rather than typing. These are ordinary
prompts:

    namzu run "/usr/local/bin is missing, what should I check?"
    namzu run "/clear the cache in redis"

Treating every leading slash as an invocation would break them, and breaking a
working prompt to fix a broken one is not a trade worth making. The test is
whether the first token names a command **this project declares** — a file in
`.namzu/commands/` is an explicit declaration by the operator, while a built-in's
name is a common English word that nobody declared. That asymmetry is the whole
rule.

One exception: a prompt that is *exactly* a bare built-in. `namzu run "/help"`
is not a sentence anyone means literally, and letting the model improvise on the
string is the same silent misfire, so it is refused with a message. With
arguments it stays prose, because there the words carry the meaning.

Placement matters too: expansion runs **after** the working directory is
resolved, since the project's commands live under it, and **before** the trust
gate, since reading `.namzu/commands` to refuse a malformed command should not
require the folder to be trusted first.

## Tests

Six, and the pass-through cases are pinned as hard as the expansion. Without
them the file would pass against an implementation that hijacks every slash —
which is the failure mode this design exists to avoid.

Mutation: discarding the expansion fails exactly one test, with
`expected '/ozet hedef.js' to contain 'Summarise hedef.js in three bullets.'` —
the reported bug verbatim — while the refusal tests correctly keep passing,
since they return before that line.

## A false kill, the third of this shape today

The first attempt at that mutation used `sed '213s/…'`. A formatter had
reformatted the file and shifted the lines, so it replaced `return EXIT_USAGE`
instead: broken syntax, three tests "failing", and the one test that *should*
have failed passing. It reads exactly like a caught mutation.

Redone with an exact-text edit, it fails one test and type-checks clean, which
is what distinguishes an assertion from a parse error. Line-numbered edits
against a file a formatter may have touched are not safe — three for three
today, and `docs/conventions/never-filter-a-verification.md` already carries the
family.

## Docs

`docs/cli/tui.md` gains "They work in scripts too", stating the declaration rule
and the built-in exception in the same place as the `$ARGUMENTS` contract.
`docs/cli/headless.md`'s exit-code table now says `64` covers a slash command
that could not run, since a script author reads that table and not a page about
the TUI.
