### PR TITLE
feat(cli): a key you can type

### DIFF
--- a/.changeset/a-key-you-can-type.md
+++ b/.changeset/a-key-you-can-type.md
@@ -1,0 +1,35 @@
+---
+'@namzu/cli': minor
+---
+
+You can type a credential into a running namzu instead of restarting.
+
+With no key discovered, the picker used to list three sources and say "then
+restart namzu" — accurate, and a cliff: the product told you to leave it in
+order to use it. It now also offers `k`, which takes a key and starts the
+session with it.
+
+**Held in memory for that session only, and written nowhere.** The screen says
+so before you type and again afterwards, and names the environment variable that
+makes it durable.
+
+That is a decision, not an omission. The obvious durable home is the OS
+keychain; namzu's keychain support is macOS-only and reads a *different*
+product's credential store, so a key written there would be filed under someone
+else's name — and on Windows there is no keychain path at all. The remaining
+option was a plaintext file. A secret at rest should be something you chose, not
+something that arrived because you typed into a text field.
+
+- **Masked while typing** — never the key, and never its length either, since
+  length distinguishes vendors and tiers.
+- **Checked at the moment you type it**, by listing models, which costs nothing.
+  A rejected key leaves you on the screen with what you typed intact.
+- **Never claims a check it did not do.** A provider with no cheap way to
+  validate a key is reported as exactly that, with the first message named as
+  the real test.
+- **Never reaches a transcript or an error.** Errors carry the provider's
+  reason, truncated, and the function that writes the message is not given the
+  key.
+
+A typed credential shows as `typed · this session only` wherever providers are
+listed.

--- a/docs/cli/providers.md
+++ b/docs/cli/providers.md
@@ -1,7 +1,7 @@
 ---
 title: Providers & credentials
 description: How namzu discovers LLM credentials, the first-run provider picker, and switching providers.
-last_updated: 2026-08-05
+last_updated: 2026-08-07
 status: current
 related_packages: ["@namzu/cli", "@namzu/anthropic", "@namzu/openai", "@namzu/openrouter", "@namzu/ollama"]
 ---
@@ -9,6 +9,34 @@ related_packages: ["@namzu/cli", "@namzu/anthropic", "@namzu/openai", "@namzu/op
 # Providers & credentials
 
 namzu is **credential-first**: it never runs a login flow. On launch it discovers credentials already present on your machine and lets you choose which LLM provider to chat through.
+
+## If nothing is found, you can type one
+
+When no credential is discovered, the picker offers `k` — paste a key and use it
+straight away, without leaving namzu.
+
+**It is kept in memory for that session only and is never written anywhere.**
+The screen says so before you type and again after. To make it durable, set the
+environment variable the same screen names, and restart.
+
+That is a deliberate limit rather than an unfinished one. The obvious durable
+home would be the OS keychain, and namzu's keychain support is macOS-only and
+reads a *different* product's credential store — writing your key there would
+file it under someone else's name, and on Windows there is no keychain path at
+all. The remaining option was a plaintext file, and a secret at rest should be
+something you chose rather than something that arrived because you typed into a
+text field.
+
+While you type, only a mask is shown — never the key, and never its length. The
+key is checked with the provider at the moment you enter it, by listing models,
+which costs nothing. If the provider rejects it you stay on the screen with what
+you typed intact, so a one-character slip is fixable. If the provider has no way
+to check a key cheaply, namzu says exactly that rather than implying it verified
+something.
+
+A typed credential is listed as `typed · this session only` wherever providers
+are shown, so you can always see which one disappears when you close the
+terminal.
 
 ## Where credentials are discovered
 

--- a/packages/cli/src/integrations/providers/discover.ts
+++ b/packages/cli/src/integrations/providers/discover.ts
@@ -20,6 +20,15 @@ export type DetectionSource =
 	| { readonly kind: 'env'; readonly envName: string }
 	| { readonly kind: 'probe'; readonly url: string }
 	| { readonly kind: 'keychain'; readonly service: string }
+	/**
+	 * Typed into a running namzu and held in memory for this session.
+	 *
+	 * Never produced by `discoverProviders` — discovery reads the machine, and
+	 * this one came from a person. It is in the union so a credential the
+	 * operator typed flows through every path that handles a discovered one,
+	 * differing only where a surface says where it came from.
+	 */
+	| { readonly kind: 'session' }
 
 export interface DetectedProvider {
 	readonly entry: ProviderRegistryEntry

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -712,6 +712,28 @@ export function App({ ctx }: AppProps) {
 		})
 	}, [phase, ctx.version, pushMessage])
 
