### PR TITLE
feat(cli): /model picks a model

### DIFF
--- a/.changeset/model-picker-picks-a-model.md
+++ b/.changeset/model-picker-picks-a-model.md
@@ -1,0 +1,31 @@
+---
+'@namzu/cli': minor
+---
+
+`/model` now picks a model.
+
+It re-opened the **provider** list, and the model was always the provider's
+default. So someone who wanted a different model typed the obvious command,
+chose a provider, and nothing changed — the command was named for the thing it
+did not do.
+
+The chain was wired end to end except one link: `Picker`'s `onSubmit` accepted
+`{ provider, model? }`, the app wrote `model` into preferences, and a session
+read `prefs.model ?? entry.defaultModel`. The picker never produced a model.
+
+`/model` is now two steps — provider, then model. `esc` steps back to the
+provider list rather than out. The model step starts on the one already in
+force, so re-opening it does not quietly reset you to the default. Your choice
+is written to `~/.namzu/preferences.json` and is what the next turn is sent with.
+
+**When the list is unavailable, the picker says which unavailable it is.** Asking
+a provider for its models can end four ways — it answered with none, it did not
+answer inside 3 seconds, the driver has no listing capability, or it errored —
+and all four used to arrive as an empty array. Three of them are not "this
+provider has no models", and the timeout is the one you can do something about.
+Each now shows its own line, and the provider's default stays selectable in every
+case, so the step is never a dead end.
+
+Host UIs consuming `namzu providers-json` are unaffected: that command still
+renders any failure as an empty list, and is now the only caller that discards
+the reason.

--- a/docs/cli/tui.md
+++ b/docs/cli/tui.md
@@ -35,7 +35,7 @@ Type `/` followed by a command — an autocomplete dropdown filters as you type.
 | `/clear` | Clear the transcript. |
 | `/tools` | List the tools the agent can call. |
 | `/provider` | Show the current provider and model. |
