### PR TITLE
fix(cli): stop overriding what tools declare about themselves

### DIFF
--- a/.changeset/exemptions-stop-contradicting-declarations.md
+++ b/.changeset/exemptions-stop-contradicting-declarations.md
@@ -1,0 +1,48 @@
+---
+'@namzu/cli': minor
+---
+
+`save_memory` now asks before it writes
+
+The CLI decided which tools could skip the permission prompt from a
+hand-maintained list of names called `READ_ONLY_TOOLS`. Three tools on it —
+`save_memory`, `task_create` and `task_update` — declare `readOnly: false` in
+the SDK. A constant asserted the exact property it was getting wrong, which is
+how the disagreement survived: nothing reading it had reason to doubt the name.
+
+**`save_memory` comes off, and this is the user-visible change.** It writes
+content that outlives the run: what is saved now is retrievable by
+`search_memory` in a later session, out of `<cwd>/.namzu/memory` inside your own
+project. So a tool result or a fetched page that talks the model into saving
+something reaches a future run's reasoning. It is not injected into the prompt
+automatically — that is `MEMORY.md`, a different thing — but retrievable is
+enough. A write that survives the process is not read-only under any reading.
+
+If the agent saves memories often in your workflow, you will now see a prompt
+where you did not. Approve-all (`a`) covers the session, and a
+`{"permissions": {"save_memory": "allow"}}` rule in `namzu.config.json` covers
+it permanently.
+
+**`task_create` and `task_update` stay exempt, honestly labelled.** They are the
+model's own plan for the current request, written several times per planning
+turn, and prompting each would put a consent dialog between the agent and its
+todo list. They now live in a set named `PROMPT_EXEMPT_WRITES` — an override
+that says it is one — with the reason recorded per entry, and `/permissions`
+discloses them.
+
+**The read-only half is no longer a list of names.** It is each tool's own
+`isReadOnly()` declaration, resolved against the live registry at the moment of
+the call, so a tool server's tools and the deferred task tools are covered too.
+A name list in the consumer is a second source of truth: a new read-only tool
+missing from it merely gets prompted, but a *renamed* tool silently changes
+posture with nothing to notice.
+
+Two comments claimed these tools "touch only the agent's own `~/.namzu` state".
+They write to `<cwd>/.namzu` — the working directory, not the home directory.
+Both are corrected.
+
+`/permissions` also now names the built-in safety gate, which hard-denies a
+narrow set of catastrophic shell patterns in every mode and which no flag can
+switch off. The page claimed to describe what decides a tool call "in the order
+it actually decides it" and began one step in; a true-but-incomplete order is
+still a wrong order.

--- a/docs/cli/tools.md
+++ b/docs/cli/tools.md
@@ -121,7 +121,9 @@ For what happens to calls no rule covered, see
 
 Under `prompt`, mutating actions ask before they run:
 
-- **Read-only / agent-state tools** (`read`/`glob`/`grep`, the memory + task tools) run silently.
+- **Tools that declare themselves read-only** (`read`, `glob`, `grep`, `ls`, `search_memory`, `read_memory`, `task_list`) run silently. That is taken from each tool's own declaration, not from a list namzu keeps.
+- **`task_create` and `task_update`** also run silently, and they are writes. They are the model's own plan for the request, written several times per planning turn, so prompting would put a dialog between the agent and its todo list; a bad write costs a polluted task list, which is visible in the transcript and grants nothing.
+- **`save_memory` prompts.** It used to be silent. What it writes outlives the run — content saved now is retrievable by `search_memory` in a later session, from `<cwd>/.namzu/memory` inside your own project — so a tool result or fetched page that talks the model into saving something reaches a future run's reasoning.
 - **Anything else** — `write`, `edit`, `bash`, and any tool not on the safe allowlist — shows a prompt with each proposed call, plus a preview for the riskiest: the content for `write`, a `- old` / `+ new` diff for `edit`.
 
 An unrecognized tool is treated as needing consent. That direction is deliberate: a tool added tomorrow prompts, rather than inheriting a permission nobody granted it.

