### PR TITLE
feat(cli): the composer sits at the bottom while it can

### DIFF
--- a/.changeset/a-list-is-refused-not-dropped.md
+++ b/.changeset/a-list-is-refused-not-dropped.md
@@ -1,0 +1,44 @@
+---
+'@namzu/sdk': major
+---
+
+`parseFrontmatter` refuses a block-sequence list instead of silently dropping it.
+
+```yaml
+---
+allowed-tools:
+  - Read
+  - Bash
+---
+```
+
+Those lines carry no `:`, so they were skipped, and the key came back **absent**
+— not empty, absent. Meanwhile the flow form `[Read, Bash]` threw. One spelling
+of a list was a hard error and the other was silence, and the silent one is the
+spelling people actually write, because the block form is the natural YAML for
+a list.
+
+**What breaks.** A file whose frontmatter uses a `- ` list now throws where it
+previously parsed. If you load skills or commands from files you did not write,
+one of them may start being refused.
+
+**What to do.** Write the value on one line:
+
+```yaml
+allowed-tools: Read, Bash
+```
+
+The error names the key and the file.
+
+**Why this is worth a major rather than left alone.** The file that now throws
+was never working. `allowed-tools` is a capability list: a skill that asked for
+`Bash`, had the request silently discarded, and ran without it is
+indistinguishable — from the author's side and from the log's — from a skill
+that never asked. That is a capability quietly not granted, which is worse than
+a file that will not load, because the second one tells you.
+
+In `@namzu/cli` this surfaces as it should: the skill is listed with `⚠` and the
+parse error rather than disappearing, and the rest of the roster keeps working.
+
+Not affected: an ordinary indented mapping still parses, and a hyphen inside a
+value — `description: a - b` — is prose, not a list, and is left alone.

--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -1,7 +1,7 @@
 ---
 title: Skills
 description: Author SKILL.md capability docs, discover them, and activate one for the session with /skill.
-last_updated: 2026-08-07
+last_updated: 2026-08-08
 status: current
 related_packages: ["@namzu/cli"]
 ---
@@ -37,6 +37,21 @@ with the parse error, so the file you can see on disk is accounted for.
 Line endings do not matter. LF, CRLF and a lone CR all parse — a `SKILL.md`
 written on Windows used to lose its frontmatter silently and show up under its
 directory name with `(no description)`.
+
+**Lists go on one line.** The reader is a flat key/value splitter, not a YAML
+engine, so write `allowed-tools: Read, Bash` rather than:
+
+```yaml
+# refused
+allowed-tools:
+  - Read
+  - Bash
+```
+
+That form used to be *dropped* — the key read as absent, so a skill that asked
+for `Bash` ran without it and looked exactly like one that never asked. It is
+refused now, naming the key, because a capability silently not granted is worse
+than a file that will not load.
 
 ## Discovery
 

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -27,6 +27,7 @@ import { appendMemory, composeMemoryPrompt, readMemory } from '../memory/store.j
 import { composeSkillsPrompt, discoverSkills, loadSkillBody } from '../skills/store.js'
 import { checkUpdates } from '../integrations/updates.js'
 import { type ActiveTool, LiveActivity, formatElapsed } from './LiveActivity.js'
+import { bottomSpacerRows } from './bottom-spacer.js'
 import { expandFileMentions } from './mentions.js'
 import { Composer } from './Composer.js'
 import { TrustPrompt } from './TrustPrompt.js'
@@ -304,6 +305,21 @@ export function App({ ctx }: AppProps) {
 		setPhase('probing')
 		void runProbe()
 	}, [ctx.cwd, runProbe])
