### PR TITLE
feat(cli): preferences hold an ordered provider chain

### DIFF
--- a/.changeset/a-chain-is-an-order-you-declare.md
+++ b/.changeset/a-chain-is-an-order-you-declare.md
@@ -1,0 +1,48 @@
+---
+'@namzu/cli': minor
+---
+
+Preferences hold an ordered chain of providers, not one
+
+`~/.namzu/preferences.json` now stores `providers`, an ordered list, in place of
+the single `provider` + `model` pair. Index 0 is the primary and is what runs.
+
+**Nothing is required of you.** A `version: 2` file is read as a one-member
+chain — one provider is a one-element list, which is unambiguous — and is
+rewritten in the new format the next time a choice is saved. A `version: 1` file
+is still refused, as before. Downgrading namzu after a chain has been written
+reports "please re-pick" rather than silently dropping the members it cannot
+represent.
+
+**Only the primary runs today.** Automatic failover is a separate change; this
+one is the configuration it will read. Declaring a longer chain is still worth
+doing now, because the whole of it is checked:
+
+- Every member must name a provider namzu knows, **including members after the
+  first**. A fallback that names a provider that does not exist used to load
+  fine and fail at construction — on the day the primary went down, which is the
+  worst moment to discover it.
+- A member may not repeat an earlier one exactly. The same provider with a
+  *different model* is allowed, and is a real chain: a large model falling back
+  to a smaller one.
+- The chain may not be empty.
+
+A rejected chain names the position that broke it (`primary provider`,
+`fallback #1`, …) and re-opens the picker.
+
+`namzu doctor` gained `providers.chain`, which prints the chain in your declared
+order with each member's credential state, so the order is legible without
+launching the TUI. A fallback with no credential is a warning; a primary with
+none is a failure.
+
+`namzu run --provider <id>` now **replaces** the chain for that run rather than
+re-heading it, so a run you scoped to one provider cannot be answered by a
+different one. `--model` on its own re-models the primary and leaves the rest of
+the chain in place. Neither changes what a single-provider setup does today.
+
+Adds the `providerChainCheck` export for embedded consumers assembling their own
+doctor registry.
+
+`namzu doctor` also indents every line of a multi-line check message. Previously
+only the first line took the report's indent and the rest broke out to column 0,
+so a multi-line answer read as though the report had ended.

--- a/docs/cli/providers.md
+++ b/docs/cli/providers.md
@@ -68,3 +68,53 @@ The picker currently wires Anthropic, OpenAI, OpenRouter, and Ollama. Other prov
 ## Switching providers
 
 Run `/model` inside the TUI to re-open the picker at any time. The new choice is saved and the session reconnects.
+
+## The provider chain
+
+`~/.namzu/preferences.json` stores an **ordered list** of providers rather than a single one:
+
+```json
+{
+  "version": 3,
+  "providers": [
+    { "id": "anthropic", "model": "claude-opus-4-7" },
+    { "id": "ollama" }
+  ]
+}
+```
+
+The order is yours to declare, and the file is meant to be read and edited directly — you do not need to launch the TUI to see it. Index 0 is the **primary**. A member that omits `model` uses that provider's registry default, resolved at launch, so it tracks the default instead of pinning whatever it was on the day you wrote it.
+
+**Today only the primary runs.** The rest of the chain is validated and reported; nothing falls over to it yet. Automatic failover is a separate change.
+
+The chain is checked as a whole when it is read:
+
+- Every member must name a provider namzu knows — including members after the first. An unusable fallback that only surfaces the day your primary goes down is what this prevents.
+- A member cannot repeat an earlier one exactly. The same provider **with a different model** is allowed and is a legitimate chain: a large model falling back to a smaller one.
+- The chain cannot be empty.
+
+If any of those fail, namzu names the offending position (`primary provider`, `fallback #1`, …) and re-opens the picker.
+
+### Seeing the chain
+
+`namzu doctor` prints it in order, one line per member, each carrying that member's position, label, the model it will use — marked `(default)` when it came from the registry rather than from your file — and whether a credential was found:
+
+```
+providers.chain  2 providers configured, in order:
+                 1. primary · <label> · <model> · credential found
+                 2. fallback 1 · <label> · <model> (default) · NO CREDENTIAL
+```
+
+A fallback with no credential is a **warning**, not a failure — your primary still runs, so you are not blocked. A primary with no credential is a failure, because no run can start.
+
+A purely local provider reports `reachable` / `NOT REACHABLE` instead, since it has no key to find.
+
+### Upgrading from the previous format
+
+A `version: 2` file (one `provider`, one optional `model`) is read as a one-member chain, so nothing needs doing. The file is rewritten in the new format the next time a choice is saved. A `version: 1` file is still refused and asks you to pick again.
+
+### Overriding on the command line
+
+`namzu run --provider <id>` **replaces** the chain for that run: the run uses exactly the provider you named and nothing else. An override that quietly kept your fallbacks could answer from a provider you did not name on that command line.
+
+`--model <name>` on its own re-models the primary and leaves the rest of the chain in place.

--- a/docs/cli/tui.md
+++ b/docs/cli/tui.md
@@ -90,8 +90,9 @@ In every one of those cases the provider's default is still offered and
 selectable, so the step is never a dead end. The default is marked `(default)`
 wherever it appears.
 
