### PR TITLE
feat(cli): refuse a chain whose providers declare different capabilities

### DIFF
--- a/.changeset/a-chain-must-agree-with-itself.md
+++ b/.changeset/a-chain-must-agree-with-itself.md
@@ -1,0 +1,55 @@
+---
+'@namzu/cli': minor
+---
+
+Refuse a provider chain whose members declare different capabilities
+
+namzu negotiates capabilities once per run, against the provider it was handed,
+and that answer decides whether tools go into the prompt and whether image and
+document attachments are mapped. A chain whose members disagree cannot be
+honoured by taking the strongest declaration — a run that fell over to a weaker
+member would arrive holding a request shaped for a provider no longer serving
+it.
+
+Nor by taking the weakest. That is the trap this refuses to walk into: an
+operator who adds a weaker fallback to gain resilience would find their
+**primary** had quietly lost tool support, on every run, to guard against a
+failure that happens rarely. A capability given up permanently for a rare
+benefit, with nothing saying so.
+
+So neither is chosen for you. A disagreeing chain is refused, naming which two
+members disagree and on what:
+
+```
+  - fallback #1 (<label>) declares it cannot call tools, while primary provider
+    (<label>) declares it can call tools — if the chain falls over to it, tools
+    become unavailable.
+```
+
+Every disagreeing capability is listed, not just the first, so the configuration
+can be fixed in one pass rather than one round-trip at a time.
+
+**To accept the limitation**, set `"allowCapabilityMismatch": true` in
+`~/.namzu/preferences.json`. The chain then runs and the disagreement is printed
+on **every** launch — the TUI, `namzu run`, and a `notice` event on
+`namzu run-stream`. Not once: an acceptance given once and forgotten is how a
+silent degradation returns through the front door.
+
+Two limits, stated because a check that overstates its authority stops being
+believed:
+
+- It compares **declarations**, at the type level. That is what is knowable
+  without constructing a provider, and constructing one needs a credential —
+  which the fallback nobody has set up yet does not have. The runtime treats a
+  constructed provider's own declaration as authoritative.
+- It says nothing about the current run. Only the primary runs today, so its
+  capabilities are in force in full; every sentence is about what happens *if
+  the chain falls over*. When failover lands, the run-level statement becomes
+  true and can be made then.
+
+A member whose declaration cannot be read — a provider with no construction path
+yet — is reported as unresolved rather than assumed to agree, and does not by
+itself refuse the chain.
+
+Adds `AgentSession.configNotices`, the channel these are surfaced on.
+Single-provider setups are unaffected and gain no new output.

--- a/docs/cli/providers.md
+++ b/docs/cli/providers.md
@@ -109,6 +109,40 @@ A fallback with no credential is a **warning**, not a failure — your primary s
 
 A purely local provider reports `reachable` / `NOT REACHABLE` instead, since it has no key to find.
 
+### When the members disagree about what they can do
+
+Providers do not all declare the same abilities. A local provider may declare it cannot call tools; a gateway may declare it cannot read image or document attachments. namzu negotiates capabilities **once per run**, against the provider it was given, and that answer decides whether tools go into the prompt and whether attachments are sent.
+
+So a chain whose members disagree cannot simply be run. Taking the strongest declaration would advertise abilities a fallback does not have. Taking the weakest would cost your **primary** a capability on every run, to guard against a failure that happens rarely — you would have added a fallback for resilience and quietly lost tool support for it.
+
+namzu chooses neither for you. It **refuses the chain and names the disagreement**:
+
+```
+The providers in your chain declare different capabilities, so namzu cannot honour the chain as written:
+  - fallback #1 (<label>) declares it cannot call tools, while primary provider (<label>) declares it can call tools — if the chain falls over to it, tools become unavailable.
+```
+
+Every disagreeing capability is listed, not just the first, so you can fix the configuration in one pass.
+
+Two ways forward: drop the member that disagrees, or accept the limitation:
+
+```json
+{
+  "version": 3,
+  "providers": [{ "id": "anthropic" }, { "id": "ollama" }],
+  "allowCapabilityMismatch": true
+}
+```
+
+With that set, the chain runs and the disagreement is **printed on every launch** — in the TUI, in `namzu run`, and as a `notice` event in `namzu run-stream`. Not once. An acceptance given months ago and forgotten is exactly how a chain quietly does less than you think.
+
+Two things this check does **not** claim:
+
+- It compares what each driver **declares**, at the type level. That is the only thing knowable without constructing a provider — and constructing one needs a credential, which the fallback you have not set up yet does not have. A constructed provider's own declaration is what the runtime ultimately honours.
+- It says nothing about the current run. Only the primary runs today, so its capabilities are in force in full. Each sentence says what happens *if the chain falls over*, because that is what is true.
+
+A member whose declaration cannot be read at all — a provider with no construction path yet — is reported as such rather than assumed to agree, and does not by itself refuse the chain.
+
 ### Upgrading from the previous format
 
 A `version: 2` file (one `provider`, one optional `model`) is read as a one-member chain, so nothing needs doing. The file is rewritten in the new format the next time a choice is saved. A `version: 1` file is still refused and asks you to pick again.

--- a/packages/cli/src/commands/run-stream.ts
+++ b/packages/cli/src/commands/run-stream.ts
@@ -235,6 +235,14 @@ export const runStreamCommand: CommandDef = {
 			return fail(said)
 		}
 