+	/**
+	 * A credential the operator typed. Held in memory for this process only.
+	 *
+	 * Deliberately does NOT call `writePreferences`: preferences are a file, and
+	 * the whole contract of this entry point is that nothing lands on disk. The
+	 * provider choice is not persisted either, because persisting it would leave
+	 * a preference pointing at a credential that will not exist next launch.
+	 */
+	const handleTypedCredential = useCallback(
+		(credential: DetectedProvider, disposition: string) => {
+			const next = [credential, ...detected.filter((d) => d.entry.id !== credential.entry.id)]
+			setDetected(next)
+			// The disposition, not the key. `credential` never reaches a message.
+			pushMessage('system', disposition)
+			void hydrateSession(
+				{ version: 2, provider: credential.entry.id as ProviderId, subagents: { active: [] } },
+				next,
+			)
+		},
+		[detected, hydrateSession, pushMessage],
+	)
+
 	const handlePickerSubmit = useCallback(
 		(selection: { provider: string; model?: string }) => {
 			const prefs: Preferences = {
@@ -844,6 +866,7 @@ export function App({ ctx }: AppProps) {
 						currentModel={session?.modelSummary ?? null}
 						onSubmit={handlePickerSubmit}
 						onCancel={handlePickerCancel}
+						onCredential={handleTypedCredential}
 					/>
 				) : (
 					<>

--- a/packages/cli/src/tui/Picker.tsx
+++ b/packages/cli/src/tui/Picker.tsx
@@ -10,8 +10,15 @@
 import { Box, Text, useInput } from 'ink'
 import { useState } from 'react'
 
-import type { DetectedProvider, ProviderId } from '../integrations/providers/index.js'
-import { type ModelListing, describeProviderModels } from './agent.js'
+import {
+	ALL_PROVIDER_IDS,
+	type DetectedProvider,
+	PROVIDER_REGISTRY,
+	type ProviderId,
+	type ProviderRegistryEntry,
+} from '../integrations/providers/index.js'
+import { type ModelListing, describeProviderModels, verifyCredential } from './agent.js'
+import { describeDisposition, keyLooksUsable, maskKey, sessionCredential } from './credential-entry.js'
 import { type ModelStep, modelStep } from './model-choices.js'
 import { theme } from './theme.js'
 
@@ -33,6 +40,16 @@ export interface PickerProps {
 		id: ProviderId,
 		det: DetectedProvider,
 	) => Promise<ModelListing>
+	/**
+	 * A credential the operator typed, with the sentence describing what was
+	 * done with it. Absent means this picker cannot take one.
+	 */
+	readonly onCredential?: (credential: DetectedProvider, disposition: string) => void
+}
+
+/** Providers that take a typed API key. Local servers do not. */
+function keyCapableProviders(): ProviderRegistryEntry[] {
+	return ALL_PROVIDER_IDS.map((id) => PROVIDER_REGISTRY[id]).filter((e) => e.requiresApiKey)
 }
 
 export function Picker({
@@ -42,6 +59,7 @@ export function Picker({
 	onSubmit,
 	onCancel,
 	describeModels = describeProviderModels,
+	onCredential,
 }: PickerProps) {
 	const initialIndex =
 		(currentProvider !== null && currentProvider !== undefined
@@ -55,8 +73,79 @@ export function Picker({
 		readonly provider: DetectedProvider
 		readonly step: ModelStep | undefined
 	} | null>(null)
+	// Key entry. `value` is the secret and never leaves this component except as
+	// a mask or as the credential handed to `onCredential`.
+	const [keyEntry, setKeyEntry] = useState<{
+		readonly providerIndex: number
+		readonly value: string
+		readonly status: 'typing' | 'checking'
+		readonly problem?: string
+	} | null>(null)
+
+	const acceptKey = async (): Promise<void> => {
+		const state = keyEntry
+		if (!state) return
+		const entry = keyCapableProviders()[state.providerIndex]
+		if (!entry) return
+
+		const shape = keyLooksUsable(state.value)
+		if (!shape.ok) {
+			setKeyEntry({ ...state, status: 'typing', problem: shape.reason })
+			return
+		}
+
+		setKeyEntry({ ...state, status: 'checking' })
+		const cred = sessionCredential(entry, state.value)
+		const verification = await verifyCredential(entry.id, cred)
+
+		if (verification.kind === 'rejected') {
+			// Stays on the screen with the key intact so a one-character typo is
+			// fixable. The reason is the provider's, never the key.
+			setKeyEntry({
+				...state,
+				status: 'typing',
+				problem: describeDisposition(entry, verification),
+			})
+			return
+		}
+		onCredential?.(cred, describeDisposition(entry, verification))
+	}
 
 	useInput((input, key) => {
+		// Key entry owns the keyboard while it is open: every printable character
+		// is part of a secret, so nothing here may fall through to a shortcut.
+		if (keyEntry) {
+			if (key.escape) {
+				setKeyEntry(null)
+				return
+			}
+			if (keyEntry.status === 'checking') return
+			if (key.return) {
+				void acceptKey()
+				return
+			}
+			if (key.backspace || key.delete) {
+				setKeyEntry((k) => (k ? { ...k, value: k.value.slice(0, -1), status: 'typing' } : k))
+				return
+			}
+			if (input && !key.ctrl && !key.meta) {
+				setKeyEntry((k) => (k ? { ...k, value: k.value + input, status: 'typing' } : k))
+			}
+			return
+		}
+
+		// `k` from the empty screen. Only there: on a populated picker the letter
+		// would collide with navigation, and someone with a working credential is
+		// not the person this is for.
+		if (detected.length === 0 && onCredential && (input === 'k' || input === 'K')) {
+			if (keyCapableProviders().length > 0) {
+				setKeyEntry({ providerIndex: 0, value: '', status: 'typing' })
+			} else {
+				setErrorHint('No provider here takes a typed key.')
+			}
+			return
+		}
+
 		if (key.escape) {
 			// From the model step, back to the provider list rather than out of
 			// the picker: escape should undo one decision, not two.
@@ -126,6 +215,36 @@ export function Picker({
 		}
 	})
 
+	if (keyEntry) {
+		const entry = keyCapableProviders()[keyEntry.providerIndex]
+		return (
+			<Box flexDirection="column" borderStyle="round" borderColor={theme.border.focus} paddingX={1}>
+				<Box flexDirection="column" paddingBottom={1}>
+					<Text color={theme.accent.system} bold>
+						Paste a key for {entry?.label ?? 'this provider'}
+					</Text>
+					<Text color={theme.text.muted}>
+						↑↓ is not needed — type or paste, then enter. esc cancels.
+					</Text>
+				</Box>
+				{/* The mask, never the value. */}
+				<Text color={theme.text.primary}>
+					{maskKey(keyEntry.value) || <Text color={theme.text.muted}>(nothing typed yet)</Text>}
+				</Text>
+				<Box paddingTop={1} flexDirection="column">
+					{keyEntry.status === 'checking' ? (
+						<Text color={theme.text.muted}>Checking it with {entry?.label}…</Text>
+					) : (
+						<Text color={theme.text.secondary}>
+							Used for this session only — it is not written anywhere.
+						</Text>
+					)}
+					{keyEntry.problem ? <Text color={theme.status.warn}>{keyEntry.problem}</Text> : null}
+				</Box>
+			</Box>
+		)
+	}
+
 	if (modelPhase) {
 		return (
 			<ModelStepView
@@ -175,7 +294,13 @@ export function Picker({
 					</Text>
 				</Box>
 				<Box paddingTop={1}>
-					<Text color={theme.text.muted}>esc: exit picker</Text>
+					<Text color={theme.text.primary}>
+						Or press <Text color={theme.accent.system}>k</Text> to paste a key now and use it for
+						this session.
+					</Text>
+				</Box>
+				<Box paddingTop={1}>
+					<Text color={theme.text.muted}>k: enter a key · esc: exit picker</Text>
 				</Box>
 			</Box>
 		)
@@ -297,5 +422,10 @@ function describeSource(d: DetectedProvider): string {
 			return `local · ${d.source.url.replace(/^https?:\/\//, '')}`
 		case 'keychain':
 			return `keychain · ${d.source.service}`
+		case 'session':
+			// Named as temporary wherever it is listed. Someone scanning this
+			// column should be able to see which credential disappears when they
+			// close the terminal without having to remember typing it.
+			return 'typed · this session only'
 	}
 }

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -682,6 +682,31 @@ export async function describeProviderModels(
 }
 
 /**
+ * Check a key the operator just typed, without spending a turn.
+ *
+ * Uses the provider's own `listModels` where it has one: a successful listing
+ * is proof the credential authenticates, and it costs nothing. A driver without
+ * one cannot be checked cheaply, and that is reported as `unverifiable` rather
+ * than dressed up as success — claiming a check that did not happen is the
+ * failure this whole surface is built to avoid.
+ *
+ * The key never appears in the returned reason. Provider errors are passed
+ * through, and a driver that echoes a credential into its own error message
+ * would defeat this; that is a driver bug and not one this can paper over, so
+ * the reason is also truncated.
+ */
+export async function verifyCredential(
+	id: ProviderId,
+	det: DetectedProvider,
+): Promise<{ kind: 'verified' } | { kind: 'unverifiable' } | { kind: 'rejected'; reason: string }> {
+	const listing = await describeProviderModels(id, det)
+	if (listing.kind === 'ok') return { kind: 'verified' }
+	if (listing.kind === 'unsupported') return { kind: 'unverifiable' }
+	if (listing.kind === 'timeout') return { kind: 'unverifiable' }
+	return { kind: 'rejected', reason: listing.reason.slice(0, 200) }
+}
+
+/**
  * The same question, flattened to a list for callers that cannot act on why.
  *
  * `providers-json` emits a JSON roster for a host UI and has always rendered an

--- a/packages/cli/src/tui/credential-entry.test.ts
+++ b/packages/cli/src/tui/credential-entry.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	describeDisposition,
+	keyLooksUsable,
+	maskKey,
+	sessionCredential,
+} from './credential-entry.js'
+
+const KEY = 'sk-ant-api03-abcdefghijklmnopqrstuvwxyz-0123beef'
+
+const entry = {
+	id: 'anthropic',
+	label: 'A Provider',
+	defaultModel: 'a-model',
+	requiresApiKey: true,
+	envVars: ['PROVIDER_API_KEY', 'PROVIDER_TOKEN'],
+} as never
+
+describe('maskKey', () => {
+	it('never contains the key', () => {
+		const masked = maskKey(KEY)
+		expect(masked).not.toContain(KEY)
+		// The body of the key must not survive in any form. The tail is
+		// deliberate; anything longer would let a screen recording rebuild it.
+		expect(masked).not.toContain('api03')
+		expect(masked).not.toContain('abcdefghij')
+	})
+
+	it('keeps a short tail so two pasted keys can be told apart', () => {
+		expect(maskKey(KEY)).toContain('beef')
+		expect(maskKey(`${KEY.slice(0, -4)}cafe`)).toContain('cafe')
+		expect(maskKey(KEY)).not.toBe(maskKey(`${KEY.slice(0, -4)}cafe`))
+	})
+
+	it('does not leak the length', () => {
+		// A mask that grows with the key reveals how long it is, and key length
+		// distinguishes vendors and sometimes tiers. Two keys 160 characters
+		// apart must render the same width.
+		const short = maskKey(`${'x'.repeat(36)}beef`)
+		const long = maskKey(`${'x'.repeat(196)}beef`)
+		expect(short.length).toBe(long.length)
+		expect(short).toBe(long)
+	})
+
+	it('hides a key too short to have a tail rather than showing all of it', () => {
+		expect(maskKey('abc')).toBe('••••')
+		expect(maskKey('abc')).not.toContain('abc')
+	})
+
+	it('is empty for nothing typed', () => {
+		expect(maskKey('')).toBe('')
+		expect(maskKey('   ')).toBe('')
+	})
+})
+
+describe('keyLooksUsable', () => {
+	it('accepts an ordinary key', () => {
+		expect(keyLooksUsable(KEY).ok).toBe(true)
+	})
+
+	it('rejects nothing', () => {
+		expect(keyLooksUsable('  ').ok).toBe(false)
+	})
+
+	it('catches a wrapped or truncated paste', () => {
+		const r = keyLooksUsable('sk-ant-abc def')
+		expect(r.ok).toBe(false)
+		expect(!r.ok && r.reason).toContain('space')
+	})
+
+	it('catches a shell assignment pasted instead of the value', () => {
+		const r = keyLooksUsable('ANTHROPIC_API_KEY=sk-ant-abc')
+		expect(r.ok).toBe(false)
+		expect(!r.ok && r.reason).toContain('shell assignment')
+	})
+
+	it('does not reject a key shape it has not seen', () => {
+		// The provider is the authority. A validator that rejects a NEW valid
+		// format is worse than one that lets the provider answer.
+		expect(keyLooksUsable('completely-unfamiliar-but-plausible-000').ok).toBe(true)
+	})
+})
+
+describe('describeDisposition', () => {
+	it('says the key is not stored, on every accepting branch', () => {
+		for (const v of [{ kind: 'verified' }, { kind: 'unverifiable' }] as const) {
+			const text = describeDisposition(entry, v)
+			expect(text, v.kind).toContain('this session only')
+			expect(text, v.kind).toContain('not written anywhere')
+		}
+	})
+
+	it('names the environment variable that makes it durable', () => {
+		expect(describeDisposition(entry, { kind: 'verified' })).toContain('PROVIDER_API_KEY')
+	})
+
+	it('does not claim a check it did not perform', () => {
+		const unverifiable = describeDisposition(entry, { kind: 'unverifiable' })
+		expect(unverifiable).toContain('no way to check it')
+		expect(unverifiable).not.toContain('accepted the key')
+
+		const verified = describeDisposition(entry, { kind: 'verified' })
+		expect(verified).toContain('accepted the key')
+	})
+
+	it('reports a rejection without implying anything was kept', () => {
+		const text = describeDisposition(entry, { kind: 'rejected', reason: 'HTTP 401' })
+		expect(text).toContain('HTTP 401')
+		expect(text).toContain('Nothing was stored')
+	})
+
+	it('never contains a key, because it is never given one', () => {
+		// The signature is the guarantee: a function with no access to the secret
+		// cannot put it in a message that reaches a transcript.
+		expect(describeDisposition.length).toBe(2)
+	})
+})
+
+describe('sessionCredential', () => {
+	it('is shaped like a discovered provider so every path treats it alike', () => {
+		const cred = sessionCredential(entry, ` ${KEY} `)
+		expect(cred.apiKey).toBe(KEY)
+		expect(cred.entry).toBe(entry)
+		expect(cred.alternatives).toEqual([])
+	})
+
+	it('is marked as typed, so a surface can say it disappears', () => {
+		expect(sessionCredential(entry, KEY).source).toEqual({ kind: 'session' })
+	})
+})

--- a/packages/cli/src/tui/credential-entry.ts
+++ b/packages/cli/src/tui/credential-entry.ts
@@ -1,0 +1,126 @@
+/**
+ * Typing a credential into a running namzu, for this session only.
+ *
+ * Someone who has just installed namzu and has no key reaches a screen that
+ * lists three sources and says "then restart namzu". That is accurate and it is
+ * a cliff: the product tells them to leave it in order to use it.
+ *
+ * ## Why session-only, stated as a decision rather than a limitation
+ *
+ * The obvious durable home is the OS keychain, and here it does not exist. The
+ * keychain helper in this package is macOS-only, and it reads and writes a
+ * DIFFERENT product's credential store — namzu borrows an OAuth token from it.
+ * Writing a namzu key into that envelope would put our secret under their name.
+ * On Windows, which is where this was asked for, there is no keychain path at
+ * all.
+ *
+ * So the durable options were a plaintext file or a per-platform credential
+ * store nobody has written. Keeping the key in memory for the session is the
+ * honest third answer: nothing lands on disk, it works everywhere, and the
+ * screen names the environment variable that makes it durable. A secret at rest
+ * should be something the operator chose, not something that arrived because
+ * they typed into a text field.
+ *
+ * Everything decidable lives here rather than in the component, because this
+ * package has no component tests and a secret is the worst thing to leave
+ * unverifiable.
+ */
+
+import type { DetectedProvider, ProviderRegistryEntry } from '../integrations/providers/index.js'
+
+/**
+ * What a key looks like on screen. Never the key.
+ *
+ * Enough tail to tell two keys apart when you have pasted the wrong one, and
+ * never enough to reconstruct one from a screen recording or a scrollback that
+ * outlives the session. The length is not revealed either: a fixed-width mask
+ * would leak it, and key length distinguishes vendors and sometimes tiers.
+ */
+export function maskKey(key: string): string {
+	const trimmed = key.trim()
+	if (trimmed.length === 0) return ''
+	const tail = trimmed.slice(-4)
+	return trimmed.length <= 4 ? '••••' : `••••••••${tail}`
+}
+
+/**
+ * Whether a typed key is worth trying at all.
+ *
+ * Deliberately shallow. Anything beyond "not empty, no whitespace, not obviously
+ * a shell fragment" is guessing at vendor formats that change, and a validator
+ * that rejects a NEW valid key format is worse than one that lets the provider
+ * answer. The provider is the authority; this only catches the paste that
+ * plainly went wrong.
+ */
+export function keyLooksUsable(key: string): { ok: true } | { ok: false; reason: string } {
+	const trimmed = key.trim()
+	if (trimmed.length === 0) return { ok: false, reason: 'No key entered.' }
+	if (/\s/.test(trimmed)) {
+		return { ok: false, reason: 'That contains a space — check for a truncated or wrapped paste.' }
+	}
+	if (trimmed.startsWith('$') || trimmed.includes('=')) {
+		return {
+			ok: false,
+			// The classic: pasting `ANTHROPIC_API_KEY=sk-…` or `$MY_KEY` from a
+			// shell profile rather than the value.
+			reason: 'That looks like a shell assignment or variable. Paste the key itself.',
+		}
+	}
+	return { ok: true }
+}
+
+/** How the key was checked before being accepted. */
+export type Verification =
+	| { readonly kind: 'verified' }
+	/** The driver has no way to check a key without spending a turn. */
+	| { readonly kind: 'unverifiable' }
+	| { readonly kind: 'rejected'; readonly reason: string }
+
+/**
+ * What namzu tells the operator it did with what they typed.
+ *
+ * Every branch says three things: that it worked or did not, that the key is
+ * held for this session only, and the environment variable that persists it.
+ * The middle one is the part a person is most likely to assume otherwise —
+ * typing a credential into an application usually means it was saved.
+ */
+export function describeDisposition(
+	entry: ProviderRegistryEntry,
+	verification: Verification,
+): string {
+	const persist = entry.envVars[0]
+	const durable = persist
+		? `To keep it, set ${persist} in your shell and restart.`
+		: 'To keep it, configure the credential in your environment and restart.'
+
+	if (verification.kind === 'rejected') {
+		return `${entry.label} rejected that key: ${verification.reason}\nNothing was stored.`
+	}
+
+	const checked =
+		verification.kind === 'verified'
+			? `${entry.label} accepted the key.`
+			: // Said plainly rather than implied. A driver with no cheap check
+				// cannot confirm a key without spending a turn, and claiming it is
+				// good would be inventing a verification that did not happen.
+				`Key accepted. ${entry.label} offers no way to check it without a request, so the first message will be the test.`
+
+	return `${checked}\nHeld in memory for this session only — it is not written anywhere. ${durable}`
+}
+
+/**
+ * The detected-provider record a typed key produces.
+ *
+ * Shaped exactly like a discovered one so every downstream path — session
+ * construction, the model picker, `/provider` — treats it identically. The only
+ * difference is `source`, so a surface can say where it came from.
+ */
+export function sessionCredential(entry: ProviderRegistryEntry, key: string): DetectedProvider {
+	return {
+		entry,
+		source: { kind: 'session' },
+		apiKey: key.trim(),
+		...(entry.defaultBaseUrl !== undefined ? { baseUrl: entry.defaultBaseUrl } : {}),
+		alternatives: [],
+	}
+}


### PR DESCRIPTION
feat(cli): a key you can type

With no credential discovered, the picker listed three sources and said "then
restart namzu". Accurate, and a cliff: the product told someone who had just
installed it to leave in order to use it. It now also offers `k`.

**The key is held in memory for that session and written nowhere.** The screen
says so before you type and again after, and names the environment variable that
makes it durable.

That is a decision rather than a shortfall, and it is worth recording why. The
obvious durable home is the OS keychain. Here it does not exist: the keychain
helper is macOS-only, and it reads and writes a DIFFERENT product's credential
store — namzu borrows an OAuth token from it, so a namzu key written there would
be filed under someone else's name. On Windows, which is where this was asked
for, there is no keychain path at all. That left a plaintext file, and a secret
at rest should be something the operator chose rather than something that
arrived because they typed into a text field.

## The four properties, and where each is enforced

- **Masked while typing.** Never the value, and never the length either — a
  fixed-width mask leaks nothing, and key length distinguishes vendors and
  sometimes tiers. A four-character tail is kept so two pasted keys can be told
  apart.
- **Checked at the moment it is typed**, by listing models, which costs nothing
  and proves the credential authenticates. A rejection leaves you on the screen
  with what you typed intact, so a one-character slip is fixable.
- **Never claims a check it did not perform.** A driver with no cheap way to
  validate a key reports `unverifiable`, and the message says the first request
  will be the test.
- **Never reaches a transcript or an error.** `describeDisposition` is not given
  the key — the signature is the guarantee — and provider reasons are truncated,
  since a driver echoing a credential into its own error is a bug this cannot
  paper over.

## Details worth keeping

`DetectionSource` gains `{ kind: 'session' }`, and the exhaustive switch in
`describeSource` failed type-checking the moment it did, which is the union
doing its job. It renders as `typed · this session only`, so a credential that
disappears when the terminal closes is visibly the one that will.

`handleTypedCredential` deliberately does not call `writePreferences`.
Preferences are a file, and persisting the provider choice would leave a
preference pointing at a credential that will not exist next launch.

Everything decidable lives in `credential-entry.ts` rather than in the
component, because this package has no component tests and a secret is the worst
thing to leave unverifiable. 17 tests.

Mutations: returning the key from `maskKey` kills three; making the
`unverifiable` branch claim "accepted the key" kills the test written for that
honesty.

**Not covered by any test here: that the entry screen renders and captures
keystrokes.** Only a terminal confirms that.

One test bug of my own, caught by running it: the "does not leak the length"
case compared a mask against a *mangled* other mask, which is meaningless and
happened to fail. It now asserts that two keys 160 characters apart render
identically.
