### PR TITLE
fix(cli): leaving the provider picker takes you back where you were

### DIFF
--- a/.changeset/leaving-the-picker.md
+++ b/.changeset/leaving-the-picker.md
@@ -1,0 +1,26 @@
+---
+'@namzu/cli': minor
+---
+
+Leaving the provider picker takes you back where you were
+
+The picker has two entry points and had one exit between them.
+
+**`/model` then `Esc` no longer throws away your session.** Cancelling sent you
+to the phase namzu uses for "I tried and cannot serve" — a screen with a
+disabled composer, from which `/model` cannot be typed again. Declining to
+change model cost you the working session you already had. It now returns to the
+chat.
+
+**`Ctrl+C` works in the picker.** The key handler was switched off for the whole
+picker phase, so on the first screen a new user sees, the interrupt did nothing
+useful: one press armed an exit whose "press again" notice is printed into a
+transcript the picker does not render, and only a second press left. It exits on
+the first press now, and the hint names it.
+
+**`Esc` on first run exits.** There is no screen behind the picker then, so
+leaving the picker is leaving the program — which is what the empty picker's
+footer has always said `esc` does.
+
+The hint now says which of the two `Esc` means: `esc keep current` when a
+session is behind it, `esc or Ctrl+C exit` when nothing is.

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -837,16 +837,50 @@ export function App({ ctx }: AppProps) {
 		[detected, hydrateSession, pushMessage],
 	)
 
+	/**
+	 * Leaving the picker returns to whatever was on screen before it.
+	 *
+	 * The picker has two entry points and used to have one exit. Opened by
+	 * `/model` from a working session, cancelling sent the operator to
+	 * `unhealthy` — a phase with a disabled composer, from which `/model` cannot
+	 * be typed again — so declining to change model threw away the session they
+	 * already had.
+	 *
+	 * `unhealthy` means namzu tried and cannot serve: it is set when a probe
+	 * throws, and when a session comes up with no provider, both carrying an
+	 * `errorHint` saying what failed. Cancelling is not a failure, and borrowing
+	 * the failure phase to express it is what made a working session look broken.
+	 *
+	 * With nothing behind the picker — first run, no session — there is no screen
+	 * to return to, so leaving the picker is leaving the program. That is also
+	 * what the empty picker's own footer has always claimed `esc` does.
+	 */
 	const handlePickerCancel = useCallback(() => {
-		setPhase('unhealthy')
-		pushMessage(
-			'system',
-			'Picker cancelled. Set an LLM credential (ANTHROPIC_API_KEY / OPENAI_API_KEY / OPENROUTER_API_KEY / start Ollama) and restart namzu.',
-		)
-	}, [pushMessage])
+		if (session?.hasProvider) {
+			setPhase('ready')
+			return
+		}
+		exit()
+	}, [session, exit])
 
 	useInput(
 		(input, key) => {
+			// The provider picker owns its own keyboard — arrows, digits, enter,
+			// esc and the typed-key screen are all its business. Ctrl+C is not: it
+			// is the one key that must work on every screen, and this handler used
+			// to be switched off for the whole picker phase. Ink runs with
+			// `exitOnCtrlC: false` and raw mode means the tty raises no SIGINT, so
+			// nothing else was going to answer it.
+			//
+			// One press, not the two the ready screen asks for. The ladder works by
+			// printing "press again" into the transcript, and the transcript is not
+			// rendered during the picker — so the old behaviour was not quite "the
+			// key is dead" but the worse "the first press does something invisible
+			// and the second exits", with nothing on screen naming either.
+			if (phase === 'picker') {
+				if (key.ctrl && input === 'c') exit()
+				return
+			}
 			// Resume picker owns the keyboard while open.
 			if (phase === 'resume') {
 				if (key.upArrow) setSelectedResume((i) => Math.max(0, i - 1))
@@ -944,7 +978,10 @@ export function App({ ctx }: AppProps) {
 				}, 2000)
 			}
 		},