+		// "Printed on every launch" has to reach a host UI too, or the one caller
+		// with no human watching is the one that never hears it. Its own event
+		// kind rather than an `error`: the run is proceeding, and a host that
+		// treats this as a failure would be wrong.
+		for (const notice of session.configNotices) {
+			write({ kind: 'notice', message: notice })
+		}
+
 		// --skills <a,b,c>: load the named skills' bodies and inject them as the
 		// turn's extra system context (the same channel the TUI's /skill uses).
 		const extraSystem = await loadSkillsContext(cwd, flags.skills)

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -283,6 +283,13 @@ export const runCommand: CommandDef = {
 			await session.close()
 			return 1
 		}
+		// "Printed on every launch" has to mean every launch, not every launch of
+		// the TUI. A scripted run under an accepted capability limitation is
+		// exactly the case where nobody is watching, so the line has to be in the
+		// output the script keeps.
+		for (const notice of session.configNotices) {
+			ctx.formatter.info(notice)
+		}
 		for (const s of session.mcpConnected) {
 			ctx.formatter.info(`tool server ${s.name} · ${s.toolCount} tools`)
 		}

--- a/packages/cli/src/integrations/providers/__tests__/chain-capabilities.test.ts
+++ b/packages/cli/src/integrations/providers/__tests__/chain-capabilities.test.ts
@@ -1,0 +1,171 @@
+import type { ResolvedProviderCapabilities } from '@namzu/sdk'
+import { describe, expect, it } from 'vitest'
+
+import {
+	type MemberCapabilities,
+	chainCapabilityDisagreements,
+	describeAcceptedMismatch,
+	describeCapabilityRefusal,
+} from '../chain-capabilities.js'
+import type { ProviderChoice } from '../preferences.js'
+
+const FULL: ResolvedProviderCapabilities = {
+	supportsTools: true,
+	supportsStreaming: true,
+	supportsFunctionCalling: true,
+	supportsVision: true,
+	supportsDocuments: true,
+}
+
+function known(over: Partial<ResolvedProviderCapabilities> = {}): MemberCapabilities {
+	return { kind: 'known', capabilities: { ...FULL, ...over } }
+}
+
+const chain: readonly ProviderChoice[] = [{ id: 'anthropic' }, { id: 'ollama' }]
+
+describe('a chain whose members agree', () => {
+	it('produces no disagreement', () => {
+		expect(chainCapabilityDisagreements(chain, [known(), known()])).toEqual([])
+	})
+
+	it('produces no refusal', () => {
+		expect(describeCapabilityRefusal([])).toBeNull()
+	})
+
+	it('is not a disagreement when a single member is the whole chain', () => {
+		expect(
+			chainCapabilityDisagreements([{ id: 'ollama' }], [known({ supportsTools: false })]),
+		).toEqual([])
+	})
+})
+
+describe('a disagreement names both members and the capability', () => {
+	it('says which member lacks it, which has it, and what is lost', () => {
+		const out = chainCapabilityDisagreements(chain, [known(), known({ supportsTools: false })])
+		expect(out).toHaveLength(1)
+		const sentence = out[0]?.sentence ?? ''
+		// The requirement in one assertion: an operator reading this can act on
+		// it without reordering things at random.
+		expect(sentence).toContain('fallback #1')
+		expect(sentence).toContain('primary provider')
+		expect(sentence).toContain('cannot call tools')
+		expect(sentence).toContain('tools become unavailable')
+	})
+
+	it('says DECLARES rather than asserting what the provider is', () => {
+		// The check is type-level; the SDK treats the constructed instance's own
+		// declaration as authoritative. Overstating that is how someone later
+		// finds the runtime disagreed and stops believing the check.
+		const out = chainCapabilityDisagreements(chain, [known(), known({ supportsTools: false })])
+		expect(out[0]?.sentence).toContain('declares')
+	})
+
+	it('makes no claim about THIS run — only about falling over', () => {
+		// Only the primary runs today. A sentence claiming the current run is
+		// degraded would be false, which is the defect this guards against.
+		const out = chainCapabilityDisagreements(chain, [known(), known({ supportsTools: false })])
+		const sentence = out[0]?.sentence ?? ''
+		expect(sentence).toContain('if the chain falls over')
+		expect(sentence).not.toMatch(/this run|currently|right now/i)
+	})
+
+	it('reports every disagreeing capability, not just the first', () => {
+		const out = chainCapabilityDisagreements(chain, [
+			known(),
+			known({ supportsTools: false, supportsVision: false, supportsDocuments: false }),
+		])
+		expect(out).toHaveLength(3)
+	})
+
+	it('reports against the FIRST member that declares the capability', () => {
+		const three = [{ id: 'anthropic' }, { id: 'openai' }, { id: 'ollama' }] as const
+		const out = chainCapabilityDisagreements(three, [
+			known(),
+			known(),
+			known({ supportsTools: false }),
+		])
+		expect(out).toHaveLength(1)
+		expect(out[0]?.declaredBy).toBe(0)
+		expect(out[0]?.missingFrom).toBe(2)
+	})
+
+	it('detects a weaker PRIMARY too, not only a weaker fallback', () => {
+		const out = chainCapabilityDisagreements(chain, [known({ supportsTools: false }), known()])
+		expect(out).toHaveLength(1)
+		expect(out[0]?.missingFrom).toBe(0)
+	})
+})
+
+describe('a smaller output ceiling is a disagreement', () => {
+	it('names both numbers and the cap that would apply', () => {
+		const out = chainCapabilityDisagreements(chain, [
+			known({ maxOutputTokens: 8192 }),
+			known({ maxOutputTokens: 4096 }),
+		])
+		expect(out).toHaveLength(1)
+		const sentence = out[0]?.sentence ?? ''
+		expect(sentence).toContain('8192')
+		expect(sentence).toContain('4096')
+		expect(sentence).toContain('capped at 4096')
+	})
+
+	it('is not a disagreement when the ceilings match', () => {
+		const out = chainCapabilityDisagreements(chain, [
+			known({ maxOutputTokens: 4096 }),
+			known({ maxOutputTokens: 4096 }),
+		])
+		expect(out).toEqual([])
+	})
+
+	it('needs two declared ceilings — one alone says nothing about the other', () => {
+		const out = chainCapabilityDisagreements(chain, [known({ maxOutputTokens: 4096 }), known()])
+		expect(out).toEqual([])
+	})
+})
+
+describe('a member whose declaration could not be read', () => {
+	it('is not counted as agreement', () => {
+		// "I could not check this" must not become "this is fine".
+		const out = chainCapabilityDisagreements(chain, [
+			known(),
+			{ kind: 'unresolved', reason: 'not wired' },
+		])
+		expect(out).toEqual([])
+	})
+
+	it('does not suppress a real disagreement elsewhere in the chain', () => {
+		const three = [{ id: 'anthropic' }, { id: 'bedrock' }, { id: 'ollama' }] as const
+		const out = chainCapabilityDisagreements(three, [
+			known(),
+			{ kind: 'unresolved', reason: 'not wired' },
+			known({ supportsTools: false }),
+		])
+		expect(out).toHaveLength(1)
+		expect(out[0]?.missingFrom).toBe(2)
+	})
+})
+
+describe('the messages an operator reads', () => {
+	it('the refusal names the escape hatch and what it costs', () => {
+		const out = chainCapabilityDisagreements(chain, [known(), known({ supportsTools: false })])
+		const refusal = describeCapabilityRefusal(out) ?? ''
+		expect(refusal).toContain('allowCapabilityMismatch')
+		expect(refusal).toContain('printed on every launch')
+		// Says why neither default was chosen, so the refusal reads as a
+		// decision rather than an inability.
+		expect(refusal).toContain('Neither is chosen for you')
+	})
+
+	it('the accepted notice states the same facts without re-offering the flag', () => {
+		const out = chainCapabilityDisagreements(chain, [known(), known({ supportsTools: false })])
+		const notice = describeAcceptedMismatch(out) ?? ''
+		expect(notice).toContain('you have accepted that')
+		expect(notice).toContain('cannot call tools')
+		expect(notice).not.toContain('allowCapabilityMismatch')
+	})
+
+	it('both are null when there is nothing to say', () => {
+		expect(describeCapabilityRefusal([])).toBeNull()
+		expect(describeAcceptedMismatch([])).toBeNull()
+	})
+})