+
+	// Blank rows above the composer, while the transcript is short enough that
+	// the answer is knowable. `liveRows` is the fixed furniture beneath the
+	// transcript — activity line, composer frame, status bar and their padding —
+	// counted generously, because over-counting costs a gap and under-counting
+	// costs the composer.
+	const spacerRows =
+		phase === 'ready'
+			? bottomSpacerRows({
+					rows: process.stdout.rows,
+					columns: process.stdout.columns,
+					transcript: messages.filter((m) => !m.pending).map((m) => m.content),
+					liveRows: 10,
+				})
+			: 0
 
 	const slashCtx: SlashContext = {
 		availableTools: session?.toolNames ?? [],
@@ -889,6 +905,13 @@ export function App({ ctx }: AppProps) {
 								}
 							/>
 						</TranscriptFrame>
+						{/* Pushes the composer to the bottom of the viewport while the
+						    transcript is short enough for that to be knowable. Returns
+						    0 once the terminal is scrolling, where the composer is
+						    already at the bottom and padding would push it out of
+						    view. See `bottom-spacer.ts` for why the estimate is safe
+						    only in this direction. */}
+						{spacerRows > 0 ? <Box height={spacerRows} /> : null}
 						<LiveActivity
 							activeTools={activeTools}
 							thinking={state === 'thinking' && !messages.some((m) => m.pending)}

--- a/packages/cli/src/tui/bottom-spacer.test.ts
+++ b/packages/cli/src/tui/bottom-spacer.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+
+import { SAFETY_ROWS, bottomSpacerRows, estimateRenderedLines } from './bottom-spacer.js'
+
+const LIVE = 8
+
+function rowsFor(transcript: readonly string[], rows = 40, columns = 80): number {
+	return bottomSpacerRows({ rows, columns, transcript, liveRows: LIVE })
+}
+
+describe('bottomSpacerRows', () => {
+	it('pads an empty transcript, which is the case people see on launch', () => {
+		expect(rowsFor([])).toBe(40 - LIVE - SAFETY_ROWS)
+	})
+
+	it('pads a short transcript', () => {
+		expect(rowsFor(['hello', 'world'])).toBeGreaterThan(0)
+	})
+
+	it('shrinks as the transcript grows', () => {
+		const a = rowsFor(['one'])
+		const b = rowsFor(['one', 'two'])
+		const c = rowsFor(['one', 'two', 'three'])
+		expect(a).toBeGreaterThan(b)
+		expect(b).toBeGreaterThan(c)
+	})
+
+	it('stops entirely once the transcript approaches the viewport', () => {
+		// The terminal is scrolling by now and the composer is already at the
+		// bottom. Padding here is what would push it out of view.
+		const long = Array.from({ length: 40 }, (_, i) => `line ${i}`)
+		expect(rowsFor(long)).toBe(0)
+	})
+
+	it('never itself pushes the layout past the viewport', () => {
+		// The property that keeps a wrong estimate merely cosmetic, stated
+		// precisely: WHEN it pads, the total must fit. When it declines to pad,
+		// the content may well exceed the viewport — that is the scrolling case,
+		// and it is the terminal's business rather than this function's.
+		//
+		// The first version of this test asserted the total unconditionally and
+		// failed at n=33, where the transcript alone is already taller than the
+		// screen. That was the test overclaiming, not the code misbehaving.
+		for (let n = 0; n < 60; n++) {
+			const transcript = Array.from({ length: n }, (_, i) => `line ${i}`)
+			const spacer = rowsFor(transcript)
+			if (spacer === 0) continue
+			const used = estimateRenderedLines(transcript, 80) + LIVE + spacer
+			expect(used, `n=${n}`).toBeLessThanOrEqual(40)
+		}
+	})
+
+	it('pads only while the content genuinely fits', () => {
+		// The complement of the above: there must BE a point where it stops, or
+		// the guard is decoration.
+		const padded = []
+		for (let n = 0; n < 60; n++) {
+			const transcript = Array.from({ length: n }, (_, i) => `line ${i}`)
+			if (rowsFor(transcript) > 0) padded.push(n)
+		}
+		expect(padded.length).toBeGreaterThan(0)
+		expect(Math.max(...padded)).toBeLessThan(40 - LIVE)
+	})
+
+	it('counts a wrapped line as more than one row', () => {
+		// Underestimating width is how a spacer pushes the composer off-screen.
+		const wide = 'x'.repeat(400)
+		expect(estimateRenderedLines([wide], 80)).toBe(5)
+		expect(rowsFor([wide])).toBeLessThan(rowsFor(['x']))
+	})
+
+	it('counts embedded newlines', () => {
+		expect(estimateRenderedLines(['a\nb\nc'], 80)).toBe(3)
+	})
+
+	it('counts an empty entry as a row, because it renders as one', () => {
+		expect(estimateRenderedLines(['', ''], 80)).toBe(2)
+	})
+})
+
+describe('refusing to guess', () => {
+	it('does nothing when there is no terminal height', () => {
+		// A pipe has no bottom to pin to.
+		expect(bottomSpacerRows({ rows: undefined, columns: 80, transcript: [], liveRows: LIVE })).toBe(
+			0,
+		)
+	})
+
+	it('does nothing on a terminal too short to reason about', () => {
+		expect(bottomSpacerRows({ rows: 8, columns: 80, transcript: [], liveRows: LIVE })).toBe(0)
+	})
+
+	it('does nothing when the height is not a number', () => {
+		expect(
+			bottomSpacerRows({ rows: Number.NaN, columns: 80, transcript: [], liveRows: LIVE }),
+		).toBe(0)
+	})
+
+	it('assumes a narrow terminal rather than a wide one when width is unknown', () => {
+		// Unknown width must resolve toward MORE wrapping — more content, less
+		// padding — because the opposite error is the one that hurts.
+		const wide = 'x'.repeat(400)
+		const unknown = estimateRenderedLines([wide], undefined)
+		expect(unknown).toBeGreaterThanOrEqual(estimateRenderedLines([wide], 200))
+	})
+
+	it('keeps a floor under the assumed width', () => {
+		// A 1-column terminal would otherwise make every line astronomically
+		// tall and the arithmetic meaningless.
+		expect(estimateRenderedLines(['hello'], 1)).toBe(1)
+	})
+})

--- a/packages/cli/src/tui/bottom-spacer.ts
+++ b/packages/cli/src/tui/bottom-spacer.ts
@@ -1,0 +1,101 @@
+/**
+ * How many blank rows to put above the composer so it sits at the bottom.
+ *
+ * ## The narrow defect
+ *
+ * Ink writes the transcript to native scrollback via `<Static>` and re-renders
+ * the live region — activity, composer, status bar — beneath it. Once the
+ * output exceeds the viewport the terminal has scrolled, and the composer is
+ * already at the bottom. The complaint is entirely the case before that: five
+ * lines on a forty-row terminal leaves the composer at row six with blank space
+ * under it, and the operator's eye has to find it.
+ *
+ * So this does not try to pin the composer always. It pads only while the
+ * transcript is unambiguously shorter than the viewport, and returns 0 the
+ * moment that stops being knowable. After that, the terminal does it.
+ *
+ * ## Why a rough estimate is safe here, and would not be in general
+ *
+ * The rendered height of a transcript is not knowable from this side: ink does
+ * not report it, and wrapping depends on ANSI, wide glyphs and markdown that
+ * this module does not model. That is exactly why the whole-session version of
+ * this idea is a bad one.
+ *
+ * It is safe in the short case because the error is **asymmetric**:
+ *
+ * - Overestimate the content ⇒ pad less, or not at all ⇒ the composer floats,
+ *   which is precisely today's behaviour. No worse than not doing this.
+ * - Underestimate the content ⇒ pad too much ⇒ the composer is pushed off the
+ *   bottom, which is worse than today.
+ *
+ * So every uncertainty is resolved toward *more* content and *less* padding:
+ * `estimateRenderedLines` counts a minimum, {@link SAFETY_ROWS} is subtracted
+ * on top, and anything unknown returns 0. Being wrong costs the feature, never
+ * the usability.
+ */
+
+/**
+ * Rows held back from the calculation.
+ *
+ * Absorbs what the estimate cannot see — a wrapped line the width maths missed,
+ * a wide glyph, a markdown block that renders taller than its source. Six is
+ * chosen to be visibly generous rather than tuned: the cost of it being too
+ * large is a small gap under the composer on a nearly-empty screen, and the
+ * cost of it being too small is a composer pushed out of view.
+ */
+export const SAFETY_ROWS = 6
+
+export interface SpacerInput {
+	/** Terminal height. `undefined` when not a TTY. */
+	readonly rows: number | undefined
+	/** Terminal width, for wrapping. `undefined` falls back to 80. */
+	readonly columns: number | undefined
+	/** The finalized transcript lines, as emitted — before ink renders them. */
+	readonly transcript: readonly string[]
+	/** Rows the live region occupies: activity, composer frame, status bar. */
+	readonly liveRows: number
+}
+
+/**
+ * A deliberate UNDER-count of how tall the transcript will render.
+ *
+ * Under, not over, because it is subtracted from the space available: counting
+ * low leaves more apparent room, and the safety margin plus the guard below are
+ * what stop that becoming padding. Each entry is at least one row, and a long
+ * entry is divided by the width to approximate wrapping.
+ */
+export function estimateRenderedLines(
+	transcript: readonly string[],
+	columns: number | undefined,
+): number {
+	const width = Math.max(20, columns ?? 80)
+	let total = 0
+	for (const entry of transcript) {
+		for (const line of entry.split('\n')) {
+			total += Math.max(1, Math.ceil(line.length / width))
+		}
+	}
+	return total
+}
+
+/**
+ * Blank rows to insert above the composer, or 0 to leave the layout alone.
+ *
+ * Returns 0 whenever the answer could be wrong: no TTY, an implausible height,
+ * or a transcript long enough that the terminal has plausibly begun to scroll.
+ */
+export function bottomSpacerRows(input: SpacerInput): number {
+	const { rows, columns, transcript, liveRows } = input
+
+	// Not a terminal, or a height too small to reason about. A pipe has no
+	// bottom to pin to.
+	if (rows === undefined || !Number.isFinite(rows) || rows < 12) return 0
+
+	const used = estimateRenderedLines(transcript, columns) + liveRows + SAFETY_ROWS
+
+	// The transcript is at or past the viewport: the terminal is scrolling and
+	// the composer is already where it should be. Padding now would push it off.
+	if (used >= rows) return 0
+
+	return rows - used
+}

--- a/packages/sdk/src/utils/__tests__/frontmatter.test.ts
+++ b/packages/sdk/src/utils/__tests__/frontmatter.test.ts
@@ -136,6 +136,61 @@ describe('refusing rather than degrading', () => {
 		)
 	})
 
