### PR TITLE
fix(cli): a draft survives a permission prompt and an interrupt

### DIFF
--- a/.changeset/a-draft-survives-a-prompt.md
+++ b/.changeset/a-draft-survives-a-prompt.md
@@ -1,0 +1,25 @@
+---
+'@namzu/cli': patch
+---
+
+A draft is no longer destroyed by a permission prompt, or by interrupting a turn
+
+The composer stays editable while the agent works, and the docs encourage typing
+a follow-up there. Two separate mechanisms then threw that text away without the
+operator doing anything to ask for it.
+
+**The permission overlay unmounted the composer.** It was rendered in a ternary
+*against* the composer, so when the agent asked to run a tool the composer was
+removed from the tree and React discarded its state — the sentence in progress,
+any pasted-text chips, and any pasted images. Nothing was pressed; the prompt
+simply arrived. The overlay and the composer are now siblings, and the composer
+draws nothing while the prompt is up instead of ceasing to exist.
+
+**Esc cleared the draft while interrupting a turn.** Both handlers fire on one
+keypress: the app aborts the turn and the composer cleared itself. The status
+bar advertises Esc as the interrupt, so following the instruction on screen
+destroyed the draft. A running turn now owns Esc; with nothing running, Esc
+still clears the composer, which is what it is for.
+
+Nothing is required of you, and nothing looks different until the moment it
+used to lose your text.

--- a/docs/cli/tui.md
+++ b/docs/cli/tui.md
@@ -186,6 +186,8 @@ edits instead of overwriting. It needs a provider, and says so if there is none.
 
 The composer stays editable while the agent is working. If you send a message mid-turn it's queued (a `⏎ N messages queued` hint shows) and sent automatically when the current turn settles — queued messages run one at a time, in order.
 
+A draft you have not sent survives whatever the agent does. If a permission prompt appears mid-sentence it takes the screen, and your text — along with any pasted-text or image attachments — comes back untouched when the prompt is answered. Pressing `Esc` to interrupt a running turn interrupts only; it does not clear what you were typing. With nothing running, `Esc` clears the composer.
+
 ## Expanding tool output
 
 Tool diffs and command output collapse to a few lines with a `… +N lines (ctrl+o to expand)` hint. Press **Ctrl+O** to toggle full expansion for everything.

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -1011,26 +1011,37 @@ export function App({ ctx }: AppProps) {
 							activeTools={activeTools}
 							thinking={state === 'thinking' && !messages.some((m) => m.pending)}
 						/>
-						{permission ? (
-							<PermissionOverlay toolCalls={permission.toolCalls} />
-						) : (
-							<ComposerFrame focus={state === 'idle' && phase === 'ready'}>
-								{queued.length > 0 ? (
-									<Box paddingX={1}>
-										<Text color={theme.text.muted}>
-											⏎ {queued.length} message{queued.length > 1 ? 's' : ''} queued — sending when
-											ready
-										</Text>
-									</Box>
-								) : null}
-								<Composer
-									disabled={phase !== 'ready' || state === 'awaiting-permission'}
-									onSubmit={handleSubmit}
-									userCommands={userCommands}
-									history={history}
-								/>
-							</ComposerFrame>
-						)}
+						{/* Siblings, not a ternary. The overlay used to REPLACE the
+						    composer, which unmounted it and destroyed whatever the
+						    operator was part-way through typing — text, paste chips
+						    and pasted images alike — on an event they did not
+						    trigger. The composer now stays mounted and draws
+						    nothing while the prompt is up, so its state survives a
+						    decision it had nothing to do with. */}
+						{permission ? <PermissionOverlay toolCalls={permission.toolCalls} /> : null}
+						<ComposerFrame
+							focus={state === 'idle' && phase === 'ready'}
+							hidden={permission !== null}
+						>
+							{queued.length > 0 && permission === null ? (
+								<Box paddingX={1}>
+									<Text color={theme.text.muted}>
+										⏎ {queued.length} message{queued.length > 1 ? 's' : ''} queued — sending when
+										ready
+									</Text>
+								</Box>
+							) : null}
+							<Composer
+								disabled={phase !== 'ready' || state === 'awaiting-permission'}
+								hidden={permission !== null}
+								// A turn is running, so Esc is the interrupt and not
+								// the composer's clear.
+								escapeInterrupts={state === 'thinking' || state === 'tool'}
+								onSubmit={handleSubmit}
+								userCommands={userCommands}
+								history={history}
+							/>
+						</ComposerFrame>
 					</>
 				)}
 				<Box paddingTop={1}>