--- a/packages/cli/src/integrations/providers/chain-capabilities.ts
+++ b/packages/cli/src/integrations/providers/chain-capabilities.ts
@@ -1,0 +1,247 @@
+/**
+ * Do the members of a provider chain agree about what they can do?
+ *
+ * The runtime negotiates capabilities ONCE per run, against the provider it was
+ * handed, and that answer decides whether tool surfaces go into the prompt and
+ * whether image and document attachments are mapped. A chain whose members
+ * disagree therefore cannot be honoured by taking the strongest answer: if the
+ * run falls over to a weaker member it arrives holding a request shaped for a
+ * provider that is no longer serving it — tools advertised that cannot be
+ * called, images the driver will not map.
+ *
+ * The alternative to refusing is intersecting: quietly take the floor of the
+ * chain. That is worse, and worse in the direction that matters. An operator who
+ * adds a weaker fallback to gain resilience would find their PRIMARY had quietly
+ * lost tool support, permanently, with nothing saying so — a capability given up
+ * on every run to guard against a failure that happens rarely. So a disagreement
+ * is refused and named, and an operator who wants the intersection anyway says
+ * so explicitly.
+ *
+ * ## This compares DECLARATIONS, and says only that
+ *
+ * What is compared is what each driver declares at the type level, which is the
+ * only thing knowable before a provider is constructed — and constructing one
+ * would need a credential, which is exactly what a not-yet-configured fallback
+ * does not have. The runtime treats the constructed INSTANCE's own declaration
+ * as authoritative, so an instance can in principle disagree with its type.
+ * Every sentence here therefore says "declares" rather than asserting what a
+ * provider IS. A check that overstates its authority is how someone later finds
+ * the runtime disagreed with it and stops believing it.
+ *
+ * ## And it is a property of the CHAIN, not of a run
+ *
+ * Only the primary runs today; nothing falls over yet. So no sentence here
+ * claims a run is degraded — each says what becomes unavailable IF the chain
+ * falls over. When failover lands the run-level statement becomes true and can
+ * be made then. Making it now would be a confident claim about a degradation
+ * that has not happened, which is the failure this line of work exists to
+ * remove.
+ */
+
+import type { ResolvedProviderCapabilities } from '@namzu/sdk'
+
+import { type ProviderChoice, chainPositionName } from './preferences.js'
+import { PROVIDER_REGISTRY } from './registry.js'
+
+/** A member paired with what it declares, or with why that could not be read. */
+export type MemberCapabilities =
+	| { readonly kind: 'known'; readonly capabilities: ResolvedProviderCapabilities }
+	| { readonly kind: 'unresolved'; readonly reason: string }
+
+export interface CapabilityDisagreement {
+	/** Index of the member that declares the capability. */
+	readonly declaredBy: number
+	/** Index of the member that declares it does not have it. */
+	readonly missingFrom: number
+	/** One sentence naming both members and what is lost. */
+	readonly sentence: string
+}
+
+/**
+ * The boolean capabilities, with the words for having one, lacking it, and
+ * losing it.
+ *
+ * `supportsStreaming` is here even though every shipped driver declares it. The
+ * field exists and a third-party driver may not have it; leaving it out would
+ * let a chain disagree on it and pass.
+ */
+const BOOLEAN_CAPABILITIES: ReadonlyArray<{
+	readonly key:
+		| 'supportsTools'
+		| 'supportsFunctionCalling'
+		| 'supportsStreaming'
+		| 'supportsVision'
+		| 'supportsDocuments'
+	readonly has: string
+	readonly lacks: string
+	readonly consequence: string
+}> = [
+	{
+		key: 'supportsTools',
+		has: 'it can call tools',
+		lacks: 'it cannot call tools',
+		consequence: 'tools become unavailable',
+	},
+	{
+		key: 'supportsFunctionCalling',
+		has: 'it supports function calling',
+		lacks: 'it does not support function calling',
+		consequence: 'function calling becomes unavailable',
+	},
+	{
+		key: 'supportsStreaming',
+		has: 'it can stream replies',
+		lacks: 'it cannot stream replies',
+		consequence: 'replies stop streaming',
+	},
+	{
+		key: 'supportsVision',
+		has: 'it can read image attachments',
+		lacks: 'it cannot read image attachments',
+		consequence: 'image attachments stop being sent',
+	},
+	{
+		key: 'supportsDocuments',
+		has: 'it can read document attachments',
+		lacks: 'it cannot read document attachments',
+		consequence: 'document attachments stop being sent',
+	},
+]
+
+function describe(index: number, member: ProviderChoice): string {
+	const entry = PROVIDER_REGISTRY[member.id]
+	return `${chainPositionName(index)} (${entry ? entry.label : member.id})`
+}
+
+/**
+ * Every way the members of this chain declare different abilities.
+ *
+ * A disagreement is reported against the FIRST member that declares the
+ * capability, because that is the behaviour the operator already has and would
+ * be surprised to lose. Members whose capabilities could not be read contribute
+ * nothing: an unestablished answer is not agreement, and counting it as one
+ * would turn "I could not check this" into "this is fine".
+ */
+export function chainCapabilityDisagreements(
+	members: readonly ProviderChoice[],
+	resolved: readonly MemberCapabilities[],
+): readonly CapabilityDisagreement[] {
+	const out: CapabilityDisagreement[] = []
+
+	for (const capability of BOOLEAN_CAPABILITIES) {
+		const firstWithIt = resolved.findIndex(
+			(entry) => entry.kind === 'known' && entry.capabilities[capability.key] === true,
+		)
+		if (firstWithIt === -1) continue
+		const has = members[firstWithIt]
+		if (!has) continue
+
+		for (const [index, entry] of resolved.entries()) {
+			if (entry.kind !== 'known' || index === firstWithIt) continue
+			if (entry.capabilities[capability.key] === true) continue
+			const lacks = members[index]
+			if (!lacks) continue
+			out.push({
+				declaredBy: firstWithIt,
+				missingFrom: index,
+				sentence:
+					`${describe(index, lacks)} declares ${capability.lacks}, while ` +
+					`${describe(firstWithIt, has)} declares ${capability.has} — ` +
+					`if the chain falls over to it, ${capability.consequence}.`,
+			})
+		}
+	}
+
+	out.push(...ceilingDisagreements(members, resolved))
+	return out
+}
+
+/**
+ * A smaller output ceiling is the same problem wearing a number: a run served by
+ * that member produces shorter replies than the chain was configured for.
+ * Reported against the LARGEST declared ceiling, for the reason the booleans are
+ * reported against the first member that has the capability.
+ */
+function ceilingDisagreements(
+	members: readonly ProviderChoice[],
+	resolved: readonly MemberCapabilities[],
+): readonly CapabilityDisagreement[] {
+	const ceilings: { index: number; value: number }[] = []
+	for (const [index, entry] of resolved.entries()) {
+		if (entry.kind !== 'known') continue
+		const value = entry.capabilities.maxOutputTokens
+		if (typeof value === 'number') ceilings.push({ index, value })
+	}
+	// No `length < 2` guard: a lone ceiling is already handled below, because it
+	// IS the largest and the comparison skips it. Adding one would be a branch
+	// that cannot change the answer, which is a check that cannot fail
+	// (`docs/conventions/a-check-that-cannot-fail.md`) — and a mutation proving
+	// exactly that is how this one was found.
+	let largest: { index: number; value: number } | undefined
+	for (const ceiling of ceilings) {
+		if (!largest || ceiling.value > largest.value) largest = ceiling
+	}
+	if (!largest) return []
+
+	const out: CapabilityDisagreement[] = []
+	for (const ceiling of ceilings) {
+		if (ceiling.value >= largest.value) continue
+		const has = members[largest.index]
+		const lacks = members[ceiling.index]
+		if (!has || !lacks) continue
+		out.push({
+			declaredBy: largest.index,
+			missingFrom: ceiling.index,
+			sentence:
+				`${describe(ceiling.index, lacks)} declares a maximum output of ${ceiling.value} tokens, ` +
+				`below ${describe(largest.index, has)} at ${largest.value} — ` +
+				`if the chain falls over to it, replies are capped at ${ceiling.value}.`,
+		})
+	}
+	return out
+}
+
+/** Members whose declarations could not be established, with the reason. */
+export function unresolvedMembers(
+	members: readonly ProviderChoice[],
+	resolved: readonly MemberCapabilities[],
+): readonly string[] {
+	const out: string[] = []
+	for (const [index, entry] of resolved.entries()) {
+		const member = members[index]
+		if (entry.kind !== 'unresolved' || !member) continue
+		out.push(`${describe(index, member)}: ${entry.reason}`)
+	}
+	return out
+}
+
+/**
+ * The refusal an operator reads, or null when the chain agrees.
+ *
+ * Every disagreement is named, not just the first: an operator who fixes the one
+ * sentence they were shown and is refused again for the next has been made to
+ * discover their own configuration one round-trip at a time.
+ */
+export function describeCapabilityRefusal(
+	disagreements: readonly CapabilityDisagreement[],
+): string | null {
+	if (disagreements.length === 0) return null
+	return [
+		'The providers in your chain declare different capabilities, so namzu cannot honour the chain as written:',
+		...disagreements.map((d) => `  - ${d.sentence}`),
+		'',
+		'Taking the strongest answer would advertise abilities a fallback does not have. Taking the weakest would cost your primary a capability on every run, to guard against a failure that happens rarely. Neither is chosen for you.',
+		'Either drop the member that disagrees, or set "allowCapabilityMismatch": true in ~/.namzu/preferences.json to accept the limitation — it is printed on every launch.',
+	].join('\n')
+}
+
+/** The same disagreements, worded for an operator who has already accepted them. */
+export function describeAcceptedMismatch(
+	disagreements: readonly CapabilityDisagreement[],
+): string | null {
+	if (disagreements.length === 0) return null
+	return [
+		'Provider chain: the members declare different capabilities, and you have accepted that.',
+		...disagreements.map((d) => `  - ${d.sentence}`),
+	].join('\n')
+}

