### PR TITLE
docs(conventions): a second instance of the filter rule, and a rule with no sentinel

### DIFF
--- a/docs/conventions/alternation-unmounts-state.md
+++ b/docs/conventions/alternation-unmounts-state.md
@@ -8,7 +8,6 @@ owner: cogitave/namzu
 status: active
 timestamp: 2026-08-09T00:00:00Z
 lastReviewed: 2026-08-09
-resource: packages/cli/src/tui/__tests__/app-draft-survives.test.tsx
 tags: [convention, react, state, ui]
 ---
 
@@ -104,16 +103,34 @@ knowing: **a test that starts failing when you fix a defect may have been
 depending on it.** Read such a failure before adjusting the test — it is
 evidence about the old behaviour, not noise.
 
-## What this rule is pinned to
+## This rule has no `resource:`, deliberately
 
-`resource:` points at the regression test, not at `App.tsx`. The first version
-pointed at the component and the gate fired within a day — on a change to the
-picker's exit keys, which touches nothing this rule depends on. That is the
-failure mode this gate's own guidance warns about: a file that churns for
-unrelated reasons trains everyone to wave the failure through.
+It went through all three options, and the reasoning is here because the next
+person writing a rule will face the same choice.
 
-The test changes when the behaviour changes and not otherwise, so a firing here
-is a real question about whether the rule still holds.
+It first pointed at `App.tsx`, where the incident happened. The gate fired
+within a day, on a change to the picker's exit keys — which touches nothing
+this rule depends on. That is exactly the failure the gate's own guidance
+warns about: a file that churns for unrelated reasons trains everyone to wave
+the failure through.
+
+The obvious repair was to repoint it at the regression test, on the grounds
+that a test changes when the behaviour changes and not otherwise. That is true
+and still wrong here. **Nothing in this repository can make this rule false.**
+It is about how React reconciles by element type at a position; the test could
+be deleted tomorrow and the rule would be exactly as true. A sentinel that
+fires would be saying "our use of this rule changed", which is not what a
+drift check means or what a reader would take it to mean.
+
+So the key is absent, which is the honest reading: no code in this tree owns
+this claim. That mirrors what the documentation standard says about the sibling
+key `verified:` — omit it rather than guess, because an absent key honestly
+reads as unestablished and a false one does not.
+
+The general form: **point `resource:` at code whose change could make the
+document wrong, not at code the document happens to be about.** A rule about
+this codebase's behaviour usually has such a file. A rule about the semantics
+of a tool we merely use usually does not.
 
 ## Related
 

--- a/docs/conventions/never-filter-a-verification.md
+++ b/docs/conventions/never-filter-a-verification.md
@@ -38,6 +38,26 @@ verdict, never on a guess at what the diagnostic will look like.
 - The same session had already adopted this rule from the first incident, in
   writing, and broke it in the next command.
 
+## And again, five days later, to someone who had read it
+
+Running the six gates by hand, `node tools/check-docs.mjs | Select-Object -First 1`
+printed `EXIT: -1` for a gate that had passed: the truncating pipe closed the
+stream and killed the process, so the exit code described the pipe rather than
+the check. It happened while writing up a report about not having run all the
+gates, in the session that ratified this rule.
+
+That is the instance worth keeping, because it says what the first four cannot.
+The failure is not ignorance of the rule — the author had read it, written about
+it, and cited it the same day. **The failure is the reflex to trim output**,
+which fires while attention is on the thing being checked rather than on the
+checking. Knowing the rule does not disarm the reflex; only refusing to put a
+filter between yourself and a verdict does.
+
+Note also which direction it failed in. A filter that manufactures a green is
+the danger this rule was written for; this one manufactured a red, and a red
+gets investigated. The same reflex produces both, and only one of them announces
+itself.
+
 ## It recurred, in a shape the rule did not spell out
 
 2026-08-07. An agent ran `node tools/check-docs.mjs 2>&1 | tail -4; echo $?`


### PR DESCRIPTION
Two amendments, both from the same session's own mistakes.

## A fifth instance of the filter rule, and the one that says something new

`node tools/check-docs.mjs | Select-Object -First 1` reported **exit -1 for a gate that had passed**: the truncating pipe closed the stream and killed the process, so the exit code described the pipe rather than the check.

It happened while writing up a report about not having run all the gates, in the session that ratified this rule, by someone who had cited it the same day.

That is what the existing four instances cannot say. **The failure is not ignorance** — the rule had been read, written about and quoted. The failure is the *reflex to trim output*, which fires while attention is on the thing being checked rather than on the checking. Knowing the rule does not disarm the reflex.

The amendment also records the direction, because it is not the one the rule was written for: this filter manufactured a **red**, and a red gets investigated. The same reflex produces both, and only one announces itself.

## A rule with no sentinel, and why

`alternation-unmounts-state` loses its `resource:` entirely. It went through all three options and the reasoning is now in the file, because the next author writing a rule will face the same choice:

1. **`App.tsx`** — where the incident happened. The gate fired within a day on a change to the picker's exit keys, which touches nothing the rule depends on. Exactly the churn the gate's own guidance warns about.
2. **The regression test** — my repair, on the grounds that a test changes when the behaviour changes and not otherwise. True, and still wrong here.
3. **Nothing** — which is what it now says.

**No file in this repository can make that rule false.** It is about how React reconciles by element type at a position; the test could be deleted tomorrow and the rule would be exactly as true. A sentinel firing there would mean *"our use of the rule changed"* — not what a drift check means, and not what a reader would take it to mean.

An absent key is the honest reading: no code in this tree owns this claim. That mirrors what the documentation standard says about the sibling key `verified:` — omit rather than guess, because an absent key reads as unestablished and a false one does not.

Generalised in the file so it does not have to be re-derived:

> Point `resource:` at code whose change could make the document **wrong**, not at code the document happens to be **about**. A rule about this codebase's behaviour usually has such a file. A rule about the semantics of a tool we merely use usually does not.

## Checks

All six, run unfiltered this time, exit codes captured before any filtering:

`pnpm build` 0 · `pnpm typecheck` 0 · `audit-external-names` 0 · `check-docs` 0 · `pnpm test` 0 (cli 609 passed, 3 skipped; sdk 2938 passed) · `pnpm lint` 0.