@@ -1118,9 +1129,24 @@ function TranscriptFrame({ children }: { readonly children: React.ReactNode }) {
 
 function ComposerFrame({
 	focus,
+	hidden = false,
 	children,
 }: {
 	readonly focus: boolean
+	/**
+	 * Draw no frame, but keep the children mounted.
+	 *
+	 * The border is dropped rather than the Box, and that is not a style
+	 * preference. React reconciles by element type at a position: returning
+	 * `<>{children}</>` here instead of `<Box>{children}</Box>` changes the
+	 * type, which unmounts and remounts the subtree — the exact destruction
+	 * this component exists to prevent, reintroduced by the guard meant to
+	 * prevent it. The first version of this fix did that and the tests caught
+	 * it. So the Box is unconditional and only its decoration varies; the
+	 * children render nothing while hidden, so an undecorated Box around
+	 * nothing prints nothing.
+	 */
+	readonly hidden?: boolean
 	readonly children: React.ReactNode
 }) {
 	// Input-field look: a rounded rule above and below the composer, no side
@@ -1128,13 +1154,13 @@ function ComposerFrame({
 	return (
 		<Box
 			flexDirection="column"
-			borderStyle="round"
+			{...(hidden ? {} : { borderStyle: 'round' as const })}
 			borderTop={true}
 			borderBottom={true}
 			borderLeft={false}
 			borderRight={false}
 			borderColor={focus ? theme.border.focus : theme.border.default}
-			marginTop={1}
+			marginTop={hidden ? 0 : 1}
 		>
 			{children}
 		</Box>

--- a/packages/cli/src/tui/Composer.tsx
+++ b/packages/cli/src/tui/Composer.tsx
@@ -23,6 +23,26 @@ export interface ComposerProps {
 	readonly history: readonly string[]
 	/** Operator-defined commands, offered in the dropdown alongside builtins. */
 	readonly userCommands?: readonly UserCommand[]
+	/**
+	 * Draw nothing, but stay mounted and keep the draft.
+	 *
+	 * The permission overlay takes the composer's place on screen. Rendering it
+	 * in a ternary against this component unmounted it, and the draft lives in
+	 * this component's own state — so a prompt arriving mid-sentence took the
+	 * sentence with it, along with any paste chips and pasted images, without
+	 * the operator touching a key.
+	 */
+	readonly hidden?: boolean
+	/**
+	 * Whether Esc belongs to something more urgent than the draft.
+	 *
+	 * While a turn runs, the status bar tells the operator that Esc interrupts
+	 * it. Both handlers fire on the same keypress, so following that instruction
+	 * also cleared the composer — the draft was collateral damage from the
+	 * documented way to stop a turn. Esc still clears an idle composer, which is
+	 * what it is for when nothing more urgent is happening.
+	 */
+	readonly escapeInterrupts?: boolean
 }
 
 const MAX_SUGGESTIONS = 6
@@ -34,6 +54,8 @@ export function Composer({
 	onSubmit,
 	history,
 	userCommands = [],
+	hidden = false,
+	escapeInterrupts = false,
 }: ComposerProps) {
 	const [value, setValue] = useState<string>('')
 	const [historyIndex, setHistoryIndex] = useState<number>(-1)
@@ -59,7 +81,19 @@ export function Composer({
 
 	useInput(
 		(input, key) => {
-			if (disabled) return
+			// Hidden means the screen belongs to something else, so a keypress
+			// aimed at that must not also land here.
+			//
+			// `hidden` is REDUNDANT with `disabled` today and is kept anyway.
+			// The only caller sets `hidden` when a permission prompt is open,
+			// and that same event sets `awaiting-permission`, which already puts
+			// `disabled` true — so removing this clause changes no behaviour and
+			// kills no test, which was confirmed by trying it. It stays because
+			// the two say different things: `disabled` is "the composer may not
+			// be used", `hidden` is "the composer is not on screen", and a
+			// component that draws nothing must not consume input on the
+			// strength of a second flag happening to agree with it.
+			if (disabled || hidden) return
 			if (key.return) {
 				if (showSuggestions) {
 					// Run the highlighted command.
@@ -82,6 +116,10 @@ export function Composer({
 				return
 			}
 			if (key.escape) {
+				// A running turn owns Esc. App aborts it on this same keypress,
+				// and clearing the draft too would punish the operator for
+				// following the hint the status bar is showing them.
+				if (escapeInterrupts) return
 				reset()
 				return
 			}
@@ -143,6 +181,11 @@ export function Composer({
 		},
 		{ isActive: true },
 	)
+
+	// After every hook, so the component keeps its state while it is off screen.
+	// This is the whole fix: React preserves a mounted component's state, and
+	// preserving it is what an unmounting ternary could not do.
+	if (hidden) return null
 
 	const promptGlyph = disabled ? '…' : '>'
 	const showPlaceholder = !disabled && value.length === 0

--- a/packages/cli/src/tui/__tests__/app-draft-survives.test.tsx
+++ b/packages/cli/src/tui/__tests__/app-draft-survives.test.tsx
@@ -1,0 +1,251 @@
+/**
+ * A draft survives the things the operator did not do.
+ *
+ * The composer holds the draft in its own state, and two separate mechanisms
+ * used to destroy it without a deliberate keystroke:
+ *
+ * 1. The permission overlay was rendered in a ternary AGAINST the composer, so
+ *    a prompt arriving mid-sentence unmounted it and took the sentence with it.
+ * 2. Esc while a turn runs fires both handlers — App aborts the turn, and the
+ *    composer cleared itself. The status bar advertises Esc as the interrupt,
+ *    so following the instruction on screen destroyed the draft.
+ *
+ * These assert against a rendered `<App>` driving a real turn and a real prompt
+ * cycle, because "the state hook still holds a value" is not the claim. The
+ * claim is that the text is back on screen afterwards.
+ *
+ * Not a terminal: this reads Ink's frames, so it establishes what was rendered,
+ * not how it looks or feels at human speed.
+ */
+
+import { render } from 'ink-testing-library'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { APPROVAL_SETTLE_MS } from '../consent-timing.js'
+import type { Preferences } from '../../integrations/providers/index.js'
+import type { AgentEvent, AgentSession, PermissionDecision, PermissionRequest } from '../agent.js'
+import type { TuiContext } from '../types.js'
+
+const PREFS: Preferences = { version: 3, providers: [{ id: 'openai' }], subagents: { active: [] } }
+
+const decisions: PermissionDecision[] = []
+/** Held open so the test controls when the prompt appears. */
+let askPermission = true
+
+vi.mock('../../integrations/trust/store.js', () => ({ isTrusted: () => true, trustDir: () => {} }))
+vi.mock('../../integrations/updates.js', () => ({ checkUpdates: async () => [] }))
+vi.mock('../../integrations/sessions/store.js', () => ({
+	openSessions: async () => ({ tenantId: 't' }),
+	startConversation: async () => 'conv',
+	appendMessages: async () => {},
+	listRecent: async () => [],
+	loadConversation: async () => [],
+}))
+vi.mock('../../user-commands/store.js', () => ({ discoverUserCommands: () => [] }))
+
+vi.mock('../agent.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../agent.js')>()
+	return {
+		...actual,
+		probeAgentSession: async () => ({
+			preferences: PREFS,
+			needsRepickReason: null,
+			detected: [],
+		}),
+		createAgentSession: async (): Promise<AgentSession> => ({
+			hasProvider: true,
+			providerSummary: 'a-provider',
+			modelSummary: 'a-model',
+			toolNames: ['bash'],
+			errorHint: null,
+			instructionFiles: [],
+			skippedInstructionFiles: [],
+			mcpConnected: [],
+			mcpFailed: [],
+			agentIds: [],
+			configNotices: [],
+			close: async () => {},
+			approvalLatched: () => false,
+			promptExemptTools: () => ['read'],
+			send: async function* (_messages, opts): AsyncIterable<AgentEvent> {
+				yield { kind: 'delta', text: 'working' } as AgentEvent
+				// Long enough for the test to type into a live composer.
+				await new Promise((r) => setTimeout(r, 120))
+				if (!askPermission) return
+				const req: PermissionRequest = {
+					toolCalls: [{ id: 'c1', name: 'bash', summary: 'rm -rf build', isDestructive: true }],
+				}
+				const decision = await opts?.onPermission?.(req)
+				if (decision) decisions.push(decision)
+			},
+		}),
+	}
+})
+
+const { App } = await import('../App.js')
+
+const ctx: TuiContext = { cwd: process.cwd(), version: '0.0.0-test' }
+const tick = (ms = 40) => new Promise((r) => setTimeout(r, ms))
+
+/**
+ * Wait for `text` to appear in the frame, or give up.
+ *
+ * Polling rather than one fixed sleep, for a reason this suite has already paid
+ * for twice: the run transforms TypeScript on the way in, so under the full
+ * parallel suite a step that takes 40ms alone can take several hundred. A fixed
+ * wait turns that into a red assertion with nothing about the code changed.
+ * Absence still needs a fixed wait — it cannot be polled for — which is why the
+ * `not.toContain` assertions below sit after a generous one.
+ */
+async function frameShows(
+	lastFrame: () => string | undefined,
+	text: string,
+	timeoutMs = 3_000,
+): Promise<void> {
+	const started = performance.now()
+	while (!(lastFrame() ?? '').includes(text) && performance.now() - started < timeoutMs) {
+		await tick(20)
+	}
+}
+
+let nowMs = 1_000_000
+const mounted: { unmount: () => void }[] = []
+
+beforeEach(() => {
+	decisions.length = 0
+	askPermission = true
+	nowMs = 1_000_000
+	vi.spyOn(Date, 'now').mockImplementation(() => nowMs)
+})
+
+afterEach(() => {
+	for (const h of mounted) h.unmount()
+	mounted.length = 0
+	vi.restoreAllMocks()
+})
+
+function settle(): void {
+	nowMs += APPROVAL_SETTLE_MS + 1
+}
+
+/** Ready, with a turn running and `draft` typed into the live composer. */
+async function turnRunningWithDraft(draft: string) {
+	const harness = render(<App ctx={ctx} />)
+	mounted.push(harness)
+	await tick(80)
+	// Keys go in separately: one `stdin.write` is one keypress, so 'go\r' would
+	// arrive as pasted text and never submit.
+	harness.stdin.write('go')
+	await tick(20)
+	harness.stdin.write('\r')
+	await tick(40)
+	harness.stdin.write(draft)
+	await tick(40)
+	expect(harness.lastFrame(), 'the draft never reached the composer').toContain(draft)
+	return harness
+}
+
+describe('a draft while a permission prompt comes and goes', () => {
+	it('is still there after the prompt is answered', async () => {
+		const draft = 'and then deploy'
+		const { stdin, lastFrame } = await turnRunningWithDraft(draft)
+
+		// The prompt takes the screen. The draft is deliberately not shown while
+		// it is up — the composer is hidden, not unmounted.
+		await frameShows(lastFrame, 'wants to run')
+		expect(lastFrame(), 'the prompt never opened').toContain('wants to run')
+
+		// Answer it, and the composer comes back with the sentence intact.
+		stdin.write('\x1B')
+		await frameShows(lastFrame, draft)
+
+		expect(decisions).toEqual([{ kind: 'reject' }])
+		expect(lastFrame(), 'the draft was destroyed by the prompt').toContain(draft)
+	})
+
+	it('keeps a pasted attachment across the same cycle', async () => {
+		// Text is the visible half; the chips are the half a user would only
+		// notice after sending an incomplete message.
+		const harness = render(<App ctx={ctx} />)
+		mounted.push(harness)
+		await tick(80)
+		harness.stdin.write('go')
+		await tick(20)
+		harness.stdin.write('\r')
+		await tick(40)
+		// A newline in one keypress is held as a paste chip.
+		harness.stdin.write('first line\nsecond line')
+		await tick(40)
+		expect(harness.lastFrame(), 'the paste chip never appeared').toContain('Pasted text')
+
+		await frameShows(harness.lastFrame, 'wants to run')
+		expect(harness.lastFrame()).toContain('wants to run')
+		harness.stdin.write('\x1B')
+		await frameShows(harness.lastFrame, 'Pasted text')
+
+		expect(harness.lastFrame(), 'the paste chip was destroyed').toContain('Pasted text')
+	})
+})
+
+describe('esc while a turn is running', () => {
+	it('interrupts the turn without clearing the draft', async () => {
+		// The status bar tells the operator Esc interrupts. Doing what it says
+		// must not also empty the composer.
+		askPermission = false
+		const draft = 'keep me'
+		const { stdin, lastFrame } = await turnRunningWithDraft(draft)
+
+		stdin.write('\x1B')
+		await frameShows(lastFrame, 'Interrupted')
+
+		expect(lastFrame(), 'the turn was not interrupted').toContain('Interrupted')
+		expect(lastFrame(), 'esc cleared the draft').toContain(draft)
+	})
+
+	it('still clears the composer when nothing is running', async () => {
+		// The other half: Esc must not become inert. With no turn in flight it
+		// is the composer's own clear, which is what it is for.
+		askPermission = false
+		const harness = render(<App ctx={ctx} />)
+		mounted.push(harness)
+		await tick(80)
+		harness.stdin.write('throwaway')
+		await tick(40)
+		expect(harness.lastFrame()).toContain('throwaway')
+
+		harness.stdin.write('\x1B')
+		await tick(120)
+
+		expect(harness.lastFrame(), 'esc did not clear an idle composer').not.toContain('throwaway')
+	})
+})
+
+describe('while the prompt is up', () => {
+	it('the composer draws nothing and takes no keys', async () => {
+		// Hidden has to mean hidden: a keystroke aimed at the prompt must not
+		// also be appended to the draft behind it.
+		//
+		// Honest about what this pins: the "takes no keys" half is currently
+		// enforced by `disabled`, not by `hidden`, because a permission prompt
+		// sets both. Removing `hidden` from the composer's input guard leaves
+		// this test green — verified by mutation. What it does pin is the
+		// outcome, which is the thing that matters if either flag later moves.
+		const draft = 'untouched'
+		const { stdin, lastFrame } = await turnRunningWithDraft(draft)
+		await frameShows(lastFrame, 'wants to run')
+		expect(lastFrame()).toContain('wants to run')
+		expect(lastFrame(), 'the composer is still drawing under the prompt').not.toContain(draft)
+
+		// `q` decides nothing at the prompt; it must not reach the composer.
+		stdin.write('q')
+		await tick(60)
+		settle()
+		stdin.write('\x1B')
+		await frameShows(lastFrame, draft)
+
+		expect(lastFrame()).toContain(draft)
+		expect(lastFrame(), 'a key meant for the prompt landed in the draft').not.toContain(
+			`${draft}q`,
+		)
+	})
+})

--- a/packages/cli/src/tui/__tests__/app-permission-keys.test.tsx
+++ b/packages/cli/src/tui/__tests__/app-permission-keys.test.tsx
@@ -298,8 +298,16 @@ describe('/permissions after approve-all', () => {
 		await decisionSettles()
 		expect(decisions, 'a did not approve-all').toEqual([{ kind: 'approve-all' }])
 
-		// The turn is over and the composer is back. Ask the page.
+		// The turn is over and the composer is back — still holding the draft
+		// that was typed while it ran, which is the point of the fix in
+		// `app-draft-survives.test.tsx`. Clear it before typing a command, or
+		// the command is appended to the draft and submitted as prose.
+		//
+		// Worth naming: this step was not needed while the composer unmounted,
+		// so this test used to pass BECAUSE the draft was being destroyed.
 		await tick(120)
+		stdin.write('\x1B')
+		await tick(60)
 		stdin.write('/permissions')
 		await tick(60)
 		stdin.write('\r')


### PR DESCRIPTION
The composer stays editable while the agent works, and `docs/cli/tui.md` encourages typing a follow-up there. Two mechanisms then threw that text away **with no keystroke from the operator**.

## 1. The permission overlay unmounted the composer

It was rendered in a ternary *against* the composer, so when the agent asked to run a tool the composer left the tree and React discarded its state: the sentence in progress, the paste chips, the pasted images. Nothing was pressed — the prompt simply arrived, on the agent's schedule, and took whatever was in the operator's hands with it.

The overlay and the composer are siblings now. The composer draws nothing while the prompt is up rather than ceasing to exist.

## 2. Esc cleared the draft while interrupting a turn

Both handlers fire on one keypress: App aborts the turn, and the composer reset itself. The status bar advertises Esc as the interrupt — so **following the instruction on screen destroyed the message being typed**.

A running turn owns Esc now. With nothing running Esc still clears the composer, which is what it is for, and that half is pinned too so the key cannot quietly become inert.

## Which fix, and what it costs

**Chosen: keep it mounted and hidden. Rejected: lifting the draft into `App`.**

Lifting moves five pieces of state up (`value`, `historyIndex`, `selected`, `pastes`, `images`) and makes **every keystroke re-render the whole tree** — transcript, bottom-spacer computation, status bar — where today a keystroke re-renders only the composer. Staying mounted also preserves the attachments and the history position for free, because it preserves the component rather than reconstructing what the component was holding.

The cost is that "hidden" is now a state the composer has to know about, so it carries a `hidden` prop and returns `null` after its hooks.

## The trap, recorded because I fell into it

The first version had `ComposerFrame` return `<>{children}</>` when hidden. **React reconciles by element type at a position**, so swapping a `<Box>` for a Fragment unmounts and remounts the subtree — reintroducing the exact destruction the guard existed to prevent, inside the guard. The tests caught it. The Box is unconditional now and only its decoration varies.

## A pre-existing test was passing *because* of the bug

The `/permissions` after-approve-all test typed a command straight after a prompt cycle. That only worked because the draft had been destroyed; with the draft surviving, the command was appended to it and submitted as prose. It clears the composer first now, and says why.

## Mutation-checked

| Mutation | Result |
| --- | --- |
| overlay replaces the composer again (the original defect) | 3 draft tests die |
| `ComposerFrame` returns a Fragment when hidden | the same 3 die |
| Esc always clears, even mid-turn | the interrupt test dies |
| **`hidden` removed from the composer's input guard** | **nothing dies** |

**That last row is a finding, not a gap.** `hidden` is redundant with `disabled`: a permission prompt sets both, so the clause changes no behaviour today. I kept it — the two flags mean different things, and a component drawing nothing should not consume input on the strength of a second flag happening to agree with it — but the redundancy is now stated in the source and in the test rather than implied to be load-bearing.

Also confirmed as a negative: inserting a conditional sibling *above* the composer does **not** remount it, because `{cond ? <X/> : null}` keeps the slot count stable. Only the alternation does.

## What the tests cover, and what only you can confirm

They drive a real turn and a real prompt cycle against a rendered `<App>` and assert the text is **back on screen** afterwards — not that a state hook still holds a value. Two of the five previously failed under the full parallel suite while passing alone (the transform-load cliff this repo has met before), so positive assertions poll for the frame rather than sleeping a fixed interval; negative assertions still use a generous fixed wait, because absence cannot be polled for.

**A frame in a harness is not a terminal.** Whether the composer reappearing under a dismissed prompt *reads* as continuity at human speed is yours to judge.

## Checks

`pnpm build` 0 · `pnpm typecheck` 0 · `pnpm test` 0 (run twice; cli 590 passed, 3 skipped) · `pnpm lint` 0.
