### PR TITLE
fix(sdk)!: a wait past the ceiling is refused, not shortened

### DIFF
--- a/.changeset/a-wait-too-long-is-refused.md
+++ b/.changeset/a-wait-too-long-is-refused.md
@@ -1,0 +1,34 @@
+---
+'@namzu/sdk': major
+---
+
+**`ProviderRetryConfig.maxRetryAfterMs` now does what it documents.** It said
+"past this we surface the error and let the caller decide"; the code fell
+through to the ordinary jittered backoff instead, so a provider asking for a
+fifteen-minute wait was re-asked in half a second. The documentation was
+correct and the code was not.
+
+**What you see differently.** A server-directed `Retry-After` **greater than**
+`maxRetryAfterMs` (60s by default) now surfaces the provider error instead of
+retrying. A `Retry-After` at or under the ceiling is unchanged — still slept
+exactly as instructed — and a failure with no `Retry-After` at all is
+unchanged.
+
+Nothing settles differently. The error thrown is the same one the
+retries-exhausted path throws, carrying `retryAfterMs`, so a run that used to
+fail after four attempts now fails after one, sooner and with the number a host
+needs to schedule its own retry. What changes is the attempts in between: they
+were sent to an endpoint that had already said it would not serve them, and
+they cost the run its budget to rediscover a rate limit it had been told about
+in advance.
+
+**If you relied on the old behaviour** — on a provider whose `Retry-After` is
+routinely longer than you are willing to wait, and which serves anyway if you
+ask again immediately — raise `maxRetryAfterMs` past that value to keep
+retrying, or set it low and handle the surfaced error. There is no setting that
+restores "ignore the header and back off short", because that was the defect.
+
+**With a provider chain this is where the ceiling pays.** A rate limit is a
+fact about the member, not the request, so surfacing it advances the chain to
+the next member at once rather than after the primary's whole retry budget is
+spent.

--- a/docs/sdk/runtime/loop-control.md
+++ b/docs/sdk/runtime/loop-control.md
@@ -149,6 +149,29 @@ flag, the HTTP `status` and a parsed `retryAfterMs`:
 `context_length_exceeded` is deliberately separate from the generic 400:
 it is the one 4xx a caller can act on.
 