-		{ isActive: phase !== 'picker' },
+		// Active on every phase. It was gated off during the picker, which is what
+		// left that screen without a usable exit; the picker branch above returns
+		// immediately, so the Picker still owns everything except Ctrl+C.
+		{ isActive: true },
 	)
 
 	// Background is left natural — we inherit the terminal's own background
@@ -1050,7 +1087,7 @@ export function App({ ctx }: AppProps) {
 						provider={session?.providerSummary ?? null}
 						model={session?.modelSummary ?? null}
 						state={state}
-						hint={hintForPhase(phase, state)}
+						hint={hintForPhase(phase, state, session?.hasProvider === true)}
 						usage={usage}
 						context={context}
 					/>
@@ -1179,13 +1216,22 @@ function formatToolCall(toolName: string, summary: string): string {
 function hintForPhase(
 	phase: LifecyclePhase,
 	state: 'idle' | 'thinking' | 'tool' | 'awaiting-permission',
+	/** Whether there is a working session behind the picker to go back to. */
+	canReturn = false,
 ): string {
 	// Enter is absent because Enter grants nothing here, deliberately — see the
 	// trust branch in the key handler above.
 	if (phase === 'trust') return 'y trust this folder · n / esc exit'
 	if (phase === 'resume') return '↑↓ navigate · enter resume · esc cancel'
 	if (phase === 'probing') return 'discovering providers…'
-	if (phase === 'picker') return '↑↓ navigate · enter accept · esc cancel'
+	// Esc does two different things here depending on how the picker was reached,
+	// so the hint says which. Naming Ctrl+C matters more here than anywhere else:
+	// it is the screen a new user meets before they know the program has keys.
+	if (phase === 'picker') {
+		return canReturn
+			? '↑↓ navigate · enter accept · esc keep current · Ctrl+C exit'
+			: '↑↓ navigate · enter accept · esc or Ctrl+C exit'
+	}
 	if (phase === 'unhealthy') return 'Ctrl+C ×2 to exit'
 	// Enter is absent because Enter decides nothing here, deliberately — see the
 	// permission gate in the key handler above.

--- a/packages/cli/src/tui/__tests__/app-picker-exits.test.tsx
+++ b/packages/cli/src/tui/__tests__/app-picker-exits.test.tsx
@@ -1,0 +1,288 @@
+/**
+ * How you leave the provider picker.
+ *
+ * The picker has two entry points — first run, and `/model` from a working
+ * session — and used to have one exit for both, plus no exit key at all.
+ *
+ * Both defects are the same missing idea: leaving the picker returns you to
+ * whatever was there before it. From `/model` that is the session you already
+ * had; on first run there is nothing behind it, so leaving the picker is
+ * leaving the program.
+ *
+ * Two worlds are needed, so both are built here with a switchable probe rather
+ * than in two files: `withSession` decides whether `probeAgentSession` returns
+ * preferences (a session comes up, `/model` reopens the picker) or none (first
+ * run, the picker is the first screen).
+ *
+ * Not a terminal. This drives Ink's own stdin, so it establishes which branch
+ * ran and what it decided — not that a real tty delivers Ctrl+C as this harness
+ * does. That Ink is launched with `exitOnCtrlC: false` is why the app has to
+ * answer the key itself, and that half is `tui/index.tsx`, not here.
+ */
+
+import { render } from 'ink-testing-library'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { DetectedProvider, Preferences } from '../../integrations/providers/index.js'
+import type { AgentEvent, AgentSession } from '../agent.js'
+import type { TuiContext } from '../types.js'
+
+const PREFS: Preferences = { version: 3, providers: [{ id: 'openai' }], subagents: { active: [] } }
+
+/** Whether the probe finds a saved provider (so a session comes up). */
+let withSession = true
+let exited = false
+
+const DETECTED = [
+	{
+		entry: {
+			id: 'openai',
+			label: 'A Provider',
+			defaultModel: 'a-default-model',
+			requiresApiKey: true,
+			envVars: ['A_KEY'],
+		},
+		source: { kind: 'env', envName: 'A_KEY' },
+		apiKey: 'not-a-real-key',
+		alternatives: [],
+	} as unknown as DetectedProvider,
+]
+
+vi.mock('../../integrations/trust/store.js', () => ({ isTrusted: () => true, trustDir: () => {} }))
+vi.mock('../../integrations/updates.js', () => ({ checkUpdates: async () => [] }))
+vi.mock('../../integrations/sessions/store.js', () => ({
+	openSessions: async () => ({ tenantId: 't' }),
+	startConversation: async () => 'conv',
+	appendMessages: async () => {},
+	listRecent: async () => [],
+	loadConversation: async () => [],
+}))
+vi.mock('../../user-commands/store.js', () => ({ discoverUserCommands: () => [] }))
+
+vi.mock('../agent.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../agent.js')>()
+	return {
+		...actual,
+		probeAgentSession: async () => ({
+			preferences: withSession ? PREFS : null,
+			needsRepickReason: null,
+			detected: DETECTED,
+		}),
+		describeProviderModels: async () => ({ kind: 'ok' as const, models: [] }),
+		createAgentSession: async (): Promise<AgentSession> => ({
+			hasProvider: true,
+			providerSummary: 'a-provider',
+			modelSummary: 'a-model',
+			toolNames: [],
+			errorHint: null,
+			instructionFiles: [],
+			skippedInstructionFiles: [],
+			mcpConnected: [],
+			mcpFailed: [],
+			agentIds: [],
+			configNotices: [],
+			close: async () => {},
+			approvalLatched: () => false,
+			promptExemptTools: () => [],
+			send: async function* (): AsyncIterable<AgentEvent> {
+				yield { kind: 'done', stopReason: 'end_turn' } as AgentEvent
+			},
+		}),
+	}
+})
+
+vi.mock('ink', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('ink')>()
+	return {
+		...actual,
+		useApp: () => ({
+			exit: () => {
+				exited = true
+			},
+		}),
+	}
+})
+
+const { App } = await import('../App.js')
+
+/**
+ * A SHORT cwd, deliberately, and the reason is a defect this file does not fix.
+ *
+ * `StatusBar` renders as one `<Text wrap="truncate-end">` with the working
+ * directory first, so a deep path or a narrow terminal pushes the hint off the
+ * end — and the hint is the only place the keys are advertised. Under this
+ * repo's own worktree path the whole hint disappears.
+ *
+ * So the two hint assertions below establish that the right hint is BUILT, not
+ * that an operator can see it. Those are different claims and the second one is
+ * currently false on a long path; it is filed separately rather than smuggled
+ * in here, because fixing it means deciding what the footer drops first.
+ */
+const ctx: TuiContext = { cwd: '/w', version: '0.0.0-test' }
+const tick = (ms = 40) => new Promise((r) => setTimeout(r, ms))
+const mounted: { unmount: () => void }[] = []
+
+/**
+ * Wait for the app to ask Ink to exit, or give up.
+ *
+ * Polling, not a fixed sleep, and the reason showed up while mutation-checking
+ * rather than in the green run. A bare `\x1B` is held briefly by the input
+ * parser to see whether an escape sequence follows; under load that outlasts a
+ * fixed wait, the assertion fails, and the exit then lands DURING THE NEXT TEST
+ * — which shares this flag and passes for a reason that has nothing to do with
+ * what it asserts. A test made green by its predecessor's late keystroke is
+ * worse than a failing one.
+ */
+async function exitedWithin(timeoutMs = 3_000): Promise<void> {
+	const started = performance.now()
+	while (!exited && performance.now() - started < timeoutMs) {
+		await tick(20)
+	}
+}
+
+async function frameShows(
+	lastFrame: () => string | undefined,
+	text: string,
+	timeoutMs = 3_000,
+): Promise<void> {
+	const started = performance.now()
+	while (!(lastFrame() ?? '').includes(text) && performance.now() - started < timeoutMs) {
+		await tick(20)
+	}
+}
+
+beforeEach(() => {
+	exited = false
+	withSession = true
+})
+
+afterEach(() => {
+	for (const h of mounted) h.unmount()
+	mounted.length = 0
+	vi.restoreAllMocks()
+})
+
+/** A ready session, then `/model` to open the picker over the top of it. */
+async function pickerFromModelCommand() {
+	withSession = true
+	const harness = render(<App ctx={ctx} />)
+	mounted.push(harness)
+	await frameShows(harness.lastFrame, 'Type a message')
+	// `frameShows` returns on the render that first shows the composer, which
+	// can be the same tick its input handler is being registered on. Writing
+	// immediately loses the keystrokes, so let the mount settle.
+	await tick(80)
+	harness.stdin.write('/model')
+	await tick(60)
+	harness.stdin.write('\r')
+	await frameShows(harness.lastFrame, 'Choose a provider')
+	expect(harness.lastFrame(), 'the picker never opened').toContain('Choose a provider')
+	await tick(60)
+	return harness
+}
+
+/** First run: no saved provider, so the picker is the first screen. */
+async function pickerOnFirstRun() {
+	withSession = false
+	const harness = render(<App ctx={ctx} />)
+	mounted.push(harness)
+	await frameShows(harness.lastFrame, 'Choose a provider')
+	expect(harness.lastFrame(), 'the picker never opened').toContain('Choose a provider')
+	return harness
+}
+
+describe('cancelling the picker opened by /model', () => {
+	it('returns to the session that was already running', async () => {
+		// The defect: declining to change model threw away a working session,
+		// landing on a phase whose composer is disabled and from which `/model`
+		// cannot be typed again.
+		const { stdin, lastFrame } = await pickerFromModelCommand()
+
+		stdin.write('\x1B')
+		await frameShows(lastFrame, 'Type a message')
+
+		expect(lastFrame(), 'did not return to the chat').toContain('Type a message')
+		expect(exited, 'cancelling a re-pick exited the program').toBe(false)
+	})
+
+	it('leaves the composer usable, which is what being stranded took away', async () => {
+		// The sharper form of the same claim. `unhealthy` disables the composer,
+		// and `/model` cannot be typed from there either — so the operator had
+		// no way back to the picker and no way to talk to the agent. Asserting
+		// on the hint text would not have caught this: the ready hint ends with
+		// the same "Ctrl+C ×2 to exit" the unhealthy hint consists of.
+		const { stdin, lastFrame } = await pickerFromModelCommand()
+
+		stdin.write('\x1B')
+		await frameShows(lastFrame, 'Type a message')
+
+		stdin.write('still here')
+		await frameShows(lastFrame, 'still here')
+
+		expect(lastFrame(), 'the composer would not accept input').toContain('still here')
+	})
+})
+
+describe('cancelling the picker on first run', () => {
+	it('leaves the program, because there is nothing behind it', async () => {
+		const { stdin } = await pickerOnFirstRun()
+
+		stdin.write('\x1B')
+		await exitedWithin()
+
+		expect(exited, 'esc on the first-run picker did not exit').toBe(true)
+	})
+})
+
+describe('Ctrl+C in the picker', () => {
+	it('exits on first run', async () => {
+		// The first screen a new user sees. Ink runs with `exitOnCtrlC: false`
+		// and this handler used to be switched off for the whole picker phase,
+		// so the key did nothing whatsoever.
+		const { stdin } = await pickerOnFirstRun()
+
+		stdin.write('\x03')
+		await exitedWithin()
+
+		expect(exited, 'Ctrl+C did nothing in the picker').toBe(true)
+	})
+
+	it('exits from a picker opened by /model too', async () => {
+		const { stdin } = await pickerFromModelCommand()
+
+		stdin.write('\x03')
+		await exitedWithin()
+
+		expect(exited).toBe(true)
+	})
+
+	it('does not disturb the keys the picker owns', async () => {
+		// Making App's handler active for this phase must not make it a second
+		// consumer of navigation. Down-arrow still belongs to the picker.
+		const { stdin, lastFrame } = await pickerOnFirstRun()
+
+		stdin.write('[B')
+		await tick(80)
+
+		expect(exited, 'an arrow key exited the program').toBe(false)
+		expect(lastFrame(), 'the picker stopped drawing').toContain('Choose a provider')
+	})
+})
+
+describe('the picker hint', () => {
+	it('names an exit on first run, where nothing else is on screen', async () => {
+		const { lastFrame } = await pickerOnFirstRun()
+		const frame = lastFrame() ?? ''
+
+		expect(frame).toContain('Ctrl+C')
+		expect(frame).toContain('exit')
+	})
+
+	it('says esc keeps the current model when there is a session behind it', async () => {
+		const { lastFrame } = await pickerFromModelCommand()
+		const frame = lastFrame() ?? ''
+
+		expect(frame).toContain('keep current')
+		expect(frame).toContain('Ctrl+C')
+	})
+})


