### PR TITLE
fix(cli): Enter is not consent at the permission prompt

### DIFF
--- a/.changeset/enter-is-not-consent.md
+++ b/.changeset/enter-is-not-consent.md
@@ -1,0 +1,34 @@
+---
+'@namzu/cli': major
+---
+
+Enter no longer approves a tool-permission prompt
+
+**Press `y` to approve.** `Enter` now decides nothing at the permission
+overlay. If you approve by reflex with `Enter`, that reflex has to change — this
+is the whole of the break, and it is deliberate.
+
+The prompt appears on the agent's schedule, not yours. The composer stays
+editable while a turn runs, and the docs encourage typing a follow-up there, so
+the overlay can take the screen while your hands are mid-sentence in the
+composer behind it. `Enter` is the key most likely to be already in flight at
+that moment — it is how you send the message you were typing — and it was wired
+to the approving branch. The result was that the keystroke sending your
+follow-up could approve a tool call you had not read. Approving is the one
+decision at this prompt that cannot be undone, so it should not be reachable by
+the key people press to dismiss whatever just appeared.
+
+`Enter` was named as an approval in `docs/cli/tools.md` and nowhere else: not on
+the overlay, not in the status hint. The overlay now names every key that
+decides it — `y` approve, `n` / `esc` reject, `a` approve all — and names no key
+that does not.
+
+Two smaller changes come with it:
+
+- **An approving key is ignored for 350ms after the prompt opens.** `y` and `a`
+  are ordinary letters, so someone mid-word when the overlay mounts was one
+  keystroke from approving. Refusal is never deferred: `n`, `Esc` and `Ctrl+C`
+  answer on the first press, because a refusal you did not mean costs a retry
+  and an approval you did not mean costs whatever the tool did.
+- **`Esc` is now advertised on the overlay.** It always rejected; it said so
+  nowhere.

--- a/docs/cli/tools.md
+++ b/docs/cli/tools.md
@@ -128,11 +128,24 @@ An unrecognized tool is treated as needing consent. That direction is deliberate
 
 | Key | Decision |
 | --- | --- |
-| `y` (or `Enter`) | Approve this batch. |
+| `y` | Approve this batch. |
 | `n` (or `Esc`) | Reject — the model is told you declined and can adapt. |
 | `a` | Approve this and everything else for the rest of the session. |
 
 `Ctrl+C` at the prompt rejects and aborts the turn.
+
+**`Enter` does not approve.** It used to, and it no longer does. The prompt
+arrives on the agent's schedule rather than yours: the composer stays editable
+while a turn runs, so the overlay can replace a composer you are part-way
+through typing into, and `Enter` is the key most likely to be already on its way
+when that happens. Approving is the one decision here that cannot be taken back,
+so it is not reachable by the key people press to dismiss things.
+
+For the same reason an approving key (`y`, `a`) is ignored for a beat after the
+prompt opens, so a keystroke aimed at the composer behind it cannot land on it.
+Rejecting is never deferred — `n`, `Esc` and `Ctrl+C` answer on the first press,
+because a refusal you did not mean costs a retry while an approval you did not
+mean costs whatever the tool did.
 
 ## The safety gate
 

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -40,6 +40,7 @@ import {
 	NAMZU_WORDMARK_MIN_WIDTH,
 } from './logo.js'
 import { PermissionOverlay } from './PermissionOverlay.js'
+import { approvalIsDeliberate } from './permission-timing.js'
 import { Picker } from './Picker.js'
 import { type ContextFill, StatusBar } from './StatusBar.js'
 import { Transcript } from './Transcript.js'
@@ -130,6 +131,14 @@ export function App({ ctx }: AppProps) {
 		setActiveTools([])
 	}, [])
 	const permissionResolveRef = useRef<((d: PermissionDecision) => void) | null>(null)
