### PR TITLE
fix(cli): /permissions reports the posture actually in force

### DIFF
--- a/.changeset/permissions-reports-what-is-in-force.md
+++ b/.changeset/permissions-reports-what-is-in-force.md
@@ -1,0 +1,42 @@
+---
+'@namzu/cli': patch
+---
+
+`/permissions` reports the approval posture actually in force
+
+The page whose whole job is to answer "how do tool calls get approved here" gave
+two answers that were not true.
+
+**It could not see "approve all".** Pressing `a` at a prompt sets a latch that
+approves every later tool batch for the rest of the session. That latch lived
+inside the agent session's closure and nothing exposed it, so `/permissions`
+reported the posture from your flags alone and kept printing *"Unreviewed calls:
+you are asked before they run"* after you had turned exactly that off. One
+keystroke inverted a security posture and the surface that exists to report it
+could not know. It now reports approve-all as automatic approval, says how to
+get back to being asked, and reads the latch when it renders rather than
+inferring it.
+
+**It never mentioned that some tools are never prompted for.** `read`, `glob`,
+`grep`, `ls`, and the memory and task tools run without asking, always. That is
+deliberate and defensible, but it is undiscoverable by using namzu — the calls
+simply never appear, so their absence reads as "the agent did not use any". The
+readout now names the set, taken from the same list the gate consults so the two
+cannot drift, and states the two limits honestly: a rule can still deny one, and
+anything flagged destructive is prompted for even if it is on the list.
+
+Two smaller corrections on the same page:
+
+- **Rules are described instead of named.** `describeRule` handled two of the
+  eight rule types and printed the bare type name for the rest. A `permissions`
+  table compiles every per-pattern entry to `custom_pattern`, so the commonest
+  real config — `"git push*" = "deny"` — was reported to its author as the
+  single word `custom_pattern`. All eight are spelled out now, with a `never`
+  guard so a ninth fails the build rather than printing itself. A compiled
+  pattern is shown as the regex it compiled to, which is not what you typed;
+  that is the form that actually decides, and inventing a prettier one would be
+  reporting a rule that is not in force.
+- **It pointed at TOML syntax for a JSON file**, telling you to add a
+  `[permissions]` table to `namzu.config.json`.
+
+No public API changes; `SlashContext` is internal to the CLI.

--- a/docs/cli/tools.md
+++ b/docs/cli/tools.md
@@ -147,6 +147,17 @@ Rejecting is never deferred — `n`, `Esc` and `Ctrl+C` answer on the first pres
 because a refusal you did not mean costs a retry while an approval you did not
 mean costs whatever the tool did.
 
+### Checking what is in force
+
+`/permissions` prints the posture actually in force, not the one your flags
+imply. That distinction matters after you press `a`: approve-all is a session
+setting, so the page reports it as automatic approval and tells you how to get
+back to being asked (restart, or re-pick a provider with `/model`).
+
+It also names the tools that never reach a prompt, because that set is otherwise
+undiscoverable — those calls simply never appear, so their absence looks like
+the agent not having used any.
+
 ## The safety gate
 
 Independent of the prompt, a verification gate hard-denies a narrow set of catastrophic shell patterns **before they ever run** — `rm -rf /`, `mkfs`, `dd if=`, fork bombs, `sudo` / `su -`, `chmod 777 /`, `curl|sh` / `wget|sh`, `ssh user@host`, and dynamic `eval`. This applies in every mode including bypass, so namzu can't be made to brick the machine. The list is deliberately narrow — everyday commands like `rm -rf node_modules` are unaffected.