### PR DESCRIPTION
The picker has two entry points — first run, and `/model` from a working session — and had **one exit** between them.

## Why these are one PR, measured rather than assumed

`unhealthy` has three producers. Two are real failures carrying an `errorHint` that names what broke (a thrown probe; a session with no provider). The third was **the user declining**.

So cancel was overloading a failure state to mean "you chose not to" — and both defects fall out of the picker having no notion of *leave*. They also interact: once cancel stops routing through `unhealthy`, the accidental exit lobby it provided is gone, **which is exactly why the picker then needs its own exit key.** Fix one without the other and you either strand the operator or take away the only way out. One mechanism, one PR.

## What was broken

**`/model` then `Esc` threw away your session.** It landed you on `unhealthy`: composer disabled, `/model` untypeable, no way back. Declining to change model cost you the session you already had.

**Ctrl+C in the picker.** Not quite "nothing", which is worth being precise about: the handler was gated off for the whole picker phase, so the key fell to the main ladder whose first press arms an exit and prints *"press again"* into a transcript **the picker does not render**. The behaviour was an invisible first press and an unexplained second.

## What changes

- Leaving the picker returns to whatever was there before it.
- On first run nothing was, so `Esc` leaves the program — which is what the empty picker's footer has always claimed it does.
- `Ctrl+C` exits on the **first** press. The double-press ladder is deliberately not used on a screen that cannot show its own "press again".
- The hint says which of the two `Esc` means: `esc keep current` with a session behind it, `esc or Ctrl+C exit` without.

