### PR TITLE
fix(scripts): the name audit reaches the files it was always about

### DIFF
--- a/.github/scripts/verify-consumer-install.sh
+++ b/.github/scripts/verify-consumer-install.sh
@@ -143,7 +143,10 @@ npm init -y >/dev/null
 # fail with ERESOLVE if any of the bumped versions falls outside that
 # range. `sandbox` was added in ses_005 alongside the multi-mount layout
 # work — its peer-range drift would block Vandal-side migration.
-DEPENDENTS=(anthropic bedrock computer-use http lmstudio ollama openai openrouter sandbox)
+# Quoted because they are literal values, not prose. Shell quoting says
+# exactly what a TypeScript string literal says, and the name audit reads it
+# that way — these are this workspace's own package names, which is identity.
+DEPENDENTS=('anthropic' 'bedrock' 'computer-use' 'http' 'lmstudio' 'ollama' 'openai' 'openrouter' 'sandbox')
 
 for dep in "${DEPENDENTS[@]}"; do
   echo ""

--- a/packages/sandbox/worker/server.js
+++ b/packages/sandbox/worker/server.js
@@ -492,10 +492,10 @@ const server = http.createServer(async (req, res) => {
 })
 
 // Defence-in-depth process-level handlers: log loudly if something
-// slips past every try/catch, but DO NOT exit the worker. The
-// Anthropic-side retry path treats a single 500 / 502 as transient,
-// while a process exit produces the catastrophic "every subsequent
-// tool call fetch fails because the container is gone" pattern.
+// slips past every try/catch, but DO NOT exit the worker. A caller's
+// retry path treats a single 500 / 502 as transient, while a process
+// exit produces the catastrophic "every subsequent tool call fetch
+// fails because the container is gone" pattern.
 process.on('unhandledRejection', (err) => {
 	console.error('[namzu-sandbox-worker] unhandledRejection:', err && err.stack ? err.stack : err)
 })

--- a/scripts/audit-external-names.mjs
+++ b/scripts/audit-external-names.mjs
@@ -80,6 +80,16 @@ const FORBIDDEN = [
 	'e2b',
 	'gvisor',
 	'fly machines',
+	// Measured when the scan reached `.github/` (issue #220): this phrase
+	// appears nowhere in the repository, and the workflows name their actions
+	// and runners as `actions/checkout@v5`, `ubuntu-latest` and the like, which
+	// this does not match. So no exemption is added for it — one would be a
+	// guard whose condition can never be false today.
+	//
+	// What would make it real: a workflow or doc naming the CI platform in
+	// prose, as the honest self-reference of a repository that runs on it. That
+	// is a path-or-context exemption, not a lexical one, and it should be
+	// written when there is a line to point at.
 	'github actions',
 ]
 