+### A wait longer than your ceiling is refused, not shortened
+
+`maxRetryAfterMs` (60s by default) is the longest server-directed wait the
+loop will sleep. A `Retry-After` **at or under** it is slept exactly as
+instructed. Past it, the error is surfaced with `retryAfterMs` intact and the
+decision is yours:
+
+```ts
+// The provider said "come back in 15 minutes". You get the error, now,
+// carrying 900_000 — schedule against it, or raise the ceiling.
+retry: { maxRetryAfterMs: 60_000 }
+```
+
+It used to fall through to the ordinary jittered backoff instead, so a provider
+asking for fifteen minutes was re-asked in half a second and the remaining
+attempts were spent on an endpoint that had already said no. Nothing settles
+differently: the error thrown is the one the exhausted path throws, so a run
+that used to fail after four attempts now fails after one.
+
+If you declare a [provider chain](../../cli/providers.md#the-provider-chain)
+this is where it pays. A rate limit is a fact about the *member*, so the chain
+advances to the next one immediately rather than after the budget is gone.
+
 Aborts propagate untouched, so a Stop still settles the run as
 `cancelled` rather than being mistaken for a transport failure.
 

--- a/packages/sdk/src/provider/__tests__/fallback.test.ts
+++ b/packages/sdk/src/provider/__tests__/fallback.test.ts
@@ -394,6 +394,45 @@ describe('withProviderFallback over withProviderRetry', () => {
 		expect(chunks.map((c) => c.delta.content ?? '').join('')).toBe('swapped anyway')
 	})
 
+	/**
+	 * A wait the primary cannot honour reaches the chain at once.
+	 *
+	 * The composition is where the retry ceiling's refusal pays. A member that
+	 * says "come back in fifteen minutes" has ended its usefulness for this
+	 * turn, and the ceiling surfaces that as a `rate_limit` — a fact about the
+	 * MEMBER — so the chain advances immediately. Retrying it shorter, which is
+	 * what the ceiling used to do, spent the whole budget arguing with a
+	 * provider that had already answered, while the member that could have
+	 * served sat unused.
+	 */
+	it('moves to the next member at once when a wait exceeds the primary’s ceiling', async () => {
+		const primary = member('primary', [
+			() => {
+				throw httpError(429, 'slow down', { 'retry-after': '900' })
+			},
+		])
+		const fallback = member('fallback', [
+			async function* () {
+				yield chunk('the fallback served it')
+			},
+		])
+		const wrapped = withProviderFallback([
+			{
+				provider: withProviderRetry(primary, {
+					sleepFn: noSleep,
+					config: { maxRetries: 3, maxRetryAfterMs: 60_000 },
+				}),
+			},
+			{ provider: fallback },
+		])
+
+		expect(await drain(wrapped.chatStream(PARAMS))).toBe('the fallback served it')
+		// One attempt, not four: the budget is not spent on a provider that named
+		// a wait nobody is allowed to sleep for.
+		expect(primary.calls).toBe(1)
+		expect(fallback.calls).toBe(1)
+	})
+
 	it('gives the new member a FRESH retry budget', async () => {
 		const primary = member('primary', [
 			() => {

--- a/packages/sdk/src/provider/__tests__/retry.test.ts
+++ b/packages/sdk/src/provider/__tests__/retry.test.ts
@@ -211,11 +211,53 @@ describe('withProviderRetry', () => {
 		expect(slept).toEqual([7000])
 	})
 
-	it('ignores an absurd Retry-After and falls back to bounded backoff', async () => {
+	/**
+	 * The ceiling refuses; it does not shorten.
+	 *
+	 * This case used to assert the opposite — a 15-minute `Retry-After` fell
+	 * through to a 500ms backoff — which is what `maxRetryAfterMs` did and the
+	 * reverse of what it documented. The doc was ruled correct: a server that
+	 * named a wait has told the caller something they asked to be told about,
+	 * and answering it in half a second honours neither the wait nor the
+	 * refusal.
+	 *
+	 * Both halves are asserted. Retrying-shorter and surfacing differ only in
+	 * what happens NEXT, so a test that watched the sleep alone would pass
+	 * against a decorator that slept nothing and then retried anyway.
+	 */
+	it('surfaces a Retry-After past the ceiling instead of retrying sooner', async () => {
 		const slept: number[] = []
 		const provider = scripted([
 			() => {
 				throw httpError(429, '', { 'retry-after': '900' }) // 15 minutes
+			},
+			async function* () {
+				yield chunk('never reached')
+			},
+		])
+		const wrapped = withProviderRetry(provider, {
+			config: { maxRetryAfterMs: 60_000, initialDelayMs: 500 },
+			random: () => 1,
+			sleepFn: async (ms) => {
+				slept.push(ms)
+			},
+		})
+
+		// The error reaches the caller carrying the wait it was told about, so a
+		// host can schedule against the number rather than re-parse it.
+		await expect(drain(wrapped.chatStream(PARAMS))).rejects.toMatchObject({
+			status: 429,
+			retryAfterMs: 900_000,
+		})
+		expect(slept).toEqual([])
+		expect(provider.calls).toBe(1)
+	})
+
+	it('still sleeps a server-directed wait that fits under the ceiling', async () => {
+		const slept: number[] = []
+		const provider = scripted([
+			() => {
+				throw httpError(429, '', { 'retry-after': '30' })
 			},
 			async function* () {
 				yield chunk('ok')
@@ -228,8 +270,9 @@ describe('withProviderRetry', () => {
 				slept.push(ms)
 			},
 		})
-		await drain(wrapped.chatStream(PARAMS))
-		expect(slept).toEqual([500])
+
+		expect(await drain(wrapped.chatStream(PARAMS))).toBe('ok')
+		expect(slept).toEqual([30_000])
 	})
 
 	it('applies full jitter — the delay is scaled by the random source', async () => {

--- a/packages/sdk/src/provider/retry.ts
+++ b/packages/sdk/src/provider/retry.ts
@@ -14,6 +14,15 @@ export interface ProviderRetryConfig {
 	 * Cap on a server-directed `Retry-After`. A provider asking for 15
 	 * minutes should not silently park an interactive run for 15 minutes;
 	 * past this we surface the error and let the caller decide.
+	 *
+	 * "Surface" is the whole of it: there is no shorter retry underneath. A
+	 * server that named a wait has said something specific, and answering it
+	 * with a half-second backoff neither honours the wait nor tells anyone it
+	 * was refused. The error carries `retryAfterMs`, so a host that wants to
+	 * come back in fifteen minutes can — that decision is above this loop.
+	 *
+	 * Raise it to let the run sleep longer; a request under the ceiling is
+	 * still slept exactly as instructed.
 	 */
 	readonly maxRetryAfterMs: number
 }
@@ -153,10 +162,48 @@ export function withProviderRetry(
 				}
 
 				const serverDirected = classified.retryAfterMs
-				const delay =
-					serverDirected !== undefined && serverDirected <= config.maxRetryAfterMs
-						? serverDirected
-						: backoffWithJitter(attempt, config, random)
+
+				// The server named a wait longer than the caller's ceiling, so the
+				// error goes to the caller — which is what `maxRetryAfterMs`
+				// documents and what it now does.
+				//
+				// It used to fall through to the jittered backoff instead, and that
+				// is degrading where the contract says refuse
+				// (`docs/conventions/refuse-do-not-degrade.md`). The ceiling was
+				// read as "how long may I sleep", so a provider asking for fifteen
+				// minutes was re-asked in half a second: the one instruction the
+				// server gave was the one thing discarded, and the retries that
+				// followed were sent to an endpoint that had already said it would
+				// not serve them. They cost the run its whole budget to rediscover
+				// a 429 it had been told about in advance.
+				//
+				// The caller loses nothing it had. This throws the SAME error the
+				// exhausted path throws, so the run settles exactly as it did
+				// before — only sooner, and with `retryAfterMs` intact for a host
+				// that wants to schedule against it. What it gains is the wait
+				// itself, which no backoff of ours can honour: fifteen minutes is
+				// not a number this loop is allowed to sleep for.
+				//
+				// With a chain declared it gains more than that. The error is a
+				// `rate_limit`, which is a fact about the MEMBER, so
+				// `withProviderFallback` moves to the next one — the run continues
+				// on another provider instead of spending its budget arguing with
+				// the first. Under the old behaviour the chain did not see the
+				// failure until those attempts were gone.
+				if (serverDirected !== undefined && serverDirected > config.maxRetryAfterMs) {
+					log?.warn('Provider call failed — server-directed wait exceeds the ceiling', {
+						provider: provider.id,
+						code: classified.code,
+						status: classified.status,
+						attempt: attempt + 1,
+						retryAfterMs: serverDirected,
+						maxRetryAfterMs: config.maxRetryAfterMs,
+						reason: 'surfacing rather than retrying — the caller decides how to wait',
+					})
+					throw isProviderRequestError(err) ? err : classified
+				}
+
+				const delay = serverDirected ?? backoffWithJitter(attempt, config, random)
 
 				log?.warn('Provider call failed — retrying', {
 					provider: provider.id,


### PR DESCRIPTION
`ProviderRetryConfig.maxRetryAfterMs` documented one behaviour and implemented its opposite:

> Cap on a server-directed `Retry-After`. A provider asking for 15 minutes should not silently park an interactive run for 15 minutes; **past this we surface the error and let the caller decide.**

The code fell through to the ordinary jittered backoff, so a provider asking for fifteen minutes was re-asked in half a second. The one instruction the server gave was the one thing discarded. This is #275's third left-out item.

## Which side is wrong, measured before changing anything

The doc comment, the code, and a test asserting the *code's* behaviour — "ignores an absurd Retry-After and falls back to bounded backoff" — all arrived in **the same commit**, `935b8f3e` (#64). So neither side of the contradiction has precedence by age, and that test is evidence of what the code did, not of a caller depending on it. Nothing in the tree reads `maxRetryAfterMs` other than a shipped-defaults bound, and the published docs never stated the behaviour either way.

What decided it on the merits is that **surfacing costs the caller nothing they had.** It throws the same error the retries-exhausted path throws, carrying `retryAfterMs`, so the run settles exactly as it did before — a 429 still reaches the run boundary as a `rate_limit` with its `Retry-After` intact. Only the attempts in between change, and those were sent to an endpoint that had already said it would not serve them; they cost the run its budget to rediscover a rate limit it had been told about in advance. Degrading where the contract says refuse, which is `docs/conventions/refuse-do-not-degrade.md`.

## The chain made it sharper than it was

A rate limit is a fact about the **member**, not the request. Surfaced, it reaches `withProviderFallback` and the chain advances to the next member immediately. Under the old behaviour the chain did not see the failure until the primary's whole retry budget had been spent arguing with a provider that had already answered — while the member that could have served sat unused. That is a new test in the composition suite, not just an argument.

## What a caller sees differently

- `Retry-After` **greater than** `maxRetryAfterMs` (60s default) → the provider error, now, instead of a retry.
- `Retry-After` at or under the ceiling → unchanged, slept exactly as instructed.
- No `Retry-After` → unchanged, jittered exponential backoff.

Anyone who wants the old outcome on a provider whose header is routinely longer than they will wait raises `maxRetryAfterMs` past that value. There is no setting that restores "ignore the header and back off short", because that was the defect.

## Mutations

| # | Mutation | Killed by |
|---|---|---|
| M11 | restore the fall-through to jittered backoff | 2 — the surfacing case and the chain case; the under-ceiling case still passes |
| M12 | refuse **every** server-directed wait, ignoring the ceiling | 3 — including the two pre-existing "honours a Retry-After" cases |

M12 is the half that matters for aim: it proves the tests are about the *ceiling* and not merely about refusing, and it names the blast radius of getting the comparison backwards.

The rewritten test asserts **both** halves — nothing slept, and no second attempt. Retrying-shorter and surfacing differ only in what happens next, so watching the sleep alone would pass against a decorator that slept nothing and retried anyway.

## Gate

`pnpm build && pnpm typecheck && pnpm lint && pnpm test` all exit 0 — sdk 329 files / 2929 passed / 7 skipped, cli 62 files / 585 passed / 3 skipped, no unhandled rejections. `scripts/audit-external-names.mjs` exits 0. `pnpm docs:check` reports 0 problems.

Depends on nothing in #280 and can be rejected or taken independently of it.
