### PR TITLE
fix(sdk)!: a list is refused, not dropped

### DIFF
--- a/.changeset/a-list-is-refused-not-dropped.md
+++ b/.changeset/a-list-is-refused-not-dropped.md
@@ -1,0 +1,44 @@
+---
+'@namzu/sdk': major
+---
+
+`parseFrontmatter` refuses a block-sequence list instead of silently dropping it.
+
+```yaml
+---
+allowed-tools:
+  - Read
+  - Bash
+---
+```
+
+Those lines carry no `:`, so they were skipped, and the key came back **absent**
+— not empty, absent. Meanwhile the flow form `[Read, Bash]` threw. One spelling
+of a list was a hard error and the other was silence, and the silent one is the
+spelling people actually write, because the block form is the natural YAML for
+a list.
+
+**What breaks.** A file whose frontmatter uses a `- ` list now throws where it
+previously parsed. If you load skills or commands from files you did not write,
+one of them may start being refused.
+
+**What to do.** Write the value on one line:
+
+```yaml
+allowed-tools: Read, Bash
+```
+
+The error names the key and the file.
+
+**Why this is worth a major rather than left alone.** The file that now throws
+was never working. `allowed-tools` is a capability list: a skill that asked for
+`Bash`, had the request silently discarded, and ran without it is
+indistinguishable — from the author's side and from the log's — from a skill
+that never asked. That is a capability quietly not granted, which is worse than
+a file that will not load, because the second one tells you.
+
+In `@namzu/cli` this surfaces as it should: the skill is listed with `⚠` and the
+parse error rather than disappearing, and the rest of the roster keeps working.
+
+Not affected: an ordinary indented mapping still parses, and a hyphen inside a
+value — `description: a - b` — is prose, not a list, and is left alone.

--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -1,7 +1,7 @@
 ---
 title: Skills
 description: Author SKILL.md capability docs, discover them, and activate one for the session with /skill.
-last_updated: 2026-08-07
+last_updated: 2026-08-08
 status: current
 related_packages: ["@namzu/cli"]
 ---
@@ -37,6 +37,21 @@ with the parse error, so the file you can see on disk is accounted for.
 Line endings do not matter. LF, CRLF and a lone CR all parse — a `SKILL.md`
 written on Windows used to lose its frontmatter silently and show up under its
 directory name with `(no description)`.
+
+**Lists go on one line.** The reader is a flat key/value splitter, not a YAML
+engine, so write `allowed-tools: Read, Bash` rather than:
+
+```yaml
+# refused
+allowed-tools:
+  - Read
+  - Bash
+```
+
+That form used to be *dropped* — the key read as absent, so a skill that asked
+for `Bash` ran without it and looked exactly like one that never asked. It is
+refused now, naming the key, because a capability silently not granted is worse
+than a file that will not load.
 
 ## Discovery
 

--- a/packages/sdk/src/utils/__tests__/frontmatter.test.ts
+++ b/packages/sdk/src/utils/__tests__/frontmatter.test.ts
@@ -136,6 +136,61 @@ describe('refusing rather than degrading', () => {
 		)
 	})
 