@@ -118,6 +128,39 @@ const WIRE_VALUE_FILES = [
 
 const isWireValueFile = (path) => WIRE_VALUE_FILES.some((prefix) => path.startsWith(prefix))
 
+/**
+ * File kinds this scans, and what each is written in.
+ *
+ * The `.ts`/`.tsx`/`.md` set is what the rule was born with. The rest arrived
+ * with issue #220: an install script, a workflow and a hook are authored
+ * material in exactly the sense a source comment is, and a product name in one
+ * of them passed CI while still breaking the rule. A gate reporting green over
+ * a directory it never opened is worse than no gate, because a green run gets
+ * taken as an answer.
+ */
+const JS_FAMILY = /\.(ts|tsx|mjs|cjs|js)$/
+const SHELL_FAMILY = /\.(sh|ps1|ya?ml)$/
+const SCANNED = /\.(ts|tsx|md|mjs|cjs|js|sh|ps1|ya?ml)$/
+
+/**
+ * Which language's comment syntax a file uses.
+ *
+ * Only three answers matter: markdown has its own prose rules, the JS family
+ * comments with `//`, and everything else here — shell, PowerShell, YAML and
+ * the extension-less git hooks — comments with `#`.
+ */
+function familyOf(path) {
+	if (path.endsWith('.md')) return 'markdown'
+	if (JS_FAMILY.test(path)) return 'js'
+	return 'shell'
+}
+
+/**
+ * The git hooks carry as much rationale prose as any source file and have no
+ * extension at all, so they are named rather than matched.
+ */
+const isHook = (path) => path.split('/').includes('.husky')
+
 async function* walk(dir) {
 	for (const entry of await readdir(dir, { withFileTypes: true })) {
 		if (SKIP_DIRS.has(entry.name)) continue
@@ -126,7 +169,7 @@ async function* walk(dir) {
 			yield* walk(full)
 			continue
 		}
-		if (/\.(ts|tsx|md)$/.test(entry.name)) yield full
+		if (SCANNED.test(entry.name) || isHook(full.split(sep).join('/'))) yield full
 	}
 }
 
@@ -197,6 +240,11 @@ function stripMarkdownCode(line) {
  * Crude on purpose: a real parse would be more precise and this rule is
  * about prose, where the crude version is exact. A false positive here
  * costs one glance; a false negative ships a borrowed name.
+ *
+ * This applies to the shell family too, and deliberately. Quoting is how
+ * shell says "this is a literal value", which is the same statement a
+ * TypeScript string literal makes — so `DEPENDENTS=('anthropic' 'bedrock')`
+ * is a list of package identities and reads as one here.
  */
 function stripStringLiterals(line) {
 	return line
@@ -204,6 +252,25 @@ function stripStringLiterals(line) {
 		.replace(/"(?:[^"\\]|\\.)*"/g, '""')
 		.replace(/`(?:[^`\\]|\\.)*`/g, '``')
 }
+
+/**
+ * A path under `packages/providers/` is identity, not prose.
+ *
+ * The script already skips `import` and `export … from` lines because a
+ * package path is the package's name rather than a borrowed idea. A shell
+ * `for` loop over package directories, or a YAML matrix listing them, is that
+ * same statement in a language with no import syntax — so `providers/anthropic`
+ * in `for pkg in … providers/anthropic …` is exempt for the reason the import
+ * line always was.
+ *
+ * Two restrictions, and both matter. It applies only to the shell family,
+ * and only on a line that is NOT a comment. Without them this is a laundering
+ * mechanism: a sentence whose only occurrence of a forbidden name sits inside a
+ * path — "we took our backoff constants directly from packages/providers/…" —
+ * would newly pass, and that is precisely the shape the rule exists to catch.
+ * Code names paths. Prose does not get to hide behind one.
+ */
+const WORKSPACE_PACKAGE_PATH = /\b(?:packages\/)?providers\/[a-z0-9][a-z0-9.-]*/g
 
 /**
  * Whether a forbidden name appears as a name rather than inside a word.
@@ -241,7 +308,8 @@ function findings(source, path) {
 	// auditing them would mean auditing the interoperability itself.
 	if (isWireValueFile(path)) return []
 
-	const isMarkdown = path.endsWith('.md')
+	const family = familyOf(path)
+	const isMarkdown = family === 'markdown'
 	if (isMarkdown && isWireValueDoc(path)) return []
 
 	const hits = []
@@ -277,8 +345,12 @@ function findings(source, path) {
 			return
 		}
 
-		const inComment = /^\s*(\/\/|\/\*|\*)/.test(line) || line.includes('//')
-		const code = stripStringLiterals(line)
+		const isShell = family === 'shell'
+		const inComment = isShell
+			? /^\s*#/.test(line)
+			: /^\s*(\/\/|\/\*|\*)/.test(line) || line.includes('//')
+		let code = stripStringLiterals(line)
+		if (isShell && !inComment) code = code.replace(WORKSPACE_PACKAGE_PATH, 'providers/')
 		const haystack = `${code} ${inComment ? line : ''}`
 
 		for (const name of FORBIDDEN) {
@@ -310,12 +382,27 @@ const all = []
 // default, not a convention, and not something to reopen from inside this
 // file. Adding a path exemption here would reverse an owner decision in the
 // least visible place available. Do not; raise it instead.
+//
+// The installers sit at this level too, and they are the most exposed files in
+// the repository: `install.sh` runs on a machine where namzu does not exist
+// yet, for a person who has read nothing else. Any top-level shell or
+// PowerShell script is taken, not just the two that exist today — naming them
+// individually would mean the next one arrives unscanned, which is the shape of
+// the gap this closes.
 for (const entry of await readdir(ROOT, { withFileTypes: true })) {
-	if (!entry.isFile() || !entry.name.endsWith('.md')) continue
+	if (!entry.isFile() || !/\.(md|sh|ps1)$/.test(entry.name)) continue
 	all.push(...findings(await readFile(join(ROOT, entry.name), 'utf-8'), entry.name))
 }
 
-for (const dir of ['packages', 'docs', 'scripts']) {
+// `tools/`, `.github/` and `.husky/` joined in issue #220. Each holds authored
+// material the rule always covered and the scan never reached: a workflow's
+// rationale comments, a gate script's docstring, a hook's explanation of what
+// it refuses. `.claude/` is here for the same reason — its skill files are
+// tracked prose that instructs an agent, which is as authored as it gets.
+//
+// Still deliberately absent: `.work/`. That exemption is a property of being
+// UNTRACKED, not of a name on this list, and it is spelled out above.
+for (const dir of ['packages', 'docs', 'scripts', 'tools', '.github', '.husky', '.claude']) {
 	try {
 		for await (const file of walk(join(ROOT, dir))) {
 			const path = relative(ROOT, file).split(sep).join('/')

--- a/scripts/audit-external-names.mjs
+++ b/scripts/audit-external-names.mjs
@@ -31,6 +31,36 @@
  * prose that happens to live in a literal. There is no general way to tell
  * that from a wire value, so it is a review question rather than a rule —
  * and the identity prompt, the only place it arose, now names no one.
+ *
+ * ## What it does not enforce, measured 2026-08-08
+ *
+ * Issue #220 widened WHERE this looks. That is the smaller half of the hole,
+ * and leaving the rest unwritten would let a green run read as a rule that is
+ * kept. It is not one.
+ *
+ * **Respelling walks through.** This matches literal spellings, so every
+ * multi-token brand crushed into one entry here is evaded by writing it the way
+ * prose actually writes it. Eleven variants were tried against the real script
+ * and all eleven passed: a space (`lang chain`, `crew ai`, `chat gpt`, `auto
+ * gen`, `llama index`, `open ai`), a hyphen, and an initialism. The sharpest
+ * case is `huggingface`: the spaced form is the brand's OWN standard spelling,
+ * so for that entry the list is simply spelled wrong for matching. This is a
+ * design question — normalise the haystack, or carry real variants per brand —
+ * not a lexical patch, and it is filed rather than guessed at here.
+ *
+ * **Four channels bypass every entry equally**, all confirmed by running this:
+ *
+ *  - a fenced code block, including one inside a doc comment;
+ *  - an inline backtick span;
+ *  - a markdown link TARGET (the link TEXT is still scanned, and is caught);
+ *  - a string or template literal.
+ *
+ * Only the last was previously written down. All four are the same trade: each
+ * exists because that construct is overwhelmingly a value rather than prose,
+ * and each is therefore a place a positioning sentence can sit unenforced. They
+ * are accepted, not closed — and an accepted gap that is recorded is a
+ * decision, while the same gap unrecorded is a surprise for whoever trusts the
+ * green.
  */
 
 import { readdir, readFile } from 'node:fs/promises'


### PR DESCRIPTION
fix(scripts): the name audit reaches the files it was always about

Closes #220.

`scripts/audit-external-names.mjs` enforces the repository's hardest rule, and
it scanned `packages/`, `docs/` and `scripts/` for `.ts`/`.tsx`/`.md` plus
top-level `*.md`. Not `install.sh`, not `*.ps1`, not `.github/**`. A product
name in any of those passed CI and was still a violation — the gate reported
green and the rule was broken, which is worse than no gate, because a green run
is taken as an answer.

## It found a real one on the first run

    packages/sandbox/worker/server.js:496
      // <vendor>-side retry path treats a single 500 / 502 as transient,

That is a design decision explained by pointing at somebody else's client, which
is exactly what the rule forbids. The file is `.js`, an extension the old list
never opened, so the gate had been silent about it for as long as it has
existed. Reworded to name the mechanism — a caller's retry path — rather than
whose.

The issue said "nobody has checked whether a violation is present today". One
was.

## Reach, and why it is not just a longer extension list

- Directories added: `tools/`, `.github/`, `.husky/`, `.claude/`.
- Extensions added: `.mjs`, `.cjs`, `.js`, `.sh`, `.ps1`, `.yml`, `.yaml`.
- Top level now takes `*.sh` and `*.ps1` as well as `*.md` — any of them, not
  the two that happen to exist, because naming them individually means the next
  one arrives unscanned.
- The husky hooks have no extension and carry as much rationale prose as any
  source file, so they are matched by directory.
- `#` is now recognised as a comment opener for shell, PowerShell and YAML.

`.work/` stays out. That exemption is a property of being untracked and is
unchanged.

## Zero new exemptions

Measured before designing: the only legitimate third-party names in the newly
reached tree are this workspace's own provider package identities. Two shapes,
two different answers, neither of them an allowlist entry.

**Path-shaped, in code.** `for pkg in … providers/anthropic …` in `ci.yml` and
`release.yml`. A package path is the package's name; the script already skips
`import` and `export … from` lines for exactly that reason, and a shell loop
over package directories is the same statement in a language with no import
syntax. So those tokens are stripped — but **only in the shell family and only
on a line that is not a comment.**

That restriction is the whole point. Unrestricted, the strip is a laundering
mechanism: a sentence whose only occurrence of a forbidden name sits inside a
path — "we took our backoff constants directly from packages/providers/…" —
would newly pass, which is precisely the shape the rule exists to catch. Code
names paths. Prose does not get to hide behind one.

**Not path-shaped.** `DEPENDENTS=(anthropic bedrock …)`, a bare list of package
short names. Fixed in the shell file, not the scanner: the array is now quoted.
Quoting is how shell says "these are literal values", which is the same
statement a TypeScript string literal makes and which this script has always
honoured. `bash -n` and `sh -n` still pass.

An earlier draft gave `verify-consumer-install.sh` a file-level exemption. That
was wrong: it is ~400 lines of overwhelmingly prose — postmortems, rationale
comments, three heredocs — carrying two lines of package data. Exempting it
would blind the audit to every future edit anywhere in it. The existing
`WIRE_VALUE_FILES` entries are small tables where the whole file genuinely is
wire values; this is not one.

## The gate is shown to fail, not merely to read green

A widened gate that has only ever been observed passing over its new territory
proves nothing about whether it enforces there. One violation was planted per
newly reached file kind and the real script run against each:

| surface | expected | actual |
|---|---|---|
| workflow YAML comment | flag | flag |
| workflow YAML value | flag | flag |
| issue template | flag | flag |
| `.github` script (`.mjs`) | flag | flag |
| `.github` shell script | flag | flag |
| `tools/` script | flag | flag |
| husky hook (no extension) | flag | flag |
| `.claude` skill prose | flag | flag |
| plain `.js` under `packages/` | flag | flag |
| top-level PowerShell | flag | flag |
| `install.sh` | flag | flag |
| `providers/openai` on an executable line | clean | clean |
| `providers/openai` inside a `#` comment | flag | flag |
| a driven service in doc prose | clean | clean |

Every probe removed afterwards; tree confirmed clean.

## A guard deliberately not added

`github actions` is on the forbidden list and appears nowhere in the newly
reached tree — the workflows name `actions/checkout@v5` and `ubuntu-latest`,
which the term does not match. So no exemption was written for it: one would be
a guard whose condition can never be false, and this repository has a convention
about those. A comment records what would make it real — a workflow naming the
CI platform in prose, which is a path-or-context exemption to write when there
is a line to point at.

## Reach is the smaller half, and the second commit says so in the script

A reach fix that reads as a completed rule would be worse than the gap it
closes. Measured against the real script, with fixtures keyed by opaque id so no
probe contained the term it tested for:

- **Eleven of eleven respellings walk straight through** — `open ai`, `OAI`,
  `Co-Pilot`, `Hugging Face`, `lang chain`, `lang graph`, `llama index`,
  `crew ai`, `chat gpt`, `auto gen`, `GH Actions`. Structural: every
  multi-token brand crushed into one list entry assumes a spelling prose does
  not follow. `Hugging Face` is the brand's own standard spelling, so that entry
  is simply spelled wrong for matching.
- **Four channels bypass every entry** — a fenced block (including inside a doc
  comment), an inline backtick span, a markdown link target, and a string
  literal. Only the last was previously written down.
- A markdown link's **text** is not among them; it survives the strip and is
  caught. Measured, because the report that prompted this said otherwise.

The second commit records all of it in the script's header. Behaviour unchanged.
The spelling gap is a design question — normalise the haystack, or carry real
variants per brand — and is filed as #255 rather than patched here: adding
`hugging face` while ten brands still walk would make the gate look more
complete than it is.

## Scope

Issue #217, the false positive on the English verb "strands", is deliberately
not in this change; a fix for it follows separately. Widening coverage while
false positives are unresolved is how a rule gets switched off, so the two were
read together — and the measurement done for #217 turned up a second live false
positive, `cohere`, which that PR now also covers.

No changeset: `packages/sandbox` is touched, but only a code comment, and bump
intent is a claim about the consumer.
