### PR TITLE
feat(sdk): the run record names the member that served

### DIFF
--- a/.changeset/the-run-record-names-who-served.md
+++ b/.changeset/the-run-record-names-who-served.md
@@ -1,0 +1,47 @@
+---
+'@namzu/sdk': major
+---
+
+**The run record names the member that served.** After a provider chain fell
+over, `run.metadata.provider` and every step's `model` still named the head. The
+wire and the metering followed the member that answered; the durable record did
+not, so a run read back six months later said the primary served a turn it never
+saw. A missing field reads as unknown and a wrong one reads as a fact.
+
+**What is major: `StepResult.model` reports a different value.** It now names
+the model the step **asked for** — the run's configured model, or a
+`prepareStep` override. It used to be the run's model unconditionally, so a host
+that routed one step to a cheaper model read the expensive one back out of the
+ledger. That defect needed no chain to see. Nothing stops compiling; the value
+changes. If you were reading `step.model` to recover the run's configured model,
+read `run.metadata.config.model`, which has always held it.
+
+**New, and additive:**
+
+- `StepResult.servedBy` — `{ providerId, model, chainIndex }`, who actually
+  answered the step. Equal to `model` and to `run.metadata.provider` on every
+  run without a chain; it diverges exactly when the chain advanced.
+  `chainIndex` is the member's position in the chain you declared (`0` is the
+  head) and is carried because a chain may name the same provider twice with
+  two models, which `providerId` alone cannot tell apart.
+- `RunStateMetadata.servingProvider` — the member the run was routed to at the
+  end, absent when the configured provider served throughout.
+  `RunStateMetadata.provider` is unchanged and still names what you configured:
+  what was asked for and what answered are two facts, and collapsing them into
+  one field is how the original defect was made.
+- `WithProviderFallbackOptions.onSwap` and the `ServingMember` type, for a host
+  composing `withProviderFallback` itself.
+
+**Two limits, stated rather than papered over.** The loop records a step only
+for a tool-calling turn, so the turn that produces the final answer is not in
+`steps` — on a chain that falls over and answers immediately,
+`metadata.servingProvider` is the only record of the swap. And the built-in disk
+store writes `metadata`, not `steps`: per-step provenance reaches you on the
+returned `Run`, so persist that if you need it.
+
+**Nothing is backfilled.** Records written by 17.0.0 could fall over without
+recording it, so their `servedBy` is absent and their `servingProvider` reads as
+"no swap" whether or not there was one; the transcript's `provider_fallback`
+events are the record for those runs. Filling them in from the declared head
+would state as fact the exact thing that release got wrong, on exactly the runs
+where it was wrong.

--- a/.github/scripts/public-surface-baseline.json
+++ b/.github/scripts/public-surface-baseline.json
@@ -1333,6 +1333,7 @@
     "SteeringBinding",
     "SteeringChannel",
     "StepContext",
+    "StepProvenance",
     "StepResult",
     "StepToolResult",
     "StopCondition",

--- a/docs/conventions/sound-about-the-wrong-thing.md
+++ b/docs/conventions/sound-about-the-wrong-thing.md
@@ -7,7 +7,7 @@ diataxis: explanation
 owner: cogitave/namzu
 status: active
 timestamp: 2026-08-06T00:00:00Z
-lastReviewed: 2026-08-08
+lastReviewed: 2026-08-09
 resource: packages/sdk/src/runtime/query/index.ts
 tags: [convention, testing, verification]
 ---
@@ -16,7 +16,8 @@ tags: [convention, testing, verification]
 
 Ratified 2026-08-06; amended the same session with "a live run is still an
 observation", and on 2026-08-08 with "it is not a rule about tests" and with the
-provider-chain instance below.
+provider-chain instance below, and on 2026-08-09 with "a comment that names the
+wrong hazard".
 
 A test can run, cover a real path, and go red under mutation, and still be
 evidence about a property nobody needed. The machinery is honest; the
@@ -86,6 +87,22 @@ the test yet.
 
 That last one is the rule pointed at source rather than at tests: a comment
 claiming which line does the protecting is a claim to mutate.
+
+## A comment that names the wrong hazard is the same defect
+
+The provenance work read "which chain member is serving" immediately after the
+provider turn returned, and the comment explaining *why not later* named a
+compaction or advisory side call advancing the cursor during tool execution.
+The mutation for it — move the read down to `recordStep` — **killed nothing**,
+and reading the loop said why: compaction and the working-memory refresh run
+BEFORE the turn, the advisory phase runs AFTER the step is recorded, and the
+only thing between the two is tool execution, which does not call that provider.
+
+Both halves of the correction matter. The placement was kept, because a phase
+inserted there later would break the attribution silently. The **comment** was
+rewritten, because a reader who checks a claimed hazard and finds it cannot
+happen learns to stop checking the claims. Defence in depth is an honest thing
+to write down; a defect it does not prevent is not.
 
 ## A live run is still an observation
 