--- a/packages/cli/src/integrations/providers/index.ts
+++ b/packages/cli/src/integrations/providers/index.ts
@@ -16,6 +16,15 @@ export {
 	refreshAgentOAuthToken,
 } from './oauth.js'
 export {
+	type CapabilityDisagreement,
+	chainCapabilityDisagreements,
+	describeAcceptedMismatch,
+	describeCapabilityRefusal,
+	type MemberCapabilities,
+	unresolvedMembers,
+} from './chain-capabilities.js'
+export {
+	chainPositionName,
 	type Preferences,
 	PREFERENCES_FILE_VERSION,
 	PreferencesError,

--- a/packages/cli/src/integrations/providers/preferences.ts
+++ b/packages/cli/src/integrations/providers/preferences.ts
@@ -70,7 +70,33 @@ export interface Preferences {
 	 * looking like a configured one.
 	 */
 	readonly providers: readonly ProviderChoice[]
+	/**
+	 * The operator has accepted a chain whose members declare different
+	 * capabilities.
+	 *
+	 * Absent (the default), such a chain is REFUSED with the disagreement named.
+	 * Taking the strongest declaration would advertise abilities a fallback does
+	 * not have; taking the weakest would cost the primary a capability on every
+	 * run to guard against a rare failure. Neither is chosen on the operator's
+	 * behalf.
+	 *
+	 * Set, the chain runs and the disagreement is printed on every launch — not
+	 * once. An acceptance given once and then forgotten is how a silent
+	 * degradation comes back through the front door.
+	 */
+	readonly allowCapabilityMismatch?: boolean
 	readonly subagents?: { readonly active: readonly string[] }
+}
+
+/**
+ * How a member is named to the operator, by position.
+ *
+ * One function because three surfaces say it — validation, the doctor listing
+ * and the capability refusal — and a chain member called `fallback #1` in one
+ * message and `fallback 1` in the next reads as two different things.
+ */
+export function chainPositionName(index: number): string {
+	return index === 0 ? 'primary provider' : `fallback #${index}`
 }
 
 export type ReadResult =
@@ -229,7 +255,7 @@ function describeInvalidChain(members: readonly ProviderChoice[]): string | null
 	}
 	const seen = new Set<string>()
 	for (const [index, member] of members.entries()) {
-		const position = index === 0 ? 'primary provider' : `fallback #${index}`
+		const position = chainPositionName(index)
 		if (!(member.id in PROVIDER_REGISTRY)) {
 			return `${position} "${member.id}" is not a provider namzu knows (known: ${Object.keys(PROVIDER_REGISTRY).join(', ')})`
 		}
@@ -275,6 +301,9 @@ function isPreferences(value: unknown): value is Preferences {
 	if (!Array.isArray(v.providers)) return false
 	for (const member of v.providers) {
 		if (!isProviderChoice(member)) return false
+	}
+	if (v.allowCapabilityMismatch !== undefined && typeof v.allowCapabilityMismatch !== 'boolean') {
+		return false
 	}
 	if (!isSubagents(v.subagents)) return false
 	return true

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -231,6 +231,12 @@ export function App({ ctx }: AppProps) {
 					'system',
 					`Connected to ${s.providerSummary}${s.modelSummary ? ` · ${s.modelSummary}` : ''} · ${s.toolNames.length} tools`,
 				)
+				// Before the rest: a limitation the operator accepted once and has
+				// been living with since is the thing they are least likely to
+				// remember and most likely to be surprised by.
+				for (const notice of s.configNotices) {
+					pushMessage('system', notice)
+				}
 				// Named, not counted. "2 files" tells a user their conventions were
 				// found but not WHICH ones, and the interesting case is the one
 				// they did not expect — an instructions file in a parent directory

--- a/packages/cli/src/tui/__fixtures__/agent-session.ts
+++ b/packages/cli/src/tui/__fixtures__/agent-session.ts
@@ -46,6 +46,9 @@ export function fakeAgentSession(overrides: Partial<AgentSession> = {}): AgentSe
 		mcpConnected: [],
 		mcpFailed: [],
 		agentIds: [],
+		// A healthy single-provider chain has nothing to report, which is the
+		// ordinary production state this fixture is meant to resemble.
+		configNotices: [],
 		send: (_messages: readonly Message[], _opts?: SendOptions): AsyncIterable<AgentEvent> =>
 			(async function* () {
 				yield { kind: 'done', stopReason: 'end_turn' } as AgentEvent

--- a/packages/cli/src/tui/__tests__/chain-capability-refusal.test.ts
+++ b/packages/cli/src/tui/__tests__/chain-capability-refusal.test.ts
@@ -1,0 +1,111 @@
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createAgentSession } from '../agent.js'
+
+/**
+ * The comparison itself is proven in
+ * `integrations/providers/__tests__/chain-capabilities.test.ts`. What is proven
+ * HERE is the hop from a session to that comparison — a helper that is correct
+ * and never called refuses nothing
+ * (`docs/conventions/reachability-is-its-own-property.md`).
+ *
+ * These drive the real registry and the real driver declarations, deliberately.
+ * A stub declaring a synthetic mismatch would pass against a `createAgentSession`
+ * that never looked at the chain at all.
+ */
+
+const detectedAnthropic = [
+	{
+		entry: {
+			id: 'anthropic',
+			label: 'Anthropic',
+			defaultModel: 'a-model',
+			requiresApiKey: true,
+			envVars: ['ANTHROPIC_API_KEY'],
+		},
+		source: { kind: 'env', envName: 'ANTHROPIC_API_KEY' },
+		apiKey: 'not-a-real-key',
+		alternatives: [],
+	},
+] as never
+
+const open: { close: () => Promise<void> }[] = []
+
+afterEach(async () => {
+	for (const session of open.splice(0)) await session.close()
+})
+
+function cwd(): string {
+	return mkdtempSync(join(tmpdir(), 'namzu-caps-'))
+}
+
+async function session(prefs: unknown) {
+	const s = await createAgentSession(prefs as never, detectedAnthropic, { cwd: cwd() })
+	open.push(s)
+	return s
+}
+
+describe('a chain whose providers disagree', () => {
+	it('is refused, and the refusal reaches the operator', async () => {
+		// The pairing an operator would most naturally build: a cloud primary
+		// with a local fallback. Those two genuinely disagree about tools, which
+		// is why this needs no synthetic capability set.
+		const s = await session({ version: 3, providers: [{ id: 'anthropic' }, { id: 'ollama' }] })
+
+		expect(s.hasProvider).toBe(false)
+		const hint = s.errorHint ?? ''
+		expect(hint).toContain('fallback #1')
+		expect(hint).toContain('primary provider')
+		expect(hint).toContain('cannot call tools')
+		expect(hint).toContain('allowCapabilityMismatch')
+	})
+
+	it('starts when the operator has accepted it, and says so', async () => {
+		const s = await session({
+			version: 3,
+			providers: [{ id: 'anthropic' }, { id: 'ollama' }],
+			allowCapabilityMismatch: true,
+		})
+
+		expect(s.hasProvider).toBe(true)
+		const notices = s.configNotices.join('\n')
+		expect(notices).toContain('you have accepted that')
+		expect(notices).toContain('cannot call tools')
+	})
+})
+
+describe('a chain whose providers agree', () => {
+	it('starts with nothing to report', async () => {
+		const s = await session({ version: 3, providers: [{ id: 'anthropic' }] })
+
+		expect(s.hasProvider).toBe(true)
+		// The case that keeps the refusal honest: a single-provider setup, which
+		// is what almost everyone has, must gain no new noise from this.
+		expect(s.configNotices).toEqual([])
+	})
+
+	it('starts for two providers that declare the same abilities', async () => {
+		const s = await session({ version: 3, providers: [{ id: 'anthropic' }, { id: 'openai' }] })
+
+		expect(s.hasProvider).toBe(true)
+		expect(s.configNotices).toEqual([])
+	})
+})
+
+describe('a member whose declaration cannot be read', () => {
+	it('does not refuse the chain, and is reported rather than assumed fine', async () => {
+		// `bedrock` is in the registry and has no construction path yet
+		// (cogitave/namzu#257), so its declaration cannot be established here.
+		// That is not a disagreement, and refusing over it would fail a chain on
+		// a question that was never answered.
+		const s = await session({ version: 3, providers: [{ id: 'anthropic' }, { id: 'bedrock' }] })
+
+		expect(s.hasProvider).toBe(true)
+		const notices = s.configNotices.join('\n')
+		expect(notices).toContain('could not be established')
+		expect(notices).toContain('fallback #1')
+	})
+})

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -45,6 +45,7 @@ import {
 	buildMemoryTools,
 	getBuiltinTools,
 	query,
+	resolveProviderCapabilities,
 } from '@namzu/sdk'
 
 import { join } from 'node:path'
@@ -58,9 +59,14 @@ import {
 } from '../integrations/mcp/servers.js'
 import {
 	type DetectedProvider,
+	type MemberCapabilities,
 	PROVIDER_REGISTRY,
 	type Preferences,
+	type ProviderChoice,
 	type ProviderId,
+	chainCapabilityDisagreements,
+	describeAcceptedMismatch,
+	describeCapabilityRefusal,
 	discoverProviders,
 	ensureFreshAnthropicToken,
 	findDetected,
@@ -68,6 +74,7 @@ import {
 	primaryProvider,
 	readAgentKeychainCredential,
 	readPreferences,
+	unresolvedMembers,
 } from '../integrations/providers/index.js'
 import { createSubagentRuntime } from '../integrations/subagents/runtime.js'
 import { composeMemoryPrompt, readMemory } from '../memory/store.js'
@@ -231,6 +238,18 @@ export interface AgentSession {
 	 * the runtime to find out.
 	 */
 	readonly agentIds: readonly string[]
+	/**
+	 * Things about this session's configuration the operator must be told, every
+	 * launch — today, an accepted capability disagreement in the provider chain,
+	 * and any member whose declaration could not be read.
+	 *
+	 * Every launch rather than once, because that is what the acceptance is worth
+	 * checking against: an operator who set the flag months ago and forgot has a
+	 * chain that will quietly do less than they think, which is precisely the
+	 * outcome the refusal exists to prevent. A notice shown once is a notice not
+	 * shown.
+	 */
+	readonly configNotices: readonly string[]
 	send(messages: readonly Message[], opts?: SendOptions): AsyncIterable<AgentEvent>
 	/**
 	 * Release what the session holds — today, the external tool servers.
@@ -400,6 +419,21 @@ export async function createAgentSession(
 	} catch (err) {
 		return emptySession(err instanceof Error ? err.message : String(err))
 	}
+
+	// Does the chain agree with itself about what it can do? Asked before the
+	// session exists, because the answer decides whether there should be one.
+	const resolvedCapabilities = await resolveChainCapabilities(prefs.providers)
+	const disagreements = chainCapabilityDisagreements(prefs.providers, resolvedCapabilities)
+	if (disagreements.length > 0 && prefs.allowCapabilityMismatch !== true) {
+		const refusal = describeCapabilityRefusal(disagreements)
+		if (refusal) return emptySession(refusal)
+	}
+	const capabilityNotice = disagreements.length > 0 ? describeAcceptedMismatch(disagreements) : null
+	// Not folded into the refusal: a member whose declaration could not be read
+	// is not a disagreement, and reporting it as one would refuse a chain over a
+	// question that was never answered.
+	const unresolvedNotice = unresolvedMembers(prefs.providers, resolvedCapabilities)
+
 	const model = primary.model ?? entry.defaultModel
 	let provider: LLMProvider
 	try {
@@ -536,6 +570,12 @@ export async function createAgentSession(
 		skippedInstructionFiles: projectInstructions.skipped,
 		mcpConnected: mcp.connected,
 		mcpFailed: mcp.failed,
+		configNotices: [
+			...(capabilityNotice ? [capabilityNotice] : []),
+			...unresolvedNotice.map(
+				(line) => `Provider chain: capabilities could not be established for ${line}.`,
+			),
+		],
 		close: () => mcp.close(),
 		errorHint: null,
 		send: async function* (messages, opts) {
@@ -587,6 +627,45 @@ export async function createAgentSession(
 			})
 		},
 	}
+}
+
+/**
+ * What each member of the chain DECLARES it can do.
+ *
+ * Type-level, via the registry, so nothing is constructed and no credential is
+ * needed — which is the whole point: the member most worth checking is the
+ * fallback nobody has set up yet, and a check that demanded a key would be
+ * unusable in exactly that case.
+ *
+ * A member that cannot be registered is reported as unresolved rather than
+ * assumed to agree. Registration is also why this cannot be a pure function:
+ * a provider package is only imported when something needs it.
+ */
+async function resolveChainCapabilities(
+	members: readonly ProviderChoice[],
+): Promise<readonly MemberCapabilities[]> {
+	const out: MemberCapabilities[] = []
+	for (const member of members) {
+		if (!(member.id in PROVIDER_REGISTRY)) {
+			out.push({ kind: 'unresolved', reason: `"${member.id}" is not a provider namzu knows` })
+			continue
+		}
+		try {
+			await ensureRegistered(member.id)
+			out.push({
+				kind: 'known',
+				capabilities: resolveProviderCapabilities({
+					capabilities: ProviderRegistry.getCapabilities(member.id),
+				}),
+			})
+		} catch (err) {
+			out.push({
+				kind: 'unresolved',
+				reason: err instanceof Error ? err.message : String(err),
+			})
+		}
+	}
+	return out
 }
 
 function constructProvider(
@@ -1329,6 +1408,8 @@ function emptySession(errorHint: string): AgentSession {
 		skippedInstructionFiles: [],
 		mcpConnected: [],
 		mcpFailed: [],
+		// Nothing ran, so there is no configuration in force to report on.
+		configNotices: [],
 		errorHint,
 		send: async function* () {
 			yield { kind: 'error' as const, message: errorHint }


### PR DESCRIPTION
Second of three. #259 gave the operator an ordered chain; this decides what happens when the members of that chain do not agree about what they can do.

## Why refusing, and not intersecting

Capabilities are negotiated **once per run**, against the provider the runtime was handed (`query/index.ts`), and that one answer decides whether tool surfaces go into the prompt and whether image and document attachments are mapped. A chain whose members disagree cannot be honoured by taking the strongest declaration: a run that fell over to a weaker member would arrive holding a request shaped for a provider that is no longer serving it — tools advertised that cannot be called, images the driver will not map.

Nor by taking the weakest, and that is the trap this exists to refuse. An operator who adds a weaker fallback **to gain resilience** would find their *primary* had quietly lost tool support — on every run, permanently, to guard against a failure that happens rarely, with nothing saying so. A capability given up for good in exchange for a rare benefit is a worse outcome than the failure it prevents.

So neither is chosen for them.

## What the operator sees

```
The providers in your chain declare different capabilities, so namzu cannot honour the chain as written:
  - fallback #1 (<label>) declares it cannot call tools, while primary provider (<label>) declares it can call tools — if the chain falls over to it, tools become unavailable.
```

Which two members, and on what. "Capability mismatch" would have someone reordering things at random; this is fixable in a line. **Every** disagreeing capability is listed, not just the first, so the configuration is repaired in one pass rather than one round-trip at a time.

`"allowCapabilityMismatch": true` accepts the limitation. The chain then runs and the disagreement is printed on **every** launch — the TUI, `namzu run`, and a new `notice` event on `namzu run-stream`. Not once. An acceptance given months ago and forgotten is exactly how a silent degradation returns through the front door.

## This is live, not theoretical

The four wired providers genuinely disagree. The most natural chain anyone would build — a cloud primary with a local fallback — differs on tools, function calling, vision **and** documents. A fallback that cannot call tools is not a fallback for an agent run. Verified against the real binary before a test was written.

## Two things the check says about itself

A check that overstates its authority is how someone later finds the runtime disagreed with it and stops believing it. So both limits are in the messages themselves:

- It compares **declarations**, at the type level. That is what is knowable without constructing a provider — and constructing one needs a credential, which is exactly what the fallback nobody has set up yet does not have. A check that demanded a key would be unusable in the case it is for. The runtime treats a constructed provider's own declaration as authoritative, so every sentence says "declares".
- It says nothing about **this run**. Only the primary runs today, so its capabilities are in force in full; each sentence is about what happens *if the chain falls over*. The original plan here was to print the resulting intersection at startup — that would have been a confident claim about a degradation that has not happened, which is the defect class this whole line of work removes. When failover lands the run-level statement becomes true and can be made then.

A member whose declaration cannot be read — a provider with no construction path yet, #257 — is reported as unresolved rather than assumed to agree. An unanswered question is not a passing check, and refusing a chain over one would fail it for something never established.

## Verification

- `pnpm typecheck`, `pnpm test` (547 CLI tests), `pnpm lint`, `pnpm docs:check` all pass; name audit clean.
- **9 mutations, all killed**: an unresolved member counting as agreement, only the first disagreement reported, ceilings ignored, an equal ceiling reported as a disagreement, the refusal dropping its escape hatch, the chain never checked at session start, the accepted notice never surfaced, the opt-in ignored, and an unreadable member silently dropped.
- The reachability test drives the **real** registry and the real driver declarations. A stub declaring a synthetic mismatch would pass against a `createAgentSession` that never looked at the chain at all.

## Notes

- **A `ceilings.length < 2` guard survived its mutation, correctly.** The comparison below it already skips a lone ceiling, since it is its own largest — the guard could not change any answer, which makes it [a check that cannot fail](docs/conventions/a-check-that-cannot-fail.md). Replaced with the narrowing the type system actually requires, and the reason left in source so it is not reintroduced as tidiness.
- **`run-stream` gained a `notice` event kind.** Unplanned. "Printed on every launch" that reached only the TUI would miss the one caller with no human watching. Its own kind rather than an `error`, because the run proceeds and a host treating it as a failure would be wrong.
- **The doctor check does not report disagreements.** Reading them needs provider registration, which lives in `tui/agent.ts`; importing that into the doctor would pull the whole session module in against the dependency direction. Headless callers still get the refusal, because `namzu run` goes through `createAgentSession`. Left for a later change rather than forced.

Single-provider setups are unaffected and gain no new output.

https://claude.ai/code/session_01RppSzAoxqCxKfD4fLYmnzs
