### PR TITLE
test(cli): pin the two screens that shipped blind

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,6 +60,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
 		"@types/react": "^19.2.15",
+		"ink-testing-library": "^4.0.0",
 		"typescript": "^5.5.0",
 		"vitest": "^3.2.6"
 	},

--- a/packages/cli/src/tui/Picker.tsx
+++ b/packages/cli/src/tui/Picker.tsx
@@ -45,6 +45,15 @@ export interface PickerProps {
 	 * done with it. Absent means this picker cannot take one.
 	 */
 	readonly onCredential?: (credential: DetectedProvider, disposition: string) => void
+	/**
+	 * Seam for tests: how a typed key is checked. Defaulted to the real thing,
+	 * so no production caller knows this exists.
+	 *
+	 * Here for the same reason as `describeModels`: the alternative is a screen
+	 * whose behaviour can only be checked by launching a terminal and typing a
+	 * live credential into it.
+	 */
+	readonly verify?: typeof verifyCredential
 }
 
 /** Providers that take a typed API key. Local servers do not. */
@@ -60,6 +69,7 @@ export function Picker({
 	onCancel,
 	describeModels = describeProviderModels,
 	onCredential,
+	verify = verifyCredential,
 }: PickerProps) {
 	const initialIndex =
 		(currentProvider !== null && currentProvider !== undefined
@@ -96,7 +106,7 @@ export function Picker({
 
 		setKeyEntry({ ...state, status: 'checking' })
 		const cred = sessionCredential(entry, state.value)
-		const verification = await verifyCredential(entry.id, cred)
+		const verification = await verify(entry.id, cred)
 
 		if (verification.kind === 'rejected') {
 			// Stays on the screen with the key intact so a one-character typo is

--- a/packages/cli/src/tui/__tests__/credential-prompt-draws.test.tsx
+++ b/packages/cli/src/tui/__tests__/credential-prompt-draws.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * The credential prompt draws, and it does not draw the key.
+ *
+ * These two screens shipped with their logic pinned and their rendering
+ * unverified — nobody could see them but the owner. `ink-testing-library`
+ * renders to a string, so `lastFrame()` is a screenshot that can be asserted on
+ * and reviewed in a diff, which an image cannot.
+ *
+ * ## What is asserted, and what is deliberately not
+ *
+ * Not a snapshot of the whole frame. That passes forever, fails on every
+ * unrelated cosmetic change, and catches nothing in between — the assertion
+ * that blocks everything and proves nothing. Each test names the specific thing
+ * it is about: the absence of the key, the sentence, the provider's own reason.
+ *
+ * ## What a rendered frame still cannot tell you
+ *
+ * This is not a terminal. Line wrapping at a real width, resize, and how ink's
+ * `<Static>` scrollback interacts with the live region are not exercised here.
+ * "The prompt draws and hides the key" moves from unverified to pinned; how it
+ * behaves in a 60-column window does not.
+ */
+
+import { render } from 'ink-testing-library'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { DetectedProvider } from '../../integrations/providers/index.js'
+import { Picker } from '../Picker.js'
+
+const KEY = 'sk-ant-api03-notarealkey-0123beef'
+
+/** Let ink flush a render after input. */
+const flush = () => new Promise((r) => setTimeout(r, 20))
+
+function open(overrides: Partial<Parameters<typeof Picker>[0]> = {}) {
+	const onCredential = vi.fn()
+	const harness = render(
+		<Picker
+			detected={[]}
+			onSubmit={vi.fn()}
+			onCancel={vi.fn()}
+			onCredential={onCredential}
+			verify={async () => ({ kind: 'verified' })}
+			{...overrides}
+		/>,
+	)
+	return { ...harness, onCredential }
+}
+
+describe('the no-credential screen', () => {
+	it('offers the key entry rather than only telling you to restart', async () => {
+		const { lastFrame, unmount } = open()
+		expect(lastFrame()).toContain('No providers detected')
+		// The cliff this closes: the screen used to end at "restart namzu".
+		expect(lastFrame()).toContain('restart namzu')
+		expect(lastFrame()).toMatch(/press .*k.* to paste a key|k: enter a key/s)
+		unmount()
+	})
+})
+
+describe('the credential prompt', () => {
+	it('appears when k is pressed', async () => {
+		const { lastFrame, stdin, unmount } = open()
+		stdin.write('k')
+		await flush()
+		expect(lastFrame()).toContain('Paste a key')
+		unmount()
+	})
+
+	it('says the key is session-only BEFORE anything is typed', async () => {
+		// Before, not after. Someone deciding whether to paste a secret needs the
+		// disposition at the moment they decide, not once it is already typed.
+		const { lastFrame, stdin, unmount } = open()
+		stdin.write('k')
+		await flush()
+		expect(lastFrame()).toContain('this session only')
+		expect(lastFrame()).toContain('not written anywhere')
+		unmount()
+	})
+
+	it('does not echo the key', async () => {
+		// The assertion that matters most here: this is a security property and it
+		// was shipped unverified.
+		const { lastFrame, stdin, unmount } = open()
+		stdin.write('k')
+		await flush()
+		stdin.write(KEY)
+		await flush()
+
+		const frame = lastFrame() ?? ''
+		expect(frame).not.toContain(KEY)
+		expect(frame).not.toContain('api03')
+		expect(frame).not.toContain('notarealkey')
+		// The mask is on screen, so something is visibly happening as they type.
+		expect(frame).toContain('••••')
+		unmount()
+	})
+
+	it('shows a tail so a wrong paste is recognisable, and nothing more', async () => {
+		const { lastFrame, stdin, unmount } = open()
+		stdin.write('k')
+		await flush()
+		stdin.write(KEY)
+		await flush()
+
+		const frame = lastFrame() ?? ''
+		expect(frame).toContain('beef')
+		// Four characters of tail, not five: the character before the tail must
+		// not be on screen.
+		expect(frame).not.toContain('3beef')
+		unmount()
+	})
+
+	it('surfaces the provider’s own reason when a key is rejected', async () => {
+		const { lastFrame, stdin, unmount, onCredential } = open({
+			verify: async () => ({ kind: 'rejected', reason: 'HTTP 401 invalid x-api-key' }),
+		})
+		stdin.write('k')
+		await flush()
+		stdin.write(KEY)
+		await flush()
+		stdin.write('\r')
+		await flush()
+
+		const frame = lastFrame() ?? ''
+		// The provider's words, not "could not verify key".
+		expect(frame).toContain('HTTP 401')
+		expect(frame).toContain('Nothing was stored')
+		// Still on the screen, so a one-character slip is fixable...
+		expect(frame).toContain('Paste a key')
+		// ...and the key is still not on it.
+		expect(frame).not.toContain(KEY)
+		expect(onCredential).not.toHaveBeenCalled()
+		unmount()
+	})
+
+	it('hands the credential up, with the disposition, when accepted', async () => {
+		const { stdin, unmount, onCredential } = open()
+		stdin.write('k')
+		await flush()
+		stdin.write(KEY)
+		await flush()
+		stdin.write('\r')
+		await flush()
+
+		expect(onCredential).toHaveBeenCalledTimes(1)
+		const [cred, disposition] = onCredential.mock.calls[0] as [DetectedProvider, string]
+		expect(cred.apiKey).toBe(KEY)
+		expect(cred.source).toEqual({ kind: 'session' })
+		// The sentence the operator reads afterwards says it again.
+		expect(disposition).toContain('this session only')
+		expect(disposition).not.toContain(KEY)
+		unmount()
+	})
+
+	it('escapes back out without keeping anything', async () => {
+		const { lastFrame, stdin, unmount, onCredential } = open()
+		stdin.write('k')
+		await flush()
+		stdin.write(KEY)
+		await flush()
+		stdin.write('\x1B')
+		await flush()
+
+		expect(lastFrame()).toContain('No providers detected')
+		expect(lastFrame()).not.toContain(KEY)
+		expect(onCredential).not.toHaveBeenCalled()
+		unmount()
+	})
+})

--- a/packages/cli/src/tui/__tests__/model-picker-draws.test.tsx
+++ b/packages/cli/src/tui/__tests__/model-picker-draws.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * The two-step `/model` picker draws, and its two navigation rules hold.
+ *
+ * `model-choices.test.ts` pins what the step is made of. This pins that the
+ * step appears at all, that `esc` undoes one decision rather than two, and that
+ * it opens on the model in force — three behaviours described in the PR and
+ * pinned by nothing until now.
+ *
+ * Assertions name the specific thing rather than snapshotting the frame. A
+ * whole-frame snapshot passes forever and fails on every cosmetic change, which
+ * is the assertion that blocks everything and catches nothing.
+ *
+ * Not a terminal: wrapping, resize and scrollback are still unexercised.
+ */
+
+import { render } from 'ink-testing-library'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { DetectedProvider } from '../../integrations/providers/index.js'
+import type { ModelListing } from '../agent.js'
+import { Picker } from '../Picker.js'
+
+const flush = () => new Promise((r) => setTimeout(r, 20))
+
+const DEFAULT_MODEL = 'a-default-model'
+
+function detected(): DetectedProvider[] {
+	return [
+		{
+			entry: {
+				id: 'openai',
+				label: 'A Provider',
+				defaultModel: DEFAULT_MODEL,
+				requiresApiKey: true,
+				envVars: ['A_KEY'],
+			},
+			source: { kind: 'env', envName: 'A_KEY' },
+			apiKey: 'not-a-real-key',
+			alternatives: [],
+		} as unknown as DetectedProvider,
+	]
+}
+
+const listing: ModelListing = {
+	kind: 'ok',
+	models: [
+		{ id: 'model-one', name: 'Model One' },
+		{ id: 'model-two', name: 'Model Two' },
+	],
+}
+
+function open(overrides: Partial<Parameters<typeof Picker>[0]> = {}) {
+	const onSubmit = vi.fn()
+	const onCancel = vi.fn()
+	const harness = render(
+		<Picker
+			detected={detected()}
+			onSubmit={onSubmit}
+			onCancel={onCancel}
+			describeModels={async () => listing}
+			{...overrides}
+		/>,
+	)
+	return { ...harness, onSubmit, onCancel }
+}
+
+/** The row the cursor is on, by its marker. */
+function selectedRow(frame: string): string | undefined {
+	return frame.split('\n').find((l) => l.includes('❯'))
+}
+
+describe('the model step', () => {
+	it('appears after a provider is accepted', async () => {
+		const { lastFrame, stdin, unmount } = open()
+		expect(lastFrame()).toContain('Choose a provider')
+
+		stdin.write('\r')
+		await flush()
+
+		expect(lastFrame()).toContain('Choose a model')
+		expect(lastFrame()).toContain('Model One')
+		expect(lastFrame()).toContain('Model Two')
+		unmount()
+	})
+
+	it('offers the provider default alongside the listed models', async () => {
+		const { lastFrame, stdin, unmount } = open()
+		stdin.write('\r')
+		await flush()
+		expect(lastFrame()).toContain(DEFAULT_MODEL)
+		expect(lastFrame()).toContain('(default)')
+		unmount()
+	})
+
+	it('opens on the model in force, not the default', async () => {
+		// Re-opening the picker must not quietly reset the operator's choice.
+		const { lastFrame, stdin, unmount } = open({ currentModel: 'model-two' })
+		stdin.write('\r')
+		await flush()
+
+		const row = selectedRow(lastFrame() ?? '')
+		expect(row, 'no row is selected').toBeDefined()
+		expect(row).toContain('Model Two')
+		expect(row).not.toContain('Model One')
+		unmount()
+	})
+
+	it('opens on the default when nothing is in force', async () => {
+		const { lastFrame, stdin, unmount } = open()
+		stdin.write('\r')
+		await flush()
+		expect(selectedRow(lastFrame() ?? '')).toContain(DEFAULT_MODEL)
+		unmount()
+	})
+
+	it('submits the model the cursor is on, not the provider default', async () => {
+		const { stdin, unmount, onSubmit } = open({ currentModel: 'model-two' })
+		stdin.write('\r')
+		await flush()
+		stdin.write('\r')
+		await flush()
+
+		expect(onSubmit).toHaveBeenCalledTimes(1)
+		expect(onSubmit.mock.calls[0]?.[0]).toEqual({ provider: 'openai', model: 'model-two' })
+		unmount()
+	})
+})
+
+describe('esc from the model step', () => {
+	it('returns to the provider list rather than leaving the picker', async () => {
+		const { lastFrame, stdin, unmount, onCancel } = open()
+		stdin.write('\r')
+		await flush()
+		expect(lastFrame()).toContain('Choose a model')
+
+		stdin.write('\x1B')
+		await flush()
+
+		// Back one decision...
+		expect(lastFrame()).toContain('Choose a provider')
+		expect(lastFrame()).not.toContain('Choose a model')
+		// ...and not out of the picker entirely.
+		expect(onCancel).not.toHaveBeenCalled()
+		unmount()
+	})
+
+	it('still leaves the picker from the provider list', async () => {
+		// The other half: esc must not become inert. A key that undoes one step
+		// and then does nothing is its own defect.
+		const { stdin, unmount, onCancel } = open()
+		stdin.write('\x1B')
+		await flush()
+		expect(onCancel).toHaveBeenCalledTimes(1)
+		unmount()
+	})
+})
+
+describe('while the list is still loading', () => {
+	it('says so, and ignores input rather than acting on a list it does not have', async () => {
+		let release: (l: ModelListing) => void = () => {}
+		const pending = new Promise<ModelListing>((r) => {
+			release = r
+		})
+		const { lastFrame, stdin, unmount, onSubmit } = open({ describeModels: () => pending })
+
+		stdin.write('\r')
+		await flush()
+		expect(lastFrame()).toContain('what it has')
+
+		// Enter here must not submit: there is no list to have chosen from.
+		stdin.write('\r')
+		await flush()
+		expect(onSubmit).not.toHaveBeenCalled()
+
+		release(listing)
+		await flush()
+		expect(lastFrame()).toContain('Model One')
+		unmount()
+	})
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
+      ink-testing-library:
+        specifier: ^4.0.0
+        version: 4.0.0(@types/react@19.2.15)
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
@@ -1908,6 +1911,15 @@ packages:
   indent-string@5.0.0:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
     engines: {node: '>=12'}
+
+  ink-testing-library@4.0.0:
+    resolution: {integrity: sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   ink@7.0.3:
     resolution: {integrity: sha512-5kxHkIj9+RuqCU3zyvP4qvYWNOSHP2TW/SHayHGHOmk87KwfVcZwvJGemi9ch+ci2gXUqerK/Eh2DGEDt5q45g==}
@@ -4071,6 +4083,10 @@ snapshots:
   ignore@5.3.2: {}
 
   indent-string@5.0.0: {}
+
+  ink-testing-library@4.0.0(@types/react@19.2.15):
+    optionalDependencies:
+      '@types/react': 19.2.15
 
   ink@7.0.3(@types/react@19.2.15)(react@19.2.6):
     dependencies:


### PR DESCRIPTION
test(cli): pin the two screens that shipped blind

The credential prompt and the two-step model picker went out with their logic
tested and their rendering unverified — nobody could see them but the owner.
`ink-testing-library` renders to a string, so `lastFrame()` is a screenshot that
can be asserted on and reviewed in a diff. That is strictly better than an
image, which proves a screen looked right once on someone else's machine.

First component tests in this package, so `ink-testing-library` joins as a
devDependency.

## What is pinned

**The credential prompt.** It appears on `k`. The session-only sentence is on
screen *before* anything is typed — the moment someone decides whether to paste
a secret, not after they already have — and again in the disposition afterwards.
**The key is not echoed**: not the value, not `api03`, not the body, with the
mask visibly present so something is happening as they type. Four characters of
tail are shown and a fifth is not. A rejected key surfaces the provider's own
words (`HTTP 401`) rather than a generic failure, stays on screen so a
one-character slip is fixable, keeps the key off the frame, and does not hand
anything upward. `esc` discards.

**The model step.** It renders after a provider is accepted, offers the default
alongside the listed models, and opens on the model **in force** rather than the
default. `esc` returns to the provider list and does **not** call `onCancel` —
and, the other half, `esc` from the provider list still exits, so the key cannot
quietly become inert. Enter while the list is still loading does not submit,
because there is no list to have chosen from.

## Not snapshots

Deliberately. A whole-frame snapshot passes forever, fails on every unrelated
cosmetic change, and catches nothing in between — the assertion that blocks
everything and proves nothing. Every test here names the specific thing it is
about: the absence of the key, the sentence, the selected row.

## Mutation-checked

Rendering `keyEntry.value` in place of `maskKey(...)` kills three tests,
including the one that exists because masking is a security property. Deleting
the `modelPhase` branch from the `esc` handler kills exactly the step-back test
while "still leaves the picker" correctly survives — the pair is what makes
either meaningful.

## One seam added

`Picker` gains `verify`, defaulted to the real `verifyCredential`, matching the
existing `describeModels` seam. Without it the credential test would send a fake
key over the network. No production caller knows either exists.

## What this still does not prove

**A rendered frame is not a terminal.** Line wrapping at a real width, resize,
and how ink's `<Static>` scrollback interacts with the live region are not
exercised by any of this. The owner remains the only person who can confirm
those. What moves from unverified to pinned is "the prompt draws, hides the key,
and the navigation rules hold" — most of the gap, and not all of it.

No changeset: test support and a devDependency, nothing a consumer imports.
`Transcript` is untouched — the pinned-composer question is still the owner's.