--- a/packages/cli/src/__tests__/a-command-file-reaches-the-turn.test.ts
+++ b/packages/cli/src/__tests__/a-command-file-reaches-the-turn.test.ts
@@ -67,7 +67,7 @@ function context(userCommands: SlashContext['userCommands']): SlashContext {
 			skipPermissions: false,
 			rules: [],
 			approvalLatched: () => false,
-			neverPrompted: [],
+			neverPrompted: () => [],
 		},
 		agentIds: [],
 		instructionFiles: [],

--- a/packages/cli/src/permissions/__tests__/mode.test.ts
+++ b/packages/cli/src/permissions/__tests__/mode.test.ts
@@ -136,11 +136,16 @@ describe('what each mode does with an undecided call', () => {
 		expect(decision.feedback).toBe('not that one')
 	})
 
-	it('read-only batches run under every mode, including strict', async () => {
+	it('exempt batches run under every mode, including strict', async () => {
 		// `strict` refuses what needs asking, and a read never needed asking.
 		// Refusing reads would make the mode unusable rather than strict.
+		//
+		// The exemption is passed in now rather than baked into the handler: it
+		// is resolved from each tool's own `readOnly` declaration against the
+		// live registry, so this test states which tool it means instead of
+		// relying on a name list that once disagreed with the declarations.
 		const readOnly = [{ id: '1', name: 'read', input: {}, isDestructive: false }] as never
-		const handler = makeResumeHandler({ all: false }, undefined, 'strict')
+		const handler = makeResumeHandler({ all: false }, undefined, 'strict', (n) => n === 'read')
 
 		expect(await handler({ type: 'tool_review', toolCalls: readOnly } as never)).toEqual({
 			action: 'approve_tools',

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -60,7 +60,6 @@ import {
 	type PermissionDecision,
 	type PermissionRequest,
 	type RunScope,
-	NEVER_PROMPTED_TOOLS,
 	createAgentSession,
 	probeAgentSession,
 } from './agent.js'
@@ -375,7 +374,7 @@ export function App({ ctx }: AppProps) {
 			// function keeps that impossible by construction rather than by a
 			// coincidence three lines away.
 			approvalLatched: () => session?.approvalLatched() ?? false,
-			neverPrompted: NEVER_PROMPTED_TOOLS,
+			neverPrompted: () => session?.promptExemptTools() ?? [],
 		},
 		agentIds: session?.agentIds ?? [],
 		instructionFiles: session?.instructionFiles ?? [],

--- a/packages/cli/src/tui/__fixtures__/agent-session.ts
+++ b/packages/cli/src/tui/__fixtures__/agent-session.ts
@@ -52,6 +52,7 @@ export function fakeAgentSession(overrides: Partial<AgentSession> = {}): AgentSe
 		// Nothing has been approved on a fresh session. A test about the latch
 		// overrides this; every other test wants the ordinary state.
 		approvalLatched: () => false,
+		promptExemptTools: () => [],
 		send: (_messages: readonly Message[], _opts?: SendOptions): AsyncIterable<AgentEvent> =>
 			(async function* () {
 				yield { kind: 'done', stopReason: 'end_turn' } as AgentEvent

--- a/packages/cli/src/tui/__tests__/app-permission-keys.test.tsx
+++ b/packages/cli/src/tui/__tests__/app-permission-keys.test.tsx
@@ -99,6 +99,9 @@ vi.mock('../agent.js', async (importOriginal) => {
 				configNotices: [],
 				close: async () => {},
 				approvalLatched: () => latched,
+				// A representative exempt roster: one declared read-only, one
+				// named override. Enough for the readout assertions below.
+				promptExemptTools: () => ['glob', 'read', 'task_create'],
 				// Streams one delta so the composer is live and a draft can be
 				// typed, then asks for permission and parks on the answer — which
 				// is exactly the moment this file is about. A second batch is

--- a/packages/cli/src/tui/agent.test.ts
+++ b/packages/cli/src/tui/agent.test.ts
@@ -1,3 +1,5 @@
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import type {
 	CheckpointId,
 	HITLDecisionRequest,
@@ -8,12 +10,14 @@ import type {
 	ToolCallSummary,
 	ToolUseId,
 } from '@namzu/sdk'
+import { DiskMemoryStore, ToolRegistry, buildMemoryTools, getBuiltinTools } from '@namzu/sdk'
 import { describe, expect, it, vi } from 'vitest'
 
 import {
 	type PermissionDecision,
 	type PermissionRequest,
 	batchNeedsPrompt,
+	isPromptExempt,
 	makeResumeHandler,
 	previewToolInput,
 	toAgentEvent,
@@ -152,20 +156,83 @@ const toolReview = (toolCalls: ToolCallSummary[]): HITLDecisionRequest => ({
 	toolCalls,
 })
 
+/** Exempt by name, for the pure-logic tests below. */
+const exemptNames =
+	(...names: string[]) =>
+	(name: string) =>
+		names.includes(name.toLowerCase())
+
 describe('batchNeedsPrompt', () => {
-	it('does not prompt for read-only batches', () => {
-		expect(batchNeedsPrompt([tc({ name: 'read' }), tc({ name: 'glob' })])).toBe(false)
-		expect(batchNeedsPrompt([tc({ name: 'Grep' })])).toBe(false) // case-insensitive
+	it('does not prompt when every call is exempt', () => {
+		expect(
+			batchNeedsPrompt([tc({ name: 'read' }), tc({ name: 'glob' })], exemptNames('read', 'glob')),
+		).toBe(false)
 	})
 
-	it('prompts when any tool mutates or is flagged destructive', () => {
-		expect(batchNeedsPrompt([tc({ name: 'read' }), tc({ name: 'write' })])).toBe(true)
-		expect(batchNeedsPrompt([tc({ name: 'edit' })])).toBe(true)
-		expect(batchNeedsPrompt([tc({ name: 'bash', isDestructive: true })])).toBe(true)
+	it('prompts when any call is not exempt', () => {
+		expect(
+			batchNeedsPrompt([tc({ name: 'read' }), tc({ name: 'write' })], exemptNames('read')),
+		).toBe(true)
 	})
 
-	it('prompts for unknown/future tools (safe-by-default)', () => {
-		expect(batchNeedsPrompt([tc({ name: 'SomeClawtoolThing' })])).toBe(true)
+	it('prompts for a destructive call even when it is exempt', () => {
+		// The override must not be able to wave through something the kernel has
+		// flagged. Exemption answers "does this need consent by default", not
+		// "is this safe".
+		expect(batchNeedsPrompt([tc({ name: 'read', isDestructive: true })], exemptNames('read'))).toBe(
+			true,
+		)
+	})
+
+	it('prompts when nothing is exempt (safe-by-default)', () => {
+		expect(batchNeedsPrompt([tc({ name: 'SomeUnknownTool' })], () => false)).toBe(true)
+	})
+})
+
+/**
+ * Against a REAL registry of real tools, so these assert the tools' own
+ * declarations rather than a restatement of them.
+ *
+ * This is the shape of test that would have caught the divergence it was
+ * written for: the CLI kept a hand-maintained `READ_ONLY_TOOLS` list that named
+ * three tools which declare `readOnly: false`, and nothing compared the two.
+ */
+describe('isPromptExempt', () => {
+	const registry = new ToolRegistry()
+	const store = new DiskMemoryStore({ baseDir: join(tmpdir(), 'namzu-exempt-test') })
+	registry.register(getBuiltinTools())
+	registry.register(buildMemoryTools(store, store.getIndex()))
+
+	it('exempts tools that declare themselves read-only', () => {
+		expect(isPromptExempt(registry, 'read', {})).toBe(true)
+		expect(isPromptExempt(registry, 'glob', {})).toBe(true)
+		expect(isPromptExempt(registry, 'search_memory', {})).toBe(true)
+		expect(isPromptExempt(registry, 'read_memory', {})).toBe(true)
+	})
+
+	it('prompts for save_memory, which declares readOnly: false', () => {
+		// The whole point. It sat on a list called READ_ONLY_TOOLS while
+		// declaring the opposite, and what it writes outlives the run: content
+		// saved now is retrievable by `search_memory` in a later session, out of
+		// the user's own repository under <cwd>/.namzu/memory.
+		expect(isPromptExempt(registry, 'save_memory', {})).toBe(false)
+	})
+
+	it('prompts for the ordinary mutating builtins', () => {
+		expect(isPromptExempt(registry, 'write', {})).toBe(false)
+		expect(isPromptExempt(registry, 'edit', {})).toBe(false)
+		expect(isPromptExempt(registry, 'bash', {})).toBe(false)
+	})
+
+	it('exempts the task tools by name, as a declared override', () => {
+		// These declare `readOnly: false` too. They are exempt anyway, and that
+		// is a decision the code states rather than disguises.
+		expect(isPromptExempt(registry, 'task_create', {})).toBe(true)
+		expect(isPromptExempt(registry, 'task_update', {})).toBe(true)
+	})
+
+	it('prompts for a tool the registry has never heard of', () => {
+		expect(isPromptExempt(registry, 'SomeUnknownTool', {})).toBe(false)
 	})
 })
 
@@ -193,12 +260,22 @@ describe('previewToolInput', () => {
 })
 
 describe('makeResumeHandler', () => {
-	it('auto-approves read-only batches without calling onPermission', async () => {
+	it('auto-approves exempt batches without calling onPermission', async () => {
 		const onPermission = vi.fn<(r: PermissionRequest) => Promise<PermissionDecision>>()
-		const handler = makeResumeHandler({ all: false }, onPermission)
+		const handler = makeResumeHandler({ all: false }, onPermission, 'prompt', exemptNames('read'))
 		const decision = await handler(toolReview([tc({ name: 'read' })]))
 		expect(decision).toEqual({ action: 'approve_tools' })
 		expect(onPermission).not.toHaveBeenCalled()
+	})
+
+	it('prompts when nothing is exempt, which is the default', async () => {
+		// The parameter defaults to "exempt nothing" rather than to a built-in
+		// list. A handler built without being told what may skip the prompt asks
+		// about everything, which is the direction a mistake should fall.
+		const onPermission = vi.fn(async () => ({ kind: 'approve' }) as PermissionDecision)
+		const handler = makeResumeHandler({ all: false }, onPermission)
+		await handler(toolReview([tc({ name: 'read' })]))
+		expect(onPermission).toHaveBeenCalledOnce()
 	})
 
 	it('prompts for destructive batches and maps approve', async () => {

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -266,6 +266,15 @@ export interface AgentSession {
 	 * are asked before they run" after the operator had turned that off.
 	 */
 	readonly approvalLatched: () => boolean
+	/**
+	 * Tools this session will run without asking, by name.
+	 *
+	 * A function for the same reason as `approvalLatched`, plus one of its own:
+	 * the roster is not final when the session is built. Task tools register
+	 * deferred inside the first `query()`, so anything captured earlier would
+	 * report a set the operator never had.
+	 */
+	readonly promptExemptTools: () => readonly string[]
 	send(messages: readonly Message[], opts?: SendOptions): AsyncIterable<AgentEvent>
 	/**
 	 * Release what the session holds — today, the external tool servers.
@@ -363,8 +372,11 @@ function buildToolRegistry(cwd: string): ToolRegistry {
 	const registry = new ToolRegistry()
 	registry.register(getBuiltinTools().filter((t) => !EXCLUDED_BUILTINS.has(t.name)))
 	// SDK memory: the agent gets search_memory / read_memory / save_memory over
-	// a structured store at ~/.namzu/memory (separate from the user-curated
-	// MEMORY.md that's injected into the prompt).
+	// a structured store at `<cwd>/.namzu/memory` — the WORKING DIRECTORY, not
+	// the home directory. Two comments here used to say `~/.namzu`, which made
+	// `save_memory` look like it touched only namzu's own state and was part of
+	// why it sat on the no-prompt list; it writes into the user's project.
+	// Separate from the user-curated MEMORY.md that is injected into the prompt.
 	const memoryStore = new DiskMemoryStore({ baseDir: join(cwd, '.namzu') })
 	registry.register(buildMemoryTools(memoryStore, memoryStore.getIndex()))
 	// `search_tools` is deliberately NOT registered here. It is only useful
@@ -596,6 +608,7 @@ export async function createAgentSession(
 		errorHint: null,
 		// Reads the same object the handler mutates, at call time.
 		approvalLatched: () => approval.all,
+		promptExemptTools: () => promptExemptToolNames(registry),
 		send: async function* (messages, opts) {
 			// Renew a lapsed OAuth token before the turn runs (no-op for valid
 			// tokens and non-keychain credentials).
@@ -974,7 +987,15 @@ async function* runTurn({
 			...(systemPrompt ? { systemPrompt } : {}),
 			messages: [...messages],
 			workingDirectory,
-			resumeHandler: makeResumeHandler(approval, opts?.onPermission, permissionMode),
+			// The exemption reads `tools` at decision time, so it sees the task
+			// tools `query()` registers deferred below and any tool server that
+			// connected after this session was built.
+			resumeHandler: makeResumeHandler(
+				approval,
+				opts?.onPermission,
+				permissionMode,
+				(name, input) => isPromptExempt(tools, name, input),
+			),
 			signal,
 			...scope,
 		})
@@ -1021,6 +1042,12 @@ export function makeResumeHandler(
 	approval: { all: boolean },
 	onPermission: PermissionFn | undefined,
 	mode: PermissionMode = onPermission ? 'prompt' : 'auto',
+	/**
+	 * Which calls skip the prompt. Injected rather than reached for, so this
+	 * handler stays testable without a registry — and so the answer comes from
+	 * the live roster at the moment of the call.
+	 */
+	exempt: (name: string, input: unknown) => boolean = () => false,
 ): ResumeHandler {
 	return async (request): Promise<HITLResumeDecision> => {
 		if (request.type !== 'tool_review') {
@@ -1031,7 +1058,7 @@ export function makeResumeHandler(
 		// mode decides what happens to the undecided, and cannot reopen anything
 		// a rule closed. That is the whole precedence story between a flag and a
 		// config file, and it is one sentence on purpose.
-		if (!batchNeedsPrompt(request.toolCalls)) {
+		if (!batchNeedsPrompt(request.toolCalls, exempt)) {
 			return { action: 'approve_tools' }
 		}
 		if (mode === 'strict') {
@@ -1069,42 +1096,81 @@ export function makeResumeHandler(
 }
 
 /**
- * Tools known to only observe, never mutate. Anything NOT in this set
- * prompts for approval (safe-by-default: unknown and future tools — e.g.
- * bridged connector tools — are treated as needing consent). Matched
- * case-insensitively so `Read`/`read` both count.
+ * Writes that skip the prompt anyway, in spite of declaring `readOnly: false`.
+ *
+ * This is an OVERRIDE of the tool's own declaration, and it is named as one.
+ * The list it replaced was called `READ_ONLY_TOOLS` and contained three tools
+ * that declare `readOnly: false` — a constant asserting the exact property it
+ * was getting wrong, which is how the disagreement survived: nothing reading it
+ * had reason to doubt the name.
+ *
+ * The bar for an entry is that prompting would be unusable AND a bad write
+ * cannot reach beyond the agent's own bookkeeping. Each one is justified here,
+ * or it does not belong here.
+ *
+ * - `task_create` / `task_update` — the model's own plan for the current
+ *   request, written several times per planning turn; prompting each would put
+ *   a consent dialog between the agent and its todo list. What a bad write
+ *   costs is a polluted task list, which is visible in the transcript and
+ *   grants nothing. Worth knowing while reading that: these DO outlive the
+ *   session, because the CLI's task store uses a fixed run id
+ *   (`run_namzu-cli`), so "run-scoped" is not the reason they are here — the
+ *   blast radius is.
+ *
+ * `save_memory` was on the list it replaced and is deliberately NOT here. Its
+ * effect outlives the run in a way the task tools' does not: content saved now
+ * is retrievable by `search_memory` in a later session, so a tool result or
+ * fetched page that talks the model into saving something reaches a future
+ * run's reasoning. It is not auto-injected into the prompt — that is
+ * `MEMORY.md`, a different thing — but retrievable is enough. A write that
+ * survives the process, into the user's own repository, is not read-only under
+ * any reading, and it now prompts.
  */
-const READ_ONLY_TOOLS = new Set([
-	'read',
-	'glob',
-	'grep',
-	'ls',
-	'verify_outputs',
-	// Memory + task tools touch only the agent's own ~/.namzu state — safe, no prompt.
-	'search_memory',
-	'read_memory',
-	'save_memory',
-	'task_create',
-	'task_update',
-	'task_list',
-])
+const PROMPT_EXEMPT_WRITES = new Set(['task_create', 'task_update'])
 
 /**
- * The same set, sorted, for a surface that has to NAME it.
+ * Whether a call runs without asking: it declares itself read-only, or it is a
+ * named exemption above.
  *
- * Derived rather than retyped: `/permissions` tells the operator which tools
- * run without asking, and a hand-written list beside the real one is a second
- * source of truth that drifts the first time a tool is added to either. The
- * readout is only worth printing if it cannot disagree with the gate.
+ * The read-only half comes from the tool's own `isReadOnly(input)`, never from
+ * a list of names kept here. A name list in the consumer is a second source of
+ * truth for a property the producer already states: a new read-only tool
+ * missing from it merely gets prompted, but a RENAMED tool silently changes
+ * posture with nothing to notice.
+ *
+ * Resolved per call rather than snapshotted, because the roster changes after
+ * this module has run — the task tools are registered deferred inside
+ * `query()`, and tool servers connect during startup, so anything computed
+ * eagerly would be answering about a registry that no longer exists.
+ *
+ * A tool the registry does not know, or one that declares nothing, prompts.
+ * That is the safe-by-default direction the previous comment claimed and this
+ * keeps: consent is the answer when the question cannot be established.
  */
-export const NEVER_PROMPTED_TOOLS: readonly string[] = [...READ_ONLY_TOOLS].sort()
+export function isPromptExempt(registry: ToolRegistry, name: string, input: unknown): boolean {
+	if (PROMPT_EXEMPT_WRITES.has(name.toLowerCase())) return true
+	const tool = registry.get(name) ?? registry.get(name.toLowerCase())
+	return tool?.isReadOnly?.(input) ?? false
+}
+
+/** The exempt roster, sorted, for the surface that has to NAME it. */
+export function promptExemptToolNames(registry: ToolRegistry): readonly string[] {
+	return registry
+		.getCallableTools()
+		.filter((t) => isPromptExempt(registry, t.name, {}))
+		.map((t) => t.name)
+		.sort()
+}
 
 /**
  * A batch needs explicit approval when any call mutates state: flagged
- * destructive by the SDK, or simply not on the read-only allowlist.
+ * destructive by the SDK, or not exempt from the prompt.
  */
-export function batchNeedsPrompt(toolCalls: readonly ToolCallSummary[]): boolean {
-	return toolCalls.some((tc) => tc.isDestructive || !READ_ONLY_TOOLS.has(tc.name.toLowerCase()))
+export function batchNeedsPrompt(
+	toolCalls: readonly ToolCallSummary[],
+	exempt: (name: string, input: unknown) => boolean,
+): boolean {
+	return toolCalls.some((tc) => tc.isDestructive || !exempt(tc.name, tc.input))
 }
 
 /**
@@ -1441,6 +1507,8 @@ function emptySession(errorHint: string): AgentSession {
 		errorHint,
 		// No turn can run here, so no prompt can have been answered.
 		approvalLatched: () => false,
+		// No registry was built, so there is no roster to report on.
+		promptExemptTools: () => [],
 		send: async function* () {
 			yield { kind: 'error' as const, message: errorHint }
 		},

--- a/packages/cli/src/tui/slashCommands.test.ts
+++ b/packages/cli/src/tui/slashCommands.test.ts
@@ -18,7 +18,7 @@ function permissions(over: Partial<SlashContext['permissions']> = {}): SlashCont
 		skipPermissions: false,
 		rules: [],
 		approvalLatched: () => false,
-		neverPrompted: [],
+		neverPrompted: () => [],
 		...over,
 	}
 }
@@ -280,11 +280,13 @@ describe('/permissions', () => {
 		// their absence reads as "the agent did not use any".
 		const r = runSlash(
 			'/permissions',
-			context({ permissions: permissions({ neverPrompted: ['glob', 'read', 'save_memory'] }) }),
+			context({
+				permissions: permissions({ neverPrompted: () => ['glob', 'read', 'task_create'] }),
+			}),
 		)
 		if (r?.kind === 'message') {
 			expect(r.content).toContain('Never prompted')
-			expect(r.content).toContain('glob, read, save_memory')
+			expect(r.content).toContain('glob, read, task_create')
 			// Must not overclaim: a rule still outranks this, and a call flagged
 			// destructive is prompted for even when it is on the list.
 			expect(r.content).toContain('deny')
@@ -348,6 +350,18 @@ describe('/permissions', () => {
 		if (r?.kind === 'message') {
 			expect(r.content).toContain('namzu.config.json')
 			expect(r.content, 'TOML syntax for a JSON file').not.toContain('[permissions]')
+		}
+	})
+
+	it('names the safety gate, which outranks everything else on the page', () => {
+		// The function claims to describe "what decides a tool call, in the order
+		// it actually decides it", and used to begin one step in. The gate is
+		// hardcoded on and no flag reaches it, so leaving it out let "a rule
+		// decides first" read as the whole story.
+		const r = runSlash('/permissions', context())
+		if (r?.kind === 'message') {
+			expect(r.content).toContain('safety gate')
+			expect(r.content).toContain('every mode')
 		}
 	})
 

--- a/packages/cli/src/tui/slashCommands.ts
+++ b/packages/cli/src/tui/slashCommands.ts
@@ -72,10 +72,15 @@ export interface SlashContext {
 		readonly approvalLatched: () => boolean
 		/**
 		 * Tools that never reach the prompt, named so the readout can say so.
+		 *
 		 * Supplied by the caller rather than imported here, because this module
-		 * is deliberately free of the agent runtime.
+		 * is deliberately free of the agent runtime. A function because the
+		 * roster is not final when a session is built — task tools register
+		 * deferred inside the first turn, and tool servers connect during
+		 * startup — so a captured array can describe a set the operator never
+		 * had.
 		 */
-		readonly neverPrompted: readonly string[]
+		readonly neverPrompted: () => readonly string[]
 	}
 	/**
 	 * Delegate ids this session can dispatch to, empty when the delegation tool
@@ -384,13 +389,14 @@ export function renderPermissions(permissions: SlashContext['permissions']): str
 	// Stated in every mode, because it is true in every mode and an operator
 	// cannot discover it by using namzu: these tools simply never appear at a
 	// prompt, so their absence reads as "the agent did not use any".
-	if (permissions.neverPrompted.length > 0) {
+	const neverPrompted = permissions.neverPrompted()
+	if (neverPrompted.length > 0) {
 		lines.push('')
-		lines.push(`Never prompted for (${permissions.neverPrompted.length}):`)
-		lines.push(`  ${permissions.neverPrompted.join(', ')}`)
-		lines.push("These either only observe, or touch only namzu's own state under")
-		lines.push('~/.namzu. A rule can still deny one, and any call the kernel flags')
-		lines.push('destructive is prompted for even if it is on this list.')
+		lines.push(`Never prompted for (${neverPrompted.length}):`)
+		lines.push(`  ${neverPrompted.join(', ')}`)
+		lines.push('Each of these declares itself read-only, or is a named exception')
+		lines.push("for the agent's own task list. A rule can still deny one, and any")
+		lines.push('call the kernel flags destructive is prompted for regardless.')
 	}
 
 	if (permissions.rules.length === 0) {
@@ -404,10 +410,20 @@ export function renderPermissions(permissions: SlashContext['permissions']): str
 	}
 
 	lines.push('')
+	// The order this function claims to describe starts here, and the page used
+	// to begin one step in. Omitting the gate is not a false statement, but it
+	// makes "a rule decides first" read as the whole story when something
+	// outranks the rules too — and a true-but-incomplete order is a wrong order
+	// for anyone reasoning about what can still get through.
+	lines.push('Before any of the below: a built-in safety gate hard-denies a narrow set')
+	lines.push('of catastrophic shell patterns (rm -rf /, mkfs, fork bombs, curl|sh, …).')
+	lines.push('It applies in every mode, including --dangerously-skip-permissions, and')
+	lines.push('nothing here can switch it off.')
+	lines.push('')
 	// Stated because the precedence is the part people get wrong, and getting it
 	// wrong in this direction is the dangerous one: assuming the flag lifts a
 	// `deny` they wrote.
-	lines.push('A rule decides first. The approval setting above only reaches calls')
+	lines.push('Then a rule decides. The approval setting above only reaches calls')
 	lines.push('no rule covered, so it can never reopen what a `deny` closed.')
 
 	return lines.join('\n')


### PR DESCRIPTION
The CLI decided which tools may skip the permission prompt from a hand-maintained list of names called `READ_ONLY_TOOLS`. **Three tools on it declare `readOnly: false` in the SDK** — `save_memory`, `task_create`, `task_update`.

A constant asserted the exact property it was getting wrong. That is how the disagreement survived: nothing reading it had reason to doubt the name.

Its justification said these tools *"touch only the agent's own `~/.namzu` state"*. They do not. The store is built with `join(cwd, '.namzu')`, so the writes land in **the user's project directory**. Two comments said `~/.namzu`; both were wrong and both are fixed.

## `save_memory` now prompts

This is the user-visible change. Its effect outlives the run in a way the task tools' does not: content saved now is retrievable by `search_memory` **in a later session**, out of `<cwd>/.namzu/memory` inside the user's own repository. So a tool result or a fetched page that talks the model into saving something reaches a future run's reasoning.

It is *not* auto-injected into the prompt — that is `MEMORY.md`, a different mechanism — but retrievable is enough. A write that survives the process is not read-only under any reading.

## `task_create` / `task_update` stay exempt, labelled as an override

They now live in `PROMPT_EXEMPT_WRITES` — a set that says what it is — with the reason recorded per entry. They are the model's plan for the current request, written several times per planning turn, so prompting would put a consent dialog between the agent and its todo list. A bad write costs a polluted task list, which is visible in the transcript and grants nothing.

**One thing worth stating plainly, because it would have been an easy false justification:** these do *not* stop at the end of the session. The CLI's task store uses a fixed run id (`run_namzu-cli`), so they persist like everything else in `.namzu`. "Run-scoped" is not why they are exempt — blast radius is, and that is what the comment now says.

## The read-only half is no longer a list of names

It reads each tool's own `isReadOnly(input)` against the live registry. A name list in the consumer is a second source of truth for a property the producer already states: a new read-only tool missing from it merely gets prompted (harmless), but a **renamed** tool silently changes posture with nothing to notice.

Two implementation points that are not incidental:

- **Resolved per call, not snapshotted.** `getCallableTools()` at session-build time does **not** contain the task tools — they are registered *deferred* inside `query()`. A set computed eagerly would have quietly started prompting for them. Resolving at decision time also covers tools from servers that connect during startup.
- **`isReadOnly` is optional and takes the input**, per `ToolDefinition`, so the call passes the input through and falls back to `false`. A tool the registry does not know, or one that declares nothing, prompts — the safe-by-default direction the old comment claimed and this keeps.

`ToolCallSummary` carries no read-only flag, so the CLI resolves this from its own registry rather than requiring a change to a published SDK contract.

## Closing the omission flagged last time

`/permissions` now names the built-in safety gate. The function claims to describe what decides a tool call *"in the order it actually decides it"* and began one step in, which let "a rule decides first" read as the whole story.

Verified rather than assumed: `VERIFICATION_GATE.denyDangerousPatterns` is hardcoded `true` and `gateFor` overrides only `rules`, so no flag reaches it.

## Mutation-checked

| Mutation | Test that dies |
| --- | --- |
| `save_memory` put back on the exempt list | *prompts for save_memory, which declares readOnly: false* |
| unknown tool defaults to exempt (fail-open) | *prompts for a tool the registry has never heard of* |
| exemption allowed to override the destructive flag | *prompts for a destructive call even when it is exempt* |
| safety-gate line removed | *names the safety gate* |
| `App` drops the exempt-roster wiring | the `<App>` readout test |

The new `isPromptExempt` tests run against a **real registry of real tools**, so they assert the tools' own declarations rather than a restatement of them. That is the shape of test that would have caught this divergence in the first place.

## What only you can confirm

Whether the extra `save_memory` prompt is tolerable in practice. If the agent saves often in your workflow it will be visible; `a` covers the session and a `{"permissions": {"save_memory": "allow"}}` rule covers it permanently, and both are in the changeset.

## Checks

`pnpm build` 0 · `pnpm typecheck` 0 · `pnpm test` 0 (cli 577 passed, 3 skipped) · `pnpm lint` 0.
