### PR TITLE
fix(cli): the status bar stops truncating away the keys it advertises

### DIFF
--- a/.changeset/the-hint-is-the-last-thing-to-go.md
+++ b/.changeset/the-hint-is-the-last-thing-to-go.md
@@ -1,0 +1,30 @@
+---
+'@namzu/cli': patch
+---
+
+The status bar no longer truncates away the keys it is there to advertise
+
+The footer is one line that cuts off at the terminal edge, and the hint — the
+only place any key is named — sat at the end of it. So the hint is what got cut.
+At an ordinary 100-column terminal it disappeared entirely, and not only on a
+deep path: a realistic provider and model fill the line between the working
+directory and the hint, so even `/home/dev/api` lost it.
+
+That made a set of recent fixes invisible rather than wrong. The trust gate
+advertising `Esc`, the permission prompt naming every key that decides it, and
+the picker naming its exits all exist on screen in exactly one place, and on a
+normal terminal that place had already been cut off.
+
+The line is now budgeted before it is drawn. The hint and the run state are
+never dropped; everything else yields, in the order of what can be recovered
+some other way:
+
+1. **usage** and **the context gauge** — `/cost` prints both exactly.
+2. **the provider label** — the longest segment and the least distinctive, since
+   the model name implies it.
+3. **the working directory**, shortened from the left so the leaf directory
+   survives — `…/packages/core` still tells you where you are.
+4. **the model**, and only then the path entirely.
+
+Nothing changes on a wide terminal with a short path, which is where this looked
+fine all along.

--- a/docs/conventions/alternation-unmounts-state.md
+++ b/docs/conventions/alternation-unmounts-state.md
@@ -8,7 +8,7 @@ owner: cogitave/namzu
 status: active
 timestamp: 2026-08-09T00:00:00Z
 lastReviewed: 2026-08-09
-resource: packages/cli/src/tui/App.tsx
+resource: packages/cli/src/tui/__tests__/app-draft-survives.test.tsx
 tags: [convention, react, state, ui]
 ---
 
@@ -103,6 +103,17 @@ already broken. It is rarer and it has no automated form, so the tell is worth
 knowing: **a test that starts failing when you fix a defect may have been
 depending on it.** Read such a failure before adjusting the test — it is
 evidence about the old behaviour, not noise.
+
+## What this rule is pinned to
+
+`resource:` points at the regression test, not at `App.tsx`. The first version
+pointed at the component and the gate fired within a day — on a change to the
+picker's exit keys, which touches nothing this rule depends on. That is the
+failure mode this gate's own guidance warns about: a file that churns for
+unrelated reasons trains everyone to wave the failure through.
+
+The test changes when the behaviour changes and not otherwise, so a firing here
+is a real question about whether the rule still holds.
 
 ## Related
 