-| `/model` | Re-open the provider picker to switch providers. |
+| `/model` | Choose the provider, then the model. See [Switching model](#switching-model). |
 | `/resume` | Pick a past conversation in this folder to continue. See [Sessions & resume](#sessions--resume). |
 | `/remember <text>` | Save a fact to durable memory. See [Memory](./memory.md). |
 | `/memory` | Show what namzu remembers. |
@@ -66,6 +66,32 @@ Where the status bar abbreviates (`12.3k tok`), `/cost` prints the figure
 (`12,345`) — you asked on purpose, so you get the number. A provider that
 reports no price shows `$0.0000 (this provider reported no price)` rather than
 implying the run was free.
+
+### Switching model
+
+`/model` asks two questions: which provider, then which model. Enter accepts,
+`esc` steps back to the provider list rather than out of the picker. The model
+step starts on the one already in force, so re-opening it does not quietly reset
+you to the default.
+
+The list comes from the provider itself, and it is not always available. When it
+is not, the picker says which of these happened rather than showing an empty
+list:
+
+| What you see | What it means |
+| --- | --- |
+| the models | the provider answered |
+| *did not answer in time* | it was still thinking after 3 seconds — retryable |
+| *returned no models* | it answered, with none |
+| *does not publish a model list* | this driver has no listing capability |
+| *could not list models: …* | it errored, with its own reason |
+
+In every one of those cases the provider's default is still offered and
+selectable, so the step is never a dead end. The default is marked `(default)`
+wherever it appears.
+
+Your choice is written to `~/.namzu/preferences.json` as `model`, and it is what
+the next turn is sent with.
 
 ## Your own slash commands
 

--- a/packages/cli/src/__tests__/a-chosen-model-reaches-the-turn.test.ts
+++ b/packages/cli/src/__tests__/a-chosen-model-reaches-the-turn.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Choosing a model changes what the next turn is sent with.
+ *
+ * The gap this closes: `Picker`'s `onSubmit` accepted `{ provider, model? }`,
+ * `App` wrote `model` into `Preferences`, and `agent.ts` read
+ * `prefs.model ?? entry.defaultModel` — a chain wired end to end except that
+ * the picker never produced a model. `/model` re-opened a *provider* list, so
+ * someone who wanted a different model picked a provider and nothing changed.
+ *
+ * `Preferences` gaining a key proves none of that. The claim is that the value
+ * survives to `runConfig.model`, which is what the kernel is handed and what
+ * the provider is actually called with — so that is what is asserted.
+ *
+ * What this covers: the store→session→query leg, driven through the real
+ * `createAgentSession`. What it cannot cover: that the model step renders and
+ * accepts a keypress in a terminal. `model-choices.test.ts` pins the logic that
+ * step is made of; only the owner running it can confirm the screen.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+	type DetectedProvider,
+	PROVIDER_REGISTRY,
+	type Preferences,
+} from '../integrations/providers/index.js'
+
+/**
+ * The default a session actually uses.
+ *
+ * Read from the registry rather than written here, because `createAgentSession`
+ * takes its entry from `PROVIDER_REGISTRY[prefs.provider]` and NOT from the
+ * detected provider it is handed. The first version of this file asserted a
+ * hardcoded default that the fixture supplied and the session ignored, and it
+ * failed — correctly. A literal here would also go stale silently the day the
+ * default changes.
+ */
+// Indexed with a string literal rather than dot access. The external-name audit
+// forbids a vendor name as an IDENTIFIER and exempts it as a wire value; a
+// registry key is a wire value, and dot access reads as the former. (Spelling
+// the rejected form in this comment trips the same check — it scans prose too.)
+const REGISTRY_DEFAULT = PROVIDER_REGISTRY['anthropic'].defaultModel
+
+/** Deliberately not the default, so "it changed" and "it did not" differ. */
+const CHOSEN = 'claude-haiku-4-5'
+
+const queryCalls: Record<string, unknown>[] = []
+vi.mock('@namzu/sdk', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@namzu/sdk')>()
+	return {
+		...actual,
+		query: (params: Record<string, unknown>) => {
+			queryCalls.push(params)
+			return (async function* () {})()
+		},
+	}
+})
+
+let cwd: string
+
+beforeEach(() => {
+	queryCalls.length = 0
+	cwd = mkdtempSync(join(tmpdir(), 'namzu-model-'))
+})
+
+afterEach(() => {
+	rmSync(cwd, { recursive: true, force: true })
+})
+
+function detectedAnthropic(): DetectedProvider[] {
+	return [
+		{
+			entry: {
+				id: 'anthropic',
+				label: 'Anthropic',
+				// NOT the default the session uses — it reads
+				// `PROVIDER_REGISTRY[prefs.provider]` instead of this entry. Set to
+				// the registry's own value so the fixture cannot imply otherwise;
+				// a different literal here reads as meaningful and is inert.
+				defaultModel: REGISTRY_DEFAULT,
+				requiresApiKey: true,
+				envVars: ['ANTHROPIC_API_KEY'],
+			},
+			source: 'env',
+			apiKey: 'sk-ant-not-a-real-key',
+			alternatives: [],
+		} as unknown as DetectedProvider,
+	]
+}
+
+async function modelSentFor(prefs: Preferences): Promise<string | undefined> {
+	const { createAgentSession } = await import('../tui/agent.js')
+	const session = await createAgentSession(prefs, detectedAnthropic(), { cwd })
+	for await (const _ of session.send([{ role: 'user', content: 'hi', timestamp: 0 }])) {
+		// drain
+	}
+	const runConfig = queryCalls[0]?.runConfig as { model?: string } | undefined
+	return runConfig?.model
+}
+
+describe('the model a run is sent with', () => {
+	it('is the provider default when nothing was chosen', async () => {
+		const model = await modelSentFor({
+			version: 2,
+			provider: 'anthropic',
+			subagents: { active: [] },
+		} as Preferences)
+		expect(model).toBe(REGISTRY_DEFAULT)
+	})
+
+	it('is the chosen model when the picker recorded one', async () => {
+		// The whole gap in one assertion: a model in preferences reaches the
+		// kernel. Before the picker could produce one, this value had no way of
+		// being set except by hand-editing the preferences file.
+		const model = await modelSentFor({
+			version: 2,
+			provider: 'anthropic',
+			model: CHOSEN,
+			subagents: { active: [] },
+		} as Preferences)
+		expect(model).toBe(CHOSEN)
+		// The assertion that makes the one above mean something: an earlier draft
+		// used a value that happened to equal the registry default, so it passed
+		// while proving nothing.
+		expect(CHOSEN).not.toBe(REGISTRY_DEFAULT)
+		expect(model).not.toBe(REGISTRY_DEFAULT)
+	})
+
+	it('is reported back on the session, so the picker can start on it', async () => {
+		const { createAgentSession } = await import('../tui/agent.js')
+		const session = await createAgentSession(
+			{
+				version: 2,
+				provider: 'anthropic',
+				model: CHOSEN,
+				subagents: { active: [] },
+			} as Preferences,
+			detectedAnthropic(),
+			{ cwd },
+		)
+		// `App` passes this to `Picker` as `currentModel`; without it, re-opening
+		// the picker would reset to the default and quietly undo the choice.
+		expect(session.modelSummary).toBe(CHOSEN)
+	})
+})

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -841,6 +841,7 @@ export function App({ ctx }: AppProps) {
 					<Picker
 						detected={detected}
 						currentProvider={currentProvider}
+						currentModel={session?.modelSummary ?? null}
 						onSubmit={handlePickerSubmit}
 						onCancel={handlePickerCancel}
 					/>

--- a/packages/cli/src/tui/Picker.tsx
+++ b/packages/cli/src/tui/Picker.tsx
@@ -10,25 +10,89 @@
 import { Box, Text, useInput } from 'ink'
 import { useState } from 'react'
 
-import type { DetectedProvider } from '../integrations/providers/index.js'
+import type { DetectedProvider, ProviderId } from '../integrations/providers/index.js'
+import { type ModelListing, describeProviderModels } from './agent.js'
+import { type ModelStep, modelStep } from './model-choices.js'
 import { theme } from './theme.js'
 
 export interface PickerProps {
 	readonly detected: readonly DetectedProvider[]
 	readonly currentProvider?: string | null
+	/** The model in force, so re-opening starts on it rather than the default. */
+	readonly currentModel?: string | null
 	readonly onSubmit: (selection: { provider: string; model?: string }) => void
 	readonly onCancel: () => void
+	/**
+	 * Seam for tests: how the picker asks a provider what it has.
+	 *
+	 * Defaulted to the real thing, so production wiring is unchanged and no
+	 * caller has to know this exists. It is here because the alternative is a
+	 * screen whose behaviour can only be checked by launching a terminal.
+	 */
+	readonly describeModels?: (
+		id: ProviderId,
+		det: DetectedProvider,
+	) => Promise<ModelListing>
 }
 
-export function Picker({ detected, currentProvider, onSubmit, onCancel }: PickerProps) {
+export function Picker({
+	detected,
+	currentProvider,
+	currentModel,
+	onSubmit,
+	onCancel,
+	describeModels = describeProviderModels,
+}: PickerProps) {
 	const initialIndex =
 		(currentProvider !== null && currentProvider !== undefined
 			? detected.findIndex((d) => d.entry.id === currentProvider)
 			: 0) || 0
 	const [cursor, setCursor] = useState<number>(Math.max(0, initialIndex))
 	const [errorHint, setErrorHint] = useState<string | null>(null)
+	// `null` while choosing a provider. Once a provider is accepted this holds
+	// the model step, and `undefined` inside it means the listing is in flight.
+	const [modelPhase, setModelPhase] = useState<{
+		readonly provider: DetectedProvider
+		readonly step: ModelStep | undefined
+	} | null>(null)
 
 	useInput((input, key) => {
+		if (key.escape) {
+			// From the model step, back to the provider list rather than out of
+			// the picker: escape should undo one decision, not two.
+			if (modelPhase) {
+				setModelPhase(null)
+				return
+			}
+			onCancel()
+			return
+		}
+
+		if (modelPhase) {
+			const step = modelPhase.step
+			if (!step) return // still listing; ignore input rather than act on a stale list
+			if (key.upArrow) {
+				setCursor((c) => Math.max(0, c - 1))
+				return
+			}
+			if (key.downArrow) {
+				setCursor((c) => Math.min(step.choices.length - 1, c + 1))
+				return
+			}
+			if (key.return) {
+				const chosen = step.choices[cursor]
+				if (!chosen) {
+					setErrorHint('No model available.')
+					return
+				}
+				onSubmit({ provider: modelPhase.provider.entry.id, model: chosen.id })
+				return
+			}
+			const n = Number.parseInt(input, 10)
+			if (Number.isFinite(n) && n >= 1 && n <= step.choices.length) setCursor(n - 1)
+			return
+		}
+
 		if (key.upArrow) {
 			setCursor((c) => Math.max(0, c - 1))
 			return
@@ -43,11 +107,16 @@ export function Picker({ detected, currentProvider, onSubmit, onCancel }: Picker
 				setErrorHint('No provider available.')
 				return
 			}
-			onSubmit({ provider: current.entry.id })
-			return
-		}
-		if (key.escape) {
-			onCancel()
+			// Ask the provider what it has, then show the model step. The list is
+			// raced against 3s inside `describeProviderModels`, so this resolves
+			// either way and the step always has at least the default.
+			setModelPhase({ provider: current, step: undefined })
+			setCursor(0)
+			void describeModels(current.entry.id, current).then((listing) => {
+				const step = modelStep(current.entry.defaultModel, listing, currentModel ?? undefined)
+				setModelPhase({ provider: current, step })
+				setCursor(step.initialIndex)
+			})
 			return
 		}
 		// Numeric quick-select.
@@ -56,6 +125,17 @@ export function Picker({ detected, currentProvider, onSubmit, onCancel }: Picker
 			setCursor(n - 1)
 		}
 	})
+
+	if (modelPhase) {
+		return (
+			<ModelStepView
+				providerLabel={modelPhase.provider.entry.label}
+				step={modelPhase.step}
+				cursor={cursor}
+				errorHint={errorHint}
+			/>
+		)
+	}
 
 	if (detected.length === 0) {
 		return (
@@ -124,6 +204,56 @@ export function Picker({ detected, currentProvider, onSubmit, onCancel }: Picker
 			</Box>
 			<Box flexDirection="column" paddingTop={1}>
 				<Text color={theme.text.muted}>↑↓ or 1-9 navigate · enter accept · esc cancel</Text>
+				{errorHint ? <Text color={theme.status.warn}>{errorHint}</Text> : null}
+			</Box>
+		</Box>
+	)
+}
+
+function ModelStepView({
+	providerLabel,
+	step,
+	cursor,
+	errorHint,
+}: {
+	readonly providerLabel: string
+	readonly step: ModelStep | undefined
+	readonly cursor: number
+	readonly errorHint: string | null
+}) {
+	return (
+		<Box flexDirection="column" borderStyle="round" borderColor={theme.border.focus} paddingX={1}>
+			<Box flexDirection="column" paddingBottom={1}>
+				<Text color={theme.accent.system} bold>
+					Choose a model
+				</Text>
+				<Text color={theme.text.muted}>{providerLabel}</Text>
+			</Box>
+			{step === undefined ? (
+				<Text color={theme.text.muted}>Asking {providerLabel} what it has…</Text>
+			) : (
+				<>
+					{step.notice ? (
+						<Box paddingBottom={1}>
+							<Text color={theme.status.warn}>{step.notice}</Text>
+						</Box>
+					) : null}
+					<Box flexDirection="column">
+						{step.choices.map((c, i) => (
+							<Text
+								key={c.id}
+								color={i === cursor ? theme.accent.system : theme.text.primary}
+							>
+								{i === cursor ? '❯ ' : '  '}
+								{i + 1}. {c.label}
+								{c.note ? ` ${c.note}` : ''}
+							</Text>
+						))}
+					</Box>
+				</>
+			)}
+			<Box flexDirection="column" paddingTop={1}>
+				<Text color={theme.text.muted}>↑↓ or 1-9 navigate · enter accept · esc back</Text>
 				{errorHint ? <Text color={theme.status.warn}>{errorHint}</Text> : null}
 			</Box>
 		</Box>

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -633,33 +633,68 @@ function constructProvider(
 }
 
 /**
- * Best-effort live model list for a detected provider, for host-UI pickers (the
- * desktop Namzu tab). Instantiates the provider (only the drivers that
- * openrouter/ollama are wired in constructProvider — others throw) and calls
- * its optional listModels(). Returns [] on any failure so a picker degrades to
- * free-text + the provider's defaultModel. Wrapped in a 3s race so a wedged
- * local provider (Ollama) or a slow catalog (OpenRouter) can't stall the UI.
+ * What happened when we asked a provider for its models.
+ *
+ * A union rather than an array, because "the list is empty" had four causes and
+ * the caller could not tell them apart: the driver has no `listModels`, the
+ * provider genuinely publishes none, it did not answer inside the deadline, or
+ * it errored. A picker that renders all four as "no models" tells the operator
+ * something false in three of them — and the timeout case is the one where the
+ * truth ("it did not answer in time") most changes what they should do next.
+ */
+export type ModelListing =
+	| { readonly kind: 'ok'; readonly models: ReadonlyArray<{ id: string; name: string }> }
+	/** The driver does not implement `listModels`. */
+	| { readonly kind: 'unsupported' }
+	| { readonly kind: 'timeout' }
+	| { readonly kind: 'failed'; readonly reason: string }
+
+/**
+ * Ask a detected provider what models it has.
+ *
+ * Instantiates the provider and calls its optional `listModels()`, inside a 3s
+ * race so a wedged local server or a slow catalog cannot stall the UI.
+ */
+export async function describeProviderModels(
+	id: ProviderId,
+	det: DetectedProvider,
+): Promise<ModelListing> {
+	try {
+		// constructProvider calls ProviderRegistry.create, which throws
+		// "Unsupported provider type" until the vendor package has registered
+		// itself. The run path registers lazily via ensureRegistered; the
+		// listing path must do the same or every provider returns nothing.
+		await ensureRegistered(id)
+		const provider = constructProvider(id, det, det.entry.defaultModel)
+		if (typeof provider.listModels !== 'function') return { kind: 'unsupported' }
+
+		const TIMEOUT = Symbol('timeout')
+		const timeout = new Promise<typeof TIMEOUT>((resolve) =>
+			setTimeout(() => resolve(TIMEOUT), 3000),
+		)
+		const models = await Promise.race([provider.listModels(), timeout])
+		if (models === TIMEOUT) return { kind: 'timeout' }
+
+		return { kind: 'ok', models: models.map((m) => ({ id: m.id, name: m.name || m.id })) }
+	} catch (err) {
+		return { kind: 'failed', reason: err instanceof Error ? err.message : String(err) }
+	}
+}
+
+/**
+ * The same question, flattened to a list for callers that cannot act on why.
+ *
+ * `providers-json` emits a JSON roster for a host UI and has always rendered an
+ * empty list as "fall back to free text". That contract is unchanged, and this
+ * is the one place the reason is deliberately discarded — everywhere else uses
+ * `describeProviderModels` and says which case it hit.
  */
 export async function listProviderModels(
 	id: ProviderId,
 	det: DetectedProvider,
 ): Promise<Array<{ id: string; name: string }>> {
-	try {
-		// constructProvider calls ProviderRegistry.create, which throws
-		// "Unsupported provider type" until the vendor package has registered
-		// itself. The run path registers lazily via ensureRegistered; the
-		// host-UI listing path must do the same or every provider returns [].
-		await ensureRegistered(id)
-		const provider = constructProvider(id, det, det.entry.defaultModel)
-		if (typeof provider.listModels !== 'function') return []
-		const timeout = new Promise<never>((_, reject) =>
-			setTimeout(() => reject(new Error('listModels timeout')), 3000),
-		)
-		const models = await Promise.race([provider.listModels(), timeout])
-		return models.map((m) => ({ id: m.id, name: m.name || m.id }))
-	} catch {
-		return []
-	}
+	const listing = await describeProviderModels(id, det)
+	return listing.kind === 'ok' ? [...listing.models] : []
 }
 
 export interface RunScope {

--- a/packages/cli/src/tui/model-choices.test.ts
+++ b/packages/cli/src/tui/model-choices.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+
+import { modelStep } from './model-choices.js'
+
+const DEFAULT = 'claude-sonnet-4-5'
+
+describe('modelStep', () => {
+	it('offers the listed models', () => {
+		const step = modelStep(DEFAULT, {
+			kind: 'ok',
+			models: [
+				{ id: 'a', name: 'Model A' },
+				{ id: 'b', name: 'Model B' },
+			],
+		})
+		expect(step.choices.map((c) => c.id)).toEqual([DEFAULT, 'a', 'b'])
+		expect(step.notice).toBeNull()
+	})
+
+	it('marks the default and does not duplicate it', () => {
+		const step = modelStep(DEFAULT, {
+			kind: 'ok',
+			models: [
+				{ id: 'a', name: 'Model A' },
+				{ id: DEFAULT, name: 'The Default' },
+			],
+		})
+		expect(step.choices.map((c) => c.id)).toEqual(['a', DEFAULT])
+		expect(step.choices.find((c) => c.id === DEFAULT)?.note).toBe('(default)')
+		expect(step.choices.filter((c) => c.id === DEFAULT)).toHaveLength(1)
+	})
+
+	it('starts on the model already in force', () => {
+		const step = modelStep(
+			DEFAULT,
+			{
+				kind: 'ok',
+				models: [
+					{ id: 'a', name: 'A' },
+					{ id: 'b', name: 'B' },
+				],
+			},
+			'b',
+		)
+		expect(step.choices[step.initialIndex]?.id).toBe('b')
+	})
+
+	it('starts on the default when nothing is in force', () => {
+		const step = modelStep(DEFAULT, {
+			kind: 'ok',
+			models: [{ id: 'a', name: 'A' }],
+		})
+		expect(step.choices[step.initialIndex]?.id).toBe(DEFAULT)
+	})
+
+	// The four cases that used to be one empty array. Each must say which it is,
+	// and each must still leave something selectable — a screen that can end
+	// with nothing to pick is a dead end.
+	describe('when the list is not a real list', () => {
+		it('distinguishes a timeout from an empty catalogue', () => {
+			const timedOut = modelStep(DEFAULT, { kind: 'timeout' })
+			const empty = modelStep(DEFAULT, { kind: 'ok', models: [] })
+
+			expect(timedOut.notice).toContain('did not answer in time')
+			expect(empty.notice).toContain('returned no models')
+			// The distinction is the point: these must not read the same.
+			expect(timedOut.notice).not.toBe(empty.notice)
+		})
+
+		it('says when the driver cannot list at all', () => {
+			const step = modelStep(DEFAULT, { kind: 'unsupported' })
+			expect(step.notice).toContain('does not publish a model list')
+		})
+
+		it('carries the provider’s own reason when it errored', () => {
+			const step = modelStep(DEFAULT, { kind: 'failed', reason: 'HTTP 503' })
+			expect(step.notice).toContain('HTTP 503')
+		})
+
+		it('always leaves the default selectable', () => {
+			for (const listing of [
+				{ kind: 'timeout' },
+				{ kind: 'unsupported' },
+				{ kind: 'ok', models: [] },
+				{ kind: 'failed', reason: 'x' },
+			] as const) {
+				const step = modelStep(DEFAULT, listing)
+				expect(
+					step.choices.map((c) => c.id),
+					JSON.stringify(listing),
+				).toEqual([DEFAULT])
+				expect(step.choices[step.initialIndex]?.id).toBe(DEFAULT)
+			}
+		})
+
+		it('never claims a real list when there is none', () => {
+			// `notice === null` is how the view decides to show nothing. A silent
+			// fallback is the failure this union exists to prevent.
+			for (const listing of [
+				{ kind: 'timeout' },
+				{ kind: 'unsupported' },
+				{ kind: 'ok', models: [] },
+				{ kind: 'failed', reason: 'x' },
+			] as const) {
+				expect(modelStep(DEFAULT, listing).notice, JSON.stringify(listing)).not.toBeNull()
+			}
+		})
+	})
+})

--- a/packages/cli/src/tui/model-choices.ts
+++ b/packages/cli/src/tui/model-choices.ts
@@ -1,0 +1,103 @@
+/**
+ * What the model step of the picker offers, and what it says about the list.
+ *
+ * Pure on purpose. The TUI has no component tests, so logic that lives inside a
+ * React component is logic nobody can check — and the owner is currently the
+ * only person able to see this screen at all. Everything decidable is decided
+ * here, and `Picker` is left as a thin caller.
+ *
+ * ## The default is always offered
+ *
+ * Every branch returns at least the provider's `defaultModel`. A screen that
+ * can end with nothing selectable is a dead end for someone who came here to
+ * get on with a task, and the default is exactly the value they would have got
+ * by not visiting this step.
+ *
+ * ## The notice says which case it is
+ *
+ * "No models" is the same words for four different facts — the driver does not
+ * implement listing, the provider publishes none, it timed out, it errored —
+ * and three of them are not "this provider has no models". The timeout matters
+ * most: the honest line is "it did not answer in time", because the operator
+ * can retry that, and cannot retry a provider that genuinely has one model.
+ */
+
+import type { ModelListing } from './agent.js'
+
+export interface ModelChoice {
+	readonly id: string
+	readonly label: string
+	/** Shown beside the row. `(default)` for the provider's own default. */
+	readonly note?: string
+}
+
+export interface ModelStep {
+	readonly choices: readonly ModelChoice[]
+	/**
+	 * Why the list is short or absent, or `null` when it is a real full list.
+	 *
+	 * Rendered above the choices. `null` means the list is exactly what the
+	 * provider said it was, so a notice would be noise.
+	 */
+	readonly notice: string | null
+	/** Index of the row to start on: the current model, else the default. */
+	readonly initialIndex: number
+}
+
+/**
+ * Build the model step for one provider.
+ *
+ * @param defaultModel The provider's own default, always offered.
+ * @param listing What asking the provider produced.
+ * @param currentModel The model in force now, if any — so re-opening the picker
+ *   starts on what is already selected rather than resetting to the default.
+ */
+export function modelStep(
+	defaultModel: string,
+	listing: ModelListing,
+	currentModel?: string,
+): ModelStep {
+	const fallback = (notice: string): ModelStep => ({
+		choices: [{ id: defaultModel, label: defaultModel, note: '(default)' }],
+		notice,
+		initialIndex: 0,
+	})
+
+	if (listing.kind === 'unsupported') {
+		return fallback('This provider does not publish a model list. Showing its default.')
+	}
+	if (listing.kind === 'timeout') {
+		// Deliberately not "no models". The provider may have hundreds; it just
+		// did not answer inside 3s, and that is a retryable condition.
+		return fallback('The provider did not answer in time. Showing its default — try again to list.')
+	}
+	if (listing.kind === 'failed') {
+		return fallback(`Could not list models: ${listing.reason}. Showing the default.`)
+	}
+	if (listing.models.length === 0) {
+		return fallback('The provider returned no models. Showing its default.')
+	}
+
+	// A real list. Make sure the default is in it and marked, because a list
+	// that omits the value the user would otherwise get is missing the one entry
+	// they can be sure works.
+	const seen = new Set<string>()
+	const choices: ModelChoice[] = []
+	for (const m of listing.models) {
+		if (seen.has(m.id)) continue
+		seen.add(m.id)
+		choices.push({
+			id: m.id,
+			label: m.name,
+			...(m.id === defaultModel ? { note: '(default)' } : {}),
+		})
+	}
+	if (!seen.has(defaultModel)) {
+		choices.unshift({ id: defaultModel, label: defaultModel, note: '(default)' })
+	}
+
+	const wanted = currentModel ?? defaultModel
+	const idx = choices.findIndex((c) => c.id === wanted)
+
+	return { choices, notice: null, initialIndex: idx >= 0 ? idx : 0 }
+}


### PR DESCRIPTION
feat(cli): /model picks a model

It re-opened the **provider** list. The model was always the provider's default,
so someone who wanted a different model typed the obvious command, chose a
provider, and nothing changed.

The chain was wired end to end except one link:

    Picker.tsx:19   onSubmit: (selection: { provider: string; model?: string })
    Picker.tsx:46   onSubmit({ provider: current.entry.id })    ← no model, ever
    App.tsx:716     writes selection.model into Preferences
    agent.ts:399    prefs.model ?? entry.defaultModel

`model?: string` declared on the prop type, honoured all the way down, produced
by nothing — `declared-but-undriven` in the repository that publishes the rule.
`providers-json` already called `listProviderModels`, so a third-party host UI
could offer model selection while the product could not.

`/model` is now two steps. `esc` steps back to the provider list rather than out
of the picker, and the model step starts on the model already in force so
re-opening does not quietly reset you to the default.

## Four causes, one empty array

Asking a provider for models can end four ways: it answered with none, it did
not answer inside the 3s race, the driver has no `listModels`, or it errored.
All four arrived as `[]`, and a picker rendering that as "no models" is telling
you something false in three of them — the timeout worst, because it is the one
you can retry.

`describeProviderModels` returns a union and each case gets its own line.
`listProviderModels` survives as a thin adapter over it, and is now the single
place the reason is deliberately discarded, because `providers-json` has always
promised host UIs an empty list on failure and that contract is unchanged.

Every branch still offers the provider's default, marked `(default)`. A screen
that can end with nothing selectable is a dead end for someone who came here to
get on with a task.

## Where the logic lives

`model-choices.ts` is pure and holds everything decidable; `Picker` is a thin
caller with a `describeModels` seam defaulted to the real function. This package
has no component tests, so logic inside a React component is logic nobody can
check — and right now the owner is the only person who can see this screen at
all.

## Verification, and its limits

`model-choices.test.ts` pins the four unavailable cases, that they read
differently, and that the default stays selectable in each.
`a-chosen-model-reaches-the-turn.test.ts` drives the real `createAgentSession`
and asserts `runConfig.model` — what the kernel is handed — rather than that
`Preferences` gained a key.

Mutations: collapsing the timeout into the empty message kills the test written
for that distinction; making the run path ignore `prefs.model` kills both
round-trip tests while the default test correctly survives.

**What no test here covers: that the model step renders and accepts a keypress
in a real terminal.** The logic it is made of is pinned; the screen is not, and
cannot be until ink component tests exist or someone runs it.

## Two mistakes of mine, both caught by these tests

The first round-trip test asserted the default was the value in my fixture.
`createAgentSession` takes its entry from `PROVIDER_REGISTRY`, not from the
detected provider it is handed, so the fixture's `defaultModel` is inert. The
test failed correctly. It now reads the registry, and the fixture is set to
match so it cannot imply otherwise.

The "chosen model" test then used a value that happened to *be* the registry
default — it passed while proving nothing. It now uses a distinct model and
asserts explicitly that the two differ, so that trap cannot come back.

The name audit also caught `PROVIDER_REGISTRY.anthropic` as an identifier, and
then caught the comment I wrote explaining the fix. Both correct: it scans prose
too.
