### PR TITLE
refactor(cli): doctor can see what the session sees

### DIFF
--- a/.changeset/doctor-can-see-what-the-session-sees.md
+++ b/.changeset/doctor-can-see-what-the-session-sees.md
@@ -1,0 +1,37 @@
+---
+'@namzu/cli': minor
+---
+
+**`namzu doctor` now reports provider-chain capability disagreements.** It
+listed which members had credentials and could not say whether the chain it was
+describing could run at all — so a chain with every key in place reported
+`pass`, and the operator found out it was unusable by trying to start a session.
+
+Reading what a provider declares requires that provider's package to be
+registered, and the only registration path was module-private inside the
+interactive session. A diagnostic that cannot see what the thing it diagnoses
+sees is checking the wrong thing. `ensureRegistered` and
+`resolveChainCapabilities` now live beside the registry, in
+`integrations/providers/register.ts`, and the session and the doctor reach them
+without either importing the other.
+
+`providers.chain` gains three outcomes:
+
+- **fail** — the members disagree and the mismatch has not been accepted, so a
+  session will be refused. Reported ahead of the credential result, because it
+  stops every run.
+- **warn** — the mismatch has been accepted. Still named: the session prints it
+  on every launch, and a diagnostic that went quiet would disagree with the
+  thing it describes.
+- **warn / fail** — a member whose declaration could not be read, listed
+  separately from the disagreements because an unanswered question is not a
+  conflict. `fail` when it is the primary, which cannot start a session either.
+
+The cost is named rather than hidden: this check now dynamically imports the
+driver package of every member in the chain. That is the price of reading a
+declaration, on a command whose whole job is to look.
+
+No behaviour changes inside a session — the registration state is one set in one
+module, as it was, because two copies would double-register and throw.
+
+Closes #262.

--- a/docs/cli/providers.md
+++ b/docs/cli/providers.md
@@ -109,6 +109,22 @@ A fallback with no credential is a **warning**, not a failure — your primary s
 
 A purely local provider reports `reachable` / `NOT REACHABLE` instead, since it has no key to find.
 