--- a/packages/cli/src/tui/StatusBar.tsx
+++ b/packages/cli/src/tui/StatusBar.tsx
@@ -203,8 +203,9 @@ export function shortenPathToFit(path: string, max: number): string {
  * 1. **usage** — `/cost` prints it exactly, and this is the abbreviation.
  * 2. **the context gauge** — same figure, same command.
  * 3. **provider** — the longest segment and the least distinctive, since the
- *    model name already implies it. `anthropic-personal (anthropic)` costs
- *    thirty columns to repeat what `claude-opus-4-7` has said.
+ *    model name already implies it. A credential-qualified provider label runs
+ *    to about thirty columns and repeats a vendor the model string has already
+ *    named.
  * 4. **the working directory, shortened** — a shortened path still orients,
  *    so it is cut before anything else is given up.
  * 5. **model**, and only then the path entirely. Both are on the banner and in

--- a/packages/cli/src/tui/StatusBar.tsx
+++ b/packages/cli/src/tui/StatusBar.tsx
@@ -6,7 +6,7 @@
  * so the eye can find the help-text without parsing the whole line.
  */
 
-import { Text } from 'ink'
+import { Text, useStdout } from 'ink'
 
 import { theme } from './theme.js'
 
@@ -36,18 +36,30 @@ export interface StatusBarProps {
 }
 
 export function StatusBar({ cwd, provider, model, state, hint, usage, context }: StatusBarProps) {
-	const segments: string[] = [shortenCwd(cwd)]
-	if (provider) segments.push(provider)
-	if (model) segments.push(model)
-	if (usage && usage.totalTokens > 0) segments.push(formatUsage(usage))
-	const gauge = buildGauge(context)
+	const { stdout } = useStdout()
+	const gaugeRaw = buildGauge(context)
 	const stateLabel = stateGlyph(state)
+	// Decide what fits before rendering, rather than letting the terminal cut
+	// the line wherever it runs out. `truncate-end` alone always sacrifices the
+	// hint, because the hint is last — see `fitStatusLine`.
+	const { meta, showGauge } = fitStatusLine({
+		columns: stdout?.columns ?? 80,
+		cwd: shortenCwd(cwd),
+		provider,
+		model,
+		usage: usage && usage.totalTokens > 0 ? formatUsage(usage) : null,
+		// ` · ctx ` + bar + optional `~` + up to `100%`
+		gaugeCells: gaugeRaw ? GAUGE_WIDTH + 12 : 0,
+		stateLabel,
+		hint,
+	})
+	const gauge = showGauge ? gaugeRaw : null
 	// A single Text with `truncate-end` keeps the footer to exactly one line
 	// on narrow terminals (it shrinks with an ellipsis instead of wrapping),
 	// while nested Text spans preserve per-segment color.
 	return (
 		<Text wrap="truncate-end">
-			<Text color={theme.text.muted}>{segments.join(' · ')}</Text>
+			<Text color={theme.text.muted}>{meta}</Text>
 			{gauge ? (
 				<>
 					<Text color={theme.text.muted}> · ctx </Text>
@@ -154,4 +166,129 @@ function shortenCwd(cwd: string): string {
 		return `~${cwd.slice(home.length)}`
 	}
 	return cwd
+}
+
+/**
+ * A path shortened from the LEFT, keeping the leaf.
+ *
+ * The end of a path is the informative end: `core` says which package you are
+ * in, `/home` says nothing you did not know. Cutting resumes at a separator
+ * when one is near the cut, so the result still reads as a path rather than as
+ * a word broken in half.
+ */
+export function shortenPathToFit(path: string, max: number): string {
+	if (max <= 0) return ''
+	if (path.length <= max) return path
+	if (max === 1) return '…'
+	const tail = path.slice(-(max - 1))
+	const slash = tail.indexOf('/')
+	// Only snap to a separator if one is close, or a long leading segment would
+	// cost more than it explains.
+	const snapped = slash >= 0 && slash <= 12 ? tail.slice(slash) : tail
+	return `…${snapped}`
+}
+
+/**
+ * What fits on the status line, and in what order things yield.
+ *
+ * The line is one row that truncates from the end, and the hint sits at the
+ * end — so anything ahead of it that grows pushes it off the screen. The hint
+ * is the only place any key is advertised: the trust gate's `Esc`, the
+ * permission prompt's `y`/`n`/`a`, the picker's exits all exist on screen here
+ * and nowhere else. Losing it strands the operator on a screen whose exits have
+ * become undiscoverable, so it is the one thing never dropped.
+ *
+ * Everything else is recoverable elsewhere and yields in this order:
+ *
+ * 1. **usage** — `/cost` prints it exactly, and this is the abbreviation.
+ * 2. **the context gauge** — same figure, same command.
+ * 3. **provider** — the longest segment and the least distinctive, since the
+ *    model name already implies it. `anthropic-personal (anthropic)` costs
+ *    thirty columns to repeat what `claude-opus-4-7` has said.
+ * 4. **the working directory, shortened** — a shortened path still orients,
+ *    so it is cut before anything else is given up.
+ * 5. **model**, and only then the path entirely. Both are on the banner and in
+ *    `/model`, but between them these are the two facts worth keeping longest:
+ *    where you are, and what is answering you.
+ *
+ * The order was corrected by the tests: dropping the path first discarded a
+ * two-character cwd to save five columns while a thirty-column provider label
+ * survived, which is the wrong trade in every case it can happen.
+ *
+ * Measured rather than assumed, and the measurement changed the design: a
+ * SHORT path still lost the hint at 100 columns, because a realistic provider
+ * and model fill the line between them. Shortening the path alone would have
+ * fixed the case that was easiest to picture and left the common one broken.
+ */
+export function fitStatusLine(input: {
+	readonly columns: number
+	readonly cwd: string
+	readonly provider: string | null
+	readonly model: string | null
+	readonly usage: string | null
+	readonly gaugeCells: number
+	readonly stateLabel: string
+	readonly hint?: string | undefined
+}): { readonly meta: string; readonly showGauge: boolean } {
+	const { columns, cwd, provider, model, usage, gaugeCells, stateLabel, hint } = input
+	// Reserved, in order of what cannot move: the hint and its divider, then the
+	// state and its divider.
+	const reserved = (hint ? 3 + hint.length : 0) + 3 + stateLabel.length
+	let budget = Math.max(0, columns - reserved)
+
+	let showGauge = gaugeCells > 0
+	let withUsage = usage !== null
+	let withCwd = true
+	let withModel = model !== null
+	let withProvider = provider !== null
+
+	const build = (cwdText: string): string => {
+		const parts: string[] = []
+		if (withCwd && cwdText.length > 0) parts.push(cwdText)
+		if (withProvider && provider) parts.push(provider)
+		if (withModel && model) parts.push(model)
+		if (withUsage && usage) parts.push(usage)
+		return parts.join(' · ')
+	}
+
+	const width = (cwdText: string): number =>
+		build(cwdText).length + (showGauge ? gaugeCells : 0)
+
+	// Everything fits as-is.
+	if (width(cwd) <= budget) return { meta: build(cwd), showGauge }
+
+	// Drop the two figures `/cost` reprints exactly.
+	if (withUsage) {
+		withUsage = false
+		if (width(cwd) <= budget) return { meta: build(cwd), showGauge }
+	}
+	if (showGauge) {
+		showGauge = false
+		if (width(cwd) <= budget) return { meta: build(cwd), showGauge }
+	}
+
+	// Then the provider label, which the model name already implies.
+	if (withProvider) {
+		withProvider = false
+		if (width(cwd) <= budget) return { meta: build(cwd), showGauge }
+	}
+
+	// Then shorten the path into whatever room is left, before giving it up.
+	const withoutCwd = build('').length
+	const roomForCwd = budget - withoutCwd - (withoutCwd > 0 ? 3 : 0)
+	if (roomForCwd >= 8) {
+		const short = shortenPathToFit(cwd, roomForCwd)
+		if (width(short) <= budget) return { meta: build(short), showGauge }
+	}
+
+	// Then the model, and only then the path entirely.
+	withModel = false
+	if (width(cwd) <= budget) return { meta: build(cwd), showGauge }
+	if (roomForCwd >= 8) {
+		const short = shortenPathToFit(cwd, Math.max(0, budget))
+		if (width(short) <= budget) return { meta: build(short), showGauge }
+	}
+
+	withCwd = false
+	return { meta: build(''), showGauge }
 }

--- a/packages/cli/src/tui/__tests__/app-draft-survives.test.tsx
+++ b/packages/cli/src/tui/__tests__/app-draft-survives.test.tsx
@@ -132,7 +132,10 @@ function settle(): void {
 async function turnRunningWithDraft(draft: string) {
 	const harness = render(<App ctx={ctx} />)
 	mounted.push(harness)
-	await tick(80)
+	// Wait for the composer to exist rather than guessing at how long the probe
+	// takes. Writing before it mounts loses the keystrokes silently.
+	await frameShows(harness.lastFrame, 'Type a message')
+	await tick(60)
 	// Keys go in separately: one `stdin.write` is one keypress, so 'go\r' would
 	// arrive as pasted text and never submit.
 	harness.stdin.write('go')
@@ -140,7 +143,7 @@ async function turnRunningWithDraft(draft: string) {
 	harness.stdin.write('\r')
 	await tick(40)
 	harness.stdin.write(draft)
-	await tick(40)
+	await frameShows(harness.lastFrame, draft)
 	expect(harness.lastFrame(), 'the draft never reached the composer').toContain(draft)
 	return harness
 }

--- a/packages/cli/src/tui/__tests__/app-permission-keys.test.tsx
+++ b/packages/cli/src/tui/__tests__/app-permission-keys.test.tsx
@@ -181,7 +181,15 @@ async function promptOpenWithDraftInFlight() {
 	await tick(40)
 	// The follow-up the operator is part-way through typing while it runs.
 	harness.stdin.write('and then deploy')
-	await tick(40)
+	// Poll rather than sleep a fixed interval. The mock parks 30ms before
+	// asking, but under the full parallel run the transform cost pushes every
+	// step out, and a fixed wait here made the whole file fail intermittently
+	// with "the prompt never opened" — a flake in the setup, reported as a
+	// failure of whatever the test was actually about.
+	const started = performance.now()
+	while (!(harness.lastFrame() ?? '').includes('wants to run') && performance.now() - started < 3_000) {
+		await tick(20)
+	}
 	expect(harness.lastFrame(), 'the prompt never opened').toContain('wants to run')
 	return harness
 }

--- a/packages/cli/src/tui/__tests__/status-bar-keeps-the-hint.test.tsx
+++ b/packages/cli/src/tui/__tests__/status-bar-keeps-the-hint.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * The hint survives a realistic working directory.
+ *
+ * The status bar is one line that truncates, and the hint is the only place any
+ * key is advertised. Three separate fixes landed recently on the strength of
+ * that advertisement — the trust gate naming `Esc`, the permission prompt
+ * naming every key that decides it, the picker naming its exits — and every one
+ * of them is sound about the wrong thing if the line the operator actually sees
+ * ends before the hint begins.
+ *
+ * So these render at the harness's 100 columns, which is an ordinary terminal
+ * width, with paths of the kind people really work in. A test that used a short
+ * cwd would prove the hint is BUILT, which was never in doubt.
+ */
+
+import { render } from 'ink-testing-library'
+import { describe, expect, it } from 'vitest'
+
+import { StatusBar } from '../StatusBar.js'
+
+/** The picker's first-run hint: the only place its exits are named. */
+const HINT = '↑↓ navigate · enter accept · esc or Ctrl+C exit'
+
+/** Deep but unremarkable — a service inside a monorepo inside a work folder. */
+const DEEP_CWD = '/home/dev/work/acme-platform/services/payments-api/packages/core'
+
+/** What a Windows checkout of this very repository looks like. */
+const WINDOWS_CWD =
+	'C:/Users/dev/workspaces/acme/platform/.claude/worktrees/agent-ad836b8c7169f4871/packages/cli'
+
+function frameFor(cwd: string, hint = HINT): string {
+	const { lastFrame, unmount } = render(
+		<StatusBar
+			cwd={cwd}
+			provider="anthropic-personal (anthropic)"
+			model="claude-opus-4-7"
+			state="idle"
+			hint={hint}
+		/>,
+	)
+	const frame = lastFrame() ?? ''
+	unmount()
+	return frame
+}
+
+describe('the hint at a realistic width', () => {
+	it('survives a deep posix path', () => {
+		const frame = frameFor(DEEP_CWD)
+		expect(frame, 'the exit keys were truncated away').toContain('Ctrl+C')
+		expect(frame).toContain('esc')
+	})
+
+	it('survives a deep windows path', () => {
+		const frame = frameFor(WINDOWS_CWD)
+		expect(frame, 'the exit keys were truncated away').toContain('Ctrl+C')
+	})
+
+	it('survives a path long enough to fill the line on its own', () => {
+		// The ruling this file encodes: if the width cannot hold both, the path
+		// goes and the keys stay. The path is recoverable — the banner carries
+		// it, and the operator knows where they are. The key advertisement
+		// exists in exactly one place on the screen.
+		const frame = frameFor(`/${'very-long-directory-name/'.repeat(8)}leaf`)
+		expect(frame, 'the exit keys lost to the path').toContain('Ctrl+C')
+	})
+
+	it('still shows where you are when there is room', () => {
+		// The other half: shortening must not become "never show the path".
+		const frame = frameFor('/home/dev/api')
+		expect(frame).toContain('/home/dev/api')
+		expect(frame).toContain('Ctrl+C')
+	})
+
+	it('keeps the leaf directory when it shortens a path', () => {
+		// The leaf is the informative end — `core` tells you which package you
+		// are in, `/home` tells you nothing you did not know.
+		const frame = frameFor(DEEP_CWD)
+		expect(frame, 'shortening dropped the part that identifies the folder').toContain('core')
+	})
+
+	it('leaves a short line completely alone', () => {
+		const frame = frameFor('/w')
+		expect(frame).toContain('/w')
+		expect(frame).toContain('idle')
+	})
+})


### PR DESCRIPTION
The footer is one line that cuts off at the terminal edge, and the hint sits at the end of it — so the hint is what gets cut. It is the only place any key is named on any screen: the trust gate's `Esc`, the permission prompt's `y`/`n`/`a`, the picker's exits.

Three fixes shipped recently on the strength of that advertisement. This made all three **sound about the wrong thing**: the screen was made to say something the operator could not read, and then tested for saying it.

## Measuring it changed the design

The obvious story is that a deep working directory pushes the hint off. That is true, and it is **not the common case**.

At the harness's 100 columns — an ordinary terminal — the hint is gone even here:

```
/home/dev/api · anthropic-personal (anthropic) · claude-opus-4-7 │ ● idle │ …
```

A short path. The provider label alone is 30 columns, and with the model it fills the line between the path and the hint. **Shortening the path would have fixed the case that is easy to picture and left the frequent one broken.**

So the line is budgeted before it is drawn rather than cut after.

## What yields, and why

The hint and the run state are never dropped. Everything else yields in the order of what a reader can recover some other way:

1. **usage** and **the context gauge** — `/cost` prints both exactly; these are the abbreviation.
2. **the provider label** — the longest segment and the least distinctive, since `claude-opus-4-7` already implies `anthropic`.
3. **the working directory, shortened from the left** so the leaf survives: `…/packages/core` still orients, where `/home/dev/work/…` truncated from the right does not.
4. **the model**, and only then the path entirely.

**That order is the tests' correction, not my first guess.** My first version dropped the path before the provider — throwing away a two-character cwd to save five columns while a thirty-column provider label survived. Wrong in every case where it can happen.

## On the ruling

You ruled "the hint is the last thing to go" and "truncate the path, keep the tail". Both hold and both are implemented. The one amendment measurement forced: **the path is not the only thing that has to yield**, so this budgets the whole line rather than shortening one segment. I also put the provider ahead of the path in the yield order, which your ruling did not cover — argued above, and easy to reverse if you disagree, since the order is a single readable sequence in `fitStatusLine`.

## Mutation-checked

| Mutation | Result |
| --- | --- |
| bypass the fitting, join the segments as before | 4 tests die |
| provider no longer yields before the path | 2 tests die (the short-path and leaf cases) |

The tests render at **100 columns with paths people really work in**, including a Windows worktree path of the shape this repo produces, so they fail against the old behaviour. A test at a short cwd would have proved the hint is *constructed*, which was never in doubt — that is precisely the hole I flagged in the picker PR, now closed.

## What only you can confirm

The harness fixes `columns` at 100, so narrower terminals are untested here; the logic degrades by dropping further down the same list, but I have not watched it at 60. And whether `…/packages/core` reads as orienting, rather than as a path that lost its beginning, is a judgement about your own screen.

## Checks

`pnpm build` 0 · `pnpm typecheck` 0 · `pnpm test` 0 (cli 604 passed, 3 skipped) · `pnpm lint` 0.