-Your choice is written to `~/.namzu/preferences.json` as `model`, and it is what
-the next turn is sent with.
+Your choice is written to `~/.namzu/preferences.json` as the primary entry's
+`model`, and it is what the next turn is sent with. See
+[the provider chain](./providers.md#the-provider-chain) for the file's shape.
 
 ## Your own slash commands
 

--- a/packages/cli/src/__tests__/a-chosen-model-reaches-the-turn.test.ts
+++ b/packages/cli/src/__tests__/a-chosen-model-reaches-the-turn.test.ts
@@ -105,8 +105,8 @@ async function modelSentFor(prefs: Preferences): Promise<string | undefined> {
 describe('the model a run is sent with', () => {
 	it('is the provider default when nothing was chosen', async () => {
 		const model = await modelSentFor({
-			version: 2,
-			provider: 'anthropic',
+			version: 3,
+			providers: [{ id: 'anthropic' }],
 			subagents: { active: [] },
 		} as Preferences)
 		expect(model).toBe(REGISTRY_DEFAULT)
@@ -117,9 +117,8 @@ describe('the model a run is sent with', () => {
 		// kernel. Before the picker could produce one, this value had no way of
 		// being set except by hand-editing the preferences file.
 		const model = await modelSentFor({
-			version: 2,
-			provider: 'anthropic',
-			model: CHOSEN,
+			version: 3,
+			providers: [{ id: 'anthropic', model: CHOSEN }],
 			subagents: { active: [] },
 		} as Preferences)
 		expect(model).toBe(CHOSEN)
@@ -134,9 +133,8 @@ describe('the model a run is sent with', () => {
 		const { createAgentSession } = await import('../tui/agent.js')
 		const session = await createAgentSession(
 			{
-				version: 2,
-				provider: 'anthropic',
-				model: CHOSEN,
+				version: 3,
+				providers: [{ id: 'anthropic', model: CHOSEN }],
 				subagents: { active: [] },
 			} as Preferences,
 			detectedAnthropic(),

--- a/packages/cli/src/__tests__/a-command-file-reaches-the-turn.test.ts
+++ b/packages/cli/src/__tests__/a-command-file-reaches-the-turn.test.ts
@@ -95,7 +95,7 @@ describe('a command file the operator wrote', () => {
 		// cannot cover: that the composed text is what the kernel is given.
 		const { createAgentSession } = await import('../tui/agent.js')
 		const session = await createAgentSession(
-			{ version: 2, provider: 'anthropic', subagents: { active: [] } } as never,
+			{ version: 3, providers: [{ id: 'anthropic' }], subagents: { active: [] } } as never,
 			[
 				{
 					entry: {

--- a/packages/cli/src/__tests__/environment-reaches-the-turn.test.ts
+++ b/packages/cli/src/__tests__/environment-reaches-the-turn.test.ts
@@ -56,8 +56,8 @@ afterEach(() => {
 })
 
 const prefs = {
-	version: 2,
-	provider: 'anthropic',
+	version: 3,
+	providers: [{ id: 'anthropic' }],
 	subagents: { active: [] },
 } as Preferences
 

--- a/packages/cli/src/__tests__/mcp-servers-reach-the-session.test.ts
+++ b/packages/cli/src/__tests__/mcp-servers-reach-the-session.test.ts
@@ -79,8 +79,8 @@ afterEach(async () => {
 })
 
 const prefs = {
-	version: 2,
-	provider: 'anthropic',
+	version: 3,
+	providers: [{ id: 'anthropic' }],
 	subagents: { active: [] },
 } as Preferences
 

--- a/packages/cli/src/__tests__/permission-rules-reach-the-turn.test.ts
+++ b/packages/cli/src/__tests__/permission-rules-reach-the-turn.test.ts
@@ -67,8 +67,8 @@ function writeProjectConfig(permissions: Record<string, unknown>): void {
 }
 
 const prefs = {
-	version: 2,
-	provider: 'anthropic',
+	version: 3,
+	providers: [{ id: 'anthropic' }],
 	subagents: { active: [] },
 } as Preferences
 

--- a/packages/cli/src/__tests__/project-instructions-reach-the-turn.test.ts
+++ b/packages/cli/src/__tests__/project-instructions-reach-the-turn.test.ts
@@ -64,8 +64,8 @@ afterEach(() => {
 })
 
 const prefs = {
-	version: 2,
-	provider: 'anthropic',
+	version: 3,
+	providers: [{ id: 'anthropic' }],
 	subagents: { active: [] },
 } as Preferences
 

--- a/packages/cli/src/commands/__tests__/provider-flags.test.ts
+++ b/packages/cli/src/commands/__tests__/provider-flags.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Preferences } from '../../integrations/providers/index.js'
+import { applyProviderFlags } from '../run-flags.js'
+
+const chain: Preferences = {
+	version: 3,
+	providers: [{ id: 'anthropic', model: 'primary-model' }, { id: 'openai' }, { id: 'ollama' }],
+}
+
+const noFlags = { provider: null, model: null }
+
+describe('applyProviderFlags', () => {
+	it('leaves the chain untouched when neither flag is given', () => {
+		expect(applyProviderFlags(chain, noFlags)).toBe(chain)
+	})
+
+	it('--provider REPLACES the chain, so the run cannot answer from an unnamed provider', () => {
+		// The decision this test exists for. Prepending and keeping the tail
+		// would let a run the operator scoped to one provider be served by a
+		// different one, with the flag they passed saying otherwise.
+		const out = applyProviderFlags(chain, { ...noFlags, provider: 'openai' })
+		expect(out.providers).toEqual([{ id: 'openai' }])
+	})
+
+	it('--provider drops the previous primary’s model rather than carrying it across', () => {
+		const out = applyProviderFlags(chain, { ...noFlags, provider: 'ollama' })
+		expect(out.providers[0]?.model).toBeUndefined()
+	})
+
+	it('--provider with --model models the single member that replaced the chain', () => {
+		const out = applyProviderFlags(chain, { provider: 'openai', model: 'chosen' })
+		expect(out.providers).toEqual([{ id: 'openai', model: 'chosen' }])
+	})
+
+	it('--model alone re-models the primary and KEEPS the fallbacks', () => {
+		// A statement about the model is not a statement about which providers
+		// are viable, so the chain survives it.
+		const out = applyProviderFlags(chain, { ...noFlags, model: 'chosen' })
+		expect(out.providers).toEqual([
+			{ id: 'anthropic', model: 'chosen' },
+			{ id: 'openai' },
+			{ id: 'ollama' },
+		])
+	})
+
+	it('preserves everything else on the preferences', () => {
+		const withSubagents: Preferences = { ...chain, subagents: { active: ['one'] } }
+		const out = applyProviderFlags(withSubagents, { ...noFlags, provider: 'openai' })
+		expect(out.subagents?.active).toEqual(['one'])
+		expect(out.version).toBe(3)
+	})
+})

--- a/packages/cli/src/commands/__tests__/run-flags.test.ts
+++ b/packages/cli/src/commands/__tests__/run-flags.test.ts
@@ -52,19 +52,26 @@ vi.mock('../../integrations/trust/store.js', () => ({
 
 vi.mock('../../tui/agent.js', () => ({
 	probeAgentSession: vi.fn(async () => ({
-		preferences: { version: 2, provider: 'mock', subagents: { active: [] } },
+		preferences: {
+			version: 3,
+			providers: [{ id: 'mock' }],
+			subagents: { active: [] },
+		},
 		needsRepickReason: null,
 		detected: [],
 	})),
 	createAgentSession: vi.fn(
 		async (
-			prefs: { provider?: string; model?: string },
+			prefs: { providers?: readonly { id?: string; model?: string }[] },
 			_detected: unknown,
 			opts?: { cwd?: string },
 		) => {
 			seen.cwd = opts?.cwd
-			seen.provider = prefs.provider
-			seen.model = prefs.model
+			// The head of the chain is what runs, so it is what this file asserts
+			// on. Reading a flat `prefs.provider` here is how this fixture went
+			// stale against production once already.
+			seen.provider = prefs.providers?.[0]?.id
+			seen.model = prefs.providers?.[0]?.model
 			// Only what this file is about is spelled out: the instruction files
 			// it drives assertions from, and a `send` that records the prompt.
 			return fakeAgentSession({

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1,4 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { runDoctorCommand } from './doctor.js'
 
@@ -24,6 +27,30 @@ describe('runDoctorCommand', () => {
 	afterEach(() => {
 		process.stdout.write = originalStdoutWrite
 		process.stderr.write = originalStderrWrite
+		vi.unstubAllEnvs()
+	})
+
+	it('indents every line of a multi-line message under its check', async () => {
+		// The provider chain prints one line per member. Rendered as a single
+		// string, only the first line took the report's indent and the rest
+		// broke out to column 0, so the report looked like it had ended and the
+		// members read as stray output from something else.
+		const home = mkdtempSync(join(tmpdir(), 'namzu-doctor-'))
+		mkdirSync(join(home, '.namzu'), { recursive: true })
+		writeFileSync(
+			join(home, '.namzu', 'preferences.json'),
+			JSON.stringify({ version: 3, providers: [{ id: 'anthropic' }, { id: 'openai' }] }),
+		)
+		vi.stubEnv('HOME', home)
+		vi.stubEnv('USERPROFILE', home)
+
+		await runDoctorCommand(['--category', 'providers'])
+
+		const memberLines = captured.split('\n').filter((l) => /^\s*\d+\. (primary|fallback)/.test(l))
+		expect(memberLines).toHaveLength(2)
+		for (const line of memberLines) {
+			expect(line.startsWith('     ')).toBe(true)
+		}
 	})
 
 	it('--help returns 0 and prints usage', async () => {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -171,8 +171,19 @@ function formatHumanReport(report: DoctorReport, verbose: boolean): string {
 		const dur = `${record.durationMs}ms`
 		const head = `  ${glyph} ${category}  ${record.id}  ${dur}`
 		lines.push(head)
-		if (record.message) lines.push(`     ${record.message}`)
-		if (record.remediation) lines.push(`     → ${record.remediation}`)
+		// A message may be several lines — a provider chain is one line per
+		// member. Pushed whole, only its first line took the indent and every
+		// line after it broke out to column 0, so the report looked like it had
+		// ended and the rest was something else's output.
+		if (record.message) {
+			for (const line of record.message.split('\n')) lines.push(`     ${line}`)
+		}
+		if (record.remediation) {
+			const [first = '', ...rest] = record.remediation.split('\n')
+			lines.push(`     → ${first}`)
+			// Aligned under the text, not under the arrow.
+			for (const line of rest) lines.push(`       ${line}`)
+		}
 	}
 	lines.push('')
 	const s = report.summary

--- a/packages/cli/src/commands/run-flags.ts
+++ b/packages/cli/src/commands/run-flags.ts
@@ -22,6 +22,8 @@
 import { statSync } from 'node:fs'
 import { resolve } from 'node:path'
 
+import type { Preferences, ProviderChoice, ProviderId } from '../integrations/providers/index.js'
+
 export interface RunFlags {
 	session: string | null
 	model: string | null
@@ -256,4 +258,47 @@ export async function loadSkillsContext(
 /** The `--flags` refusal message both commands use, so they word it the same. */
 export function unknownOptionMessage(unknown: readonly string[]): string {
 	return `unknown option(s): ${unknown.join(', ')} — pass \`--\` before a prompt that starts with a dash`
+}
+
+/**
+ * Apply `--provider` / `--model` to the configured provider chain.
+ *
+ * Here rather than in each command for the reason at the top of this file: both
+ * commands take the same input, and the two `--provider` readings below differ
+ * in a way that only shows up once failover exists. Written twice, they drift
+ * once.
+ *
+ * **`--provider X` replaces the chain with X alone**, rather than moving X to
+ * the head and keeping the rest as fallbacks. An operator who names one provider
+ * on a command line and gets an answer from a different one has been switched
+ * silently — and they would have no way to see it, because the flag they passed
+ * says otherwise. Today the two readings behave identically, since nothing falls
+ * over; the decision is recorded now so it is not settled later by whichever is
+ * easier to write.
+ *
+ * **`--model` alone re-models the existing primary** and leaves the chain
+ * intact: it is a statement about the model, not about which providers are
+ * viable. Passed together with `--provider`, it models the single member that
+ * replaced the chain.
+ */
+export function applyProviderFlags(
+	prefs: Preferences,
+	flags: Pick<RunFlags, 'provider' | 'model'>,
+): Preferences {
+	if (!flags.provider && !flags.model) return prefs
+
+	if (flags.provider) {
+		const member: ProviderChoice = {
+			id: flags.provider as ProviderId,
+			...(flags.model ? { model: flags.model } : {}),
+		}
+		return { ...prefs, providers: [member] }
+	}
+
+	const [head, ...rest] = prefs.providers
+	if (!head) return prefs
+	// `flags.model` is non-null here: the early return above covers the case
+	// where neither flag was given, and the branch above covers `--provider`.
+	const remodelled: ProviderChoice = { id: head.id, model: flags.model as string }
+	return { ...prefs, providers: [remodelled, ...rest] }
 }

--- a/packages/cli/src/commands/run-stream.ts
+++ b/packages/cli/src/commands/run-stream.ts
@@ -30,7 +30,7 @@
 import { type Message, configureLogger } from '@namzu/sdk'
 
 import { EXIT_UNTRUSTED } from '../exit-codes.js'
-import type { DetectedProvider, Preferences, ProviderId } from '../integrations/providers/index.js'
+import type { DetectedProvider, Preferences } from '../integrations/providers/index.js'
 import {
 	appendMessages,
 	loadConversation,
@@ -43,6 +43,7 @@ import { compilePermissions } from '../permissions/rules.js'
 import { SLASH_COMMANDS } from '../tui/slashCommands.js'
 import { expandHeadlessCommand } from '../user-commands/store.js'
 import {
+	applyProviderFlags,
 	loadSkillsContext,
 	parseRunFlags,
 	resolveWorkingDirectory,
@@ -59,7 +60,9 @@ async function readStdin(): Promise<string> {
 
 function defaultPrefs(detected: readonly DetectedProvider[]): Preferences | null {
 	const first = detected[0]
-	return first ? { version: 2, provider: first.entry.id, subagents: { active: [] } } : null
+	return first
+		? { version: 3, providers: [{ id: first.entry.id }], subagents: { active: [] } }
+		: null
 }
 
 /** Parse stdin as a prior Message[]; tolerate the UI's {role,content} shape. */
@@ -184,8 +187,7 @@ export const runStreamCommand: CommandDef = {
 		}
 		// --provider/--model override the persona's configured provider+model for
 		// this run, so the Namzu tab's picks win over ~/.namzu/preferences.json.
-		if (flags.provider) prefs = { ...prefs, provider: flags.provider as ProviderId }
-		if (flags.model) prefs = { ...prefs, model: flags.model }
+		prefs = applyProviderFlags(prefs, flags)
 
 		// The operator's rules and mode reach this command too. They did not:
 		// `[permissions]` was compiled for `run` and never for `run-stream`, so a

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -22,7 +22,7 @@ import { configureLogger } from '@namzu/sdk'
 import type { Message, StopReason } from '@namzu/sdk'
 
 import { EXIT_UNTRUSTED, EXIT_USAGE } from '../exit-codes.js'
-import type { DetectedProvider, Preferences, ProviderId } from '../integrations/providers/index.js'
+import type { DetectedProvider, Preferences } from '../integrations/providers/index.js'
 import { openSessions } from '../integrations/sessions/store.js'
 import { decideHeadlessTrust } from '../permissions/headless-trust.js'
 import { resolvePermissionMode } from '../permissions/mode.js'
@@ -31,6 +31,7 @@ import { SLASH_COMMANDS } from '../tui/slashCommands.js'
 import { expandHeadlessCommand } from '../user-commands/store.js'
 import { resolveResume } from './resume.js'
 import {
+	applyProviderFlags,
 	loadSkillsContext,
 	parseRunFlags,
 	resolveWorkingDirectory,
@@ -106,7 +107,9 @@ export function composePrompt(fromArgs: string, piped: string): string {
 
 function defaultPrefs(detected: readonly DetectedProvider[]): Preferences | null {
 	const first = detected[0]
-	return first ? { version: 2, provider: first.entry.id, subagents: { active: [] } } : null
+	return first
+		? { version: 3, providers: [{ id: first.entry.id }], subagents: { active: [] } }
+		: null
 }
 
 export const runCommand: CommandDef = {
@@ -234,8 +237,7 @@ export const runCommand: CommandDef = {
 			})
 			return 1
 		}
-		if (flags.provider) prefs = { ...prefs, provider: flags.provider as ProviderId }
-		if (flags.model) prefs = { ...prefs, model: flags.model }
+		prefs = applyProviderFlags(prefs, flags)
 
 		// A permission the operator wrote and which was silently dropped is the
 		// worst outcome available here: they believe a control is in force and it

--- a/packages/cli/src/doctor/checks/__tests__/chain.test.ts
+++ b/packages/cli/src/doctor/checks/__tests__/chain.test.ts
@@ -1,0 +1,128 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { describeProviderChain, providerChainCheck } from '../chain.js'
+import { builtInDoctorChecks } from '../index.js'
+
+let home: string
+
+beforeEach(() => {
+	home = mkdtempSync(join(tmpdir(), 'namzu-chain-'))
+})
+
+afterEach(() => {
+	vi.unstubAllEnvs()
+})
+
+function writePrefs(body: unknown): void {
+	mkdirSync(join(home, '.namzu'), { recursive: true })
+	writeFileSync(join(home, '.namzu', 'preferences.json'), JSON.stringify(body))
+}
+
+/**
+ * Probes are skipped throughout: a real one reaches for localhost, which would
+ * make the result depend on whatever happens to be listening on the machine
+ * running the suite.
+ */
+function check(env: Record<string, string> = {}) {
+	return describeProviderChain({ home, env, skipProbes: true })
+}
+
+describe('the provider chain check', () => {
+	it('is inconclusive, not failing, when nothing is configured yet', async () => {
+		const r = await check()
+		expect(r.status).toBe('inconclusive')
+		expect(r.message ?? '').toMatch(/no provider chain configured/)
+	})
+
+	it('prints every member in declared order, so the order is readable without the TUI', async () => {
+		writePrefs({
+			version: 3,
+			providers: [{ id: 'anthropic' }, { id: 'openai', model: 'a-model' }],
+		})
+		const r = await check({ ANTHROPIC_API_KEY: 'x', OPENAI_API_KEY: 'y' })
+		expect(r.status).toBe('pass')
+		const message = r.message ?? ''
+		const primaryAt = message.indexOf('primary')
+		const fallbackAt = message.indexOf('fallback 1')
+		expect(primaryAt).toBeGreaterThanOrEqual(0)
+		// Order, not merely presence: members printed in an arbitrary order
+		// would not answer the question this check exists for.
+		expect(fallbackAt).toBeGreaterThan(primaryAt)
+		expect(message).toContain('a-model')
+	})
+
+	it('shows the registry default for a member that pinned no model', async () => {
+		writePrefs({ version: 3, providers: [{ id: 'anthropic' }] })
+		const r = await check({ ANTHROPIC_API_KEY: 'x' })
+		expect(r.message ?? '').toContain('(default)')
+	})
+
+	it('WARNS when only a fallback is unusable — the primary still runs', async () => {
+		writePrefs({ version: 3, providers: [{ id: 'anthropic' }, { id: 'openai' }] })
+		const r = await check({ ANTHROPIC_API_KEY: 'x' })
+		expect(r.status).toBe('warn')
+		expect(r.message ?? '').toContain('NO CREDENTIAL')
+		expect(r.remediation ?? '').toMatch(/not a fallback/)
+	})
+
+	it('FAILS when the primary is unusable — no run can start', async () => {
+		writePrefs({ version: 3, providers: [{ id: 'anthropic' }, { id: 'openai' }] })
+		const r = await check({ OPENAI_API_KEY: 'y' })
+		expect(r.status).toBe('fail')
+	})
+
+	it('says which member is bad when the chain itself is unusable', async () => {
+		writePrefs({ version: 3, providers: [{ id: 'anthropic' }, { id: 'not-a-provider' }] })
+		const r = await check({ ANTHROPIC_API_KEY: 'x' })
+		expect(r.status).toBe('fail')
+		expect(r.message ?? '').toContain('fallback #1')
+	})
+
+	it('reports a lone provider as having no fallback', async () => {
+		writePrefs({ version: 3, providers: [{ id: 'anthropic' }] })
+		const r = await check({ ANTHROPIC_API_KEY: 'x' })
+		expect(r.status).toBe('pass')
+		expect(r.message ?? '').toMatch(/no fallback/)
+	})
+
+	it('reads a v2 file as a one-member chain rather than refusing it', async () => {
+		writePrefs({ version: 2, provider: 'anthropic' })
+		const r = await check({ ANTHROPIC_API_KEY: 'x' })
+		expect(r.status).toBe('pass')
+		expect(r.message ?? '').toMatch(/no fallback/)
+	})
+})
+
+describe('the check is reachable, not merely correct', () => {
+	it('ships in builtInDoctorChecks, so `namzu doctor` actually runs it', () => {
+		expect(builtInDoctorChecks.map((c) => c.id)).toContain('providers.chain')
+	})
+
+	it('passes the doctor context env through to discovery', async () => {
+		// Drives `providerChainCheck.run`, not the helper: a helper proven in
+		// isolation says nothing about whether the check reaches it, and a
+		// `run` reading `process.env` instead of `ctx.env` would be invisible
+		// to every case above.
+		//
+		// The credential is put ONLY on the context. `os.homedir()` reads
+		// `HOME` on POSIX and `USERPROFILE` on Windows, so stubbing both points
+		// the real code path at the temp home without mocking a module. If
+		// `run` consulted `process.env`, it would find no key and report
+		// `fail` — which is what makes the `pass` below mean something.
+		writePrefs({ version: 3, providers: [{ id: 'anthropic' }] })
+		vi.stubEnv('HOME', home)
+		vi.stubEnv('USERPROFILE', home)
+		expect(process.env.ANTHROPIC_API_KEY).toBeUndefined()
+
+		const r = await providerChainCheck.run({
+			cwd: process.cwd(),
+			env: { ANTHROPIC_API_KEY: 'only-on-the-context' },
+			projectRoot: null,
+		})
+
+		expect(r.status).toBe('pass')
+	})
+})

--- a/packages/cli/src/doctor/checks/chain.ts
+++ b/packages/cli/src/doctor/checks/chain.ts
@@ -1,0 +1,140 @@
+import { homedir } from 'node:os'
+
+import type { DoctorCheck, DoctorCheckResult } from '@namzu/sdk'
+
+import { type DiscoverOptions, discoverProviders } from '../../integrations/providers/discover.js'
+import { preferencesPath, readPreferences } from '../../integrations/providers/preferences.js'
+import { PROVIDER_REGISTRY } from '../../integrations/providers/registry.js'
+
+export interface ProviderChainCheckOptions {
+	/** Where `.namzu/preferences.json` lives. Defaults to the real home. */
+	readonly home?: string
+	readonly env?: DiscoverOptions['env']
+	/** Skip localhost probes. Off in production: a local server being up is the answer. */
+	readonly skipProbes?: boolean
+}
+
+/**
+ * The configured provider chain, in the operator's declared order.
+ *
+ * Two jobs, and the second is the one that earns this check.
+ *
+ * First, the order has to be readable without launching the TUI. A chain that
+ * can only be seen by opening an interactive picker is not something an
+ * operator can check on a server, paste into an issue, or diff after an edit.
+ *
+ * Second — and this is why it reports per MEMBER rather than a count — a
+ * fallback is only worth having if it works, and a broken one is invisible by
+ * construction: nothing exercises it until the primary is already down, which
+ * is the worst moment to find out the key was never set. So every member's
+ * credential is resolved here, on a day when nothing is broken.
+ *
+ * Exported separately from the `DoctorCheck` so it can be driven with an
+ * explicit home and environment. The check itself is still exercised through
+ * `providerChainCheck.run`, because a helper proven in isolation says nothing
+ * about whether the check reaches it.
+ */
+export async function describeProviderChain(
+	options: ProviderChainCheckOptions = {},
+): Promise<DoctorCheckResult> {
+	const home = options.home ?? homedir()
+	const path = preferencesPath(home)
+
+	let read: ReturnType<typeof readPreferences>
+	try {
+		read = readPreferences(home)
+	} catch (err) {
+		return {
+			status: 'fail',
+			message: `could not read ${path}: ${err instanceof Error ? err.message : String(err)}`,
+			remediation: 'Fix or delete the file, then run `namzu` to pick a provider again.',
+		}
+	}
+
+	if (read.status === 'missing') {
+		return {
+			status: 'inconclusive',
+			message: `no provider chain configured (${path} does not exist)`,
+			remediation: 'Run `namzu` and pick a provider; the choice is saved to that file.',
+		}
+	}
+	if (read.status === 'needs-repick') {
+		return {
+			status: 'fail',
+			message: `provider chain unusable: ${read.reason}`,
+			remediation: 'Run `namzu` to pick again, or edit that file by hand.',
+		}
+	}
+
+	let detected: Awaited<ReturnType<typeof discoverProviders>>
+	try {
+		detected = await discoverProviders({
+			...(options.env ? { env: options.env } : {}),
+			...(options.skipProbes ? { skipProbes: true } : {}),
+		})
+	} catch (err) {
+		// Name the step that failed. Reporting "no credentials" when discovery
+		// itself broke would send the operator looking for a key that is
+		// already there.
+		return {
+			status: 'inconclusive',
+			message: `provider chain read, but credential discovery failed: ${
+				err instanceof Error ? err.message : String(err)
+			}`,
+		}
+	}
+
+	const members = read.prefs.providers
+	const lines: string[] = []
+	let unusable = 0
+	let primaryUnusable = false
+
+	for (const [index, member] of members.entries()) {
+		const entry = PROVIDER_REGISTRY[member.id]
+		const position = index === 0 ? 'primary' : `fallback ${index}`
+		const model = member.model ?? `${entry.defaultModel} (default)`
+		const det = detected.find((d) => d.entry.id === member.id)
+		const usable = entry.requiresApiKey ? Boolean(det?.apiKey) : Boolean(det)
+		if (!usable) {
+			unusable++
+			if (index === 0) primaryUnusable = true
+		}
+		const state = entry.requiresApiKey
+			? usable
+				? 'credential found'
+				: 'NO CREDENTIAL'
+			: usable
+				? 'reachable'
+				: 'NOT REACHABLE'
+		lines.push(`${index + 1}. ${position} · ${entry.label} · ${model} · ${state}`)
+	}
+
+	const chain = lines.join('\n')
+
+	if (unusable === 0) {
+		return {
+			status: 'pass',
+			message:
+				members.length === 1
+					? `1 provider configured (no fallback):\n${chain}`
+					: `${members.length} providers configured, in order:\n${chain}`,
+		}
+	}
+
+	return {
+		// `warn`, not `fail`, when only a fallback is broken: the primary still
+		// runs, so namzu is usable and the operator is not blocked by a
+		// degraded spare. A broken PRIMARY stops every run, and reads as such.
+		status: primaryUnusable ? 'fail' : 'warn',
+		message: `${unusable} of ${members.length} chain member(s) cannot be used:\n${chain}`,
+		remediation: primaryUnusable
+			? 'The primary provider has no usable credential, so no run can start. Set its key, or run `namzu` to pick a provider that has one.'
+			: 'The primary still works, so runs will start. But a fallback with no credential is not a fallback — set its key, or take it out of the chain.',
+	}
+}
+
+export const providerChainCheck: DoctorCheck = {
+	id: 'providers.chain',
+	category: 'providers',
+	run: (ctx): Promise<DoctorCheckResult> => describeProviderChain({ env: ctx.env }),
+}

--- a/packages/cli/src/doctor/checks/index.ts
+++ b/packages/cli/src/doctor/checks/index.ts
@@ -1,5 +1,6 @@
 import type { DoctorCheck } from '@namzu/sdk'
 
+import { providerChainCheck } from './chain.js'
 import { credentialSourcesCheck } from './credentials.js'
 import { providersRegisteredCheck } from './providers.js'
 import { cwdWritableCheck, tmpdirWritableCheck } from './runtime.js'
@@ -9,6 +10,7 @@ import { vaultRegisteredCheck } from './vault.js'
 
 export {
 	credentialSourcesCheck,
+	providerChainCheck,
 	providersRegisteredCheck,
 	cwdWritableCheck,
 	tmpdirWritableCheck,
@@ -23,6 +25,10 @@ export const builtInDoctorChecks: readonly DoctorCheck[] = [
 	tmpdirWritableCheck,
 	providersRegisteredCheck,
 	credentialSourcesCheck,
+	// After the credential scan: this one reports which of the credentials that
+	// found are actually WIRED INTO the chain, which only reads sensibly once
+	// the operator has seen what was found.
+	providerChainCheck,
 	vaultRegisteredCheck,
 	telemetryInstalledCheck,
 ]

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,7 @@ export {
 	builtInDoctorChecks,
 	credentialSourcesCheck,
 	cwdWritableCheck,
+	providerChainCheck,
 	providersRegisteredCheck,
 	sandboxPlatformCheck,
 	telemetryInstalledCheck,

--- a/packages/cli/src/integrations/providers/index.ts
+++ b/packages/cli/src/integrations/providers/index.ts
@@ -20,6 +20,8 @@ export {
 	PREFERENCES_FILE_VERSION,
 	PreferencesError,
 	preferencesPath,
+	primaryProvider,
+	type ProviderChoice,
 	type ReadResult,
 	readPreferences,
 	writePreferences,

--- a/packages/cli/src/integrations/providers/preferences.test.ts
+++ b/packages/cli/src/integrations/providers/preferences.test.ts
@@ -1,11 +1,13 @@
-import { mkdirSync, mkdtempSync, statSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 import {
+	type Preferences,
 	PreferencesError,
 	preferencesPath,
+	primaryProvider,
 	readPreferences,
 	writePreferences,
 } from './preferences.js'
@@ -20,7 +22,12 @@ import {
 const IS_WINDOWS = process.platform === 'win32'
 
 function tmpHome(): string {
-	return mkdtempSync(join(tmpdir(), 'namzu-prefs-v2-'))
+	return mkdtempSync(join(tmpdir(), 'namzu-prefs-'))
+}
+
+function writeRaw(home: string, body: unknown): void {
+	mkdirSync(join(home, '.namzu'), { recursive: true })
+	writeFileSync(join(home, '.namzu', 'preferences.json'), JSON.stringify(body))
 }
 
 describe('readPreferences', () => {
@@ -28,28 +35,13 @@ describe('readPreferences', () => {
 		expect(readPreferences(tmpHome())).toEqual({ status: 'missing' })
 	})
 
-	it('detects a v1 file as needs-repick (legacy schema)', () => {
+	it('refuses a v1 file rather than guessing at it', () => {
 		const home = tmpHome()
-		mkdirSync(join(home, '.namzu'))
-		writeFileSync(
-			join(home, '.namzu', 'preferences.json'),
-			JSON.stringify({ version: 1, default: 'claude', active: ['claude'] }),
-		)
+		writeRaw(home, { version: 1, default: 'peer', active: ['peer'] })
 		const r = readPreferences(home)
 		expect(r.status).toBe('needs-repick')
 		if (r.status === 'needs-repick') {
 			expect(r.reason).toMatch(/older schema/)
-		}
-	})
-
-	it('round-trips a v2 selection', () => {
-		const home = tmpHome()
-		writePreferences({ version: 2, provider: 'anthropic', model: 'claude-opus-4-7' }, home)
-		const r = readPreferences(home)
-		expect(r.status).toBe('ok')
-		if (r.status === 'ok') {
-			expect(r.prefs.provider).toBe('anthropic')
-			expect(r.prefs.model).toBe('claude-opus-4-7')
 		}
 	})
 
@@ -59,39 +51,192 @@ describe('readPreferences', () => {
 		writeFileSync(join(home, '.namzu', 'preferences.json'), '{ not json')
 		expect(() => readPreferences(home)).toThrow(PreferencesError)
 	})
-})
 
-describe('writePreferences', () => {
-	it.skipIf(IS_WINDOWS)('enforces mode 0600 on file and 0700 on dir', () => {
+	it('round-trips a chain, in the order it was written', () => {
 		const home = tmpHome()
-		writePreferences({ version: 2, provider: 'openai' }, home)
-		const fileMode = statSync(preferencesPath(home)).mode & 0o777
-		const dirMode = statSync(join(home, '.namzu')).mode & 0o777
-		expect(fileMode).toBe(0o600)
-		expect(dirMode).toBe(0o700)
-	})
-
-	it('rejects an empty provider', () => {
-		expect(() => writePreferences({ version: 2, provider: '' as never }, tmpHome())).toThrow(
-			PreferencesError,
+		writePreferences(
+			{
+				version: 3,
+				providers: [
+					{ id: 'anthropic', model: 'a-model' },
+					{ id: 'openai', model: 'another-model' },
+					{ id: 'ollama' },
+				],
+			},
+			home,
 		)
+		const r = readPreferences(home)
+		expect(r.status).toBe('ok')
+		if (r.status !== 'ok') throw new Error('expected ok')
+		expect(r.prefs.providers.map((p) => p.id)).toEqual(['anthropic', 'openai', 'ollama'])
+		expect(r.prefs.providers[1]?.model).toBe('another-model')
+		// Omitted stays omitted: a member must not acquire a pinned model it
+		// never asked for, or it stops tracking the registry default.
+		expect(r.prefs.providers[2]?.model).toBeUndefined()
 	})
 
 	it('preserves subagents.active when present', () => {
 		const home = tmpHome()
 		writePreferences(
 			{
-				version: 2,
-				provider: 'anthropic',
-				subagents: { active: ['claude', 'codex'] },
+				version: 3,
+				providers: [{ id: 'anthropic' }],
+				subagents: { active: ['one', 'two'] },
 			},
 			home,
 		)
 		const r = readPreferences(home)
-		if (r.status === 'ok') {
-			expect(r.prefs.subagents?.active).toEqual(['claude', 'codex'])
-		} else {
-			throw new Error('expected ok status')
+		if (r.status !== 'ok') throw new Error('expected ok status')
+		expect(r.prefs.subagents?.active).toEqual(['one', 'two'])
+	})
+})
+
+describe('readPreferences migrates v2', () => {
+	it('reads a v2 file as a one-element chain, carrying the model', () => {
+		const home = tmpHome()
+		writeRaw(home, { version: 2, provider: 'anthropic', model: 'a-model' })
+		const r = readPreferences(home)
+		expect(r.status).toBe('ok')
+		if (r.status !== 'ok') throw new Error('expected ok')
+		expect(r.prefs.version).toBe(3)
+		expect(r.prefs.providers).toEqual([{ id: 'anthropic', model: 'a-model' }])
+	})
+
+	it('does not invent a model for a v2 file that pinned none', () => {
+		const home = tmpHome()
+		writeRaw(home, { version: 2, provider: 'openai' })
+		const r = readPreferences(home)
+		if (r.status !== 'ok') throw new Error('expected ok')
+		expect(r.prefs.providers).toEqual([{ id: 'openai' }])
+	})
+
+	it('carries subagents across the migration', () => {
+		const home = tmpHome()
+		writeRaw(home, { version: 2, provider: 'anthropic', subagents: { active: ['one'] } })
+		const r = readPreferences(home)
+		if (r.status !== 'ok') throw new Error('expected ok')
+		expect(r.prefs.subagents?.active).toEqual(['one'])
+	})
+
+	it('does not rewrite the file — a read has no write side effect', () => {
+		const home = tmpHome()
+		writeRaw(home, { version: 2, provider: 'anthropic' })
+		readPreferences(home)
+		const onDisk = JSON.parse(readFileSync(preferencesPath(home), 'utf8')) as { version: number }
+		expect(onDisk.version).toBe(2)
+	})
+
+	it('still validates a migrated v2 chain', () => {
+		const home = tmpHome()
+		writeRaw(home, { version: 2, provider: 'not-a-provider' })
+		const r = readPreferences(home)
+		expect(r.status).toBe('needs-repick')
+		if (r.status !== 'needs-repick') throw new Error('expected needs-repick')
+		expect(r.reason).toMatch(/not a provider namzu knows/)
+	})
+})
+
+describe('a chain is validated in full, not just at the head', () => {
+	it('refuses an unknown provider in the TAIL, naming its position', () => {
+		const home = tmpHome()
+		writeRaw(home, {
+			version: 3,
+			providers: [{ id: 'anthropic' }, { id: 'not-a-provider' }],
+		})
+		const r = readPreferences(home)
+		expect(r.status).toBe('needs-repick')
+		if (r.status !== 'needs-repick') throw new Error('expected needs-repick')
+		expect(r.reason).toContain('fallback #1')
+		expect(r.reason).toContain('not-a-provider')
+	})
+
+	it('refuses a member repeated with the same model', () => {
+		const home = tmpHome()
+		writeRaw(home, {
+			version: 3,
+			providers: [
+				{ id: 'anthropic', model: 'a-model' },
+				{ id: 'anthropic', model: 'a-model' },
+			],
+		})
+		const r = readPreferences(home)
+		expect(r.status).toBe('needs-repick')
+		if (r.status !== 'needs-repick') throw new Error('expected needs-repick')
+		expect(r.reason).toMatch(/cannot be its own fallback/)
+	})
+
+	it('refuses a member repeated with no model on either', () => {
+		const home = tmpHome()
+		writeRaw(home, { version: 3, providers: [{ id: 'openai' }, { id: 'openai' }] })
+		expect(readPreferences(home).status).toBe('needs-repick')
+	})
+
+	it('ALLOWS one provider twice with different models', () => {
+		// A large model falling back to a small one on the same provider is a
+		// real chain. Refusing every repeated id would forbid it.
+		const home = tmpHome()
+		writeRaw(home, {
+			version: 3,
+			providers: [
+				{ id: 'anthropic', model: 'big' },
+				{ id: 'anthropic', model: 'small' },
+			],
+		})
+		expect(readPreferences(home).status).toBe('ok')
+	})
+
+	it('refuses an empty chain', () => {
+		const home = tmpHome()
+		writeRaw(home, { version: 3, providers: [] })
+		expect(readPreferences(home).status).toBe('needs-repick')
+	})
+})
+
+describe('writePreferences', () => {
+	it.skipIf(IS_WINDOWS)('enforces mode 0600 on file and 0700 on dir', () => {
+		const home = tmpHome()
+		writePreferences({ version: 3, providers: [{ id: 'openai' }] }, home)
+		const fileMode = statSync(preferencesPath(home)).mode & 0o777
+		const dirMode = statSync(join(home, '.namzu')).mode & 0o777
+		expect(fileMode).toBe(0o600)
+		expect(dirMode).toBe(0o700)
+	})
+
+	it('rejects an empty chain', () => {
+		expect(() => writePreferences({ version: 3, providers: [] }, tmpHome())).toThrow(
+			PreferencesError,
+		)
+	})
+
+	it('rejects a chain naming a provider that does not exist', () => {
+		expect(() =>
+			writePreferences({ version: 3, providers: [{ id: 'nope' as never }] }, tmpHome()),
+		).toThrow(PreferencesError)
+	})
+
+	it('rejects a repeated member', () => {
+		expect(() =>
+			writePreferences({ version: 3, providers: [{ id: 'openai' }, { id: 'openai' }] }, tmpHome()),
+		).toThrow(PreferencesError)
+	})
+
+	it('refuses to write an unsupported version', () => {
+		expect(() =>
+			writePreferences({ version: 2, providers: [{ id: 'openai' }] } as never, tmpHome()),
+		).toThrow(PreferencesError)
+	})
+})
+
+describe('primaryProvider', () => {
+	it('is the head of the chain', () => {
+		const prefs: Preferences = {
+			version: 3,
+			providers: [{ id: 'openai', model: 'a-model' }, { id: 'anthropic' }],
 		}
+		expect(primaryProvider(prefs)).toEqual({ id: 'openai', model: 'a-model' })
+	})
+
+	it('throws rather than inventing a provider nobody chose', () => {
+		expect(() => primaryProvider({ version: 3, providers: [] })).toThrow(PreferencesError)
 	})
 })

--- a/packages/cli/src/integrations/providers/preferences.ts
+++ b/packages/cli/src/integrations/providers/preferences.ts
@@ -1,19 +1,41 @@
 /**
- * `~/.namzu/preferences.json` — the user's primary-chat picker selection.
+ * `~/.namzu/preferences.json` — the operator's provider chain.
  *
- * Schema (current = v2):
+ * Schema (current = v3):
  *   {
- *     "version": 2,
- *     "provider": "anthropic",            // ProviderId
- *     "model": "claude-opus-4-7",         // optional model override
+ *     "version": 3,
+ *     "providers": [                      // ordered; index 0 is the primary
+ *       { "id": "anthropic", "model": "claude-opus-4-7" },
+ *       { "id": "openai" }                // model omitted → the registry default
+ *     ],
  *     "subagents": { "active": [...] }    // instances reserved for subagent dispatch
  *   }
  *
- * The previous schema (v1) stored a peer instance as the
- * default — a different primitive (subagent dispatch, not primary
- * chat). On-disk v1 files trigger a forced re-pick rather than an
- * auto-migration: mapping between the two semantics would surprise
- * more than help.
+ * The chain is an ORDER the operator declares, replacing the single provider v2
+ * held. It is deliberately a plain readable array in a file the operator owns:
+ * the order has to be legible and editable without launching the TUI, which a
+ * value only reachable through an interactive picker is not.
+ *
+ * **Only `providers[0]` runs today.** The rest are validated and reported (see
+ * `readPreferences` and the `providers.chain` doctor check) but nothing falls
+ * over to them yet. That is the point of shipping this first: a chain you can
+ * declare, read back, and have checked is useful before failover exists, and it
+ * is what failover will consume.
+ *
+ * ## Versions
+ *
+ * v1 stored a peer instance as the default — a different primitive (subagent
+ * dispatch, not primary chat). It is still REFUSED rather than migrated, because
+ * mapping between the two semantics would surprise more than help.
+ *
+ * v2 stored a single `provider` + optional `model`. It IS migrated, on read, in
+ * memory: one provider is a one-element chain, which is unambiguous, and the
+ * distinction from v1 is exactly that. Migration does not rewrite the file — a
+ * reader with a write side effect would rewrite `$HOME` on a `--help`. The next
+ * `writePreferences` lands v3.
+ *
+ * Note the consequence: a v3 file read by an older namzu reports `needs-repick`
+ * rather than silently losing the tail, which is the safe direction.
  */
 
 import { randomBytes } from 'node:crypto'
@@ -21,16 +43,33 @@ import { chmodSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'n
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 
-import type { ProviderId } from './registry.js'
+import { PROVIDER_REGISTRY, type ProviderId } from './registry.js'
 
 const FILE_MODE = 0o600
 const DIR_MODE = 0o700
-export const PREFERENCES_FILE_VERSION = 2 as const
+export const PREFERENCES_FILE_VERSION = 3 as const
+
+/**
+ * One member of the provider chain.
+ *
+ * `model` omitted means the registry default for that provider, resolved at
+ * construction rather than stored — so a member does not pin itself to whatever
+ * the default happened to be on the day it was written.
+ */
+export interface ProviderChoice {
+	readonly id: ProviderId
+	readonly model?: string
+}
 
 export interface Preferences {
-	readonly version: 2
-	readonly provider: ProviderId
-	readonly model?: string
+	readonly version: 3
+	/**
+	 * The chain, in the operator's declared order. Index 0 is the primary and is
+	 * the one that runs. Never empty — an empty chain is refused at read and at
+	 * write, because it describes a namzu that cannot call anything while
+	 * looking like a configured one.
+	 */
+	readonly providers: readonly ProviderChoice[]
 	readonly subagents?: { readonly active: readonly string[] }
 }
 
@@ -44,6 +83,29 @@ export class PreferencesError extends Error {
 		super(message)
 		this.name = 'PreferencesError'
 	}
+}
+
+/**
+ * The member that actually runs.
+ *
+ * A helper rather than `prefs.providers[0]` at each call site: the chain is
+ * guaranteed non-empty by validation, and every reader repeating an index
+ * lookup plus a non-null assertion would be four places to get that wrong.
+ */
+export function primaryProvider(prefs: Preferences): ProviderChoice {
+	// Optional-chained rather than indexed: a caller handing over an object of
+	// the old shape is a real case (a stale test fixture did exactly that), and
+	// a `TypeError: cannot read '0' of undefined` names neither the field nor
+	// the fix, while the error below names both.
+	const first = prefs.providers?.[0]
+	if (!first) {
+		// Unreachable through readPreferences/writePreferences, both of which
+		// refuse an empty chain. Reachable only from a hand-built object, and
+		// silently returning a placeholder there would put the caller on a
+		// provider nobody chose.
+		throw new PreferencesError('preferences.providers is empty — no provider to run')
+	}
+	return first
 }
 
 export function preferencesPath(home: string = homedir()): string {
@@ -80,6 +142,15 @@ export function readPreferences(home: string = homedir()): ReadResult {
 				'preferences file uses an older schema (v1) — namzu now picks an LLM provider client directly. Please re-pick.',
 		}
 	}
+	if (v.version === 2) {
+		const migrated = migrateV2(parsed)
+		if (!migrated) {
+			throw new PreferencesError(`${path} has an unexpected shape for a v2 file`)
+		}
+		const invalid = describeInvalidChain(migrated.providers)
+		if (invalid) return { status: 'needs-repick', reason: `${invalid} — please re-pick.` }
+		return { status: 'ok', prefs: migrated }
+	}
 	if (v.version !== PREFERENCES_FILE_VERSION) {
 		return {
 			status: 'needs-repick',
@@ -89,6 +160,14 @@ export function readPreferences(home: string = homedir()): ReadResult {
 	if (!isPreferences(parsed)) {
 		throw new PreferencesError(`${path} has an unexpected shape`)
 	}
+	// Shape is right; the CONTENT may still name a provider that does not exist
+	// or repeat a member. Reported as `needs-repick` with the offending member
+	// named, not thrown: a bad chain is something the operator can fix by
+	// picking again, and it is the tail this is really for — an unusable
+	// fallback that only surfaces the day the primary goes down is the failure
+	// this check exists to prevent.
+	const invalid = describeInvalidChain(parsed.providers)
+	if (invalid) return { status: 'needs-repick', reason: `${invalid} — please re-pick.` }
 	return { status: 'ok', prefs: parsed }
 }
 
@@ -98,9 +177,12 @@ export function writePreferences(prefs: Preferences, home: string = homedir()): 
 			`unsupported preferences version: ${String(prefs.version)} (expected ${PREFERENCES_FILE_VERSION})`,
 		)
 	}
-	if (typeof prefs.provider !== 'string' || prefs.provider.length === 0) {
-		throw new PreferencesError('preferences.provider is required')
+	if (!Array.isArray(prefs.providers) || prefs.providers.length === 0) {
+		throw new PreferencesError('preferences.providers must list at least one provider')
 	}
+	const invalid = describeInvalidChain(prefs.providers)
+	if (invalid) throw new PreferencesError(invalid)
+
 	const path = preferencesPath(home)
 	mkdirSync(dirname(path), { recursive: true, mode: DIR_MODE })
 	const body = `${JSON.stringify(prefs, null, 2)}\n`
@@ -110,19 +192,90 @@ export function writePreferences(prefs: Preferences, home: string = homedir()): 
 	renameSync(tmp, path)
 }
 
+/**
+ * A v2 file as a one-element chain, or null if it was not a well-formed v2.
+ *
+ * `model` is carried only when present, so a v2 file that never pinned a model
+ * does not gain one.
+ */
+function migrateV2(value: unknown): Preferences | null {
+	const v = value as Record<string, unknown>
+	if (typeof v.provider !== 'string' || v.provider.length === 0) return null
+	if (v.model !== undefined && typeof v.model !== 'string') return null
+	if (!isSubagents(v.subagents)) return null
+	const member: ProviderChoice = {
+		id: v.provider as ProviderId,
+		...(typeof v.model === 'string' ? { model: v.model } : {}),
+	}
+	return {
+		version: PREFERENCES_FILE_VERSION,
+		providers: [member],
+		...(v.subagents !== undefined
+			? { subagents: v.subagents as { readonly active: readonly string[] } }
+			: {}),
+	}
+}
+
+/**
+ * Why this chain is unusable, or null if it is fine.
+ *
+ * Every member is checked, not only the head. A chain exists to be fallen back
+ * to, so a tail member naming a provider that does not exist is precisely as
+ * broken as a bad head — it is just broken later, on the worst day.
+ */
+function describeInvalidChain(members: readonly ProviderChoice[]): string | null {
+	if (members.length === 0) {
+		return 'preferences lists no providers'
+	}
+	const seen = new Set<string>()
+	for (const [index, member] of members.entries()) {
+		const position = index === 0 ? 'primary provider' : `fallback #${index}`
+		if (!(member.id in PROVIDER_REGISTRY)) {
+			return `${position} "${member.id}" is not a provider namzu knows (known: ${Object.keys(PROVIDER_REGISTRY).join(', ')})`
+		}
+		// Compared as the pair the operator WROTE, not against the resolved
+		// default model. Resolving would make a file that was valid yesterday
+		// invalid the day a registry default changes, which is a config that
+		// breaks on upgrade. Two entries for one provider with different models
+		// stay legitimate: falling back from a large model to a small one on the
+		// same provider is a real chain.
+		const key = JSON.stringify([member.id, member.model ?? null])
+		if (seen.has(key)) {
+			const shown = member.model ? `${member.id} (${member.model})` : member.id
+			return `${position} repeats "${shown}", which is already earlier in the chain — a provider cannot be its own fallback`
+		}
+		seen.add(key)
+	}
+	return null
+}
+
+function isSubagents(value: unknown): boolean {
+	if (value === undefined) return true
+	if (typeof value !== 'object' || value === null) return false
+	const sa = value as Record<string, unknown>
+	if (!Array.isArray(sa.active)) return false
+	for (const item of sa.active) {
+		if (typeof item !== 'string') return false
+	}
+	return true
+}
+
+function isProviderChoice(value: unknown): value is ProviderChoice {
+	if (typeof value !== 'object' || value === null) return false
+	const v = value as Record<string, unknown>
+	if (typeof v.id !== 'string' || v.id.length === 0) return false
+	if (v.model !== undefined && typeof v.model !== 'string') return false
+	return true
+}
+
 function isPreferences(value: unknown): value is Preferences {
 	if (typeof value !== 'object' || value === null) return false
 	const v = value as Record<string, unknown>
 	if (v.version !== PREFERENCES_FILE_VERSION) return false
-	if (typeof v.provider !== 'string' || v.provider.length === 0) return false
-	if (v.model !== undefined && typeof v.model !== 'string') return false
-	if (v.subagents !== undefined) {
-		if (typeof v.subagents !== 'object' || v.subagents === null) return false
-		const sa = v.subagents as Record<string, unknown>
-		if (!Array.isArray(sa.active)) return false
-		for (const item of sa.active) {
-			if (typeof item !== 'string') return false
-		}
+	if (!Array.isArray(v.providers)) return false
+	for (const member of v.providers) {
+		if (!isProviderChoice(member)) return false
 	}
+	if (!isSubagents(v.subagents)) return false
 	return true
 }

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -20,6 +20,7 @@ import {
 	type DetectedProvider,
 	type Preferences,
 	type ProviderId,
+	primaryProvider,
 	writePreferences,
 } from '../integrations/providers/index.js'
 import { isTrusted, trustDir } from '../integrations/trust/store.js'
@@ -223,7 +224,7 @@ export function App({ ctx }: AppProps) {
 					reserved: SLASH_COMMANDS.map((c) => c.name),
 				}),
 			)
-			setCurrentProvider(prefs.provider)
+			setCurrentProvider(primaryProvider(prefs).id)
 			if (s.hasProvider) {
 				setPhase('ready')
 				pushMessage(
@@ -743,7 +744,11 @@ export function App({ ctx }: AppProps) {
 			// The disposition, not the key. `credential` never reaches a message.
 			pushMessage('system', disposition)
 			void hydrateSession(
-				{ version: 2, provider: credential.entry.id as ProviderId, subagents: { active: [] } },
+				{
+					version: 3,
+					providers: [{ id: credential.entry.id as ProviderId }],
+					subagents: { active: [] },
+				},
 				next,
 			)
 		},
@@ -752,10 +757,16 @@ export function App({ ctx }: AppProps) {
 
 	const handlePickerSubmit = useCallback(
 		(selection: { provider: string; model?: string }) => {
+			// One member for now. The picker builds a longer chain in a later
+			// change; the shape it writes into is already the chain.
 			const prefs: Preferences = {
-				version: 2,
-				provider: selection.provider as ProviderId,
-				model: selection.model,
+				version: 3,
+				providers: [
+					{
+						id: selection.provider as ProviderId,
+						...(selection.model !== undefined ? { model: selection.model } : {}),
+					},
+				],
 				subagents: { active: [] },
 			}
 			try {

--- a/packages/cli/src/tui/__tests__/deferred-tool-discovery.test.ts
+++ b/packages/cli/src/tui/__tests__/deferred-tool-discovery.test.ts
@@ -71,8 +71,8 @@ afterEach(() => {
 })
 
 const prefs = {
-	version: 2,
-	provider: 'anthropic',
+	version: 3,
+	providers: [{ id: 'anthropic' }],
 	subagents: { active: [] },
 } as Preferences
 

--- a/packages/cli/src/tui/__tests__/working-directory.test.ts
+++ b/packages/cli/src/tui/__tests__/working-directory.test.ts
@@ -79,8 +79,8 @@ describe('a file tool resolves against the working directory it is given', () =>
 
 describe('createAgentSession runs where it is told to', () => {
 	const prefs: Preferences = {
-		version: 2,
-		provider: 'anthropic',
+		version: 3,
+		providers: [{ id: 'anthropic' }],
 		subagents: { active: [] },
 	} as Preferences
 

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -65,6 +65,7 @@ import {
 	ensureFreshAnthropicToken,
 	findDetected,
 	isAnthropicOAuthToken,
+	primaryProvider,
 	readAgentKeychainCredential,
 	readPreferences,
 } from '../integrations/providers/index.js'
@@ -381,25 +382,28 @@ export async function createAgentSession(
 ): Promise<AgentSession> {
 	const scope = options.scope ?? mintScope()
 	const cwd = options.cwd ?? process.cwd()
-	const entry = PROVIDER_REGISTRY[prefs.provider]
+	// Only the head of the chain runs. The tail is validated at read time and
+	// reported by `namzu doctor`; nothing falls over to it yet.
+	const primary = primaryProvider(prefs)
+	const entry = PROVIDER_REGISTRY[primary.id]
 	if (!entry) {
-		return emptySession(`Unknown provider "${prefs.provider}" — pick another.`)
+		return emptySession(`Unknown provider "${primary.id}" — pick another.`)
 	}
-	const det = findDetected(detected, prefs.provider)
+	const det = findDetected(detected, primary.id)
 	if (entry.requiresApiKey && (!det || !det.apiKey)) {
 		return emptySession(
 			`No credential found for ${entry.label}. Set one of: ${entry.envVars.join(', ')} — or pick another provider.`,
 		)
 	}
 	try {
-		await ensureRegistered(prefs.provider)
+		await ensureRegistered(primary.id)
 	} catch (err) {
 		return emptySession(err instanceof Error ? err.message : String(err))
 	}
-	const model = prefs.model ?? entry.defaultModel
+	const model = primary.model ?? entry.defaultModel
 	let provider: LLMProvider
 	try {
-		provider = constructProvider(prefs.provider, det, model)
+		provider = constructProvider(primary.id, det, model)
 	} catch (err) {
 		return emptySession(
 			`Failed to construct ${entry.label}: ${err instanceof Error ? err.message : String(err)}`,
@@ -411,7 +415,7 @@ export async function createAgentSession(
 	// we re-read the keychain (another process may have rotated it) and refresh a
 	// stale token, rebuilding the client only when the token actually changed.
 	// Gated on `det.oauth` so env / secrets credentials are never touched.
-	const keychainRefresh = prefs.provider === 'anthropic' && Boolean(det?.oauth)
+	const keychainRefresh = primary.id === 'anthropic' && Boolean(det?.oauth)
 	let currentToken = det?.apiKey
 	const refreshTokenIfNeeded = async (): Promise<void> => {
 		if (!keychainRefresh) return
@@ -482,7 +486,7 @@ export async function createAgentSession(
 			readEnvironment: async () => composeEnvironmentPrompt(await readEnvironmentFacts(cwd)),
 			buildProvider: () =>
 				constructProvider(
-					prefs.provider,
+					primary.id,
 					det ? { ...det, apiKey: currentToken ?? det.apiKey } : det,
 					model,
 				),


### PR DESCRIPTION
`~/.namzu/preferences.json` stores `providers`, an ordered list, in place of the single `provider` + `model` pair. Index 0 is the primary and is what runs; the order is the operator's to declare, in a plain file they can read and edit without launching the TUI.

This is the first of three. It is the configuration failover will read — **only the primary runs today**, and nothing claims otherwise.

## The tail had to be driven

A list whose `[0]` alone is ever consulted is exactly what [`declared-but-undriven`](docs/conventions/declared-but-undriven.md) names. Two things read the whole chain, both real:

- **Validation covers every member.** An unknown provider or an exactly-repeated member *anywhere* is refused with its position named (`fallback #1`). Before, a bad tail member loaded fine and threw at `constructProvider` — on the day the primary went down, which is the worst possible moment to discover a config error.
- **`namzu doctor` gained `providers.chain`**, which prints the chain in declared order with each member's credential state. An unusable fallback becomes visible on a day when nothing is broken.

A provider repeated with a **different model** stays legal — a large model falling back to a small one is a real chain. Duplicates are compared as the pair the operator *wrote*, not against the resolved default: comparing against the default would make a file that was valid yesterday invalid the day a registry default changed elsewhere, which is a trap with no visible cause.

## Migration

A `version: 2` file is read as a one-member chain, in memory — one provider *is* a one-element chain, which is unambiguous, and that is exactly what separates it from `version: 1`, which stays refused. The read has no write side effect (a reader that rewrote the home directory on a `--help` would be a surprise); the next save lands v3. Downgrading after a chain is written reports "please re-pick" rather than silently dropping members it cannot represent.

## Command-line override

`--provider <id>` now **replaces** the chain for that run rather than re-heading it, so a run scoped to one provider cannot be answered by a different one. `--model` alone re-models the primary and keeps the rest. Behaviour is identical today; the decision is recorded now so it is not settled later by whichever reading is easier to write.

It lives in `run-flags.ts` because both one-shots share that parser, and that file's own header says "one parser, so the two cannot drift again".

## Unplanned, and why it belongs here

`namzu doctor` now indents every line of a multi-line check message. The chain is the first multi-line message; rendered whole, only its first line took the report's indent and the members broke out to column 0, so the listing read as though the report had ended. That is a defect *of* the chain listing, not an unrelated tidy — splitting it would ship the surface this PR exists to provide rendering wrong in the same release.

## Verification

- `pnpm typecheck`, `pnpm test`, `pnpm lint` and `pnpm docs:check` all pass; the external-name audit is clean.
- **11 mutations, all killed** — tail-only validation, duplicate-by-id, migration dropping the model, v2 refused instead of migrated, `--provider` prepending, `--model` discarding fallbacks, a broken primary downgraded to `warn`, the check reading the process environment instead of the doctor context's, unordered members, and both renderer regressions.
- **Live run of the built binary**, four paths: a 3-member chain printed in order with mixed states; a v2 file migrated and passed; an unknown tail member failed naming `fallback #1`; a credential-less primary failed while a credentialled fallback did not rescue it.

## Two things found on the way

- A **NUL byte** reached `preferences.ts` in the duplicate-detection key — invisible in source, and enough to make `grep` treat the file as binary. Caught only because a mutation anchor failed to match, which is the mutation discipline paying off on something it was not aimed at. Replaced with an explicit `JSON.stringify([id, model])` key; every committed file was then scanned for control characters.
- Two test fixtures carried the old shape and still type-checked, because they cast. Both failed at runtime rather than at build — [`fixture-must-match-production`](docs/conventions/fixture-must-match-production.md), found the way that rule says it gets found. `primaryProvider` now optional-chains so a stale caller gets a named error instead of a `TypeError`.

## Filed separately, not fixed here

- #257 — three providers are pickable but throw at construction. A live foot-gun for this feature: the chain validator accepts them, because their ids genuinely are in the registry.
- #258 — discovery's probe-failed branch is empty and its condition is a double-negated no-op.

https://claude.ai/code/session_01RppSzAoxqCxKfD4fLYmnzs