--- a/docs/sdk/runtime/loop-control.md
+++ b/docs/sdk/runtime/loop-control.md
@@ -112,6 +112,7 @@ query({
 | Field | |
 | --- | --- |
 | `stepNumber`, `model`, `messageId` | identity |
+| `servedBy` | which provider and model actually answered |
 | `content`, `toolCalls`, `toolResults` | what happened |
 | `finishReason` | why the turn ended |
 | `usage`, `costDelta` | **this step's** consumption, not the running total |
@@ -119,6 +120,39 @@ query({
 
 `toolResults` is ordered by the tool *calls*, so it lines up with
 `toolCalls` index for index.
+
+### What was asked for, and what answered
+
+`model` is the model the step **asked for** — the run's configured model, or
+the override a [`prepareStep`](#5-shaping-each-step) hook returned for this
+step. `servedBy` is who answered it:
+
+```ts
+step.model    // 'primary-model' — what the step asked for
+step.servedBy // { providerId: 'fallback-provider', model: 'fallback-model', chainIndex: 1 }
+```
+
+They are equal on every run without a provider chain. They diverge when a
+chain falls over ([CLI chain
+docs](../../cli/providers.md#the-provider-chain)): the request goes to the next
+member, and `servedBy.chainIndex`
+is that member's position in the chain you declared — `0` is the head. The index
+is there because a chain may name the same provider twice with two models, and
+`providerId` alone could not tell those apart.
+
+At run level, `run.metadata.provider` stays the provider you **configured** and
+`run.metadata.servingProvider` names the member the run was routed to at the
+end, absent when the configured one served throughout.
+
+Two limits worth knowing before you build on this:
+
+- **Only tool-calling turns are recorded.** The turn that produces the final
+  answer ends the loop before a step is written, so it is not in `steps`. On a
+  chain that falls over and answers immediately, `run.metadata.servingProvider`
+  is the only record of the swap.
+- **The built-in store writes `metadata`, not `steps`.** `run.json` carries
+  `servingProvider`; per-step provenance reaches you on the returned `Run`, so
+  persist that if you need it.
 
 ## 3. Transient Provider Failures
 

--- a/packages/sdk/src/manager/run/persistence.ts
+++ b/packages/sdk/src/manager/run/persistence.ts
@@ -286,6 +286,20 @@ export class RunPersistence {
 		this.run.steps = steps
 	}
 
+	/**
+	 * Record that a provider chain advanced, so the run record stops naming a
+	 * member that did not serve.
+	 *
+	 * Last writer wins on purpose: a chain of four can advance three times in
+	 * one run, and `metadata.servingProvider` answers "who was serving when
+	 * this ended", not "who was ever asked". The full sequence is in the
+	 * transcript's `provider_fallback` events and, per turn, in
+	 * `steps[].servedBy`.
+	 */
+	setServingProvider(providerId: string): void {
+		this.run.metadata.servingProvider = providerId
+	}
+
 	clearLastPromptTokens(): void {
 		this._lastPromptTokens = undefined
 		this._lastPromptMessageCount = undefined

--- a/packages/sdk/src/provider/__tests__/fallback.test.ts
+++ b/packages/sdk/src/provider/__tests__/fallback.test.ts
@@ -331,6 +331,116 @@ describe('withProviderFallback', () => {
 		const wrapped = withProviderFallback([{ provider: primary }, { provider: fallback }])
 		expect(wrapped.id).toBe('primary')
 	})
+
+	/**
+	 * `onSwap` announces SERVICE, not selection, and the two are separated by a
+	 * suspension the consumer controls.
+	 */
+	describe('onSwap', () => {
+		it('announces the replacement when it is asked', async () => {
+			const primary = member('primary', [
+				() =>
+					(async function* () {
+						throw httpError(401)
+						// biome-ignore lint/correctness/noUnreachable: the generator must be one
+						yield chunk('')
+					})(),
+			])
+			const fallback = member('fallback', [
+				() =>
+					(async function* () {
+						yield chunk('served')
+					})(),
+			])
+			const seen: Array<{ index: number; providerId: string; model?: string }> = []
+
+			const wrapped = withProviderFallback(
+				[{ provider: primary }, { provider: fallback, model: 'tail-model' }],
+				{ onSwap: (to) => seen.push(to) },
+			)
+			expect(await drain(wrapped.chatStream({ model: 'head-model', messages: [] }))).toBe('served')
+
+			expect(seen).toEqual([{ index: 1, providerId: 'fallback', model: 'tail-model' }])
+		})
+
+		/**
+		 * The window this closes: the cursor moves inside the catch, the notice
+		 * chunk goes out, and the replacement is only asked when the consumer
+		 * comes back. A consumer that leaves at the notice — a Stop, a `break`,
+		 * a host abandoning the iterator — has selected a member and asked it
+		 * nothing.
+		 *
+		 * Announcing at cursor-move passes every other case in this file and
+		 * fails only this one, which is why it is here: a run record built on
+		 * that announcement would say a provider served a turn it never
+		 * received.
+		 */
+		it('says nothing when the consumer leaves at the notice and the replacement is never asked', async () => {
+			const primary = member('primary', [
+				() =>
+					(async function* () {
+						throw httpError(401)
+						// biome-ignore lint/correctness/noUnreachable: the generator must be one
+						yield chunk('')
+					})(),
+			])
+			const fallback = member('fallback', [
+				() =>
+					(async function* () {
+						yield chunk('never reached')
+					})(),
+			])
+			const seen: unknown[] = []
+
+			const wrapped = withProviderFallback([{ provider: primary }, { provider: fallback }], {
+				onSwap: (to) => seen.push(to),
+			})
+
+			// Take exactly the notice and stop, the way an abandoned iterator does.
+			const it_ = wrapped.chatStream({ model: 'm', messages: [] })[Symbol.asyncIterator]()
+			const notice = await it_.next()
+			await it_.return?.(undefined)
+
+			expect(notice.value?.fallback?.toProviderId).toBe('fallback')
+			expect(fallback.calls).toBe(0)
+			expect(seen).toEqual([])
+		})
+
+		it('announces once per swap, not once per request to the same member', async () => {
+			const failOnce = member('primary', [
+				() =>
+					(async function* () {
+						throw httpError(401)
+						// biome-ignore lint/correctness/noUnreachable: the generator must be one
+						yield chunk('')
+					})(),
+			])
+			const fallback = member('fallback', [
+				() =>
+					(async function* () {
+						yield chunk('one')
+					})(),
+				() =>
+					(async function* () {
+						yield chunk('two')
+					})(),
+			])
+			const seen: unknown[] = []
+
+			const wrapped = withProviderFallback([{ provider: failOnce }, { provider: fallback }], {
+				onSwap: (to) => seen.push(to),
+			})
+
+			await drain(wrapped.chatStream({ model: 'm', messages: [] }))
+			// The cursor's lifetime is the wrapper's, so the second request goes
+			// straight to the member already serving. A listener that started at
+			// member 0 and applied the one call it got is still correct.
+			await drain(wrapped.chatStream({ model: 'm', messages: [] }))
+
+			expect(fallback.calls).toBe(2)
+			expect(seen).toHaveLength(1)
+		})
+	})
 })
 
 /**

--- a/packages/sdk/src/provider/fallback.ts
+++ b/packages/sdk/src/provider/fallback.ts
@@ -45,8 +45,75 @@ export interface ProviderChainMember {
 	readonly model?: string
 }
 
+/**
+ * The member serving from now on.
+ *
+ * `index` is a position in the chain the host declared, so a reader can name
+ * the member without holding the chain: "member 2 of 4" is the sentence an
+ * operator writes in an incident note.
+ */
+export interface ServingMember {
+	readonly index: number
+	readonly providerId: string
+	/** Absent for a member declared without one — see {@link ProviderChainMember.model}. */
+	readonly model?: string
+}
+
 export interface WithProviderFallbackOptions {
 	readonly log?: Logger
+	/**
+	 * Called once per swap, with the member that serves from here on.
+	 *
+	 * A callback is enough to describe the WHOLE truth, not a sample of it,
+	 * and that is a property of the cursor rather than of this option: the
+	 * chain never rewinds, so "who is serving" is exactly "the head, plus
+	 * every swap so far". A listener that starts at member 0 and applies each
+	 * call is never behind.
+	 *
+	 * It exists beside the in-band `fallback` chunk rather than instead of it
+	 * because the two have different observers and neither covers the other's
+	 * case. The chunk reaches whoever is iterating the stream, at the moment
+	 * of the swap — that is the operator. This reaches a party that has to
+	 * know AFTER the request is over and may never have iterated the stream at
+	 * all — that is the run record. Two things follow that the chunk alone
+	 * cannot give it:
+	 *
+	 *  - the cursor outlives the request, so a swap on the turn at step 3
+	 *    still describes steps 4..N, which emit no further chunk;
+	 *  - a side call that aggregates the stream through `collect()` — the
+	 *    compaction verifier and the forced-final summary both do — drops the
+	 *    `fallback` chunk on the floor, so a swap inside one is invisible to
+	 *    every chunk consumer. (The advisory executor calls its OWN advisor's
+	 *    provider, not the run's, so it is not one of these.)
+	 *
+	 * ## Fired when the replacement is ASKED, not when the cursor moves
+	 *
+	 * The two are not the same instant and the difference is observable. The
+	 * cursor moves inside the catch; the notice chunk is then yielded, and the
+	 * replacement request is only issued when the consumer comes back for
+	 * another chunk. A consumer that stops there — a Stop, a `break`, a host
+	 * that abandons the iterator — leaves a chain that selected a member and
+	 * never asked it.
+	 *
+	 * Announcing at cursor-move would report that member as serving, and a
+	 * ledger saying a provider served a turn it was never sent is the exact
+	 * defect this callback exists to end, reintroduced one layer down. So the
+	 * announcement sits at the top of the loop, immediately before the
+	 * replacement's `chatStream` — the earliest moment at which the member is
+	 * actually being asked.
+	 *
+	 * ## One stream at a time
+	 *
+	 * `cursor` is shared by every concurrent `chatStream` on this wrapper, so
+	 * two overlapping calls can advance it under one another: one call's
+	 * failure moves the cursor while the other is still being served by the
+	 * head, and a listener would hear about a member that answered nothing for
+	 * that call. Nothing here serializes or refuses concurrency — the
+	 * property held before this option existed and is not introduced by it.
+	 * `query()` issues its main turn and its side calls in sequence, which is
+	 * what makes the reading exact there.
+	 */
+	readonly onSwap?: (to: ServingMember) => void
 }
 
 /**
@@ -199,10 +266,22 @@ export function withProviderFallback(
 	// A one-member chain is the identity. Returning the provider itself rather
 	// than a wrapper that can never advance keeps the no-chain path byte-identical
 	// to what it was before this file existed.
+	//
+	// `onSwap` is therefore never called on this path, and that is the correct
+	// reading rather than a hole: a listener starts at member 0 and a one-member
+	// chain never leaves it. Announcing member 0 here would say "the chain
+	// advanced" about a chain that cannot.
 	if (members.length === 1) return first.provider
 
 	const log = options.log
 	let cursor = 0
+	/**
+	 * The last position {@link WithProviderFallbackOptions.onSwap} was told
+	 * about. Lags `cursor` for exactly as long as the consumer has the notice
+	 * chunk and has not come back for more — which is the window in which a
+	 * selected member has not been asked anything. See that option's doc.
+	 */
+	let announced = 0
 
 	async function* chatStream(params: ChatCompletionParams): AsyncIterable<StreamChunk> {
 		for (;;) {
@@ -212,6 +291,15 @@ export function withProviderFallback(
 			// calling `chatStream` on undefined, which names neither the field nor
 			// the fix.
 			if (!member) throw new Error(`provider chain has no member at position ${cursor}`)
+
+			if (announced !== cursor) {
+				announced = cursor
+				options.onSwap?.({
+					index: cursor,
+					providerId: member.provider.id,
+					...(member.model !== undefined ? { model: member.model } : {}),
+				})
+			}
 
 			const request = member.model !== undefined ? { ...params, model: member.model } : params
 			let produced = false

--- a/packages/sdk/src/provider/index.ts
+++ b/packages/sdk/src/provider/index.ts
@@ -36,4 +36,8 @@ export {
 export { DEFAULT_PROVIDER_RETRY, withProviderRetry } from './retry.js'
 export type { ProviderRetryConfig, WithProviderRetryOptions } from './retry.js'
 export { withProviderFallback } from './fallback.js'
-export type { ProviderChainMember, WithProviderFallbackOptions } from './fallback.js'
+export type {
+	ProviderChainMember,
+	ServingMember,
+	WithProviderFallbackOptions,
+} from './fallback.js'

--- a/packages/sdk/src/runtime/query/__tests__/provider-chain-provenance.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/provider-chain-provenance.test.ts
@@ -1,0 +1,277 @@
+/**
+ * The run RECORD names the member that served.
+ *
+ * The wire and the metering already followed the chain when this file was
+ * written; the durable record did not. It named the head — which is worse than
+ * naming nothing, because a missing field reads as unknown and a wrong one
+ * reads as a fact. Six months later a reader would conclude the primary served
+ * a turn it never saw.
+ *
+ * Every case here reads the property off `run` — the object a host persists —
+ * and not off the event stream. The events were already right
+ * (`provider-chain-failover.test.ts` pins them), so an assertion on them would
+ * pass with this whole change deleted:
+ * `docs/conventions/sound-about-the-wrong-thing.md`.
+ *
+ * Every scripted turn that must appear in the ledger calls a tool, and that is
+ * load-bearing rather than decorative. The loop records a step only on the
+ * tool-calling path: `if (forceFinalize || !hasToolCalls)` breaks out before
+ * `recordStep`, so the turn that produces the ANSWER is not in `steps` at all.
+ * A first draft of this file scripted text-only turns and asserted against an
+ * empty ledger. That gap is older than this change and is not fixed here — it
+ * is why `metadata.servingProvider` matters, since the commonest failover of
+ * all is a fallback that answers on its first turn and leaves no step behind.
+ */
+
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { removeTempDirs } from '../../../__fixtures__/temp-dir.js'
+import { MockLLMProvider } from '../../../provider/mock.js'
+import { ToolRegistry } from '../../../registry/tool/execute.js'
+import type { SessionId, TenantId } from '../../../types/ids/index.js'
+import { createUserMessage } from '../../../types/message/index.js'
+import type {
+	ChatCompletionParams,
+	LLMProvider,
+	StreamChunk,
+} from '../../../types/provider/index.js'
+import type { ProjectId, ThreadId } from '../../../types/session/ids.js'
+import { drainQuery } from '../index.js'
+
+/** A provider that always fails the way `status` says, before any chunk. */
+function failing(id: string, status: number): LLMProvider {
+	return {
+		id,
+		name: id,
+		chatStream: (_params: ChatCompletionParams): AsyncIterable<StreamChunk> =>
+			(async function* () {
+				throw Object.assign(new Error(`HTTP ${status}`), { status })
+				// biome-ignore lint/correctness/noUnreachable: the generator must be one
+				yield { id: '', delta: {} } as StreamChunk
+			})(),
+	} as unknown as LLMProvider
+}
+
+/**
+ * A provider that serves `okTurns` turns and then fails every later one.
+ *
+ * The point of the shape is the step AFTER the swap: a chain that falls over on
+ * turn 2 emits its notice during turn 2 and nothing at all on turn 3, so a
+ * record built from the in-band chunk alone gets turn 3 wrong.
+ */
+function healthyThenFailing(id: string, okTurns: number, status: number): LLMProvider {
+	const inner = new MockLLMProvider({
+		nextTurn: (_params, index) =>
+			index < okTurns
+				? { toolCalls: [{ id: `c${index}`, name: 'echo', rawArguments: '{}' }] }
+				: { error: { message: `HTTP ${status}`, status } },
+	})
+	return {
+		id,
+		name: id,
+		chatStream: (params: ChatCompletionParams) => inner.chatStream(params),
+	} as unknown as LLMProvider
+}
+
+function registerEcho(tools: ToolRegistry): void {
+	tools.register({
+		name: 'echo',
+		description: 'Echo the text back.',
+		inputSchema: z.object({ text: z.string().optional() }),
+		execute: async () => ({ success: true, output: 'ok' }),
+	})
+}
+
+function baseParams(
+	provider: LLMProvider,
+	tools: ToolRegistry,
+	workingDirectory: string,
+	maxIterations = 1,
+) {
+	return {
+		provider,
+		tools,
+		runConfig: {
+			model: 'primary-model',
+			timeoutMs: 5_000,
+			tokenBudget: 100_000,
+			maxIterations,
+			maxResponseTokens: 256,
+		},
+		agentId: 'agent_test',
+		agentName: 'Test Agent',
+		workingDirectory,
+		sessionId: 'ses_prov' as SessionId,
+		threadId: 'thd_prov' as ThreadId,
+		projectId: 'prj_prov' as ProjectId,
+		tenantId: 'tnt_prov' as TenantId,
+		// Every failure below is on a code the retry decorator declines, so this
+		// only guards against an accidental retryable status parking the suite.
+		retry: false as const,
+	}
+}
+
+describe('the run record names the member that served', () => {
+	let workdirs: string[] = []
+
+	afterEach(async () => {
+		await removeTempDirs(workdirs)
+		workdirs = []
+	})
+
+	async function mkWorkdir(): Promise<string> {
+		const dir = await mkdtemp(join(tmpdir(), 'namzu-prov-'))
+		workdirs.push(dir)
+		return dir
+	}
+
+	it('attributes the step to the member that answered, not to the declared head', async () => {
+		const primary = failing('primary', 401)
+		const fallback = new MockLLMProvider({
+			turns: [
+				{ toolCalls: [{ id: 'f1', name: 'echo', rawArguments: '{}' }] },
+				{ text: 'answered' },
+			],
+		})
+		const tools = new ToolRegistry()
+		registerEcho(tools)
+
+		const run = await drainQuery({
+			...baseParams(primary, tools, await mkWorkdir(), 2),
+			fallbackProviders: [{ provider: fallback, model: 'fallback-model' }],
+			messages: [createUserMessage('hello')],
+		})
+
+		expect(run.status).toBe('completed')
+		expect(run.steps?.[0]?.servedBy).toEqual({
+			providerId: fallback.id,
+			model: 'fallback-model',
+			chainIndex: 1,
+		})
+	})
+
+	it('keeps the declared head on `metadata.provider` and puts the server beside it', async () => {
+		const primary = failing('primary', 401)
+		const fallback = new MockLLMProvider({ turns: [{ text: 'ok' }] })
+
+		const run = await drainQuery({
+			...baseParams(primary, new ToolRegistry(), await mkWorkdir()),
+			fallbackProviders: [{ provider: fallback, model: 'fallback-model' }],
+			messages: [createUserMessage('hello')],
+		})
+
+		// Two facts that differ, and both are kept. Overwriting `provider` would
+		// lose what the operator configured; leaving it alone was what made the
+		// record wrong.
+		expect(run.metadata.provider).toBe('primary')
+		expect(run.metadata.servingProvider).toBe(fallback.id)
+	})
+
+	it('names the serving member even when the run dies before a step is recorded', async () => {
+		const primary = failing('primary', 401)
+		const secondary = failing('secondary', 503)
+
+		const run = await drainQuery({
+			...baseParams(primary, new ToolRegistry(), await mkWorkdir()),
+			fallbackProviders: [{ provider: secondary }],
+			messages: [createUserMessage('hello')],
+		})
+
+		// Nothing served, so there is no step ledger to read — which is exactly
+		// the case `metadata.servingProvider` exists for. The run still has to be
+		// able to say whose failure ended it.
+		expect(run.status).toBe('failed')
+		expect(run.steps ?? []).toHaveLength(0)
+		expect(run.metadata.servingProvider).toBe('secondary')
+	})
+
+	it('carries the swap forward to later steps, which emit no notice of their own', async () => {
+		// Turn 1 is served by the primary and calls a tool; turn 2 fails and the
+		// chain advances; turns 2 and 3 are the fallback's. Only turn 2 has a
+		// notice chunk, so turn 3 is the step a record built from the stream
+		// alone gets wrong.
+		const primary = healthyThenFailing('primary', 1, 401)
+		const fallback = new MockLLMProvider({
+			turns: [
+				{ toolCalls: [{ id: 'f1', name: 'echo', rawArguments: '{}' }] },
+				{ toolCalls: [{ id: 'f2', name: 'echo', rawArguments: '{}' }] },
+				{ text: 'done' },
+			],
+		})
+		const tools = new ToolRegistry()
+		registerEcho(tools)
+
+		const run = await drainQuery({
+			...baseParams(primary, tools, await mkWorkdir(), 4),
+			fallbackProviders: [{ provider: fallback, model: 'fallback-model' }],
+			messages: [createUserMessage('hello')],
+		})
+
+		expect(run.steps?.map((s) => s.servedBy?.providerId)).toEqual([
+			'primary',
+			fallback.id,
+			fallback.id,
+		])
+		expect(run.steps?.map((s) => s.servedBy?.model)).toEqual([
+			'primary-model',
+			'fallback-model',
+			'fallback-model',
+		])
+	})
+
+	it('records the declared provider on a run with no chain, rather than nothing', async () => {
+		const provider = new MockLLMProvider({
+			turns: [{ toolCalls: [{ id: 'c1', name: 'echo', rawArguments: '{}' }] }, { text: 'ok' }],
+		})
+		const tools = new ToolRegistry()
+		registerEcho(tools)
+
+		const run = await drainQuery({
+			...baseParams(provider, tools, await mkWorkdir(), 2),
+			messages: [createUserMessage('hello')],
+		})
+
+		// Written even when it agrees with the head. A ledger that carries the
+		// fact only when it is surprising cannot be read as evidence: absence
+		// would mean both "the head served" and "nobody wrote it down".
+		expect(run.steps?.[0]?.servedBy).toEqual({
+			providerId: provider.id,
+			model: 'primary-model',
+			chainIndex: 0,
+		})
+		// Absence here is the statement "the declared provider served every
+		// call", so a run that never fell over must not carry it.
+		expect(run.metadata.servingProvider).toBeUndefined()
+	})
+
+	it("records the model the STEP asked for, not the run's", async () => {
+		// No chain anywhere in this case. The ledger took the run's model while
+		// the request took `step.model ?? model` from the line above it, so a
+		// host routing one step to a cheaper model read the expensive one back.
+		const provider = new MockLLMProvider({
+			turns: [
+				{ toolCalls: [{ id: 'c1', name: 'echo', rawArguments: '{}' }] },
+				{ toolCalls: [{ id: 'c2', name: 'echo', rawArguments: '{}' }] },
+				{ text: 'done' },
+			],
+		})
+		const tools = new ToolRegistry()
+		registerEcho(tools)
+
+		const run = await drainQuery({
+			...baseParams(provider, tools, await mkWorkdir(), 3),
+			prepareStep: ({ stepNumber }: { stepNumber: number }) =>
+				stepNumber === 2 ? { model: 'cheap-model' } : {},
+			messages: [createUserMessage('hello')],
+		})
+
+		expect(run.steps?.map((s) => s.model)).toEqual(['primary-model', 'cheap-model'])
+		// And the same correction reaches the provenance, because a member
+		// declared without a model serves whatever the step asked for.
+		expect(run.steps?.map((s) => s.servedBy?.model)).toEqual(['primary-model', 'cheap-model'])
+	})
+})

--- a/packages/sdk/src/runtime/query/index.ts
+++ b/packages/sdk/src/runtime/query/index.ts
@@ -16,7 +16,11 @@ import type { CompactionConfig } from '../../config/runtime.js'
 import { TOOL_OUTPUT_DIR_NAME } from '../../constants/tools/index.js'
 import { EmergencySaveManager } from '../../manager/run/emergency.js'
 import { resolveProviderCapabilities } from '../../provider/capabilities.js'
-import { type ProviderChainMember, withProviderFallback } from '../../provider/fallback.js'
+import {
+	type ProviderChainMember,
+	type ServingMember,
+	withProviderFallback,
+} from '../../provider/fallback.js'
 import { type ProviderRetryConfig, withProviderRetry } from '../../provider/retry.js'
 import type { PathBuilder } from '../../session/workspace/path-builder.js'
 import {
@@ -566,9 +570,28 @@ export async function* query(params: QueryParams): AsyncGenerator<RunEvent, Run>
 		params.retry === false
 			? provider
 			: withProviderRetry(provider, { config: params.retry, log: getRootLogger() })
+	// Who is serving right now, for the run RECORD rather than for the request.
+	//
+	// It starts at the head and moves only when the chain does, which is the
+	// whole of the truth because the cursor never rewinds. The run cannot read
+	// this off `resilientProvider`: that wrapper reports the head's `id` on
+	// purpose, so asking it produces the declaration back — the defect this
+	// record exists to fix.
+	const serving: { current: ServingMember } = {
+		current: { index: 0, providerId: params.provider.id },
+	}
 	const resilientProvider = withProviderFallback(
 		chain.map((member) => ({ ...member, provider: withRetry(member.provider) })),
-		{ log: getRootLogger() },
+		{
+			log: getRootLogger(),
+			onSwap: (to) => {
+				serving.current = to
+				// `ctx` is declared below and is initialized before anything can
+				// call the provider: this fires from inside a `chatStream`, and
+				// the first one is issued by the loop that `ctx` is built for.
+				ctx.runMgr.setServingProvider(to.providerId)
+			},
+		},
 	)
 
 	const ctx = RunContextFactory.build({
@@ -898,6 +921,7 @@ export async function* query(params: QueryParams): AsyncGenerator<RunEvent, Run>
 
 	const iterationOrchestrator = new IterationOrchestrator({
 		provider: resilientProvider,
+		servingMember: () => serving.current,
 		runConfig: params.runConfig,
 		...(params.stopWhen ? { stopWhen: params.stopWhen } : {}),
 		...(params.prepareStep ? { prepareStep: params.prepareStep } : {}),

--- a/packages/sdk/src/runtime/query/iteration/index.ts
+++ b/packages/sdk/src/runtime/query/iteration/index.ts
@@ -32,6 +32,7 @@ import type { AnswerReview } from '../../../types/run/answer-review.js'
 import type {
 	PrepareStepResult,
 	RunEvent,
+	StepProvenance,
 	StepResult,
 	StopReason,
 } from '../../../types/run/index.js'
@@ -425,6 +426,40 @@ export class IterationOrchestrator {
 						iterSpan,
 					)
 
+					// Who answered THIS turn.
+					//
+					// The read is exact at this point and stays exact: a chain that
+					// has produced output cannot fall over again inside the same
+					// request, so the member at the cursor when the stream ends is
+					// the one whose bytes are in `response`.
+					//
+					// It is taken here rather than at `recordStep` several hundred
+					// lines below, and the honest account of that is defence in
+					// depth, not a defect it currently prevents. Moving it down
+					// fails no test, because nothing between the two asks this
+					// provider for anything: compaction and working memory run
+					// BEFORE the turn, the advisory phase runs after the step is
+					// already recorded, and the only thing in between is tool
+					// execution. That is a fact about today's phase order, which a
+					// later phase inserted here would change silently — and the
+					// symptom would be a step attributed to a member that first
+					// served the turn after it, which is the class of wrongness
+					// this whole field exists to end.
+					const servedBy: StepProvenance = ((): StepProvenance => {
+						const member = this.ctx.servingMember?.() ?? {
+							index: 0,
+							providerId: this.ctx.provider.id,
+						}
+						return {
+							providerId: member.providerId,
+							// A member declared without a model asked for the model the
+							// step named — which is what the decorator does with the
+							// request, so this is a reading of it and not a guess.
+							model: member.model ?? stepModel,
+							chainIndex: member.index,
+						}
+					})()
+
 					// Main-loop turn: also records the prompt size compaction reads.
 					runMgr.recordTurnUsage(response.usage)
 
@@ -746,7 +781,12 @@ export class IterationOrchestrator {
 					// and a caller reconstructing cost per step must see it.
 					this.recordStep({
 						stepNumber: iterationNum,
-						model,
+						// The model this step ASKED for. It used to be `model`, the
+						// run's own — so a `prepareStep` that routed one step to a
+						// cheaper model was recorded as the expensive one, with no
+						// provider chain involved.
+						model: stepModel,
+						servedBy,
 						messageId,
 						response,
 						toolResults: reviewOutcome.results,
@@ -1201,6 +1241,7 @@ export class IterationOrchestrator {
 	private recordStep(input: {
 		stepNumber: number
 		model: string
+		servedBy: StepProvenance
 		messageId: MessageId
 		response: ChatCompletionResponse
 		toolResults: readonly ToolCallOutcome[]
@@ -1216,6 +1257,7 @@ export class IterationOrchestrator {
 		const step: StepResult = {
 			stepNumber: input.stepNumber,
 			model: input.model,
+			servedBy: input.servedBy,
 			messageId: input.messageId,
 			content: input.response.message.content,
 			toolCalls,

--- a/packages/sdk/src/runtime/query/iteration/phases/context.ts
+++ b/packages/sdk/src/runtime/query/iteration/phases/context.ts
@@ -6,6 +6,7 @@ import type { CompactionConfig } from '../../../../config/runtime.js'
 import type { CompletionInbox } from '../../../../gateway/completion-inbox.js'
 import type { PlanManager } from '../../../../manager/plan/lifecycle.js'
 import type { RunPersistence } from '../../../../manager/run/persistence.js'
+import type { ServingMember } from '../../../../provider/fallback.js'
 import type { ActivityStore } from '../../../../store/activity/memory.js'
 import type { TaskGateway } from '../../../../types/agent/gateway.js'
 import type { WorkingMemoryProvider } from '../../../../types/agent/working-memory.js'
@@ -37,6 +38,22 @@ import type { ToolGrantSet } from '../../tool-grants.js'
 
 export interface IterationContext {
 	readonly provider: LLMProvider
+	/**
+	 * Which chain member `provider` will route the NEXT request to.
+	 *
+	 * `provider` cannot answer this itself: `withProviderFallback` keeps its
+	 * `id` transparently equal to the head's, deliberately, because that is
+	 * what capability negotiation and the run's `gen_ai.system` attribute are
+	 * about. Asking the wrapper who it is gets the declaration; this gets the
+	 * observation.
+	 *
+	 * Optional because a host may build an `IterationContext` without a chain
+	 * at all. Absent, the loop attributes each step to `provider.id` and the
+	 * model it requested, which is exactly right when nothing can fall over —
+	 * and exactly wrong when something can, so the wiring from `query()` is
+	 * covered end-to-end rather than by a unit test on this accessor.
+	 */
+	readonly servingMember?: () => ServingMember
 	/**
 	 * The run's `invoke_agent` span, so each iteration can parent itself to
 	 * it. Explicit rather than ambient because this loop is an async

--- a/packages/sdk/src/types/run/entity.ts
+++ b/packages/sdk/src/types/run/entity.ts
@@ -11,7 +11,45 @@ export interface RunStateMetadata {
 	agentId: string
 	agentName: string
 	config: AgentRunConfig
+	/**
+	 * The provider the run was CONFIGURED with — the head of the chain, and
+	 * the counterpart of `config.model` beside it.
+	 *
+	 * It is a declaration, not an observation, and it stays one. After a
+	 * provider chain falls over it still names the head, which is correct for
+	 * a field that answers "what was asked for"; it was only ever misleading
+	 * because nothing else answered "what served". See {@link servingProvider}
+	 * for the run-level answer and `steps[].servedBy` for the per-step one.
+	 */
 	provider: string
+	/**
+	 * The chain member the run was routed to at the end, when that is not the
+	 * one it was configured with.
+	 *
+	 * Absent means the declared provider served every call. That reading holds
+	 * for stored records too, with one bounded exception: the sdk major that
+	 * shipped the chain could fall over without recording it, so a run from
+	 * that release reads as "no swap" whether or not there was one. Its
+	 * transcript still carries the `provider_fallback` events. The exception
+	 * is one release wide and it is stated rather than migrated away, because
+	 * a migration would have to invent the answer for exactly the records that
+	 * do not have it.
+	 *
+	 * **This is the durable half.** `RunDiskStore.writeRunMeta` writes
+	 * `metadata` and not `steps`, so on the built-in store this field is the
+	 * whole of what survives the process. `steps[].servedBy` is the finer
+	 * record — the one to read for "which member answered turn 4" — and it
+	 * reaches a host only on the returned `Run`.
+	 *
+	 * It also covers the case no step ledger can: a run that falls over and
+	 * then dies before a single step is recorded still has to be able to say
+	 * whose failure ended it. That is why the wording is "routed to" and not
+	 * "served by" — this member was asked, and on that path it answered with
+	 * an error. It is never a member that was merely selected: the chain
+	 * announces a replacement when it issues its request, not when it picks
+	 * it, so a run cancelled at the swap notice does not name one.
+	 */
+	servingProvider?: string
 }
 
 export type SessionMetadata = RunStateMetadata

--- a/packages/sdk/src/types/run/step.ts
+++ b/packages/sdk/src/types/run/step.ts
@@ -15,7 +15,46 @@ import type { ToolCall } from '../message/index.js'
 export interface StepResult {
 	/** 1-based, matching `iteration` on the run events. */
 	stepNumber: number
+	/**
+	 * The model this step ASKED for: the run's configured model, or the
+	 * override a `prepareStep` hook returned for this step.
+	 *
+	 * It used to be the run's model unconditionally — the loop passed its own
+	 * `model` here while building the request from `step.model ?? model` a few
+	 * lines above — so a host that routed one step to a cheaper model read the
+	 * expensive one back out of the ledger. No chain was needed to see it.
+	 *
+	 * What was asked for and what answered are two facts, and after a provider
+	 * chain falls over they differ. This is the first; {@link servedBy} is the
+	 * second.
+	 */
 	model: string
+	/**
+	 * Who actually answered, and with which model.
+	 *
+	 * Equal to {@link model} and to `run.metadata.provider` on every run
+	 * without a chain, which is most of them; it diverges exactly when
+	 * `withProviderFallback` advanced. Recorded even when it agrees, because a
+	 * ledger that carries the fact only when it is surprising cannot be read as
+	 * evidence — a reader could not tell "the head served" from "nobody wrote
+	 * it down".
+	 *
+	 * Optional only for records that predate the field. Absence means "not
+	 * recorded", and it is left meaning that rather than backfilled: the sdk
+	 * shipped a chain that could fall over one release before it recorded
+	 * which member did, so filling those in from the declared head would state
+	 * as fact the exact thing that release got wrong, on exactly the runs
+	 * where it was wrong. Every step this build produces has it.
+	 *
+	 * **Reaches a host through the returned `Run`, not through `run.json`.**
+	 * `RunDiskStore.writeRunMeta` persists the metadata and the counters and
+	 * does not write `steps` at all, so the built-in store carries the
+	 * run-level {@link
+	 * import('./entity.js').RunStateMetadata.servingProvider} and none of
+	 * this. A host that wants per-step provenance on disk persists the `Run`
+	 * it is handed.
+	 */
+	servedBy?: StepProvenance
 	messageId: MessageId
 	/** Assistant text for this step, if any. */
 	content: string | null
@@ -32,6 +71,21 @@ export interface StepResult {
 	durationMs: number
 	/** Portion of `durationMs` spent inside tools. */
 	toolExecutionMs: number
+}
+
+/**
+ * The chain member that served one step.
+ *
+ * `chainIndex` is a position in the chain the host declared, and it is here
+ * rather than derived from `providerId` because a chain may legitimately name
+ * the same provider twice — two models, or two credentials, on one driver.
+ * `providerId` alone could not tell those apart.
+ */
+export interface StepProvenance {
+	readonly providerId: string
+	readonly model: string
+	/** 0 is the head, i.e. the provider the run was configured with. */
+	readonly chainIndex: number
 }
 
 export interface StepToolResult {


### PR DESCRIPTION
`run.metadata.provider` named the head of the chain after a swap, and so did every step's `model`. The wire followed the member that answered and the metering followed the member that answered; the durable record did not. Someone reading a run six months from now would have concluded the primary served a turn it never saw — which is worse than a blank, because a missing field reads as unknown and a wrong one reads as a fact.

This is #275's first left-out item, and #275 named it: *"the wire and the metering follow the member; the run record does not. Fixing it touches `StepResult`."*

## Two facts, two fields

`metadata.provider` is not wrong; it is a **declaration**, and it sits beside `config`, which is the rest of the declaration. What was missing was the observation. Overwriting one with the other would have lost what the operator configured, and collapsing two facts into one field is how the original defect got made — so `provider` is unchanged and documented as declared, and the observation arrives beside it.

- **`StepResult.servedBy`** — `{ providerId, model, chainIndex }`. `chainIndex` is the member's position in the declared chain and it is carried rather than derived, because a chain may legitimately name the same provider twice — two models, or two credentials — and `providerId` alone could not tell those apart. It is recorded even when it agrees with the head: a ledger that carries a fact only when it is surprising cannot be read as evidence, because absence would mean both "the head served" and "nobody wrote it down".
- **`RunStateMetadata.servingProvider`** — the member the run was routed to at the end, absent when the configured one served throughout.

## Where the record actually lives, measured

`RunDiskStore.writeRunMeta` writes `id`, `status`, `metadata`, the counters and a message count. **It does not write `steps`.** So `servingProvider` is the half that survives the process, and `servedBy` reaches a host on the returned `Run`. Both doc comments and the changeset say so rather than letting "durable run record" stand.

That measurement also earns the run-level field its keep on its own: a run whose chain falls over and then dies before a single step is recorded has no step ledger at all, and still has to be able to say whose failure ended it.

## `StepResult.model` was wrong before any of this

`recordStep` was handed the run's `model` while the request was built from `step.model ?? model` twenty lines above it. A `prepareStep` that routed one step to a cheaper model read the expensive one back out of the ledger. No chain involved, and it is the reason this is a major: the field's value changes for anyone using per-step model overrides. It now names the model the step **asked for**, with `servedBy.model` naming what answered.

## The announcement is at the request, not at the cursor

The chain's own signal fires when the replacement is **asked**, not when the cursor moves. Those are separated by the notice chunk and a suspension the consumer controls: the cursor moves inside the catch, the notice goes out, and the replacement request is issued only when the consumer comes back for another chunk. A consumer that leaves there — a Stop, a `break`, an abandoned iterator — has selected a member and asked it nothing, and recording that as service would be this same defect one layer down.

An adversarial review caught that; it was announcing at cursor-move in the first draft. Three other findings from the same review changed the code or the prose: `run.json` not persisting `steps` (above), the advisory executor calling its **own** advisor's provider rather than the run's (so the side calls that swallow a `fallback` chunk are the compaction verifier and the forced-final summary, and the comment now says that), and the disk migration this design originally proposed being unsafe.

## Nothing is backfilled, deliberately

Schema v1 **coexists** with chains — 17.0.0 shipped under store version 1 — so a v1 record can come from a chain-enabled writer. A migration filling `servedBy` from `metadata.provider` would state as fact the exact thing that release got wrong, on exactly the runs where it was wrong. Both new fields are optional and absence means "not recorded"; the transcript's `provider_fallback` events are the record for those runs.

## Mutation profile — 10 mutations

| # | Mutation | Killed by |
|---|---|---|
| M1 | `recordStep({model})` back to the run's model | 1 — the `prepareStep` case |
| M2 | `servedBy` always reads `ctx.provider.id` | 2 — both swap-attribution cases |
| M3 | `query()` stops passing `servingMember` | 2 — the same two; the wiring is driven end-to-end |
| M4 | decorator never announces a swap | 4 — every chain case, while 18 decorator and 4 failover tests stay green |
| M5 | the announcement stops updating run metadata | 2 — the metadata cases only |
| M6 | read the cursor at `recordStep` instead of after the turn | **nothing** |
| M7 | the member's model is ignored | 2 |
| M8 | `chainIndex` hardcoded to `0` | 1 |
| M9 | announce at cursor-move instead of at the request | 1 — the abandoned-iterator case |
| M10 | announce on every request | 3 — all three announcement cases |

**M6 killed nothing, and the comment claiming otherwise was wrong.** The first draft said a compaction or advisory side call could advance the cursor between the turn and `recordStep`. Measured: compaction and working-memory refresh run *before* the turn, the advisory phase runs *after* the step is recorded, and the only thing in between is tool execution, which does not call this provider. The early read is defence in depth, not a fix for a live defect — `sound-about-the-wrong-thing`'s "attributed the protection to the wrong mechanism", pointed at source rather than at a test. The comment now says what is true.

## Gate

`pnpm build && pnpm typecheck && pnpm lint && pnpm test` all exit 0 — sdk 330 files / 2936 passed / 7 skipped, cli 62 files / 585 passed / 3 skipped, no unhandled rejections. `scripts/audit-external-names.mjs` exits 0. `pnpm docs:check` reports 0 problems.

## Left out, and why

- **The answering turn is still not in `steps`.** The loop records a step only on the tool-calling path; `if (forceFinalize || !hasToolCalls)` breaks out before `recordStep`, so the turn that produces the answer leaves no step behind. That is older than this change and it is a different claim. It is disclosed in the docs and in the test file's header, and it is why `metadata.servingProvider` matters — the commonest failover of all is a fallback that answers on its first turn.
- **Side-call swaps still reach no event surface.** `collect()` drops the `fallback` chunk, so a swap inside the compaction verifier or the forced-final summary is invisible to the transcript, the SSE mapper, the A2A mapper and the reporter. It now reaches the run record, which is what this PR is about, but the event gap is #275's and wants its own fix.
- **`withProviderFallback` does not serialize concurrent streams.** One cursor is shared across every `chatStream` on the wrapper, so overlapping calls could advance it under one another. `query()` issues its main turn and its side calls in sequence, which is what makes the reading exact there; the property predates this PR and is now written down on the option.
- **Resume and replay do not carry provenance.** A resumed run re-enters `query()` with a fresh cursor and no restored serving member. Worth an issue.
- **`RunMetadata` in `types/run/metadata.ts`** — a second public provider-bearing shape with no producer anywhere in the tree. Left alone rather than grown a field nothing writes.