+The same check also reports whether the members **agree about what they can do**, which is the other way a chain with every credential in place still cannot run:
+
+```
+providers.chain  provider chain cannot be honoured as written:
+                 1. primary · <label> · <model> · credential found
+                 2. fallback 1 · <label> · <model> · credential found
+                 The members declare different capabilities, so a session will be REFUSED:
+                   - fallback #1 (<label>) declares it cannot read images, while primary provider (<label>) declares it can — if the chain falls over to it, image attachments stop reaching the model.
+```
+
+That is a **failure**, because a session refuses such a chain outright — see [when the members disagree](#when-the-members-disagree-about-what-they-can-do). If you have accepted the mismatch it is reported as a warning instead and still named, because it is still true.
+
+A member whose declaration cannot be read at all — one with a registry entry but no construction path — is listed separately under `Could not read what these members declare`, and is not counted as a disagreement: an unanswered question is not a conflict.
+
+Reading declarations means loading each member's driver, so this is the one check that pays for what it looks at.
+
 ### When a member cannot serve
 
 If your primary fails a turn, namzu moves to the next member of the chain, keeps the conversation, and carries on from where it stopped. You are told, every time:
@@ -180,6 +196,8 @@ Two things this check does **not** claim:
 - It is about the chain, not about any one run. Capabilities are still negotiated once, against your **primary**, and that answer stays in force after a fallover — which is exactly why a disagreement is refused before a run starts rather than discovered during one. Each sentence says what happens *if the chain falls over*.
 
 A member whose declaration cannot be read at all — a provider with no construction path yet — is reported as such rather than assumed to agree, and does not by itself refuse the chain.
+
+You do not have to start a session to find any of this out. `namzu doctor` asks the same question of the same declarations — see [seeing the chain](#seeing-the-chain) — which is the point: the day to learn that your fallback is unusable is not the day your primary goes down.
 
 ### Upgrading from the previous format
 

--- a/packages/cli/src/doctor/checks/__tests__/chain.test.ts
+++ b/packages/cli/src/doctor/checks/__tests__/chain.test.ts
@@ -94,6 +94,79 @@ describe('the provider chain check', () => {
 		expect(r.status).toBe('pass')
 		expect(r.message ?? '').toMatch(/no fallback/)
 	})
+
+	/**
+	 * The half this check could not see before.
+	 *
+	 * Every member below has a credential, so the older reading of this chain is
+	 * `pass` — and a session would still be refused the moment the operator
+	 * tried to start one, because the members declare different abilities.
+	 * `doctor` exists to be asked on a calm day; a `pass` on a chain that cannot
+	 * run is the worst answer it can give.
+	 *
+	 * The declarations are the drivers' real ones, not a fixture. A fixture
+	 * would prove the sentence-builder works and say nothing about whether this
+	 * check can reach a real declaration, which is the whole subject
+	 * (`docs/conventions/fixture-must-match-production.md`).
+	 */
+	describe('capability disagreements', () => {
+		it('FAILS a chain whose members disagree, even though every credential is present', async () => {
+			writePrefs({ version: 3, providers: [{ id: 'anthropic' }, { id: 'openrouter' }] })
+			const r = await check({ ANTHROPIC_API_KEY: 'x', OPENROUTER_API_KEY: 'y' })
+
+			expect(r.status).toBe('fail')
+			// Not a credential problem, and it must not read as one.
+			expect(r.message ?? '').not.toContain('NO CREDENTIAL')
+			expect(r.message ?? '').toMatch(/declare different capabilities/)
+			expect(r.remediation ?? '').toMatch(/allowCapabilityMismatch/)
+		})
+
+		it('WARNS instead of failing once the operator has accepted the mismatch', async () => {
+			writePrefs({
+				version: 3,
+				providers: [{ id: 'anthropic' }, { id: 'openrouter' }],
+				allowCapabilityMismatch: true,
+			})
+			const r = await check({ ANTHROPIC_API_KEY: 'x', OPENROUTER_API_KEY: 'y' })
+
+			// Named, not silenced: the limitation is real and the session prints it
+			// on every launch, so a diagnostic that went quiet would disagree with
+			// the thing it describes.
+			expect(r.status).toBe('warn')
+			expect(r.message ?? '').toMatch(/you have accepted that/)
+		})
+
+		it('still passes a chain whose members agree', async () => {
+			writePrefs({ version: 3, providers: [{ id: 'anthropic' }, { id: 'openai' }] })
+			const r = await check({ ANTHROPIC_API_KEY: 'x', OPENAI_API_KEY: 'y' })
+
+			expect(r.status).toBe('pass')
+			expect(r.message ?? '').not.toMatch(/declare different capabilities/)
+		})
+
+		/**
+		 * A member with a registry entry and no wiring reads as unresolved rather
+		 * than as agreement. That is issue #257 surfacing where an operator can
+		 * see it: the entry, the label and the default model all advertise a
+		 * provider that cannot be built.
+		 */
+		it('reports a member whose declaration cannot be read, without calling it a disagreement', async () => {
+			writePrefs({ version: 3, providers: [{ id: 'anthropic' }, { id: 'bedrock' }] })
+			const r = await check({ ANTHROPIC_API_KEY: 'x', AWS_ACCESS_KEY_ID: 'y' })
+
+			expect(r.status).toBe('warn')
+			expect(r.message ?? '').toMatch(/Could not read what these members declare/)
+			expect(r.message ?? '').not.toMatch(/declare different capabilities/)
+		})
+
+		it('FAILS when it is the PRIMARY whose declaration cannot be read', async () => {
+			writePrefs({ version: 3, providers: [{ id: 'bedrock' }, { id: 'anthropic' }] })
+			const r = await check({ AWS_ACCESS_KEY_ID: 'y', ANTHROPIC_API_KEY: 'x' })
+
+			expect(r.status).toBe('fail')
+			expect(r.remediation ?? '').toMatch(/no run can start/)
+		})
+	})
 })
 
 describe('the check is reachable, not merely correct', () => {

--- a/packages/cli/src/doctor/checks/chain.ts
+++ b/packages/cli/src/doctor/checks/chain.ts
@@ -2,8 +2,13 @@ import { homedir } from 'node:os'
 
 import type { DoctorCheck, DoctorCheckResult } from '@namzu/sdk'
 
+import {
+	chainCapabilityDisagreements,
+	unresolvedMembers,
+} from '../../integrations/providers/chain-capabilities.js'
 import { type DiscoverOptions, discoverProviders } from '../../integrations/providers/discover.js'
 import { preferencesPath, readPreferences } from '../../integrations/providers/preferences.js'
+import { resolveChainCapabilities } from '../../integrations/providers/register.js'
 import { PROVIDER_REGISTRY } from '../../integrations/providers/registry.js'
 
 export interface ProviderChainCheckOptions {
@@ -28,6 +33,27 @@ export interface ProviderChainCheckOptions {
  * construction: nothing exercises it until the primary is already down, which
  * is the worst moment to find out the key was never set. So every member's
  * credential is resolved here, on a day when nothing is broken.
+ *
+ * ## Two ways a chain is unusable, and this reports both
+ *
+ * A credential is the obvious one. The other is a capability DISAGREEMENT: a
+ * run negotiates tools, vision and documents once, against the primary, and
+ * keeps that answer across a swap — so a chain whose members declare different
+ * abilities would land a run on a member holding a request shaped for someone
+ * else. `createAgentSession` refuses such a chain outright, which means an
+ * operator who has one learns about it by trying to start a session.
+ *
+ * That check used to be unreachable from here. Reading what a provider declares
+ * requires its package to be registered, and the only registration path lived
+ * inside the interactive session module — so `doctor` could report which
+ * members had keys and not whether the chain it was describing could run at
+ * all. A diagnostic that cannot see what the thing it diagnoses sees is
+ * checking the wrong thing. `ensureRegistered` now lives beside the registry
+ * (`integrations/providers/register.ts`) and both reach it.
+ *
+ * The cost is real and worth naming: this check dynamically imports the driver
+ * package of every member in the chain. That is the price of reading a
+ * declaration, and it is paid on a command whose entire job is to look.
  *
  * Exported separately from the `DoctorCheck` so it can be driven with an
  * explicit home and environment. The check itself is still exercised through
@@ -111,25 +137,78 @@ export async function describeProviderChain(
 
 	const chain = lines.join('\n')
 
-	if (unusable === 0) {
+	// What each member DECLARES. Type-level, so no credential is needed — which
+	// is what makes it answerable about the fallback nobody has configured yet,
+	// the member most worth asking about.
+	const resolved = await resolveChainCapabilities(members)
+	const disagreements = chainCapabilityDisagreements(members, resolved)
+	const accepted = read.prefs.allowCapabilityMismatch === true
+	const unreadable = unresolvedMembers(members, resolved)
+	const primaryUnreadable = resolved[0]?.kind === 'unresolved'
+
+	const sections: string[] = [chain]
+	if (disagreements.length > 0) {
+		sections.push(
+			accepted
+				? 'The members declare different capabilities, and you have accepted that:'
+				: 'The members declare different capabilities, so a session will be REFUSED:',
+			...disagreements.map((d) => `  - ${d.sentence}`),
+		)
+	}
+	if (unreadable.length > 0) {
+		// Kept separate from the disagreements above, for the reason the session
+		// keeps them separate: a member whose declaration could not be read is not
+		// a member that disagrees, and reporting it as one would name a conflict
+		// nobody established.
+		sections.push(
+			'Could not read what these members declare:',
+			...unreadable.map((line) => `  - ${line}`),
+		)
+	}
+	const message = sections.join('\n')
+
+	// Ordered by what stops a run. An unaccepted disagreement and an unusable
+	// primary both mean no session starts at all; everything else leaves namzu
+	// working with less than the operator declared.
+	if (disagreements.length > 0 && !accepted) {
 		return {
-			status: 'pass',
+			status: 'fail',
+			message: `provider chain cannot be honoured as written:\n${message}`,
+			remediation:
+				'Drop the member that disagrees, or set "allowCapabilityMismatch": true in your preferences to accept the limitation. namzu will not choose between advertising abilities a fallback lacks and costing your primary a capability on every run.',
+		}
+	}
+	if (primaryUnusable || primaryUnreadable) {
+		return {
+			status: 'fail',
+			message: `${unusable} of ${members.length} chain member(s) cannot be used:\n${message}`,
+			remediation: primaryUnusable
+				? 'The primary provider has no usable credential, so no run can start. Set its key, or run `namzu` to pick a provider that has one.'
+				: 'The primary provider could not be loaded, so no run can start. Run `namzu` to pick a provider that can.',
+		}
+	}
+	if (unusable > 0 || unreadable.length > 0 || disagreements.length > 0) {
+		return {
+			// `warn`, not `fail`: the primary still runs, so namzu is usable and the
+			// operator is not blocked by a degraded spare.
+			status: 'warn',
 			message:
-				members.length === 1
-					? `1 provider configured (no fallback):\n${chain}`
-					: `${members.length} providers configured, in order:\n${chain}`,
+				unusable > 0
+					? `${unusable} of ${members.length} chain member(s) cannot be used:\n${message}`
+					: `provider chain usable, with limitations:\n${message}`,
+			remediation:
+				unusable > 0
+					? 'The primary still works, so runs will start. But a fallback with no credential is not a fallback — set its key, or take it out of the chain.'
+					: 'The primary still works. A fallback that declares less than your primary will serve shorter or less capable turns if the chain ever falls over to it.',
 		}
 	}
 
 	return {
-		// `warn`, not `fail`, when only a fallback is broken: the primary still
-		// runs, so namzu is usable and the operator is not blocked by a
-		// degraded spare. A broken PRIMARY stops every run, and reads as such.
-		status: primaryUnusable ? 'fail' : 'warn',
-		message: `${unusable} of ${members.length} chain member(s) cannot be used:\n${chain}`,
-		remediation: primaryUnusable
-			? 'The primary provider has no usable credential, so no run can start. Set its key, or run `namzu` to pick a provider that has one.'
-			: 'The primary still works, so runs will start. But a fallback with no credential is not a fallback — set its key, or take it out of the chain.',
+		status: 'pass',
+		message:
+			members.length === 1
+				? `1 provider configured (no fallback):\n${message}`
+				: `${members.length} providers configured, in order:\n${message}`,
 	}
 }
 

--- a/packages/cli/src/integrations/providers/index.ts
+++ b/packages/cli/src/integrations/providers/index.ts
@@ -42,3 +42,4 @@ export {
 	type ProviderRegistryEntry,
 	type SdkProviderType,
 } from './registry.js'
+export { ensureRegistered, isRegistered, resolveChainCapabilities } from './register.js'

--- a/packages/cli/src/integrations/providers/register.ts
+++ b/packages/cli/src/integrations/providers/register.ts
@@ -1,0 +1,128 @@
+/**
+ * Put a driver package into the SDK's `ProviderRegistry`, once per process.
+ *
+ * This is the only place the wired driver packages are imported, so it decides
+ * what a `namzu` invocation actually pulls in and when. The imports are dynamic
+ * for that reason: a run on one provider does not load the other three, and a
+ * command that never touches a model loads none.
+ *
+ * ## Why it lives here rather than in the session module
+ *
+ * It used to be module-private inside the interactive session, which made
+ * reading what a provider DECLARES a privilege of having started a session.
+ * Registration is a precondition of that read — the SDK cannot report the
+ * capabilities of a package nobody imported — so `namzu doctor`, whose whole
+ * job is to answer questions about the setup before a session exists, could not
+ * ask. The alternative was for the diagnostic to import the session module and
+ * with it the query runtime, the subagent runtime, MCP, memory and skills, for
+ * one map lookup.
+ *
+ * So it sits beside `PROVIDER_REGISTRY`, which is the data it switches over,
+ * and both the session and the doctor reach it without either importing the
+ * other.
+ *
+ * ## One set, and that is load-bearing
+ *
+ * `registered` makes registration idempotent. It must exist exactly once: two
+ * copies would each believe a provider was unregistered and register it twice,
+ * and the SDK's registry rejects that with a duplicate-provider error. That is
+ * the whole reason this is a module rather than a function anyone may copy —
+ * the state is the API as much as the function is.
+ */
+
+import { ProviderRegistry } from '@namzu/sdk'
+import type { ResolvedProviderCapabilities } from '@namzu/sdk'
+import { resolveProviderCapabilities } from '@namzu/sdk'
+
+import type { MemberCapabilities } from './chain-capabilities.js'
+import type { ProviderChoice } from './preferences.js'
+import { PROVIDER_REGISTRY, type ProviderId } from './registry.js'
+
+const registered = new Set<ProviderId>()
+
+/**
+ * Import and register the driver for `id`, unless it is already registered.
+ *
+ * Throws for a provider that has a registry entry but no wiring here. That
+ * asymmetry is a known defect, not a design: the entry, the label, the default
+ * model and the discovery probe all cooperate to advertise a provider that
+ * cannot be built. See issue #257.
+ */
+export async function ensureRegistered(id: ProviderId): Promise<void> {
+	if (registered.has(id)) return
+	switch (id) {
+		case 'anthropic': {
+			const mod = await import('@namzu/anthropic')
+			mod.registerAnthropic()
+			break
+		}
+		case 'openai': {
+			const mod = await import('@namzu/openai')
+			mod.registerOpenAI()
+			break
+		}
+		case 'openrouter': {
+			const mod = await import('@namzu/openrouter')
+			mod.registerOpenRouter()
+			break
+		}
+		case 'ollama': {
+			const mod = await import('@namzu/ollama')
+			mod.registerOllama()
+			break
+		}
+		default:
+			throw new Error(`provider "${id}" is not wired yet; pick another or wait for support`)
+	}
+	registered.add(id)
+}
+
+/**
+ * Has this provider's driver been registered in THIS process?
+ *
+ * Read by the chain builder to skip a member whose registration failed, so the
+ * failure is reported once — as an unresolved capability — rather than twice in
+ * different words.
+ */
+export function isRegistered(id: ProviderId): boolean {
+	return registered.has(id)
+}
+
+/**
+ * What each member of the chain DECLARES it can do.
+ *
+ * Type-level, via the registry, so nothing is constructed and no credential is
+ * needed — which is the whole point: the member most worth checking is the
+ * fallback nobody has set up yet, and a check that demanded a key would be
+ * unusable in exactly that case.
+ *
+ * A member that cannot be registered is reported as unresolved rather than
+ * assumed to agree. Registration is also why this cannot be a pure function: a
+ * provider package is only imported when something needs it.
+ */
+export async function resolveChainCapabilities(
+	members: readonly ProviderChoice[],
+): Promise<readonly MemberCapabilities[]> {
+	const out: MemberCapabilities[] = []
+	for (const member of members) {
+		if (!(member.id in PROVIDER_REGISTRY)) {
+			out.push({ kind: 'unresolved', reason: `"${member.id}" is not a provider namzu knows` })
+			continue
+		}
+		try {
+			await ensureRegistered(member.id)
+			out.push({
+				kind: 'known',
+				capabilities: resolveProviderCapabilities({
+					capabilities: ProviderRegistry.getCapabilities(member.id),
+				} as { capabilities: ResolvedProviderCapabilities | undefined }),
+			})
+		} catch (err) {
+			out.push({
+				kind: 'unresolved',
+				reason: err instanceof Error ? err.message : String(err),
+			})
+		}
+	}
+	return out
+}

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -71,11 +71,14 @@ import {
 	describeCapabilityRefusal,
 	discoverProviders,
 	ensureFreshAnthropicToken,
+	ensureRegistered,
 	findDetected,
 	isAnthropicOAuthToken,
+	isRegistered,
 	primaryProvider,
 	readAgentKeychainCredential,
 	readPreferences,
+	resolveChainCapabilities,
 	unresolvedMembers,
 } from '../integrations/providers/index.js'
 import { createSubagentRuntime } from '../integrations/subagents/runtime.js'
@@ -320,37 +323,6 @@ export async function probeAgentSession(): Promise<AgentSessionContext> {
 		case 'needs-repick':
 			return { preferences: null, needsRepickReason: read.reason, detected }
 	}
-}
-
-const registered = new Set<ProviderId>()
-
-async function ensureRegistered(id: ProviderId): Promise<void> {
-	if (registered.has(id)) return
-	switch (id) {
-		case 'anthropic': {
-			const mod = await import('@namzu/anthropic')
-			mod.registerAnthropic()
-			break
-		}
-		case 'openai': {
-			const mod = await import('@namzu/openai')
-			mod.registerOpenAI()
-			break
-		}
-		case 'openrouter': {
-			const mod = await import('@namzu/openrouter')
-			mod.registerOpenRouter()
-			break
-		}
-		case 'ollama': {
-			const mod = await import('@namzu/ollama')
-			mod.registerOllama()
-			break
-		}
-		default:
-			throw new Error(`provider "${id}" is not wired yet; pick another or wait for support`)
-	}
-	registered.add(id)
 }
 
 // Builtins we don't expose: `verify_outputs` — a host-side check rather
@@ -757,7 +729,7 @@ function planFallbacks(
 			)
 			continue
 		}
-		if (!registered.has(member.id)) {
+		if (!isRegistered(member.id)) {
 			// `resolveChainCapabilities` already tried to register every member and
 			// reported the failure as an unresolved capability. Saying it twice in
 			// different words would read as two problems.
@@ -792,45 +764,6 @@ function planFallbacks(
 			return out
 		},
 	}
-}
-
-/**
- * What each member of the chain DECLARES it can do.
- *
- * Type-level, via the registry, so nothing is constructed and no credential is
- * needed — which is the whole point: the member most worth checking is the
- * fallback nobody has set up yet, and a check that demanded a key would be
- * unusable in exactly that case.
- *
- * A member that cannot be registered is reported as unresolved rather than
- * assumed to agree. Registration is also why this cannot be a pure function:
- * a provider package is only imported when something needs it.
- */
-async function resolveChainCapabilities(
-	members: readonly ProviderChoice[],
-): Promise<readonly MemberCapabilities[]> {
-	const out: MemberCapabilities[] = []
-	for (const member of members) {
-		if (!(member.id in PROVIDER_REGISTRY)) {
-			out.push({ kind: 'unresolved', reason: `"${member.id}" is not a provider namzu knows` })
-			continue
-		}
-		try {
-			await ensureRegistered(member.id)
-			out.push({
-				kind: 'known',
-				capabilities: resolveProviderCapabilities({
-					capabilities: ProviderRegistry.getCapabilities(member.id),
-				}),
-			})
-		} catch (err) {
-			out.push({
-				kind: 'unresolved',
-				reason: err instanceof Error ? err.message : String(err),
-			})
-		}
-	}
-	return out
 }
 
 function constructProvider(


### PR DESCRIPTION
Closes #262.

## The issue is not stale — I checked before implementing it

#262 predates the chain actually running, so the first job was to see whether it still describes the world. It does, and the part that survived is the part that matters:

- `chainCapabilityDisagreements` — the pure comparison — already lives in `integrations/providers/chain-capabilities.ts`.
- `resolveChainCapabilities` — the half that **reads** declarations, and therefore needs `ensureRegistered` — was still module-private in `tui/agent.ts`.
- `doctor/checks/chain.ts` reported credential state and nothing else.

So the gap the issue names is exactly the gap that exists: enforcement was never missing, advance warning was.

## Why it matters more than when it was filed

`namzu doctor` is where an operator learns their chain is unusable *before* the day the primary goes down. A chain with every credential in place reported **`pass`** while a session would refuse it outright the moment one was started — so the answer doctor gave was wrong in the direction that costs the most: reassuring.

A diagnostic that cannot see what the thing it diagnoses sees is checking the wrong thing.

## The move

`ensureRegistered`, `isRegistered` and `resolveChainCapabilities` now live in `integrations/providers/register.ts`, beside `PROVIDER_REGISTRY` — the data `ensureRegistered` switches over. The alternative the issue rules out is still ruled out: importing the session module into a diagnostic would pull the query runtime, the subagent runtime, MCP, memory and skills along for one map lookup.

**One `registered` set, in one module.** The issue flags this and it is load-bearing: two copies would each believe a provider unregistered and register it twice, which the SDK's registry rejects. That is why `isRegistered` is exported rather than the set — the state is as much the API as the function is.

Nothing changes inside a session. The chain builder's `registered.has(...)` became `isRegistered(...)` and reads the same set.

## What `providers.chain` reports now

Ordered by what stops a run:

- **fail** — the members disagree and the mismatch has not been accepted, so a session will be refused. Reported ahead of the credential result, because this stops every run rather than degrading a spare.
- **warn** — the mismatch has been accepted. Still named. The session prints it on every launch, so a diagnostic that went quiet about it would disagree with the thing it describes.
- **fail / warn** — a member whose declaration could not be read, listed **separately** from the disagreements. An unanswered question is not a conflict, and reporting it as one would name a disagreement nobody established. `fail` when it is the primary, which cannot start a session either.

The cost is named rather than hidden: this check now dynamically imports the driver package of every member. That is the price of reading a declaration, paid on a command whose whole job is to look.

## The tests drive real declarations, not a fixture

I probed what the wired drivers actually declare before writing a case, so the disagreeing pair is a real one and the agreeing pair is too. A fixture would have proved the sentence-builder works and said nothing about whether this check can reach a real declaration, which is the entire subject.

The chosen pair differs **only** in capability — both require a key, both have one in the test — so a `fail` cannot be a credential result wearing a new message. The test asserts that too.

## Mutations

| # | Mutation | Killed by |
|---|---|---|
| M13 | doctor stops failing on an unaccepted disagreement | 1 — and the agreeing-chain case still passes |
| M14 | acceptance ignored | 1 — the accepted case |
| M15 | primary-unreadable ignored | 1 |
| M16 | `isRegistered` always returns false | **2 TUI chain tests** |

M16 is the one that says something about the *refactor* rather than about the new feature: the moved state is still driven from the session side, not merely from the doctor. Without it, this PR's own tests would have been perfectly green against a move that quietly broke the chain builder.

## Gate

`pnpm build && pnpm typecheck && pnpm lint && pnpm test` all exit 0 — sdk 329 files / 2927 passed / 7 skipped, cli 62 files / 590 passed / 3 skipped, no unhandled rejections. `scripts/audit-external-names.mjs` exits 0. `pnpm docs:check` reports 0 problems.

## Left out

**#257 — three providers are pickable and throw at construction.** #262 asks whether the two move together; they do not, here. `register.ts`'s `default:` arm and `constructProvider`'s sibling arm are still the pair that issue describes, and choosing between wiring them and refusing them earlier is its own decision with its own blast radius.

What this PR does do is make the symptom visible: a chain member with a registry entry and no wiring now shows up in `namzu doctor` as a declaration that could not be read, instead of being silently assumed to agree.

Independent of #280 and #281; takes or drops on its own.