+	it('refuses a block sequence rather than reading the key as absent', () => {
+		// The gap this closed. These lines carry no `:`, so they were skipped and
+		// the key came back ABSENT — one spelling of a list threw, the other was
+		// silent, and the silent one is the shape people write.
+		const raw = ['---', 'name: x', 'allowed-tools:', '  - Read', '  - Bash', '---'].join('\n')
+		expect(() => parseFrontmatter(raw, SOURCE)).toThrow(/block sequence/)
+	})
+
+	it('names the key whose list was refused', () => {
+		// Without the key, the author has a file that will not parse and no idea
+		// which line to look at.
+		const raw = ['---', 'allowed-tools:', '  - Read', '---'].join('\n')
+		expect(() => parseFrontmatter(raw, SOURCE)).toThrow(/"allowed-tools"/)
+	})
+
+	it('says why silence would have been worse', () => {
+		// `allowed-tools` is the key that makes this a capability question rather
+		// than a formatting one: a skill that asked for a tool and silently did
+		// not get it is indistinguishable from one that never asked.
+		const raw = ['---', 'allowed-tools:', '  - Bash', '---'].join('\n')
+		expect(() => parseFrontmatter(raw, SOURCE)).toThrow(/absent/)
+	})
+
+	it('refuses a sequence of mappings, which used to become a key named "- name"', () => {
+		const raw = ['---', 'tools:', '  - name: Read', '---'].join('\n')
+		expect(() => parseFrontmatter(raw, SOURCE)).toThrow(/block sequence/)
+	})
+
+	it('does not refuse a hyphen inside an indented VALUE', () => {
+		// The over-refusal this could easily have caused. A dash in prose is not
+		// a list, and a reader that rejected it would break working files.
+		const raw = ['---', 'metadata:', '  note: some - dashed - text', '---'].join('\n')
+		const { values } = parseFrontmatter(raw, SOURCE)
+		expect(values.metadata).toEqual({
+			kind: 'mapping',
+			entries: { note: 'some - dashed - text' },
+		})
+	})
+
+	it('does not refuse a hyphen inside a top-level value', () => {
+		const raw = ['---', 'description: a - b - c', '---'].join('\n')
+		const { values } = parseFrontmatter(raw, SOURCE)
+		expect(values.description).toEqual({ kind: 'scalar', value: 'a - b - c' })
+	})
+
+	it('still reads an ordinary indented mapping', () => {
+		// The refusal must not have taken the supported nesting with it.
+		const raw = ['---', 'metadata:', '  author: someone', '  year: 2026', '---'].join('\n')
+		const { values } = parseFrontmatter(raw, SOURCE)
+		expect(values.metadata).toEqual({
+			kind: 'mapping',
+			entries: { author: 'someone', year: '2026' },
+		})
+	})
+
 	it('refuses the same conflict when the block comes from a later duplicate key', () => {
 		const raw = [
 			'---',

--- a/packages/sdk/src/utils/frontmatter.ts
+++ b/packages/sdk/src/utils/frontmatter.ts
@@ -16,19 +16,24 @@
  * half-understands YAML produces a value that passes validation and means
  * nothing.
  *
- * **Known gap, stated rather than implied.** The refusal is not yet total. A
- * *block* sequence
+ * That refusal is now total for lists. A *block* sequence
  *
  * ```yaml
  * allowed-tools:
  *   - Read
  * ```
  *
- * is silently dropped — its lines carry no `:` and are skipped — while the
- * flow form `[Read, Grep]` throws. Both readers this replaced behaved that
- * way, so it is inherited rather than introduced, but it contradicts
- * `docs/conventions/refuse-do-not-degrade.md` and is tracked as a follow-up.
- * Do not read the paragraph above as a guarantee it does not make.
+ * used to be silently dropped — its lines carry no `:` and were skipped, so the
+ * key came back **absent** — while the flow form `[Read, Grep]` threw. One
+ * spelling of a list was a hard error and the other was silence, and the silent
+ * one is the shape an author actually writes, because the block form is the
+ * natural YAML for a list.
+ *
+ * It matters most for a key like `allowed-tools`: a skill that asked for `Bash`
+ * and silently did not get it is indistinguishable from one that never asked,
+ * which is a capability quietly not granted rather than a formatting nicety.
+ * Both readers this replaced behaved that way, so it was inherited rather than
+ * introduced; it is now refused, naming the key.
  *
  * **Vocabulary belongs to the caller.** This returns the parsed map; it does
  * not know what a skill needs or what a command needs, and it validates no
@@ -176,6 +181,26 @@ export function parseFrontmatter(raw: string, source: string): ParsedFrontmatter
 
 		if (/^\s/.test(line)) {
 			if (!currentKey) continue
+
+			// A block sequence item. Refused, not skipped.
+			//
+			// These lines carry no `:`, so the `continue` below used to drop them
+			// and the key — having no scalar value and no mapping entries — came
+			// back ABSENT. The flow form `[Read, Grep]` already threw, so one
+			// spelling of a list was a hard error and the other was silence.
+			//
+			// The block form is the more natural YAML for a list, which is what
+			// made this worth closing: `allowed-tools` is a list, so this is the
+			// shape an author actually writes, and a skill that asked for `Bash`
+			// and silently did not get it is indistinguishable from one that never
+			// asked. A capability quietly not granted is the worst thing this
+			// reader can produce.
+			if (/^\s*-\s/.test(line)) {
+				throw new Error(
+					`${source}: "${currentKey}" uses a block sequence (a "- " list), which this reader does not support. Write it as a single-line value instead. Refusing rather than reading "${currentKey}" as absent, which is what silently dropping the list would mean.`,
+				)
+			}
+
 			const colonIdx = line.indexOf(':')
 			if (colonIdx === -1) continue
 			const key = line.slice(0, colonIdx).trim()


### PR DESCRIPTION
fix(sdk)!: a list is refused, not dropped

```yaml
allowed-tools:
  - Read
  - Bash
```

Those lines carry no `:`, so the indented branch skipped them — and with no
scalar value and no mapping entries, the key came back **absent**. Not empty:
absent. The flow form `[Read, Bash]` threw. One spelling of a list was a hard
error, the other was silence, and the silent one is the spelling people write,
because the block form is the natural YAML for a list.

It matters because of which keys are lists. `allowed-tools` is a capability
request: a skill that asked for `Bash`, had the request discarded, and ran
without it is indistinguishable — from the author's side and from the log's —
from a skill that never asked. A capability quietly not granted is worse than a
file that will not load, because the second one tells you.

A second case was worse and is also closed: `  - name: Read` DOES contain a
colon, so it used to produce a mapping key literally named `- name`.

## Not over-refusing

The risk in this shape of fix is rejecting things that are not lists. The test
requires the line to begin, after its indent, with `- ` — so an indented value
containing a dash (`note: some - dashed - text`) and a top-level one
(`description: a - b - c`) both still parse. Three tests pin that, and they
correctly SURVIVE the mutation that removes the refusal. That is what makes the
four that die mean something.

## Major, deliberately

A file using the block form previously loaded, with the key absent, and now
throws. Backward-incompatible by this repository's own rule, even though the
file was never really working. The changeset names the one-line fix, and the
error names the key and the file.

Public surface verified unchanged by name: 530 runtime / 1219 declared. No new
exports — this is behaviour only.

The module docstring had honestly recorded this as a known gap, so it is
updated; leaving it would have been a false claim in the other direction.
`@namzu/cli` already surfaces the refusal correctly through `SkillInfo.problem`
— the skill is listed with its parse error and the roster survives — so no CLI
change was needed.

Closes #239.
