### PR TITLE
docs(conventions): rendering two things in a ternary destroys the state of both

### DIFF
--- a/docs/conventions/alternation-unmounts-state.md
+++ b/docs/conventions/alternation-unmounts-state.md
@@ -1,0 +1,115 @@
+---
+uid: namzu.conventions.alternation-unmounts-state
+title: Rendering two things in a ternary destroys the state of both
+description: A component swapped for another at the same position is unmounted, and its state goes with it. The guard written to preserve that state reintroduced the loss when it changed the element type it returned.
+type: Convention
+diataxis: explanation
+owner: cogitave/namzu
+status: active
+timestamp: 2026-08-09T00:00:00Z
+lastReviewed: 2026-08-09
+resource: packages/cli/src/tui/App.tsx
+tags: [convention, react, state, ui]
+---
+
+# Rendering two things in a ternary destroys the state of both
+
+Ratified 2026-08-09, from the composer-unmount fix.
+
+React reconciles by **element type at a position**. Render a different type in
+the same slot and the old subtree is unmounted, its state discarded and its
+effects torn down. This is correct, documented behaviour. It becomes a defect
+when the state being discarded is the user's, and when nothing on screen says it
+happened.
+
+## The incident
+
+The TUI's permission overlay was rendered as the alternative to the composer:
+
+```tsx
+{permission ? <PermissionOverlay … /> : <ComposerFrame><Composer /></ComposerFrame>}
+```
+
+The draft lives in `Composer`'s own `useState`. So when the agent asked to run a
+tool, the composer was unmounted and the operator's half-typed sentence, paste
+chips and pasted images went with it — on an event they did not trigger, with no
+keypress, and no message saying anything had been lost.
+
+The fix makes them siblings and hides the composer instead of replacing it.
+
+## The same mistake, inside the fix
+
+The first version of that fix had `ComposerFrame` return early when hidden:
+
+```tsx
+if (hidden) return <>{children}</>   // was: <Box …>{children}</Box>
+```
+
+That changes the element type at the position from `Box` to `Fragment`, so React
+unmounted and remounted the subtree — **reintroducing the exact destruction the
+guard had just been written to prevent.** The children were still "rendered", the
+prop was honoured, the code read as obviously correct, and it would have passed
+review.
+
+Three tests caught it, and that is the argument for having written them first: a
+guard whose own defect is caught by its own tests costs an hour, and the same
+guard shipped costs a user their message with no way to know why. The tests
+asserted the draft was *back on screen* after a real prompt cycle — not that a
+state hook still held a value, which would have passed.
+
+So: when a component must disappear without dying, **keep the element type
+stable and vary its decoration**. Here the `Box` became unconditional and only
+its border and margin change; the children render `null` while hidden, so an
+undecorated box around nothing prints nothing.
+
+## The rule is about alternation, not about conditionals
+
+This is the half that keeps the rule usable rather than superstitious, and it
+was measured rather than assumed. Putting a component behind a condition is
+fine. Two shapes, one destructive:
+
+```tsx
+{cond ? <A /> : <B />}      // ALTERNATION — swaps the type, unmounts
+{cond ? <A /> : null}       // fine — the slot stays, holding nothing
+```
+
+A conditional sibling *above* a component does not remount it: `{cond ? <X/> :
+null}` keeps the slot count stable, so the component after it stays at the same
+position. This was confirmed by mutation — inserting exactly that sibling killed
+no test, correctly.
+
+Read as "never render a component conditionally", the rule would be wrong and
+would be cargo-culted into worse code. It is narrower than that: **only
+alternation destroys.**
+
+## Where to look for it
+
+The shape is worth grepping for wherever a component owns state a user typed:
+
+- a ternary whose two branches are different components;
+- an early `return` in a component that changes what element type it yields;
+- a wrapper that drops its own element when some prop is set.
+
+## A tell: a test whose green depended on the defect
+
+When the draft started surviving, an unrelated test broke. It typed a slash
+command straight after a permission cycle, and had only ever worked because the
+composer was being emptied for it — with the draft preserved, the command was
+appended to the leftover text and submitted as prose.
+
+This is the inverse of a mutation check. A mutation check asks whether a test
+fails when the code breaks; this is a test that passed *because* the code was
+already broken. It is rarer and it has no automated form, so the tell is worth
+knowing: **a test that starts failing when you fix a defect may have been
+depending on it.** Read such a failure before adjusting the test — it is
+evidence about the old behaviour, not noise.
+
+## Related
+
+- [Finding an emitter is not evidence that every path reaches it](one-site-is-not-every-site.md)
+  — the same shape: the mechanism was right and one path through it did not use
+  it.
+- [Mutate every test](mutation-check-every-test.md) — including the negative
+  results, which are what made the alternation rule precise here.
+- [A check that cannot fail is worse than no check](a-check-that-cannot-fail.md)
+  — a test asserting a hook's value rather than the screen would have been one.