## Mutation-checking corrected the diagnosis

My first mutation was **unfaithful**: flipping `isActive` back while leaving the new picker branch in place is not the pre-fix code. It produced a result I could not explain — "Ctrl+C exits on first run" *passing* under the mutation — so I did not trust it or ship it.

Reverting **both halves together**, as the original had them, kills exactly the three exit tests. And it kills the `Esc` test too — which routes through the *Picker's own* handler, code this change never touches.

That means the original diagnosis was incomplete. Gating the handler did more than unregister it: Ink's `useInput` runs `setRawMode(false)` in the cleanup when `isActive` flips, so toggling it on a mounted handler tears down raw mode for the screen. Keeping the handler always active avoids the toggle entirely. **Recorded as observed, not as fully characterised** — I did not chase Ink's refcounting further than the fix required.

| Mutation | Result |
| --- | --- |
| cancel always goes to `unhealthy` | the 3 cancel tests die |
| `isActive` gated off **and** picker branch removed (faithful) | the 3 exit tests die |
| hint stops distinguishing the entry points | the `/model` hint test dies |
| `isActive` gated off **alone** (unfaithful) | inverted, unexplained — not used |

## Found while here, not fixed

`StatusBar` renders as a single `<Text wrap="truncate-end">` with the **cwd first**, so a deep path or a narrow terminal truncates the hint off the end — and the hint is the only place keys are advertised. Under this repo's own worktree path the entire hint disappears.

The two hint tests therefore use a short cwd and say so in the file: they establish that the right hint is **built**, not that an operator can see it. Those are different claims and the second is currently false on a long path. Filed rather than smuggled in, because fixing it means deciding what the footer drops first.

## What only you can confirm

The harness drives Ink's own stdin, so it establishes which branch ran and what it decided. It cannot establish that a real tty delivers Ctrl+C the same way, and it cannot tell you whether exiting on the *first* press feels right on the first screen a new user meets.

## Checks

`pnpm build` 0 · `pnpm typecheck` 0 · `pnpm test` 0 (cli 598 passed, 3 skipped) · `pnpm lint` 0.
