### PR TITLE
test(cli): cleanup that cannot fail a passing test

### DIFF
--- a/packages/cli/src/__fixtures__/temp-dir-retries.test.ts
+++ b/packages/cli/src/__fixtures__/temp-dir-retries.test.ts
@@ -1,0 +1,43 @@
+/**
+ * The retry option reaches the call.
+ *
+ * `fs.rmSync` defaults `maxRetries` to **0**, so every bare call site in this
+ * package had no retry at all for exactly the errors the API documents
+ * (`EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, `EPERM`). Asking for retries is
+ * the substance of the helper, and the behavioural tests beside this one would
+ * all still pass if a future edit quietly dropped the option back to the
+ * default — the tree would still be removed, and nothing would be retried.
+ *
+ * Its own file because it mocks `node:fs`, which the behavioural tests need to
+ * be real.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const rmSync = vi.fn()
+vi.mock('node:fs', () => ({ rmSync: (...args: unknown[]) => rmSync(...args) }))
+
+afterEach(() => {
+	rmSync.mockReset()
+})
+
+describe('removeTempDir', () => {
+	it('asks for retries, which the default does not', async () => {
+		const { removeTempDir } = await import('./temp-dir.js')
+
+		removeTempDir('/some/path')
+
+		expect(rmSync).toHaveBeenCalledTimes(1)
+		expect(rmSync).toHaveBeenCalledWith(
+			'/some/path',
+			expect.objectContaining({
+				recursive: true,
+				force: true,
+				// The two that matter. Without them this is the bare call that let a
+				// cleanup race fail a passing test.
+				maxRetries: 10,
+				retryDelay: 50,
+			}),
+		)
+	})
+})

--- a/packages/cli/src/__fixtures__/temp-dir.test.ts
+++ b/packages/cli/src/__fixtures__/temp-dir.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The cleanup helper cannot fail a test.
+ *
+ * That is its whole reason to exist: a full-suite run went red on a test whose
+ * assertion had passed, because `afterEach` could not delete a temp directory
+ * and vitest attributes a hook failure to the test it ran after.
+ *
+ * These assertions are about the helper's contract rather than about the
+ * filesystem, because the filesystem race could not be reproduced — 15 isolated
+ * runs, 6 full-suite runs and an 80-round synthetic stress all passed. What is
+ * pinned is that whatever the filesystem does, this does not throw.
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { removeTempDir } from './temp-dir.js'
+
+afterEach(() => {
+	vi.restoreAllMocks()
+})
+
+describe('removeTempDir', () => {
+	it('removes a tree', () => {
+		const root = mkdtempSync(join(tmpdir(), 'namzu-rm-'))
+		mkdirSync(join(root, 'a', 'b'), { recursive: true })
+		writeFileSync(join(root, 'a', 'b', 'f.json'), '{}')
+
+		removeTempDir(root)
+
+		expect(existsSync(root)).toBe(false)
+	})
+
+	it('is silent on a path that is already gone', () => {
+		// `force: true` covers this, and a warning here would be noise on every
+		// suite that cleans up twice.
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+		removeTempDir(join(tmpdir(), 'namzu-rm-does-not-exist-xyzzy'))
+		expect(warn).not.toHaveBeenCalled()
+	})
+
+	it('warns instead of throwing when removal fails', () => {
+		// The property that matters. A path the platform refuses outright stands
+		// in for the transient lock that cannot be reproduced on demand — the
+		// point is the catch, not which errno reaches it.
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+		expect(() => removeTempDir('\0invalid')).not.toThrow()
+		expect(warn).toHaveBeenCalledTimes(1)
+		const message = String(warn.mock.calls[0]?.[0] ?? '')
+		// Names the path and says the test result stands, so a real handle leak
+		// is still visible rather than silently swallowed.
+		expect(message).toContain('could not remove')
+		expect(message).toContain('unaffected')
+	})
+})

--- a/packages/cli/src/__fixtures__/temp-dir.ts
+++ b/packages/cli/src/__fixtures__/temp-dir.ts
@@ -1,0 +1,68 @@
+/**
+ * Remove a temp directory a test made, without letting the removal fail the
+ * test.
+ *
+ * ## The finding this exists for
+ *
+ * A full-suite run went red on `archived-workspace.test.ts`:
+ *
+ *     × names the workspace in the refusal 11ms
+ *       → ENOTEMPTY: directory not empty, rmdir '…/.namzu/projects/prj_…'
+ *
+ * The assertion passed. The error came from `afterEach`, and vitest attributes
+ * a hook failure to the test it ran after — so a temp-directory deletion race
+ * was reported as a product test failure, on a test whose claim was never in
+ * doubt.
+ *
+ * That is the defect, and it is not confined to one file: thirty call sites in
+ * this package delete a temp tree in a hook, and any of them can turn a passing
+ * assertion into a red run for a reason that has nothing to do with the code
+ * under test. A suite that goes red for unexplained reasons teaches people to
+ * re-run rather than read, which costs more than the flake.
+ *
+ * ## Retry first, because the platform documents this exact case
+ *
+ * `fs.rmSync` takes `maxRetries` precisely for `EBUSY`, `EMFILE`, `ENFILE`,
+ * `ENOTEMPTY` and `EPERM`, and defaults it to **0** — so every one of those
+ * sites had no retry at all on the platform where transient locking is
+ * ordinary. Using the remedy the API provides is not a guess about the cause.
+ *
+ * ## Warn rather than throw, because nothing here was ever a check
+ *
+ * If the retries are exhausted this warns and returns. That is not a check
+ * being degraded: no test asserts that cleanup succeeded, so there was no check
+ * to lose. What is removed is a channel that can only ever produce a FALSE red,
+ * and the warning keeps the information — a genuine handle leak still shows up,
+ * named, on every affected run, instead of surfacing as an unrelated test
+ * failing one time in ten.
+ *
+ * A leftover directory under the OS temp root is not a defect worth failing a
+ * passing test over; the OS reclaims it.
+ *
+ * ## What is NOT claimed
+ *
+ * The original `ENOTEMPTY` was observed once and could not be reproduced — not
+ * in 15 isolated runs, not in 6 full-suite runs, not in an 80-round synthetic
+ * stress with concurrent filesystem load. So this does not assert a root cause.
+ * It removes the ability of cleanup to report a failure the code did not have,
+ * which is correct whatever the cause turns out to be.
+ */
+
+import { rmSync } from 'node:fs'
+
+export function removeTempDir(path: string): void {
+	try {
+		// Linear backoff: ~50ms, 100ms, … up to ten attempts. Generous, because
+		// this runs once per test and a slow delete costs less than a false red.
+		rmSync(path, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
+	} catch (err) {
+		const reason = err instanceof Error ? err.message : String(err)
+		// biome-ignore lint/suspicious/noConsole: the warning IS the feature. This
+		// runs only in tests, and the whole point of not throwing is that the
+		// information survives somewhere a reader will see it. Routing it through
+		// a logger nobody configures in a test process would lose it.
+		console.warn(
+			`[test cleanup] could not remove ${path} after 10 attempts: ${reason}\n  The test result above is unaffected. If this recurs, something is holding a handle.`,
+		)
+	}
+}

--- a/packages/cli/src/__tests__/a-chosen-model-reaches-the-turn.test.ts
+++ b/packages/cli/src/__tests__/a-chosen-model-reaches-the-turn.test.ts
@@ -17,10 +17,11 @@
  * step is made of; only the owner running it can confirm the screen.
  */
 
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { removeTempDir } from '../__fixtures__/temp-dir.js'
 
 import {
 	type DetectedProvider,
@@ -67,7 +68,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-	rmSync(cwd, { recursive: true, force: true })
+	removeTempDir(cwd)
 })
 
 function detectedAnthropic(): DetectedProvider[] {

--- a/packages/cli/src/__tests__/a-command-file-reaches-the-turn.test.ts
+++ b/packages/cli/src/__tests__/a-command-file-reaches-the-turn.test.ts
@@ -19,10 +19,11 @@
  * pass with the App never sending it.
  */
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { removeTempDir } from '../__fixtures__/temp-dir.js'
 
 import { SLASH_COMMANDS, type SlashContext, runSlash } from '../tui/slashCommands.js'
 import { discoverUserCommands } from '../user-commands/store.js'
@@ -47,7 +48,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-	rmSync(cwd, { recursive: true, force: true })
+	removeTempDir(cwd)
 })
 
 function writeCommand(name: string, body: string): void {

--- a/packages/cli/src/__tests__/a-command-works-headless.test.ts
+++ b/packages/cli/src/__tests__/a-command-works-headless.test.ts
@@ -24,10 +24,11 @@
  * them this file would pass with an implementation that hijacks every slash.
  */
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { removeTempDir } from '../__fixtures__/temp-dir.js'
 
 import { runCommand } from '../commands/run.js'
 import type { CommandContext } from '../commands/types.js'
@@ -72,7 +73,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-	rmSync(cwd, { recursive: true, force: true })
+	removeTempDir(cwd)
 })
 
 function writeCommand(name: string, body: string): void {

--- a/packages/cli/src/__tests__/environment-reaches-the-turn.test.ts
+++ b/packages/cli/src/__tests__/environment-reaches-the-turn.test.ts
@@ -15,10 +15,11 @@
  */
 
 import { execFileSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { mkdirSync, mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { removeTempDir } from '../__fixtures__/temp-dir.js'
 
 import { type AgentDefinition, AgentRegistry } from '@namzu/sdk'
 
@@ -51,7 +52,7 @@ beforeEach(() => {
 
 afterEach(() => {
 	vi.restoreAllMocks()
-	rmSync(root, { recursive: true, force: true })
+	removeTempDir(root)
 })
 
 const prefs = {

--- a/packages/cli/src/__tests__/headless-trust-gate.test.ts
+++ b/packages/cli/src/__tests__/headless-trust-gate.test.ts
@@ -20,10 +20,11 @@
  * too: a gate nothing can get past is a gate that has broken the product.
  */
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { removeTempDir } from '../__fixtures__/temp-dir.js'
 
 import type { CommandContext } from '../commands/types.js'
 import { EXIT_UNTRUSTED } from '../exit-codes.js'
@@ -83,8 +84,8 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-	rmSync(home, { recursive: true, force: true })
-	rmSync(stranger, { recursive: true, force: true })
+	removeTempDir(home)
+	removeTempDir(stranger)
 })
 
 function context(): { ctx: CommandContext; errors: string[]; lines: string[] } {

--- a/packages/cli/src/__tests__/mcp-servers-reach-the-session.test.ts
+++ b/packages/cli/src/__tests__/mcp-servers-reach-the-session.test.ts
@@ -14,10 +14,11 @@
  * the list `/tools` prints and the registry the turn is built from.
  */
 
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { removeTempDir } from '../__fixtures__/temp-dir.js'
 
 import { loadConfig } from '../config/load.js'
 import type { DetectedProvider, Preferences } from '../integrations/providers/index.js'
@@ -68,13 +69,13 @@ beforeEach(() => {
 afterEach(async () => {
 	for (let attempt = 0; attempt < 20; attempt++) {
 		try {
-			rmSync(work, { recursive: true, force: true })
+			removeTempDir(work)
 			return
 		} catch {
 			await new Promise((resolve) => setTimeout(resolve, 50))
 		}
 	}
-	rmSync(work, { recursive: true, force: true })
+	removeTempDir(work)
 })
 
 const prefs = {

--- a/packages/cli/src/__tests__/permission-rules-reach-the-turn.test.ts
+++ b/packages/cli/src/__tests__/permission-rules-reach-the-turn.test.ts
@@ -28,10 +28,11 @@
  * who clicks approve never learns their `deny` was ignored.
  */
 
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { removeTempDir } from '../__fixtures__/temp-dir.js'
 
 import { loadConfig } from '../config/load.js'
 import type { DetectedProvider, Preferences } from '../integrations/providers/index.js'
@@ -57,7 +58,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-	rmSync(workDir, { recursive: true, force: true })
+	removeTempDir(workDir)
 })
 
 /** A real config file, in the real project-config location and format. */

--- a/packages/cli/src/__tests__/project-instructions-reach-the-turn.test.ts
+++ b/packages/cli/src/__tests__/project-instructions-reach-the-turn.test.ts
@@ -21,10 +21,11 @@
  * honour the project's rules and every task it delegated would quietly not.
  */
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { removeTempDir } from '../__fixtures__/temp-dir.js'
 
 import { type AgentDefinition, AgentRegistry } from '@namzu/sdk'
 
@@ -59,7 +60,7 @@ beforeEach(() => {
 
 afterEach(() => {
 	vi.restoreAllMocks()
-	rmSync(root, { recursive: true, force: true })
+	removeTempDir(root)
 })
 
 const prefs = {

--- a/packages/cli/src/commands/__tests__/run-flags.test.ts
+++ b/packages/cli/src/commands/__tests__/run-flags.test.ts
@@ -8,11 +8,12 @@
  * unparsed, and silently ran in the process's own directory.
  */
 
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Readable } from 'node:stream'
 import { describe, expect, it, vi } from 'vitest'
+import { removeTempDir } from '../../__fixtures__/temp-dir.js'
 
 import { EXIT_USAGE } from '../../exit-codes.js'
 import { fakeAgentSession } from '../../tui/__fixtures__/agent-session.js'
@@ -130,7 +131,7 @@ describe('namzu run reads its options instead of reciting them', () => {
 			// model was asked to act on.
 			expect(seen.prompt).toBe('fix the test')
 		} finally {
-			rmSync(elsewhere, { recursive: true, force: true })
+			removeTempDir(elsewhere)
 		}
 	})
 

--- a/packages/cli/src/commands/__tests__/run-stream-flags.test.ts
+++ b/packages/cli/src/commands/__tests__/run-stream-flags.test.ts
@@ -1,7 +1,8 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { removeTempDir } from '../../__fixtures__/temp-dir.js'
 
 import { openSessions } from '../../integrations/sessions/store.js'
 import { fakeAgentSession } from '../../tui/__fixtures__/agent-session.js'
@@ -143,7 +144,7 @@ describe('run-stream works in the directory it was pointed at', () => {
 		try {
 			await run(['--cwd', elsewhere, '--session', 'k', 'read', 'notes.txt'])
 		} finally {
-			rmSync(elsewhere, { recursive: true, force: true })
+			removeTempDir(elsewhere)
 		}
 
 		expect(sessionOptions[0]?.cwd).toBe(elsewhere)
@@ -215,7 +216,7 @@ describe('skills-json lists the directory it was pointed at', () => {
 			await skillsJSONCommand.handler({ rawArgs: ['--cwd', elsewhere], ctx } as never)
 		} finally {
 			restore()
-			rmSync(elsewhere, { recursive: true, force: true })
+			removeTempDir(elsewhere)
 		}
 
 		const names = (JSON.parse(lines.join('').trim()) as Array<{ name: string }>).map((s) => s.name)
@@ -247,7 +248,7 @@ describe('history reads the directory it was pointed at', () => {
 			} as never)
 		} finally {
 			restore()
-			rmSync(elsewhere, { recursive: true, force: true })
+			removeTempDir(elsewhere)
 		}
 
 		expect(openSessions).toHaveBeenCalledWith(elsewhere)

--- a/packages/cli/src/context/__tests__/environment.test.ts
+++ b/packages/cli/src/context/__tests__/environment.test.ts
@@ -8,10 +8,11 @@
  */
 
 import { execFileSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { mkdirSync, mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { removeTempDir } from '../../__fixtures__/temp-dir.js'
 
 import {
 	type EnvironmentFacts,
@@ -27,7 +28,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-	rmSync(root, { recursive: true, force: true })
+	removeTempDir(root)
 })
 
 function initRepo(dir: string, branch: string): void {

--- a/packages/cli/src/context/__tests__/project.test.ts
+++ b/packages/cli/src/context/__tests__/project.test.ts
@@ -9,10 +9,11 @@
  * block says when a file was cut.
  */
 
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { removeTempDir } from '../../__fixtures__/temp-dir.js'
 
 import {
 	MAX_BYTES_TO_READ,
@@ -29,7 +30,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-	rmSync(root, { recursive: true, force: true })
+	removeTempDir(root)
 })
 
 /** `<root>/outside/repo/pkg`, with `repo` marked as a repository root. */
@@ -156,7 +157,7 @@ function canSymlink(): boolean {
 	} catch {
 		return false
 	} finally {
-		rmSync(probe, { recursive: true, force: true })
+		removeTempDir(probe)
 	}
 }
 

--- a/packages/cli/src/integrations/mcp/__tests__/connect.test.ts
+++ b/packages/cli/src/integrations/mcp/__tests__/connect.test.ts
@@ -8,10 +8,11 @@
  * a handshake that answers, or does not.
  */
 
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { removeTempDir } from '../../../__fixtures__/temp-dir.js'
 
 import { connectMcpServers, transportFor } from '../servers.js'
 
@@ -29,13 +30,13 @@ afterEach(async () => {
 	// died, which is the failure `close()` exists to prevent.
 	for (let attempt = 0; attempt < 20; attempt++) {
 		try {
-			rmSync(dir, { recursive: true, force: true })
+			removeTempDir(dir)
 			return
 		} catch {
 			await new Promise((resolve) => setTimeout(resolve, 50))
 		}
 	}
-	rmSync(dir, { recursive: true, force: true })
+	removeTempDir(dir)
 })
 
 /**

--- a/packages/cli/src/integrations/sessions/__tests__/archived-workspace.test.ts
+++ b/packages/cli/src/integrations/sessions/__tests__/archived-workspace.test.ts
@@ -18,10 +18,11 @@
  * fire on.
  */
 
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { removeTempDir } from '../../../__fixtures__/temp-dir.js'
 
 import { ProjectManager, type TenantId, UNKNOWN_TENANT_ID } from '@namzu/sdk'
 
@@ -34,7 +35,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-	rmSync(cwd, { recursive: true, force: true })
+	removeTempDir(cwd)
 })
 
 describe('a workspace its owner has closed', () => {

--- a/packages/cli/src/integrations/trust/store.test.ts
+++ b/packages/cli/src/integrations/trust/store.test.ts
@@ -1,6 +1,7 @@
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { mkdirSync, mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { removeTempDir } from '../../__fixtures__/temp-dir.js'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
@@ -15,8 +16,8 @@ beforeEach(() => {
 	mkdirSync(join(home, '.namzu'), { recursive: true })
 })
 afterEach(() => {
-	rmSync(home, { recursive: true, force: true })
-	rmSync(work, { recursive: true, force: true })
+	removeTempDir(home)
+	removeTempDir(work)
 })
 
 describe('trust store', () => {
@@ -48,7 +49,7 @@ describe('trust store', () => {
 		const other = mkdtempSync(join(tmpdir(), 'namzu-other-'))
 		trustDir(work, home)
 		expect(isTrusted(other, home)).toBe(false)
-		rmSync(other, { recursive: true, force: true })
+		removeTempDir(other)
 	})
 
 	it('does not treat a path-prefix sibling as trusted', () => {

--- a/packages/cli/src/memory/store.test.ts
+++ b/packages/cli/src/memory/store.test.ts
@@ -1,7 +1,8 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { mkdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { removeTempDir } from '../__fixtures__/temp-dir.js'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
@@ -20,7 +21,7 @@ beforeEach(() => {
 	mkdirSync(join(home, '.namzu'), { recursive: true })
 })
 afterEach(() => {
-	rmSync(home, { recursive: true, force: true })
+	removeTempDir(home)
 })
 
 describe('readMemory', () => {

--- a/packages/cli/src/skills/store.test.ts
+++ b/packages/cli/src/skills/store.test.ts
@@ -1,6 +1,7 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { removeTempDir } from '../__fixtures__/temp-dir.js'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
@@ -21,8 +22,8 @@ beforeEach(() => {
 	mkdirSync(join(home, '.namzu'), { recursive: true })
 })
 afterEach(() => {
-	rmSync(home, { recursive: true, force: true })
-	rmSync(cwd, { recursive: true, force: true })
+	removeTempDir(home)
+	removeTempDir(cwd)
 })
 
 describe('parseSkillMarkdown', () => {

--- a/packages/cli/src/tui/__tests__/deferred-tool-discovery.test.ts
+++ b/packages/cli/src/tui/__tests__/deferred-tool-discovery.test.ts
@@ -21,10 +21,11 @@
  * exactly the state this file was written against.
  */
 
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { removeTempDir } from '../../__fixtures__/temp-dir.js'
 
 import type { ToolRegistryContract } from '@namzu/sdk'
 
@@ -66,7 +67,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-	rmSync(workDir, { recursive: true, force: true })
+	removeTempDir(workDir)
 })
 
 const prefs = {

--- a/packages/cli/src/tui/__tests__/working-directory.test.ts
+++ b/packages/cli/src/tui/__tests__/working-directory.test.ts
@@ -10,10 +10,11 @@
  * string in every assertion. These two do.
  */
 
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { removeTempDir } from '../../__fixtures__/temp-dir.js'
 
 import { getBuiltinTools } from '@namzu/sdk'
 import type { RunId, ToolContext } from '@namzu/sdk'
@@ -45,7 +46,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-	rmSync(workDir, { recursive: true, force: true })
+	removeTempDir(workDir)
 })
 
 function toolContext(workingDirectory: string): ToolContext {

--- a/packages/cli/src/user-commands/store.test.ts
+++ b/packages/cli/src/user-commands/store.test.ts
@@ -1,7 +1,8 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { removeTempDir } from '../__fixtures__/temp-dir.js'
 
 import { discoverUserCommands, expandCommand } from './store.js'
 
@@ -14,8 +15,8 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-	rmSync(home, { recursive: true, force: true })
-	rmSync(cwd, { recursive: true, force: true })
+	removeTempDir(home)
+	removeTempDir(cwd)
 })
 
 function write(root: string, name: string, body: string): void {


### PR DESCRIPTION
test(cli): cleanup that cannot fail a passing test

The `ENOTEMPTY` flake was not what it looked like. Re-reading the run that
produced it:

    × names the workspace in the refusal 11ms
      → ENOTEMPTY: directory not empty, rmdir '…/.namzu/projects/prj_…'

**The assertion passed.** The error came from `afterEach`, and vitest attributes
a hook failure to the test it ran after — so a temp-directory deletion race was
reported as a product test failure, on a test whose claim was never in doubt.

That is the defect, and it is not one file's. Thirty bare
`rmSync(dir, { recursive: true, force: true })` call sites across twenty test
files in this package delete a temp tree in a hook, and any of them can turn a
passing assertion into a red run for a reason unrelated to the code under test.
There are fourteen more in the SDK, left for a separate change.

## What is deliberately not claimed

**I could not reproduce it.** Fifteen isolated runs of the file, six full-suite
runs, and an eighty-round synthetic stress with four concurrent writers all
passed. One observation, no reproduction — so this asserts no root cause, and
the helper's docstring says so.

What it removes is the ability of cleanup to report a failure the code did not
have, which is correct whatever the cause turns out to be.

## Retry, because the platform documents this exact case

`fs.rmSync` accepts `maxRetries` precisely for `EBUSY`, `EMFILE`, `ENFILE`,
`ENOTEMPTY` and `EPERM`, and **defaults it to 0**. Every one of those thirty
sites had no retry at all for the errors the API exists to absorb. Using the
remedy the API provides is not a guess.

## Warn rather than throw, because nothing here was ever a check

If the retries are exhausted the helper warns and returns. That is not a check
being degraded: no test asserts that cleanup succeeded, so there is no check to
lose — only a channel that can produce a false red. The warning names the path
and says the result stands, so a genuine handle leak still appears on every
affected run instead of surfacing as an unrelated test failing one time in ten.

A leftover directory under the OS temp root is not worth failing a passing test
over.

## Mutation-checked

Dropping `maxRetries` fails the retry test while the three behavioural tests
correctly survive — they would all pass against a bare call, which is why that
assertion has its own file and its own mock. Making the helper throw fails the
warn test.

## Two false signals of my own

The codemod broke twenty files on its first run: inserting "after the last
import line" matched `import {`, the opening line of a multi-line block, and
spliced the new statement inside it. Reverted; it now inserts before the first
import, and no longer regex-strips the newly-unused `rmSync` — biome removes an
unused import correctly, and letting the tool that understands the syntax do the
syntax is the lesson.

The helper's first test file reported `no tests` at exit 1, which reads exactly
like a failure and was a load error from an `await import` in a sync callback.