+	/**
+	 * When the pending prompt took the screen, or `null` with none open.
+	 *
+	 * A ref rather than state because the keypress handler reads it in the same
+	 * tick the prompt opens, before any re-render could carry a new value — see
+	 * `permission-timing.ts` for why an approving key has to wait on this.
+	 */
+	const permissionOpenedAtRef = useRef<number | null>(null)
 	// SDK-backed conversation persistence (DiskSessionStore). `scopeRef` carries
 	// the active session id used by query() — mutated in place on /resume so new
 	// turns attribute to the resumed conversation.
@@ -399,6 +408,7 @@ export function App({ ctx }: AppProps) {
 	const resolvePermission = useCallback((decision: PermissionDecision) => {
 		const resolve = permissionResolveRef.current
 		permissionResolveRef.current = null
+		permissionOpenedAtRef.current = null
 		setPermission(null)
 		if (resolve) resolve(decision)
 	}, [])
@@ -409,6 +419,7 @@ export function App({ ctx }: AppProps) {
 		(req: PermissionRequest) =>
 			new Promise<PermissionDecision>((resolve) => {
 				permissionResolveRef.current = resolve
+				permissionOpenedAtRef.current = Date.now()
 				setPermission(req)
 				setState('awaiting-permission')
 			}),
@@ -583,6 +594,7 @@ export function App({ ctx }: AppProps) {
 			} finally {
 				abortRef.current = null
 				permissionResolveRef.current = null
+				permissionOpenedAtRef.current = null
 				setPermission(null)
 				clearActiveTools()
 				setState('idle')
@@ -819,14 +831,26 @@ export function App({ ctx }: AppProps) {
 			// A pending permission prompt owns the keyboard: y/n/a decide it.
 			if (permissionResolveRef.current) {
 				const ch = input.toLowerCase()
-				if (key.ctrl && (input === 'c' || input === '\x03')) {
+				// Refusing is never deferred or gated — it is the direction a
+				// mistake is recoverable in, so it answers on the first press.
+				if (key.ctrl && input === 'c') {
 					resolvePermission({ kind: 'reject', feedback: 'User interrupted.' })
 					abortRef.current?.abort()
 					return
 				}
-				if (ch === 'y' || key.return) resolvePermission({ kind: 'approve' })
+				if (ch === 'n' || key.escape) {
+					resolvePermission({ kind: 'reject' })
+					return
+				}
+				// Enter is deliberately NOT an approval. It is the key people press
+				// to dismiss a thing that appeared, it is the key already in flight
+				// when a turn's follow-up was being typed, and it is named nowhere
+				// on this prompt — so reading it as consent approves a tool call the
+				// operator never looked at. `y` and `a` are the only approvals, and
+				// they must arrive after the prompt has been up long enough to read.
+				if (!approvalIsDeliberate(permissionOpenedAtRef.current, Date.now())) return
+				if (ch === 'y') resolvePermission({ kind: 'approve' })
 				else if (ch === 'a') resolvePermission({ kind: 'approve-all' })
-				else if (ch === 'n' || key.escape) resolvePermission({ kind: 'reject' })
 				return
 			}
 			// Esc interrupts a running turn (Ctrl+C stays reserved for exit). Mirrors
@@ -843,7 +867,7 @@ export function App({ ctx }: AppProps) {
 				setExpanded((e) => !e)
 				return
 			}
-			if (key.ctrl && (input === 'c' || input === '\x03')) {
+			if (key.ctrl && input === 'c') {
 				// A turn is running → first Ctrl+C interrupts it, not exits.
 				if (abortRef.current) {
 					abortRef.current.abort()
@@ -1081,7 +1105,9 @@ function hintForPhase(
 	if (phase === 'probing') return 'discovering providers…'
 	if (phase === 'picker') return '↑↓ navigate · enter accept · esc cancel'
 	if (phase === 'unhealthy') return 'Ctrl+C ×2 to exit'
-	if (state === 'awaiting-permission') return 'y approve · n reject · a approve all'
+	// Enter is absent because Enter decides nothing here, deliberately — see the
+	// permission gate in the key handler above.
+	if (state === 'awaiting-permission') return 'y approve · n / esc reject · a approve all'
 	if (state !== 'idle') return 'agent is working — esc to interrupt'
 	return '/help · @file / Ctrl+V to attach · Ctrl+C ×2 to exit'
 }

--- a/packages/cli/src/tui/PermissionOverlay.tsx
+++ b/packages/cli/src/tui/PermissionOverlay.tsx
@@ -69,7 +69,11 @@ export function PermissionOverlay({ toolCalls }: PermissionOverlayProps) {
 					<Text color={theme.accent.user} bold>
 						a
 					</Text>{' '}
-					approve all for this session
+					approve all for this session ·{' '}
+					<Text color={theme.status.error} bold>
+						esc
+					</Text>{' '}
+					reject
 				</Text>
 			</Box>
 		</Box>

--- a/packages/cli/src/tui/__tests__/app-permission-keys.test.tsx
+++ b/packages/cli/src/tui/__tests__/app-permission-keys.test.tsx
@@ -19,7 +19,7 @@
  */
 
 import { render } from 'ink-testing-library'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { Preferences } from '../../integrations/providers/index.js'
 import type { AgentEvent, AgentSession, PermissionDecision, PermissionRequest } from '../agent.js'
@@ -30,8 +30,23 @@ const PREFS: Preferences = { version: 3, providers: [{ id: 'openai' }], subagent
 
 /** Decisions the fake session was given, in order. */
 const decisions: PermissionDecision[] = []
-/** Resolves once the agent has asked and the overlay is up. */
-let asked!: Promise<void>
+
+/**
+ * The clock the settle window is measured against, driven by the test.
+ *
+ * `Date.now` is stubbed rather than waited on. The window is 350ms of REAL
+ * time, and an earlier version of this file simply raced it — writing the key
+ * quickly and trusting the harness to get there first. That made the result a
+ * function of how loaded the machine was: the suite transforms TypeScript on
+ * the way in, and a slow run drifted past 350ms and flipped a passing
+ * assertion to a failing one with nothing about the code changed. The repo has
+ * met this cliff before; `vitest.config.ts` is entirely about the last time.
+ *
+ * Stubbing the clock makes "before the window" and "after the window" exact.
+ * Real timers still drive Ink's own rendering, because `setTimeout` does not
+ * consult `Date.now` — so only the quantity under test becomes deterministic.
+ */
+let nowMs = 1_000_000
 
 vi.mock('../../integrations/trust/store.js', () => ({
 	isTrusted: () => true,
@@ -39,7 +54,7 @@ vi.mock('../../integrations/trust/store.js', () => ({
 }))
 
 vi.mock('../../integrations/updates.js', () => ({
-	checkUpdates: async () => null,
+	checkUpdates: async () => [],
 }))
 
 vi.mock('../../integrations/sessions/store.js', () => ({
@@ -101,6 +116,27 @@ const ctx: TuiContext = { cwd: process.cwd(), version: '0.0.0-test' }
 const tick = (ms = 40) => new Promise((r) => setTimeout(r, ms))
 
 /**
+ * Wait until a decision lands, or give up after `timeoutMs`.
+ *
+ * Polling rather than one fixed sleep, because the two are not
+ * interchangeable here. A bare `\x1B` is the prefix of every arrow and function
+ * key, so an input parser holds it briefly to see whether more follows, and
+ * under a loaded parallel run that hold stretches. A fixed 60ms wait passed
+ * this file alone and failed inside the full suite — the same load cliff
+ * `vitest.config.ts` documents, arrived at from a different direction.
+ *
+ * Absence cannot be polled for, so the tests asserting that NOTHING was decided
+ * still wait a fixed, generous interval. That asymmetry is inherent: proving a
+ * decision happened only needs enough time, proving one did not needs all of it.
+ */
+async function decisionSettles(timeoutMs = 3_000): Promise<void> {
+	const started = performance.now()
+	while (decisions.length === 0 && performance.now() - started < timeoutMs) {
+		await tick(20)
+	}
+}
+
+/**
  * Render, reach a running turn, type a draft, and stop with the prompt open.
  *
  * Returns once the overlay is on screen — every assertion below starts here, so
@@ -108,10 +144,23 @@ const tick = (ms = 40) => new Promise((r) => setTimeout(r, ms))
  */
 async function promptOpenWithDraftInFlight() {
 	const harness = render(<App ctx={ctx} />)
+	// Registered for teardown BEFORE the first assertion below, so an assertion
+	// that throws still gets torn down. Unmounting at the end of each test
+	// instead looks tidier and is a trap: the first failure then leaks a live
+	// Ink instance into the next test, and every following test fails with "the
+	// prompt never opened" — four misleading failures stacked on one real one.
+	// Found while mutation-checking this file, where exactly that happened.
+	mounted.push(harness)
 	// Probe → session → ready.
 	await tick(60)
-	// Start a turn.
-	harness.stdin.write('go\r')
+	// Start a turn. The keys go in separately on purpose: Ink delivers one
+	// `stdin.write` as ONE keypress, so `'go\r'` arrives as a single event whose
+	// `input` is the whole string and whose `key.return` is false — the
+	// composer takes it as pasted text and nothing is ever submitted. A test
+	// that batched them would sit there asserting against a turn that never ran.
+	harness.stdin.write('go')
+	await tick(20)
+	harness.stdin.write('\r')
 	await tick(40)
 	// The follow-up the operator is part-way through typing while it runs.
 	harness.stdin.write('and then deploy')
@@ -120,66 +169,84 @@ async function promptOpenWithDraftInFlight() {
 	return harness
 }
 
+/** Harnesses to tear down, whatever the test did. */
+const mounted: { unmount: () => void }[] = []
+
 beforeEach(() => {
 	decisions.length = 0
-	asked = Promise.resolve()
-	void asked
+	nowMs = 1_000_000
+	vi.spyOn(Date, 'now').mockImplementation(() => nowMs)
 })
 
+afterEach(() => {
+	for (const h of mounted) h.unmount()
+	mounted.length = 0
+	vi.restoreAllMocks()
+})
+
+/** Move the stubbed clock past the settle window. */
+function settle(): void {
+	nowMs += APPROVAL_SETTLE_MS + 1
+}
+
 describe('the permission prompt', () => {
-	it('does not approve on Enter', async () => {
+	it('does not approve on Enter, even once the prompt has settled', async () => {
 		// The heart of it. Enter is the key that submits the draft the operator
 		// was typing, it is in flight exactly when the overlay appears, and it is
 		// named on no screen — so it must decide nothing here.
-		const { stdin, lastFrame, unmount } = await promptOpenWithDraftInFlight()
+		//
+		// The wait is what gives this test its teeth. Pressing Enter immediately
+		// proves nothing: the settle window would swallow it whether or not the
+		// approving branch still read `key.return`, and an earlier draft of this
+		// test passed with the defect restored for exactly that reason. Waiting
+		// past the window leaves the binding as the only thing that can decide
+		// it — `y` at this same moment approves, one test down.
+		const { stdin, lastFrame } = await promptOpenWithDraftInFlight()
 
+		settle()
 		stdin.write('\r')
-		await tick(60)
+		await tick(400)
 
 		expect(decisions, 'Enter decided the prompt').toEqual([])
 		expect(lastFrame(), 'the prompt closed without a decision').toContain('wants to run')
-		unmount()
 	})
 
 	it('ignores an approving key that arrives before the prompt can have been read', async () => {
 		// `y` is an ordinary letter. Someone mid-word when the overlay mounts is
 		// one keystroke from approving a call they have not seen.
-		const { stdin, unmount } = await promptOpenWithDraftInFlight()
+		const { stdin } = await promptOpenWithDraftInFlight()
 
 		stdin.write('y')
-		await tick(60)
+		await tick(400)
 
 		expect(decisions, 'an immediate y approved').toEqual([])
-		unmount()
 	})
 
 	it('approves on y once the prompt has been up long enough to read', async () => {
 		// The other half: the guard must not make the advertised key inert. A
 		// deferred approval that never arrives is its own defect.
-		const { stdin, unmount } = await promptOpenWithDraftInFlight()
+		const { stdin } = await promptOpenWithDraftInFlight()
 
-		await tick(APPROVAL_SETTLE_MS + 60)
+		settle()
 		stdin.write('y')
-		await tick(60)
+		await decisionSettles()
 
 		expect(decisions).toEqual([{ kind: 'approve' }])
-		unmount()
 	})
 
 	it('rejects on esc immediately, without waiting out the guard', async () => {
 		// Refusal is not deferred: it is the recoverable direction, and a reject
 		// key that ignored the first press would read as a frozen prompt.
-		const { stdin, unmount } = await promptOpenWithDraftInFlight()
+		const { stdin } = await promptOpenWithDraftInFlight()
 
 		stdin.write('\x1B')
-		await tick(60)
+		await decisionSettles()
 
 		expect(decisions).toEqual([{ kind: 'reject' }])
-		unmount()
 	})
 
 	it('names every key that decides it, and no key that does not', async () => {
-		const { lastFrame, unmount } = await promptOpenWithDraftInFlight()
+		const { lastFrame } = await promptOpenWithDraftInFlight()
 		const frame = lastFrame() ?? ''
 
 		expect(frame).toContain('y')
@@ -189,6 +256,5 @@ describe('the permission prompt', () => {
 		// The advertisement is the contract the handler is held to. `enter` must
 		// not appear, because Enter no longer does anything here.
 		expect(frame.toLowerCase()).not.toContain('enter')
-		unmount()
 	})
 })

--- a/packages/cli/src/tui/__tests__/app-permission-keys.test.tsx
+++ b/packages/cli/src/tui/__tests__/app-permission-keys.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * What decides an open permission prompt — asserted against a rendered `<App>`.
+ *
+ * This is the first harness that mounts the root component. Everything in
+ * `App.tsx`'s key handler was previously unreachable from a test: both existing
+ * Ink harnesses render `<Picker>`, so the Ctrl+C ladder, the Esc-interrupt and
+ * this prompt had no coverage at all. That gap is why `Ctrl+O` shipped inert and
+ * why Enter could approve a tool call while being named on no screen.
+ *
+ * The scenario is the real one rather than a convenient one: a turn is running,
+ * the operator is typing a follow-up into the composer (which stays live while
+ * the agent works, and which the docs encourage using that way), and the agent
+ * asks to run a tool. The overlay takes the screen under their hands.
+ *
+ * Not a terminal. This drives Ink's own stdin and reads Ink's own frames, so it
+ * proves which handler ran and what it decided. Real key repeat, real paste
+ * timing, terminal-specific escape sequences and how any of this FEELS at human
+ * speed are outside what a harness can establish.
+ */
+
+import { render } from 'ink-testing-library'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Preferences } from '../../integrations/providers/index.js'
+import type { AgentEvent, AgentSession, PermissionDecision, PermissionRequest } from '../agent.js'
+import { APPROVAL_SETTLE_MS } from '../permission-timing.js'
+import type { TuiContext } from '../types.js'
+
+const PREFS: Preferences = { version: 3, providers: [{ id: 'openai' }], subagents: { active: [] } }
+
+/** Decisions the fake session was given, in order. */
+const decisions: PermissionDecision[] = []
+/** Resolves once the agent has asked and the overlay is up. */
+let asked!: Promise<void>
+
+vi.mock('../../integrations/trust/store.js', () => ({
+	isTrusted: () => true,
+	trustDir: () => {},
+}))
+
+vi.mock('../../integrations/updates.js', () => ({
+	checkUpdates: async () => null,
+}))
+
+vi.mock('../../integrations/sessions/store.js', () => ({
+	openSessions: async () => ({ tenantId: 't' }),
+	startConversation: async () => 'conv',
+	appendMessages: async () => {},
+	listRecent: async () => [],
+	loadConversation: async () => [],
+}))
+
+vi.mock('../../user-commands/store.js', () => ({
+	discoverUserCommands: () => [],
+}))
+
+vi.mock('../agent.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../agent.js')>()
+	return {
+		...actual,
+		probeAgentSession: async () => ({
+			preferences: PREFS,
+			needsRepickReason: null,
+			detected: [],
+		}),
+		createAgentSession: async (): Promise<AgentSession> => ({
+			hasProvider: true,
+			providerSummary: 'a-provider',
+			modelSummary: 'a-model',
+			toolNames: ['bash'],
+			errorHint: null,
+			instructionFiles: [],
+			skippedInstructionFiles: [],
+			mcpConnected: [],
+			mcpFailed: [],
+			agentIds: [],
+			configNotices: [],
+			close: async () => {},
+			// Streams one delta so the composer is live and a draft can be typed,
+			// then asks for permission and parks on the answer — which is exactly
+			// the moment this file is about.
+			send: async function* (_messages, opts): AsyncIterable<AgentEvent> {
+				yield { kind: 'delta', text: 'working' } as AgentEvent
+				await new Promise((r) => setTimeout(r, 30))
+				const req: PermissionRequest = {
+					toolCalls: [
+						{ id: 'call-1', name: 'bash', summary: 'rm -rf build', isDestructive: true },
+					],
+				}
+				const decision = await opts?.onPermission?.(req)
+				if (decision) decisions.push(decision)
+			},
+		}),
+	}
+})
+
+const { App } = await import('../App.js')
+
+const ctx: TuiContext = { cwd: process.cwd(), version: '0.0.0-test' }
+
+const tick = (ms = 40) => new Promise((r) => setTimeout(r, ms))
+
+/**
+ * Render, reach a running turn, type a draft, and stop with the prompt open.
+ *
+ * Returns once the overlay is on screen — every assertion below starts here, so
+ * the setup is shared rather than restated with slightly different waits.
+ */
+async function promptOpenWithDraftInFlight() {
+	const harness = render(<App ctx={ctx} />)
+	// Probe → session → ready.
+	await tick(60)
+	// Start a turn.
+	harness.stdin.write('go\r')
+	await tick(40)
+	// The follow-up the operator is part-way through typing while it runs.
+	harness.stdin.write('and then deploy')
+	await tick(40)
+	expect(harness.lastFrame(), 'the prompt never opened').toContain('wants to run')
+	return harness
+}
+
+beforeEach(() => {
+	decisions.length = 0
+	asked = Promise.resolve()
+	void asked
+})
+
+describe('the permission prompt', () => {
+	it('does not approve on Enter', async () => {
+		// The heart of it. Enter is the key that submits the draft the operator
+		// was typing, it is in flight exactly when the overlay appears, and it is
+		// named on no screen — so it must decide nothing here.
+		const { stdin, lastFrame, unmount } = await promptOpenWithDraftInFlight()
+
+		stdin.write('\r')
+		await tick(60)
+
+		expect(decisions, 'Enter decided the prompt').toEqual([])
+		expect(lastFrame(), 'the prompt closed without a decision').toContain('wants to run')
+		unmount()
+	})
+
+	it('ignores an approving key that arrives before the prompt can have been read', async () => {
+		// `y` is an ordinary letter. Someone mid-word when the overlay mounts is
+		// one keystroke from approving a call they have not seen.
+		const { stdin, unmount } = await promptOpenWithDraftInFlight()
+
+		stdin.write('y')
+		await tick(60)
+
+		expect(decisions, 'an immediate y approved').toEqual([])
+		unmount()
+	})
+
+	it('approves on y once the prompt has been up long enough to read', async () => {
+		// The other half: the guard must not make the advertised key inert. A
+		// deferred approval that never arrives is its own defect.
+		const { stdin, unmount } = await promptOpenWithDraftInFlight()
+
+		await tick(APPROVAL_SETTLE_MS + 60)
+		stdin.write('y')
+		await tick(60)
+
+		expect(decisions).toEqual([{ kind: 'approve' }])
+		unmount()
+	})
+
+	it('rejects on esc immediately, without waiting out the guard', async () => {
+		// Refusal is not deferred: it is the recoverable direction, and a reject
+		// key that ignored the first press would read as a frozen prompt.
+		const { stdin, unmount } = await promptOpenWithDraftInFlight()
+
+		stdin.write('\x1B')
+		await tick(60)
+
+		expect(decisions).toEqual([{ kind: 'reject' }])
+		unmount()
+	})
+
+	it('names every key that decides it, and no key that does not', async () => {
+		const { lastFrame, unmount } = await promptOpenWithDraftInFlight()
+		const frame = lastFrame() ?? ''
+
+		expect(frame).toContain('y')
+		expect(frame).toContain('reject')
+		expect(frame).toContain('approve all')
+		expect(frame).toContain('esc')
+		// The advertisement is the contract the handler is held to. `enter` must
+		// not appear, because Enter no longer does anything here.
+		expect(frame.toLowerCase()).not.toContain('enter')
+		unmount()
+	})
+})

--- a/packages/cli/src/tui/permission-timing.test.ts
+++ b/packages/cli/src/tui/permission-timing.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { APPROVAL_SETTLE_MS, approvalIsDeliberate } from './permission-timing.js'
+
+/**
+ * The predicate only. That the permission handler actually consults it — the
+ * part that matters and the part a helper test cannot establish — is pinned in
+ * `__tests__/app-permission-keys.test.tsx` against a rendered `<App>`.
+ */
+describe('approvalIsDeliberate', () => {
+	it('refuses a keypress that arrives with the prompt', () => {
+		const opened = 1_000
+		expect(approvalIsDeliberate(opened, opened)).toBe(false)
+	})
+
+	it('refuses a keypress still inside the settling window', () => {
+		const opened = 1_000
+		expect(approvalIsDeliberate(opened, opened + APPROVAL_SETTLE_MS - 1)).toBe(false)
+	})
+
+	it('accepts one on the boundary and after it', () => {
+		const opened = 1_000
+		expect(approvalIsDeliberate(opened, opened + APPROVAL_SETTLE_MS)).toBe(true)
+		expect(approvalIsDeliberate(opened, opened + 10_000)).toBe(true)
+	})
+
+	it('refuses when no prompt is recorded as open', () => {
+		// The fail-safe direction. `null` means the caller cannot establish that
+		// anything was shown, and "I cannot establish this" is not consent.
+		expect(approvalIsDeliberate(null, 10_000)).toBe(false)
+	})
+})

--- a/packages/cli/src/tui/permission-timing.ts
+++ b/packages/cli/src/tui/permission-timing.ts
@@ -1,0 +1,39 @@
+/**
+ * When an approving keystroke at the permission prompt counts as a decision.
+ *
+ * The prompt takes the screen on the agent's schedule, not the operator's. The
+ * composer stays live while a turn runs and the docs encourage typing a
+ * follow-up there, so the moment the agent asks to run a tool the overlay
+ * replaces a composer someone's hands are already in. A keystroke begun before
+ * that swap was aimed at the composer behind it, and must not be read as
+ * consent for a tool call nobody has had time to read.
+ *
+ * So approval is deferred for a beat after the prompt opens. Refusal is NOT:
+ * rejecting a call the operator wanted costs them a retry, while approving one
+ * they never saw cannot be taken back, and a guard that hesitates in both
+ * directions would make the safe key feel broken to buy nothing.
+ */
+
+/**
+ * How long after the prompt opens an approving key is ignored.
+ *
+ * Long enough to swallow a keystroke already in flight, short enough that
+ * someone who read the prompt and reached for `y` never waits on it. A fast
+ * typist runs near 100ms between characters, so this covers roughly three
+ * characters of overshoot.
+ */
+export const APPROVAL_SETTLE_MS = 350
+
+/**
+ * Whether an approving keypress arriving `now` should decide the prompt that
+ * opened at `openedAt`.
+ *
+ * `null` — no recorded open — is refused rather than allowed. The value exists
+ * only while a prompt is up, so its absence means the caller cannot establish
+ * that the operator has seen anything, and the fail-safe reading of "I cannot
+ * establish this" is not consent.
+ */
+export function approvalIsDeliberate(openedAt: number | null, now: number): boolean {
+	if (openedAt === null) return false
+	return now - openedAt >= APPROVAL_SETTLE_MS
+}


### PR DESCRIPTION
`App.tsx` read `ch === 'y' || key.return` as approval. Enter is the key people press to dismiss whatever just appeared, and at this prompt it authorised a tool call.

## Why this is worse than a bad default

It is about *when* the prompt arrives. The composer stays editable while a turn runs, and `docs/cli/tui.md` actively encourages typing a follow-up there. So the overlay replaces a composer the operator's hands are already in — and Enter is precisely the key in flight at that moment, because it is how the message being typed gets sent. The keystroke that sent a follow-up could approve a tool call nobody had read.

**A correction to how this was first reported.** Enter-approves was *not* undocumented: `docs/cli/tools.md` listed the approve key as ``y`` (or ``Enter``). It was documented in a reference page and named nowhere on the prompt itself — not on the overlay, not in the status hint. So the one key that could approve by accident was also the one key the screen never mentioned, and the operator most likely to hit it was the one who had never read that page.

## What changes

- **Approval requires `y` or `a`.** Enter decides nothing here.
- **An approving key is ignored for 350ms after the prompt opens.** `y` and `a` are ordinary letters; someone mid-word when the overlay mounts was one keystroke from approving.
- **Refusal is never deferred.** `n`, `Esc` and `Ctrl+C` answer on the first press. The asymmetry is the point and is stated in the source so it is not later "simplified" into symmetry: a refusal the operator did not mean costs a retry, an approval they did not mean costs whatever the tool did. A settle window with no prompt recorded as open refuses, because "I cannot establish that anything was shown" is not consent.
- **The overlay now names every key that decides it and no key that does not**, `Esc` included — it always rejected and said so nowhere.
- Drops the dead `input === '\x03'` disjuncts. For a ctrl chord Ink sets `input` to the key *name*, so 0x03 arrives as `'c'` and the raw-byte branch tested a case that cannot occur (`docs/conventions/declared-but-undriven.md`).

## Why it shipped: nothing rendered `<App>`

Both existing Ink harnesses render `<Picker>`. The entire key handler — this prompt, the Ctrl+C ladder, Esc-interrupt, trust and resume — had **no test at all**. This PR adds the first harness that mounts the root component, driving the real scenario: a draft half-typed while a turn runs, then the prompt opening under it. It asserts on the decision the session received, not on a frame.

While building it: **`ink-testing-library` is declared in `packages/cli/package.json` but was not installed**, so both existing Ink harnesses could only ever run in CI. A suite that cannot run on a developer's machine is a suite nobody iterates on, which is part of why this area went untested for so long.

## Mutation-checked

Every test was checked by restoring the defect and confirming the test dies. Each mutation kills exactly one test and nothing else:

| Mutation | Test that dies |
| --- | --- |
| approving branch reads `key.return` again | does not approve on Enter |
| settle guard deleted | ignores an approving key that arrives too early |
| refusal deferred too | rejects on esc immediately |
| `esc` unadvertised | names every key that decides it |

That exercise found four defects in the tests themselves, fixed in the second commit — most importantly an Enter test that **passed with the bug restored**, because it pressed Enter inside the settle window and the window swallowed it either way.

## What the tests cover, and what only you can confirm

They drive Ink's own stdin and read Ink's own frames, so they establish which handler ran and what it decided. **A frame in a harness is not a terminal.** Real key repeat, real paste timing, terminal-specific escape sequences, and whether 350ms *feels* right at human speed are outside what this can establish — the duration is a judgement, not a measurement.

## Checks

`pnpm typecheck` 0 · `pnpm test` 0 (run twice; cli 556 passed, 3 skipped) · `pnpm lint` 0.