--- a/docs/conventions/index.md
+++ b/docs/conventions/index.md
@@ -22,6 +22,9 @@ Read the rule that matches what you are about to change before you change it.
   — the behaviour is covered; the hop from the surface a host builds is not.
 - [Finding an emitter is not evidence that every path reaches it](one-site-is-not-every-site.md)
   — the some-sites case, plus: how many shapes does this concept have?
+- [Rendering two things in a ternary destroys the state of both](alternation-unmounts-state.md)
+  — and the guard written to prevent it did it again. Only alternation
+  destroys; a conditional sibling does not.
 
 ### Refusing rather than degrading
 

--- a/docs/conventions/meta.json
+++ b/docs/conventions/meta.json
@@ -6,6 +6,7 @@
     "declared-but-undriven",
     "reachability-is-its-own-property",
     "one-site-is-not-every-site",
+    "alternation-unmounts-state",
     "---Refusing vs Degrading---",
     "refuse-do-not-degrade",
     "an-optional-dependency-may-not-degrade-a-check",

--- a/docs/conventions/mutation-check-every-test.md
+++ b/docs/conventions/mutation-check-every-test.md
@@ -121,6 +121,23 @@ A skip is a result to look at, not a rounding error. Platform-gated with the
 reason written in the file is fine; a contract test skipped for want of a
 credential is a hole wearing a green summary.
 
+## The inverse: a test whose green depended on the defect
+
+Mutation asks whether a test fails when the code breaks. The rarer case is a
+test that passed *because* the code was already broken, and it announces itself
+by failing when you fix something unrelated to it.
+
+Fixing the composer unmount broke a `/permissions` test. It typed a slash
+command straight after a permission cycle, and had only ever worked because the
+composer was being emptied for it; with the draft preserved, the command was
+appended to the leftover text and submitted as prose.
+
+There is no automated form of this, so the tell is the discipline: **a test that
+starts failing when you fix a defect may have been depending on it.** Read the
+failure as evidence about the old behaviour before adjusting the test, and
+record why the adjustment was needed — otherwise the next reader sees an
+unexplained edit to an unrelated test in a bug-fix diff.
+
 ## Related
 
 - [A declaration nothing drives is a defect](declared-but-undriven.md)


### PR DESCRIPTION
Two rules extracted from the composer-unmount fix ([#277](https://github.com/cogitave/namzu/pull/277)), promoted so the next person meets them where they will hit them rather than in a merged PR body.

## New: rendering two things in a ternary destroys the state of both

React reconciles by element type at a position, so alternation unmounts. That is documented behaviour and not news. What makes it a rule here is **where it bit**: the TUI rendered its permission overlay as the *alternative* to the composer, so a prompt arriving mid-sentence unmounted the composer and discarded the operator's draft.

And then it bit again, inside the fix. The first version had `ComposerFrame` return `<>{children}</>` instead of its `<Box>` when hidden — changing the element type at that position, unmounting the subtree, **reintroducing the exact destruction the guard had just been written to prevent.**

It is recorded because that version read as obviously correct and would have passed review. **Three tests caught it**, which is the argument for having written them first: the guard shipped costs a user their message with no way to know why. The tests asserted the draft was back *on screen* after a real prompt cycle — a test asserting a state hook still held a value would have passed.

### The negative result is in the rule on purpose

```tsx
{cond ? <A /> : <B />}   // ALTERNATION — swaps the type, unmounts
{cond ? <A /> : null}    // fine — the slot stays, holding nothing
```

A conditional sibling *above* a component does not remount it, because `{cond ? <X/> : null}` keeps the slot count stable. Confirmed by a mutation that killed nothing, correctly.

Without that half the rule reads as *"never render a component conditionally"* — which is wrong, and is exactly the sort of thing that gets cargo-culted into worse code. **Only alternation destroys.**

## Amended: the inverse of a mutation check

Fixing the unmount broke an unrelated `/permissions` test. It typed a slash command straight after a permission cycle, and had only ever passed **because the composer was being emptied for it**; with the draft preserved, the command was appended to the leftover text and submitted as prose.

A mutation check asks whether a test fails when the code breaks. This is a test that passed *because* the code was already broken. It is rarer and has no automated form, so it goes in as a tell: **a test that starts failing when you fix a defect may have been depending on it** — read the failure as evidence about the old behaviour before adjusting the test, and record why the adjustment was needed, or the next reader sees an unexplained edit to an unrelated test inside a bug-fix diff.

## Placement

Filed under *Declarations and reachability* rather than a new React section — it is the same shape as `one-site-is-not-every-site`: the mechanism was right and one path through it did not use it. `resource:` points at `App.tsx`, so the gate will flag the rule if that file moves on without it.

## Checks

`pnpm docs:check` 0 — 0 problems across 13 checked files.