--- a/packages/cli/src/__tests__/a-command-file-reaches-the-turn.test.ts
+++ b/packages/cli/src/__tests__/a-command-file-reaches-the-turn.test.ts
@@ -63,7 +63,12 @@ function context(userCommands: SlashContext['userCommands']): SlashContext {
 		providerSummary: 'mock (mock)',
 		modelSummary: 'mock-model',
 		usage: null,
-		permissions: { skipPermissions: false, rules: [] },
+		permissions: {
+			skipPermissions: false,
+			rules: [],
+			approvalLatched: () => false,
+			neverPrompted: [],
+		},
 		agentIds: [],
 		instructionFiles: [],
 		userCommands,

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -60,6 +60,7 @@ import {
 	type PermissionDecision,
 	type PermissionRequest,
 	type RunScope,
+	NEVER_PROMPTED_TOOLS,
 	createAgentSession,
 	probeAgentSession,
 } from './agent.js'
@@ -136,7 +137,7 @@ export function App({ ctx }: AppProps) {
 	 *
 	 * A ref rather than state because the keypress handler reads it in the same
 	 * tick the prompt opens, before any re-render could carry a new value — see
-	 * `permission-timing.ts` for why an approving key has to wait on this.
+	 * `consent-timing.ts` for why an approving key has to wait on this.
 	 */
 	const permissionOpenedAtRef = useRef<number | null>(null)
 	/**
@@ -362,6 +363,19 @@ export function App({ ctx }: AppProps) {
 		permissions: {
 			skipPermissions: ctx.skipPermissions === true,
 			rules: ctx.rules ?? [],
+			// Called when `/permissions` renders, not read here.
+			//
+			// A boolean would also be correct TODAY, and only by accident: this
+			// object is a fresh literal each render and sits in `handleSubmit`'s
+			// dependency array, so the callback is rebuilt every render and
+			// never holds a stale one. Memoising `slashCtx` is an obvious
+			// optimisation for exactly that reason — and it would silently turn
+			// a captured boolean stale, putting this security readout back to
+			// reporting a posture the operator has already changed. The
+			// function keeps that impossible by construction rather than by a
+			// coincidence three lines away.
+			approvalLatched: () => session?.approvalLatched() ?? false,
+			neverPrompted: NEVER_PROMPTED_TOOLS,
 		},
 		agentIds: session?.agentIds ?? [],
 		instructionFiles: session?.instructionFiles ?? [],

--- a/packages/cli/src/tui/__fixtures__/agent-session.ts
+++ b/packages/cli/src/tui/__fixtures__/agent-session.ts
@@ -49,6 +49,9 @@ export function fakeAgentSession(overrides: Partial<AgentSession> = {}): AgentSe
 		// A healthy single-provider chain has nothing to report, which is the
 		// ordinary production state this fixture is meant to resemble.
 		configNotices: [],
+		// Nothing has been approved on a fresh session. A test about the latch
+		// overrides this; every other test wants the ordinary state.
+		approvalLatched: () => false,
 		send: (_messages: readonly Message[], _opts?: SendOptions): AsyncIterable<AgentEvent> =>
 			(async function* () {
 				yield { kind: 'done', stopReason: 'end_turn' } as AgentEvent

--- a/packages/cli/src/tui/__tests__/app-permission-keys.test.tsx
+++ b/packages/cli/src/tui/__tests__/app-permission-keys.test.tsx
@@ -78,34 +78,48 @@ vi.mock('../agent.js', async (importOriginal) => {
 			needsRepickReason: null,
 			detected: [],
 		}),
-		createAgentSession: async (): Promise<AgentSession> => ({
-			hasProvider: true,
-			providerSummary: 'a-provider',
-			modelSummary: 'a-model',
-			toolNames: ['bash'],
-			errorHint: null,
-			instructionFiles: [],
-			skippedInstructionFiles: [],
-			mcpConnected: [],
-			mcpFailed: [],
-			agentIds: [],
-			configNotices: [],
-			close: async () => {},
-			// Streams one delta so the composer is live and a draft can be typed,
-			// then asks for permission and parks on the answer — which is exactly
-			// the moment this file is about.
-			send: async function* (_messages, opts): AsyncIterable<AgentEvent> {
-				yield { kind: 'delta', text: 'working' } as AgentEvent
-				await new Promise((r) => setTimeout(r, 30))
-				const req: PermissionRequest = {
-					toolCalls: [
-						{ id: 'call-1', name: 'bash', summary: 'rm -rf build', isDestructive: true },
-					],
-				}
-				const decision = await opts?.onPermission?.(req)
-				if (decision) decisions.push(decision)
-			},
-		}),
+		createAgentSession: async (): Promise<AgentSession> => {
+			// Stands in for the `approval` object the real session closes over
+			// (`agent.ts`), which `makeResumeHandler` flips on approve-all and
+			// which `approvalLatched` reads. Emulated rather than imported
+			// because this mock replaces the handler that owns it; that the real
+			// handler sets the flag is pinned separately in `agent.test.ts`.
+			let latched = false
+			return {
+				hasProvider: true,
+				providerSummary: 'a-provider',
+				modelSummary: 'a-model',
+				toolNames: ['bash'],
+				errorHint: null,
+				instructionFiles: [],
+				skippedInstructionFiles: [],
+				mcpConnected: [],
+				mcpFailed: [],
+				agentIds: [],
+				configNotices: [],
+				close: async () => {},
+				approvalLatched: () => latched,
+				// Streams one delta so the composer is live and a draft can be
+				// typed, then asks for permission and parks on the answer — which
+				// is exactly the moment this file is about. A second batch is
+				// never requested, because approve-all is asserted through
+				// `/permissions` rather than through a second prompt.
+				send: async function* (_messages, opts): AsyncIterable<AgentEvent> {
+					yield { kind: 'delta', text: 'working' } as AgentEvent
+					await new Promise((r) => setTimeout(r, 30))
+					const req: PermissionRequest = {
+						toolCalls: [
+							{ id: 'call-1', name: 'bash', summary: 'rm -rf build', isDestructive: true },
+						],
+					}
+					const decision = await opts?.onPermission?.(req)
+					if (decision) {
+						decisions.push(decision)
+						if (decision.kind === 'approve-all') latched = true
+					}
+				},
+			}
+		},
 	}
 })
 
@@ -256,5 +270,46 @@ describe('the permission prompt', () => {
 		// The advertisement is the contract the handler is held to. `enter` must
 		// not appear, because Enter no longer does anything here.
 		expect(frame.toLowerCase()).not.toContain('enter')
+	})
+})
+
+/**
+ * That `/permissions` reports the posture actually in force.
+ *
+ * Here rather than in `slashCommands.test.ts` because the unit test there can
+ * only prove that `renderPermissions` calls the reader it is handed. Whether
+ * `App` hands it a LIVE reader or a value snapshotted during some earlier
+ * render is a different property, invisible from that level, and it is the one
+ * that was broken: the latch lives in a closure inside the agent session, and
+ * the context object carrying it is assembled on one render and read from a
+ * callback captured on another.
+ *
+ * So this drives the whole path — press `a` at a real prompt, then ask.
+ */
+describe('/permissions after approve-all', () => {
+	it('reports automatic approval once `a` has been pressed', async () => {
+		const { stdin, lastFrame } = await promptOpenWithDraftInFlight()
+
+		settle()
+		stdin.write('a')
+		await decisionSettles()
+		expect(decisions, 'a did not approve-all').toEqual([{ kind: 'approve-all' }])
+
+		// The turn is over and the composer is back. Ask the page.
+		await tick(120)
+		stdin.write('/permissions')
+		await tick(60)
+		stdin.write('\r')
+		await tick(200)
+
+		const frame = lastFrame() ?? ''
+		expect(frame, 'the readout never rendered').toContain('Unreviewed calls')
+		expect(frame).toContain('approved automatically')
+		expect(frame, 'still claims calls are reviewed').not.toContain('you are asked')
+		// And that App hands the readout the REAL never-prompted set. The unit
+		// test supplies its own list, so it would pass just as happily against an
+		// empty one — this is the assertion that fails if the wiring is dropped.
+		expect(frame, 'the never-prompted disclosure is missing').toContain('Never prompted')
+		expect(frame).toContain('glob')
 	})
 })

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -250,6 +250,22 @@ export interface AgentSession {
 	 * shown.
 	 */
 	readonly configNotices: readonly string[]
+	/**
+	 * Whether "approve all" has been chosen at a prompt during this session.
+	 *
+	 * A FUNCTION, not a boolean, and that is the whole point of it. The latch
+	 * lives in a mutable object the permission handler closes over, and it flips
+	 * mid-turn on a single keystroke. A surface handed a boolean would be handed
+	 * whatever the value was when the surface was built — and `/permissions` is
+	 * rendered from a context object assembled on an earlier render, so a
+	 * snapshot would reintroduce the staleness one layer up from where it was
+	 * fixed.
+	 *
+	 * It exists because `/permissions` reported the approval posture from the
+	 * operator's flags alone and could not see this, so it kept printing "you
+	 * are asked before they run" after the operator had turned that off.
+	 */
+	readonly approvalLatched: () => boolean
 	send(messages: readonly Message[], opts?: SendOptions): AsyncIterable<AgentEvent>
 	/**
 	 * Release what the session holds — today, the external tool servers.
@@ -578,6 +594,8 @@ export async function createAgentSession(
 		],
 		close: () => mcp.close(),
 		errorHint: null,
+		// Reads the same object the handler mutates, at call time.
+		approvalLatched: () => approval.all,
 		send: async function* (messages, opts) {
 			// Renew a lapsed OAuth token before the turn runs (no-op for valid
 			// tokens and non-keychain credentials).
@@ -1072,6 +1090,16 @@ const READ_ONLY_TOOLS = new Set([
 ])
 
 /**
+ * The same set, sorted, for a surface that has to NAME it.
+ *
+ * Derived rather than retyped: `/permissions` tells the operator which tools
+ * run without asking, and a hand-written list beside the real one is a second
+ * source of truth that drifts the first time a tool is added to either. The
+ * readout is only worth printing if it cannot disagree with the gate.
+ */
+export const NEVER_PROMPTED_TOOLS: readonly string[] = [...READ_ONLY_TOOLS].sort()
+
+/**
  * A batch needs explicit approval when any call mutates state: flagged
  * destructive by the SDK, or simply not on the read-only allowlist.
  */
@@ -1411,6 +1439,8 @@ function emptySession(errorHint: string): AgentSession {
 		// Nothing ran, so there is no configuration in force to report on.
 		configNotices: [],
 		errorHint,
+		// No turn can run here, so no prompt can have been answered.
+		approvalLatched: () => false,
 		send: async function* () {
 			yield { kind: 'error' as const, message: errorHint }
 		},

--- a/packages/cli/src/tui/slashCommands.test.ts
+++ b/packages/cli/src/tui/slashCommands.test.ts
@@ -10,6 +10,20 @@ import {
 } from './slashCommands.js'
 
 /**
+ * The permission half of a context, for the same reason `context` exists below:
+ * these were inline literals, so each new field had to be added to all four.
+ */
+function permissions(over: Partial<SlashContext['permissions']> = {}): SlashContext['permissions'] {
+	return {
+		skipPermissions: false,
+		rules: [],
+		approvalLatched: () => false,
+		neverPrompted: [],
+		...over,
+	}
+}
+
+/**
  * A context with nothing interesting in it, plus whatever this test is about.
  *
  * Built through a helper rather than as literals so that a field added to
@@ -22,7 +36,7 @@ function context(over: Partial<SlashContext> = {}): SlashContext {
 		providerSummary: null,
 		modelSummary: null,
 		usage: null,
-		permissions: { skipPermissions: false, rules: [] },
+		permissions: permissions(),
 		agentIds: [],
 		instructionFiles: [],
 		userCommands: [],
@@ -197,7 +211,7 @@ describe('/permissions', () => {
 	it('names the flag when approval is automatic', () => {
 		const r = runSlash(
 			'/permissions',
-			context({ permissions: { skipPermissions: true, rules: [] } }),
+			context({ permissions: permissions({ skipPermissions: true }) }),
 		)
 		if (r?.kind === 'message') {
 			expect(r.content).toContain('approved automatically')
@@ -209,13 +223,12 @@ describe('/permissions', () => {
 		const r = runSlash(
 			'/permissions',
 			context({
-				permissions: {
-					skipPermissions: false,
+				permissions: permissions({
 					rules: [
 						{ type: 'deny_by_name', toolNames: ['bash'] },
 						{ type: 'allow_by_name', toolNames: ['read', 'glob'] },
 					],
-				},
+				}),
 			}),
 		)
 		if (r?.kind === 'message') {
@@ -226,12 +239,124 @@ describe('/permissions', () => {
 		}
 	})
 
+	it('reports approve-all as automatic approval, not as "you are asked"', () => {
+		// The defect this readout was rewritten for. One `a` at a prompt turns
+		// every later tool call into an automatic approval, and the page whose
+		// job is to report that posture kept reporting the opposite.
+		const r = runSlash(
+			'/permissions',
+			context({ permissions: permissions({ approvalLatched: () => true }) }),
+		)
+		if (r?.kind === 'message') {
+			expect(r.content).toContain('approved automatically')
+			expect(r.content).toContain('approve all')
+			expect(r.content, 'still claims calls are reviewed').not.toContain('you are asked')
+		}
+	})
+
+	it('reads the latch when it renders, not when the context was built', () => {
+		// The staleness this is really guarding against. The context object is
+		// assembled during a render and read later from a callback that captured
+		// it, so a boolean field would report whatever was true at build time.
+		// Here the latch flips AFTER the context exists — which is exactly what
+		// happens when the operator presses `a` mid-turn.
+		let latched = false
+		const ctxLive = context({ permissions: permissions({ approvalLatched: () => latched }) })
+
+		const before = runSlash('/permissions', ctxLive)
+		if (before?.kind === 'message') expect(before.content).toContain('you are asked')
+
+		latched = true
+
+		const after = runSlash('/permissions', ctxLive)
+		if (after?.kind === 'message') {
+			expect(after.content).toContain('approved automatically')
+			expect(after.content).not.toContain('you are asked')
+		}
+	})
+
+	it('discloses the tools that never reach a prompt', () => {
+		// Undiscoverable by using namzu: these calls simply never appear, so
+		// their absence reads as "the agent did not use any".
+		const r = runSlash(
+			'/permissions',
+			context({ permissions: permissions({ neverPrompted: ['glob', 'read', 'save_memory'] }) }),
+		)
+		if (r?.kind === 'message') {
+			expect(r.content).toContain('Never prompted')
+			expect(r.content).toContain('glob, read, save_memory')
+			// Must not overclaim: a rule still outranks this, and a call flagged
+			// destructive is prompted for even when it is on the list.
+			expect(r.content).toContain('deny')
+			expect(r.content).toContain('destructive')
+		}
+	})
+
+	it('describes a pattern rule instead of printing its type name', () => {
+		// A `permissions` table compiles every per-pattern entry to
+		// `custom_pattern`, so this is the shape of the commonest real config.
+		// It used to render as the single word `custom_pattern`.
+		const r = runSlash(
+			'/permissions',
+			context({
+				permissions: permissions({
+					rules: [
+						{
+							type: 'custom_pattern',
+							pattern: '^bash .*git push.*$',
+							target: 'both',
+							decision: 'deny',
+						},
+					],
+				}),
+			}),
+		)
+		if (r?.kind === 'message') {
+			expect(r.content).toContain('deny')
+			expect(r.content).toContain('git push')
+			expect(r.content, 'printed the enum name').not.toContain('custom_pattern')
+		}
+	})
+
+	it('describes an argument rule by naming the argument it tests', () => {
+		const r = runSlash(
+			'/permissions',
+			context({
+				permissions: permissions({
+					rules: [
+						{
+							type: 'argument_pattern',
+							toolNames: ['bash'],
+							argument: 'command',
+							pattern: '^rm ',
+							decision: 'deny',
+						},
+					],
+				}),
+			}),
+		)
+		if (r?.kind === 'message') {
+			expect(r.content).toContain('bash')
+			expect(r.content).toContain('command')
+			expect(r.content).not.toContain('argument_pattern')
+		}
+	})
+
+	it('points at the config in the syntax the config is actually written in', () => {
+		// It said `[permissions] table`, which is TOML, in a file that is JSON.
+		const r = runSlash('/permissions', context())
+		if (r?.kind === 'message') {
+			expect(r.content).toContain('namzu.config.json')
+			expect(r.content, 'TOML syntax for a JSON file').not.toContain('[permissions]')
+		}
+	})
+
 	it('states that a rule outranks the approval setting', () => {
 		// The precedence people get wrong, and wrong in the dangerous direction:
 		// assuming the bypass flag lifts a `deny` they wrote. It does not.
 		const r = runSlash(
 			'/permissions',
-			context({ permissions: { skipPermissions: true, rules: [] } }),
+			context({ permissions: permissions({ skipPermissions: true }) }),
 		)
 		if (r?.kind === 'message') expect(r.content).toContain('never reopen what a')
 	})

--- a/packages/cli/src/tui/slashCommands.ts
+++ b/packages/cli/src/tui/slashCommands.ts
@@ -52,11 +52,30 @@ export interface SlashContext {
 	 * a question someone asked on purpose.
 	 */
 	readonly usage: { readonly totalTokens: number; readonly costUsd: number } | null
-	/** What the operator's config and flags decided about tool approval. */
+	/** What decides a tool call right now — flags, config, and session state. */
 	readonly permissions: {
 		/** `--yolo` / `--dangerously-skip-permissions`. */
 		readonly skipPermissions: boolean
 		readonly rules: readonly VerificationRule[]
+		/**
+		 * Whether "approve all" is in force, read at render time.
+		 *
+		 * A function because this is the one field here that CHANGES while
+		 * namzu runs. The other two come from flags and a config file and are
+		 * fixed for the process; this one flips on a keystroke mid-turn. Since
+		 * this context object is assembled during a render and read later from
+		 * a callback that captured it, a boolean would report whatever was true
+		 * when the object was built — which is precisely the staleness that let
+		 * `/permissions` claim tools were still being reviewed after they were
+		 * not.
+		 */
+		readonly approvalLatched: () => boolean
+		/**
+		 * Tools that never reach the prompt, named so the readout can say so.
+		 * Supplied by the caller rather than imported here, because this module
+		 * is deliberately free of the agent runtime.
+		 */
+		readonly neverPrompted: readonly string[]
 	}
 	/**
 	 * Delegate ids this session can dispatch to, empty when the delegation tool
@@ -347,15 +366,36 @@ export function renderCost(usage: SlashContext['usage']): string {
 export function renderPermissions(permissions: SlashContext['permissions']): string {
 	const lines: string[] = []
 
-	lines.push(
-		permissions.skipPermissions
-			? 'Unreviewed calls: approved automatically (--dangerously-skip-permissions).'
-			: 'Unreviewed calls: you are asked before they run.',
-	)
+	// Three states, most permissive first, and the middle one is the reason this
+	// function was rewritten: it is reachable from a single keystroke at a
+	// prompt, it silently outranks the default, and it used to be invisible
+	// here — so the page answering "how do tool calls get approved" gave the
+	// safe answer to an operator who had already turned the safety off.
+	if (permissions.skipPermissions) {
+		lines.push('Unreviewed calls: approved automatically (--dangerously-skip-permissions).')
+	} else if (permissions.approvalLatched()) {
+		lines.push('Unreviewed calls: approved automatically — "approve all" was chosen at')
+		lines.push('an earlier prompt. Nothing will ask again while this session lasts;')
+		lines.push('restart namzu, or re-pick a provider with /model, to be asked again.')
+	} else {
+		lines.push('Unreviewed calls: you are asked before they run.')
+	}
+
+	// Stated in every mode, because it is true in every mode and an operator
+	// cannot discover it by using namzu: these tools simply never appear at a
+	// prompt, so their absence reads as "the agent did not use any".
+	if (permissions.neverPrompted.length > 0) {
+		lines.push('')
+		lines.push(`Never prompted for (${permissions.neverPrompted.length}):`)
+		lines.push(`  ${permissions.neverPrompted.join(', ')}`)
+		lines.push("These either only observe, or touch only namzu's own state under")
+		lines.push('~/.namzu. A rule can still deny one, and any call the kernel flags')
+		lines.push('destructive is prompted for even if it is on this list.')
+	}
 
 	if (permissions.rules.length === 0) {
 		lines.push('')
-		lines.push('No rules configured. Add a [permissions] table to namzu.config.json')
+		lines.push('No rules configured. Add a "permissions" object to namzu.config.json')
 		lines.push('to allow or deny tools by name without being asked each time.')
 	} else {
 		lines.push('')
@@ -373,10 +413,54 @@ export function renderPermissions(permissions: SlashContext['permissions']): str
 	return lines.join('\n')
 }
 
+/**
+ * One rule, as a line an operator can check against what they wrote.
+ *
+ * Every arm is spelled out and the default is a `never`, so a ninth rule type
+ * fails the build here instead of printing its own name. The previous version
+ * handled two of the eight and returned `rule.type` for the rest — and the
+ * most common config in existence compiles to `custom_pattern`, so a
+ * per-argument rule someone wrote as `"git push*" = "deny"` was reported to
+ * them as the single word `custom_pattern`.
+ *
+ * The kernel exports a `describeRule` of its own, deliberately not reused: it
+ * is phrased to tell a MODEL why one call was refused ("denied by name … so a
+ * different input will not change it"). This one is a table of standing policy
+ * for a person. Same facts, different question.
+ */
 function describeRule(rule: VerificationRule): string {
-	if (rule.type === 'deny_by_name') return `deny   ${rule.toolNames.join(', ')}`
-	if (rule.type === 'allow_by_name') return `allow  ${rule.toolNames.join(', ')}`
-	return rule.type
+	switch (rule.type) {
+		case 'deny_by_name':
+			return `deny   ${rule.toolNames.join(', ')}`
+		case 'allow_by_name':
+			return `allow  ${rule.toolNames.join(', ')}`
+		case 'allow_by_category':
+			return `allow  any tool in category: ${rule.categories.join(', ')}`
+		case 'allow_by_tier':
+			return `allow  any tool in tier: ${rule.tiers.join(', ')}`
+		case 'allow_read_only':
+			return 'allow  any tool that only observes'
+		case 'deny_dangerous_patterns':
+			return 'deny   the built-in catastrophic-command patterns'
+		case 'argument_pattern': {
+			const verb = rule.decision === 'deny' ? 'deny  ' : 'allow '
+			return `${verb} ${rule.toolNames.join(', ')} when ${rule.argument} matches ${rule.pattern}`
+		}
+		case 'custom_pattern': {
+			// The pattern is shown as the regex it compiled to, which is not
+			// what the operator typed — a `permissions` table turns
+			// `"git push*"` into `^bash .*git push.*$`. Shown anyway: the
+			// compiled form is what actually decides, and inventing a
+			// prettier one would be reporting a rule that is not in force.
+			const verb = rule.decision === 'deny' ? 'deny  ' : 'allow '
+			const where = rule.target === 'both' ? 'name+args' : rule.target
+			return `${verb} ${where} matching ${rule.pattern}`
+		}
+		default: {
+			const exhaustive: never = rule
+			return `unrecognised rule: ${JSON.stringify(exhaustive)}`
+		}
+	}
 }
 
 /** The delegate roster, and an honest answer when there is none. */


### PR DESCRIPTION
The page whose whole job is to answer *"how do tool calls get approved here"* gave two answers that were not true. Both are fixed together, because a page that stops lying about one while silently omitting the other lies **less**, and that is not the bar for a security readout.

## 1. It could not see "approve all"

Pressing `a` at a permission prompt sets a latch that approves every later tool batch for the rest of the session. That latch is created in `createAgentSession`, set and read inside `makeResumeHandler`'s closure, and exposed nowhere. `SlashContext.permissions` carried `skipPermissions` and `rules` — both fixed for the life of the process — so `/permissions` kept printing:

> Unreviewed calls: you are asked before they run.

…after the operator had turned exactly that off. **One keystroke inverted the security posture, and the surface that exists to report that posture could not know.**

It now reports approve-all as automatic approval, and says how to get back to being asked.

## 2. It never mentioned that some tools are never prompted for

`batchNeedsPrompt` approves any batch whose calls are all on a read-only allowlist, so `read`, `glob`, `grep`, `ls` and the memory/task tools run without asking — always, in every mode.

That is deliberate and defensible. Being silent about it is not, and it is **undiscoverable by using namzu**: those calls simply never appear at a prompt, so their absence reads as "the agent did not use any". The readout now names the set — printed from the same list the gate consults, so the page cannot drift from the behaviour — and states both limits honestly: a rule still outranks it, and anything flagged destructive is prompted for even when it is on the list.

## A finding that changed what I claim

I was asked to prove the latch test fails when the reader goes back to reading a static flag. So I mutated `App` to pass a snapshot instead of a live reader — **and nothing died.**

`slashCtx` is a fresh object literal every render *and* sits in `handleSubmit`'s dependency array, so the callback is rebuilt each render and never holds a stale one. **A boolean would be correct today** — by coincidence, not by design.

I kept the function anyway, because memoising `slashCtx` is an obvious optimisation for exactly that reason, and it would silently turn a captured boolean stale and put this readout straight back to reporting a posture the operator has already changed. The function makes that impossible by construction rather than by a coincidence three lines away. **The source comment now says that plainly, and no test claims to prove a staleness that is not currently reachable.**

## Two smaller corrections on the same page

- **Rules are described, not named.** `describeRule` handled two of the eight rule types and printed the bare type name for the rest. A `permissions` table compiles *every* per-pattern entry to `custom_pattern`, so the commonest real config — `"git push*": "deny"` — was reported to its author as the single word `custom_pattern`. All eight are spelled out now, with a `never` guard so a ninth fails the build instead of printing itself. A compiled pattern is shown as the regex it compiled to; that is what actually decides, and inventing a prettier one would report a rule that is not in force.
- **It pointed at TOML syntax for a JSON file** — "add a `[permissions]` table to `namzu.config.json`".

## Mutation-checked

| Mutation | Result |
| --- | --- |
| readout ignores the latch | all 3 latch tests die, including the `<App>` one |
| read-only disclosure removed | its test dies |
| `describeRule` reverted to two arms | both rule-description tests die |
| TOML wording restored | its test dies |
| **`App` passes an empty never-prompted set** | **the `<App>` test dies** |
| `App` passes a snapshot instead of a live reader | *nothing dies* — see above |

That fifth row is the reachability half: the unit test supplies its own list, so it would pass just as happily against an empty one. Only the `<App>` test fails when the wiring is dropped.

## What the tests cover, and what only you can confirm

The `<App>` test drives the real path — press `a` at a live prompt, then type `/permissions` — so it establishes that the latch reaches the readout. **A frame in a harness is not a terminal**: whether the wording reads clearly at a glance, mid-session, when it matters, is yours to judge.

Also worth a look: the never-prompted list includes `save_memory`, `task_create` and `task_update`, which write to `~/.namzu` rather than only observing. I described the set as "either only observe, or touch only namzu's own state" rather than calling it read-only, but whether those three belong on a no-prompt list at all is a policy question I have not touched.

## Checks

`pnpm build` 0 · `pnpm typecheck` 0 · `pnpm test` 0 (cli 569 passed, 3 skipped) · `pnpm lint` 0.