+	it('refuses a block sequence rather than reading the key as absent', () => {
+		// The gap this closed. These lines carry no `:`, so they were skipped and
+		// the key came back ABSENT — one spelling of a list threw, the other was
+		// silent, and the silent one is the shape people write.
+		const raw = ['---', 'name: x', 'allowed-tools:', '  - Read', '  - Bash', '---'].join('\n')
+		expect(() => parseFrontmatter(raw, SOURCE)).toThrow(/block sequence/)
+	})
+
+	it('names the key whose list was refused', () => {
+		// Without the key, the author has a file that will not parse and no idea
+		// which line to look at.
+		const raw = ['---', 'allowed-tools:', '  - Read', '---'].join('\n')
+		expect(() => parseFrontmatter(raw, SOURCE)).toThrow(/"allowed-tools"/)
+	})
+
+	it('says why silence would have been worse', () => {
+		// `allowed-tools` is the key that makes this a capability question rather
+		// than a formatting one: a skill that asked for a tool and silently did
+		// not get it is indistinguishable from one that never asked.
+		const raw = ['---', 'allowed-tools:', '  - Bash', '---'].join('\n')
+		expect(() => parseFrontmatter(raw, SOURCE)).toThrow(/absent/)
+	})
+
+	it('refuses a sequence of mappings, which used to become a key named "- name"', () => {
+		const raw = ['---', 'tools:', '  - name: Read', '---'].join('\n')
+		expect(() => parseFrontmatter(raw, SOURCE)).toThrow(/block sequence/)
+	})
+
+	it('does not refuse a hyphen inside an indented VALUE', () => {
+		// The over-refusal this could easily have caused. A dash in prose is not
+		// a list, and a reader that rejected it would break working files.
+		const raw = ['---', 'metadata:', '  note: some - dashed - text', '---'].join('\n')
+		const { values } = parseFrontmatter(raw, SOURCE)
+		expect(values.metadata).toEqual({
+			kind: 'mapping',
+			entries: { note: 'some - dashed - text' },
+		})
+	})
+
+	it('does not refuse a hyphen inside a top-level value', () => {
+		const raw = ['---', 'description: a - b - c', '---'].join('\n')
+		const { values } = parseFrontmatter(raw, SOURCE)
+		expect(values.description).toEqual({ kind: 'scalar', value: 'a - b - c' })
+	})
+
+	it('still reads an ordinary indented mapping', () => {
+		// The refusal must not have taken the supported nesting with it.
+		const raw = ['---', 'metadata:', '  author: someone', '  year: 2026', '---'].join('\n')
+		const { values } = parseFrontmatter(raw, SOURCE)
+		expect(values.metadata).toEqual({
+			kind: 'mapping',
+			entries: { author: 'someone', year: '2026' },
+		})
+	})
+
 	it('refuses the same conflict when the block comes from a later duplicate key', () => {
 		const raw = [
 			'---',

--- a/packages/sdk/src/utils/frontmatter.ts
+++ b/packages/sdk/src/utils/frontmatter.ts
@@ -16,19 +16,24 @@
  * half-understands YAML produces a value that passes validation and means
  * nothing.
  *
- * **Known gap, stated rather than implied.** The refusal is not yet total. A
- * *block* sequence
+ * That refusal is now total for lists. A *block* sequence
  *
  * ```yaml
  * allowed-tools:
  *   - Read
  * ```
  *
- * is silently dropped — its lines carry no `:` and are skipped — while the
- * flow form `[Read, Grep]` throws. Both readers this replaced behaved that
- * way, so it is inherited rather than introduced, but it contradicts
- * `docs/conventions/refuse-do-not-degrade.md` and is tracked as a follow-up.
- * Do not read the paragraph above as a guarantee it does not make.
+ * used to be silently dropped — its lines carry no `:` and were skipped, so the
+ * key came back **absent** — while the flow form `[Read, Grep]` threw. One
+ * spelling of a list was a hard error and the other was silence, and the silent
+ * one is the shape an author actually writes, because the block form is the
+ * natural YAML for a list.
+ *
+ * It matters most for a key like `allowed-tools`: a skill that asked for `Bash`
+ * and silently did not get it is indistinguishable from one that never asked,
+ * which is a capability quietly not granted rather than a formatting nicety.
+ * Both readers this replaced behaved that way, so it was inherited rather than
+ * introduced; it is now refused, naming the key.
  *
  * **Vocabulary belongs to the caller.** This returns the parsed map; it does
  * not know what a skill needs or what a command needs, and it validates no
@@ -176,6 +181,26 @@ export function parseFrontmatter(raw: string, source: string): ParsedFrontmatter
 
 		if (/^\s/.test(line)) {
 			if (!currentKey) continue
+
+			// A block sequence item. Refused, not skipped.
+			//
+			// These lines carry no `:`, so the `continue` below used to drop them
+			// and the key — having no scalar value and no mapping entries — came
+			// back ABSENT. The flow form `[Read, Grep]` already threw, so one
+			// spelling of a list was a hard error and the other was silence.
+			//
+			// The block form is the more natural YAML for a list, which is what
+			// made this worth closing: `allowed-tools` is a list, so this is the
+			// shape an author actually writes, and a skill that asked for `Bash`
+			// and silently did not get it is indistinguishable from one that never
+			// asked. A capability quietly not granted is the worst thing this
+			// reader can produce.
+			if (/^\s*-\s/.test(line)) {
+				throw new Error(
+					`${source}: "${currentKey}" uses a block sequence (a "- " list), which this reader does not support. Write it as a single-line value instead. Refusing rather than reading "${currentKey}" as absent, which is what silently dropping the list would mean.`,
+				)
+			}
+
 			const colonIdx = line.indexOf(':')
 			if (colonIdx === -1) continue
 			const key = line.slice(0, colonIdx).trim()


### PR DESCRIPTION
feat(cli): the composer sits at the bottom while it can

**The two-models framing was wrong, and testing it before spending the trade was
the right call.** Native scrollback is not traded away here — nothing in
`Transcript` or `<Static>` changes.

The complaint is entirely the short-session case: five lines on a forty-row
terminal leaves the composer at row six with blank space beneath it. Once the
output exceeds the viewport the terminal has scrolled and the composer is
already at the bottom. So this pads only while the transcript is short enough
for the answer to be knowable, and stops the moment it is not.

## Why a rough estimate is safe here and would not be in general

Rendered height is genuinely not knowable from this side — ink does not report
it, and wrapping depends on ANSI, wide glyphs and markdown this does not model.
That is why the always-pinned version of this idea is a bad one.

It is safe in the short case because the error is **asymmetric**:

- Overestimate the content ⇒ pad less or not at all ⇒ the composer floats,
  which is exactly today's behaviour. No worse than not doing this.
- Underestimate ⇒ pad too much ⇒ the composer is pushed off the bottom, which
  is worse than today.

So every uncertainty resolves toward *more* content and *less* padding: the
line count is a deliberate under-count, six rows are held back on top, an
unknown width assumes a narrow terminal rather than a wide one, and anything
unknowable — no TTY, an implausible height — returns 0. Getting it wrong costs
the feature, never the usability.

## What is pinned

The arithmetic is a pure function with fourteen tests: it pads an empty
transcript, shrinks as the transcript grows, stops entirely as the viewport
fills, counts wrapping and embedded newlines, and declines on a pipe or a
tiny window.

Two of them are the load-bearing pair — **when it pads, the total fits**, and
**there is a point where it stops padding**. Without the second the guard could
be decoration.

Mutation: removing the scrolling guard fails the test written for it.

## What no test here can see

**This is the one change where the tests cannot observe the thing being
changed.** `lastFrame()` gives a frame, not a terminal with a real width, a
resize event, or a scrollback buffer. What is verified is the arithmetic and
that the spacer is rendered above the composer. What is **not** verified:

- how it looks at a real width, where wrapping may differ from the estimate;
- what happens on resize, since `process.stdout.rows` is read per render but no
  resize event is exercised;
- how it interacts with `<Static>` output already in scrollback.

The owner is the only instrument for those and will know within a minute of
running it. If the estimate is off, the visible symptom is a gap that is too
large or too small under the composer — cosmetic, and tunable through one
constant (`SAFETY_ROWS`).

An earlier version of one test asserted the total unconditionally and failed at
33 lines, where the transcript alone is already taller than the screen. That was
the test overclaiming rather than the code misbehaving, and stating the property
conditionally is what made it true.
