### PR TITLE
fix(cli): a provider namzu cannot build is no longer offered as if it could

### DIFF
--- a/.changeset/a-provider-namzu-cannot-build.md
+++ b/.changeset/a-provider-namzu-cannot-build.md
@@ -1,0 +1,36 @@
+---
+'@namzu/cli': minor
+---
+
+**A provider namzu cannot build is no longer offered as if it could.** Three
+registry entries advertised providers whose driver packages are not
+dependencies of the CLI. Two of them are genuinely discovered — one by a local
+probe, one by an ambient `AWS_ACCESS_KEY_ID` — so the picker listed them,
+choosing one saved it, and the next session refused it on a screen with a
+disabled composer where the advice "pick another" cannot be followed.
+
+`ProviderRegistryEntry` gains **`constructible`**: whether this build of the
+CLI bundles a driver for the entry. It is a statement about the CLI's
+dependencies, not about the provider. Four consumers read the registry as truth
+and only `constructProvider` knew better; now they all read the same answer.
+
+What changes for an operator:
+
+- **The picker** still lists a discovered-but-unbuildable provider, marked
+  `unavailable in this build`, and refuses to accept it with a message naming
+  the providers that do work. Hiding the row was rejected: someone whose only
+  local server is one of these would see "No providers detected", which is
+  false.
+- **A saved primary** naming one is refused when preferences are read, which
+  routes to the picker with the reason. This is the fix — refusing later, at
+  construction, is what produced the dead end.
+- **`writePreferences`** refuses to save one as a primary.
+- **A fallback** naming one is unchanged: dropped from the chain at launch with
+  a notice, session runs. Refusing the whole file over a spare would take away
+  a working primary.
+
+No dependencies were added. Bundling the three drivers is a supply-chain
+decision with a real cost — one pulls a large cloud SDK into every install —
+and it belongs to the owner. This change makes the entries stop lying either
+way; wiring any of them later is a one-line flag flip plus a switch arm, held
+in agreement by a test. Closes #257.

--- a/docs/cli/providers.md
+++ b/docs/cli/providers.md
@@ -65,6 +65,26 @@ namzu detects which kind of Anthropic credential it has and authenticates accord
 
 The picker currently wires Anthropic, OpenAI, OpenRouter, and Ollama. Other providers in the registry surface as they gain credential detection.
 
+### A provider this build cannot run
+
+namzu knows about more providers than it bundles drivers for. A driver package exists in the repository for each one, but only the four above are dependencies of the CLI, so only those four can be loaded and used.
+
+The rest are still **discovered**, because discovery is honest — a local server really is running, a credential really is present — and they appear in the picker with `unavailable in this build` beside the source. They cannot be chosen:
+
+```
+2. fallback 1 · <label> · <model> · local · localhost:1234 · unavailable in this build
+```
+
+Choosing one is refused with the reason and the providers you can pick instead. The same refusal happens in three other places, so there is no route around it:
+
+- a **saved primary** naming one is refused when `preferences.json` is read, and you land in the picker with the reason printed above it;
+- **`writePreferences`** will not save one as the primary at all;
+- **`namzu doctor`** reports it under `Could not read what these members declare`.
+
+A **fallback** naming one is treated differently on purpose: it is dropped from the chain at launch with a notice, and your session runs. Refusing the whole file over a spare would take away a primary that works.
+
+Excluding these rows from the picker entirely was considered and rejected — an operator whose only local server is one of them would then see `No providers detected`, which is false. namzu found it and declined it, and a refusal that presents as an absence is not a refusal.
+
 ## Switching providers
 
 Run `/model` inside the TUI to re-open the picker at any time. The new choice is saved and the session reconnects.

--- a/packages/cli/src/doctor/checks/__tests__/chain.test.ts
+++ b/packages/cli/src/doctor/checks/__tests__/chain.test.ts
@@ -159,12 +159,42 @@ describe('the provider chain check', () => {
 			expect(r.message ?? '').not.toMatch(/declare different capabilities/)
 		})
 
-		it('FAILS when it is the PRIMARY whose declaration cannot be read', async () => {
+		/**
+		 * This case used to assert that doctor reaches its `primaryUnreadable`
+		 * branch for a provider with no bundled driver. It cannot any more, and
+		 * the reason is the fix: such a primary is now refused when the
+		 * preferences file is READ, so doctor answers from its `needs-repick`
+		 * branch and never resolves capabilities at all.
+		 *
+		 * Rewritten to assert what is true rather than deleted, because the
+		 * operator-visible property is unchanged and still worth pinning: doctor
+		 * FAILS, and it points at the picker, which is the one screen that can
+		 * fix it.
+		 *
+		 * `primaryUnreadable` is kept in the check and is not dead: `constructible`
+		 * only promises that this build BUNDLES the driver, and a bundled import
+		 * can still throw on a broken or partial install. That is a nameable
+		 * input, which is what distinguishes a guard worth keeping from one that
+		 * cannot fail (`docs/conventions/a-check-that-cannot-fail.md`).
+		 */
+		it('FAILS a primary with no bundled driver, and sends the operator to the picker', async () => {
 			writePrefs({ version: 3, providers: [{ id: 'bedrock' }, { id: 'anthropic' }] })
 			const r = await check({ AWS_ACCESS_KEY_ID: 'y', ANTHROPIC_API_KEY: 'x' })
 
 			expect(r.status).toBe('fail')
-			expect(r.remediation ?? '').toMatch(/no run can start/)
+			expect(r.message ?? '').toMatch(/not available in this build/)
+			expect(r.remediation ?? '').toMatch(/pick again/)
+		})
+
+		it('does NOT refuse the file over an unbuildable FALLBACK — the primary still runs', async () => {
+			// The asymmetry, read from the outside. A spare namzu cannot build is
+			// dropped with a notice; taking the whole session away over it would be
+			// the opposite trade.
+			writePrefs({ version: 3, providers: [{ id: 'anthropic' }, { id: 'bedrock' }] })
+			const r = await check({ ANTHROPIC_API_KEY: 'x', AWS_ACCESS_KEY_ID: 'y' })
+
+			expect(r.status).toBe('warn')
+			expect(r.message ?? '').toMatch(/Could not read what these members declare/)
 		})
 	})
 })

--- a/packages/cli/src/integrations/providers/__tests__/register.test.ts
+++ b/packages/cli/src/integrations/providers/__tests__/register.test.ts
@@ -1,0 +1,122 @@
+/**
+ * `constructible` and the switch arms are one fact in two places, and this is
+ * what stops them drifting.
+ *
+ * The registry entry is data five consumers read as truth; `ensureRegistered`
+ * is the only thing that knows which drivers this build actually bundles. The
+ * flag exists so the other four can know it too — which is worth nothing if the
+ * flag can go stale, and staleness is exactly the defect being fixed (#257).
+ *
+ * Both directions matter and they fail differently:
+ *
+ *  - a flag saying `true` with no arm is the original defect, restored: the
+ *    picker offers a row that throws;
+ *  - an arm with the flag saying `false` refuses a provider that works, which
+ *    nothing else in the codebase would catch, because refusing looks like the
+ *    fix.
+ */
+
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+
+import { ensureRegistered, isRegistered } from '../register.js'
+import { ALL_PROVIDER_IDS, PROVIDER_REGISTRY, unsupportedProviderMessage } from '../registry.js'
+
+/**
+ * Ask `ensureRegistered` itself rather than re-reading its source.
+ *
+ * A test that parsed the switch for `case` labels would be asserting against a
+ * copy of the thing it is checking; this drives the real function and reads the
+ * real outcome. A provider whose driver is bundled registers (or throws
+ * something OTHER than the refusal, on a broken install); one that is not
+ * bundled throws the refusal.
+ */
+async function bundlesADriver(id: (typeof ALL_PROVIDER_IDS)[number]): Promise<boolean> {
+	try {
+		await ensureRegistered(id)
+		return true
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err)
+		return message !== unsupportedProviderMessage(id)
+	}
+}
+
+const UNBUNDLED_IDS = ALL_PROVIDER_IDS.filter((id) => !PROVIDER_REGISTRY[id].constructible)
+
+/** The dependency list this package actually ships with. */
+const CLI_DEPENDENCIES: Record<string, string> = JSON.parse(
+	readFileSync(new URL('../../../../package.json', import.meta.url), 'utf8'),
+).dependencies
+
+/**
+ * The flag is checked against the DEPENDENCY LIST, which is what makes it true.
+ *
+ * Two earlier drafts were worse, and both were caught by mutation rather than
+ * by reading:
+ *
+ *  - iterating a list derived from `constructible` meant flipping a flag simply
+ *    removed that id from the loop, so the mutation restoring the original
+ *    defect passed. A guard filtered by the thing it guards cannot fail
+ *    (`docs/conventions/a-check-that-cannot-fail.md`).
+ *  - driving `ensureRegistered` for all seven ids caught it, at the cost of
+ *    pulling four driver module graphs through vite's transform in this worker.
+ *    That starved a neighbouring render-loop test badly enough to fail it in
+ *    two runs out of three — and widening that test's wall-clock budget did not
+ *    help, because it then consumed whatever ceiling it was given. The cost was
+ *    not marginal and paying it was not an option.
+ *
+ * A dependency this package does not declare cannot be imported, so
+ * `package.json` is not a proxy for the truth here — it IS the truth, and
+ * comparing against it is both cheaper and more direct than comparing against
+ * the switch that reads it. The switch is still driven below, once, and for the
+ * unbundled ids, which is where the refusal has to be exact.
+ */
+describe('constructible agrees with what this package actually depends on', () => {
+	it.each([...ALL_PROVIDER_IDS])('%s', (id) => {
+		expect(`@namzu/${id}` in CLI_DEPENDENCIES).toBe(PROVIDER_REGISTRY[id].constructible)
+	})
+
+	it.each([...UNBUNDLED_IDS])('refuses %s, rather than merely being flagged', async (id) => {
+		// The flag and the refusal are two things, and a flag nothing enforces is
+		// the shape of the defect being fixed. Cheap: these ids reach the
+		// `default:` arm without importing anything.
+		expect(await bundlesADriver(id)).toBe(false)
+	})
+
+	it('registers a bundled driver, so `isRegistered` reports it afterwards', async () => {
+		// The flag promising a driver is worth nothing if registration does not
+		// happen. Without this, a switch whose arms all fell through to a no-op
+		// would satisfy every case above.
+		const id = ALL_PROVIDER_IDS.find((candidate) => PROVIDER_REGISTRY[candidate].constructible)
+		if (!id) throw new Error('no constructible provider in the registry')
+		await ensureRegistered(id)
+		expect(isRegistered(id)).toBe(true)
+	})
+
+	it('leaves an unbundled provider unregistered rather than half-registered', async () => {
+		const id = UNBUNDLED_IDS[0]
+		if (!id) throw new Error('no unbuildable provider in the registry')
+		await expect(ensureRegistered(id)).rejects.toThrow(/not available in this build/)
+		expect(isRegistered(id)).toBe(false)
+	})
+})
+
+describe('the refusal names what an operator can act on', () => {
+	it('names the provider, the reason, and only providers that actually work', () => {
+		const id = UNBUNDLED_IDS[0]
+		if (!id) throw new Error('no unbuildable provider in the registry')
+		const message = unsupportedProviderMessage(id)
+
+		expect(message).toContain(PROVIDER_REGISTRY[id].label)
+		expect(message).toMatch(/not available in this build/)
+		// The suggestions must be usable. Listing an unbuildable provider as the
+		// remedy for an unbuildable provider is the failure mode this sentence
+		// exists to avoid.
+		for (const id of ALL_PROVIDER_IDS) {
+			if (PROVIDER_REGISTRY[id].constructible) continue
+			expect(message.includes('Pick one of:')).toBe(true)
+			expect(message.split('Pick one of:')[1] ?? '').not.toContain(id)
+		}
+	})
+})

--- a/packages/cli/src/integrations/providers/index.ts
+++ b/packages/cli/src/integrations/providers/index.ts
@@ -41,5 +41,6 @@ export {
 	type ProviderId,
 	type ProviderRegistryEntry,
 	type SdkProviderType,
+	unsupportedProviderMessage,
 } from './registry.js'
 export { ensureRegistered, isRegistered, resolveChainCapabilities } from './register.js'

--- a/packages/cli/src/integrations/providers/preferences.test.ts
+++ b/packages/cli/src/integrations/providers/preferences.test.ts
@@ -240,3 +240,52 @@ describe('primaryProvider', () => {
 		expect(() => primaryProvider({ version: 3, providers: [] })).toThrow(PreferencesError)
 	})
 })
+
+/**
+ * A saved primary this build cannot construct is refused when the file is READ.
+ *
+ * Where the refusal happens is the whole fix, not a detail. `needs-repick`
+ * routes the operator to the picker with the reason printed above it;
+ * construction-time refusal returns an empty session, which sets the
+ * `unhealthy` phase — a disabled composer where `/model` cannot be typed. The
+ * old message told them to pick another provider on the one screen that will
+ * not let them.
+ */
+describe('a provider with no bundled driver', () => {
+	it('refuses a saved PRIMARY at read time, so the operator lands in the picker', () => {
+		const home = mkdtempSync(join(tmpdir(), 'namzu-prefs-'))
+		mkdirSync(join(home, '.namzu'), { recursive: true })
+		writeFileSync(
+			join(home, '.namzu', 'preferences.json'),
+			JSON.stringify({ version: 3, providers: [{ id: 'bedrock' }] }),
+		)
+
+		const read = readPreferences(home)
+
+		// `needs-repick`, not a throw and not `ok`. A throw would take the
+		// operator out of the program; `ok` is what produced the dead end.
+		expect(read.status).toBe('needs-repick')
+		expect(read.status === 'needs-repick' && read.reason).toMatch(/not available in this build/)
+	})
+
+	it('does NOT refuse the file over a FALLBACK naming one', () => {
+		// The asymmetry with the unknown-id check above it. An unbuildable spare
+		// is dropped from the chain at launch with a notice and the session runs;
+		// refusing the file would take a working primary away over it.
+		const home = mkdtempSync(join(tmpdir(), 'namzu-prefs-'))
+		mkdirSync(join(home, '.namzu'), { recursive: true })
+		writeFileSync(
+			join(home, '.namzu', 'preferences.json'),
+			JSON.stringify({ version: 3, providers: [{ id: 'anthropic' }, { id: 'bedrock' }] }),
+		)
+
+		expect(readPreferences(home).status).toBe('ok')
+	})
+
+	it('cannot be written as a primary at all, so the picker can never save one', () => {
+		const home = mkdtempSync(join(tmpdir(), 'namzu-prefs-'))
+		expect(() => writePreferences({ version: 3, providers: [{ id: 'lmstudio' }] }, home)).toThrow(
+			/not available in this build/,
+		)
+	})
+})

--- a/packages/cli/src/integrations/providers/preferences.ts
+++ b/packages/cli/src/integrations/providers/preferences.ts
@@ -43,7 +43,7 @@ import { chmodSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'n
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 
-import { PROVIDER_REGISTRY, type ProviderId } from './registry.js'
+import { PROVIDER_REGISTRY, type ProviderId, unsupportedProviderMessage } from './registry.js'
 
 const FILE_MODE = 0o600
 const DIR_MODE = 0o700
@@ -258,6 +258,27 @@ function describeInvalidChain(members: readonly ProviderChoice[]): string | null
 		const position = chainPositionName(index)
 		if (!(member.id in PROVIDER_REGISTRY)) {
 			return `${position} "${member.id}" is not a provider namzu knows (known: ${Object.keys(PROVIDER_REGISTRY).join(', ')})`
+		}
+		// Unbuildable PRIMARY only, and the asymmetry with the check above is
+		// deliberate rather than an oversight about the tail.
+		//
+		// An unknown id breaks a chain wherever it sits, so that one is checked
+		// everywhere. An unbuildable one does not: a fallback naming it is
+		// dropped from the chain at launch with a notice, and the session runs
+		// on the primary the operator has. Refusing the whole file for it would
+		// take a working session away over a spare — the opposite of the trade
+		// the notice already makes.
+		//
+		// A primary is the other case entirely, and refusing HERE rather than at
+		// construction is the whole point. Read time returns `needs-repick`,
+		// which puts the operator in the picker with this sentence printed above
+		// it. Construction time returns an empty session, which sets the
+		// `unhealthy` phase — a disabled composer where `/model` cannot be typed
+		// — so the old refusal told an operator to pick another provider on the
+		// one screen that will not let them. A refusal whose advice cannot be
+		// followed is not a refusal; it is a dead end wearing one.
+		if (index === 0 && !PROVIDER_REGISTRY[member.id].constructible) {
+			return unsupportedProviderMessage(member.id)
 		}
 		// Compared as the pair the operator WROTE, not against the resolved
 		// default model. Resolving would make a file that was valid yesterday

--- a/packages/cli/src/integrations/providers/register.ts
+++ b/packages/cli/src/integrations/providers/register.ts
@@ -36,17 +36,23 @@ import { resolveProviderCapabilities } from '@namzu/sdk'
 
 import type { MemberCapabilities } from './chain-capabilities.js'
 import type { ProviderChoice } from './preferences.js'
-import { PROVIDER_REGISTRY, type ProviderId } from './registry.js'
+import { PROVIDER_REGISTRY, type ProviderId, unsupportedProviderMessage } from './registry.js'
 
 const registered = new Set<ProviderId>()
 
 /**
  * Import and register the driver for `id`, unless it is already registered.
  *
- * Throws for a provider that has a registry entry but no wiring here. That
- * asymmetry is a known defect, not a design: the entry, the label, the default
- * model and the discovery probe all cooperate to advertise a provider that
- * cannot be built. See issue #257.
+ * Throws for a provider this build ships no driver for — the arms below are
+ * exactly the entries flagged `constructible` in `PROVIDER_REGISTRY`, and
+ * `register.test.ts` holds the two in agreement.
+ *
+ * **This is the last line of defence, not the first.** By the time a session
+ * reaches it the operator has already chosen, and a refusal here lands them on
+ * a screen with a disabled composer where the advice "pick another" cannot be
+ * followed. The refusals that matter are earlier: `describeInvalidChain`
+ * refuses a saved primary at READ time, which routes to the picker with the
+ * reason, and the picker declines to offer the row at all.
  */
 export async function ensureRegistered(id: ProviderId): Promise<void> {
 	if (registered.has(id)) return
@@ -72,7 +78,7 @@ export async function ensureRegistered(id: ProviderId): Promise<void> {
 			break
 		}
 		default:
-			throw new Error(`provider "${id}" is not wired yet; pick another or wait for support`)
+			throw new Error(unsupportedProviderMessage(id))
 	}
 	registered.add(id)
 }

--- a/packages/cli/src/integrations/providers/registry.ts
+++ b/packages/cli/src/integrations/providers/registry.ts
@@ -34,6 +34,26 @@ export interface ProviderRegistryEntry {
 	readonly defaultModel: string
 	/** Does this provider require an apiKey? `false` for purely local. */
 	readonly requiresApiKey: boolean
+	/**
+	 * Can THIS BUILD of the CLI construct one?
+	 *
+	 * A statement about `@namzu/cli`'s dependencies, not about the provider. A
+	 * driver package exists in this repo for every entry below; only four of
+	 * them are dependencies of this package, so only four can be imported and
+	 * registered. Read the sentence that way or it will be deleted the day a
+	 * driver ships, which would put the lie back.
+	 *
+	 * It exists because five things read this registry as truth — discovery,
+	 * the picker, the chain validator, the doctor and `constructProvider` — and
+	 * only the last of them knew better. It found out at the worst possible
+	 * moment: after the operator had chosen from a list namzu offered them.
+	 *
+	 * `register.ts` is where the fact is *enforced*, and the two cannot drift:
+	 * `register.test.ts` asserts the switch arms and these flags agree in both
+	 * directions. A flag with no arm is the defect this field was added for; an
+	 * arm with no flag would refuse a provider that works.
+	 */
+	readonly constructible: boolean
 }
 
 export const PROVIDER_REGISTRY: Readonly<Record<ProviderId, ProviderRegistryEntry>> = Object.freeze(
@@ -47,6 +67,7 @@ export const PROVIDER_REGISTRY: Readonly<Record<ProviderId, ProviderRegistryEntr
 			envVars: ['ANTHROPIC_API_KEY', 'ANTHROPIC_TOKEN', 'CLAUDE_CODE_OAUTH_TOKEN'],
 			defaultModel: 'claude-opus-4-7',
 			requiresApiKey: true,
+			constructible: true,
 		},
 		openai: {
 			id: 'openai',
@@ -54,6 +75,7 @@ export const PROVIDER_REGISTRY: Readonly<Record<ProviderId, ProviderRegistryEntr
 			envVars: ['OPENAI_API_KEY'],
 			defaultModel: 'gpt-4o',
 			requiresApiKey: true,
+			constructible: true,
 		},
 		openrouter: {
 			id: 'openrouter',
@@ -62,6 +84,7 @@ export const PROVIDER_REGISTRY: Readonly<Record<ProviderId, ProviderRegistryEntr
 			defaultBaseUrl: 'https://openrouter.ai/api/v1',
 			defaultModel: 'anthropic/claude-opus-4-7',
 			requiresApiKey: true,
+			constructible: true,
 		},
 		ollama: {
 			id: 'ollama',
@@ -71,6 +94,7 @@ export const PROVIDER_REGISTRY: Readonly<Record<ProviderId, ProviderRegistryEntr
 			probeUrl: 'http://localhost:11434/api/tags',
 			defaultModel: 'llama3.2',
 			requiresApiKey: false,
+			constructible: true,
 		},
 		lmstudio: {
 			id: 'lmstudio',
@@ -80,6 +104,7 @@ export const PROVIDER_REGISTRY: Readonly<Record<ProviderId, ProviderRegistryEntr
 			probeUrl: 'http://localhost:1234/v1/models',
 			defaultModel: 'auto',
 			requiresApiKey: false,
+			constructible: false,
 		},
 		bedrock: {
 			id: 'bedrock',
@@ -87,6 +112,7 @@ export const PROVIDER_REGISTRY: Readonly<Record<ProviderId, ProviderRegistryEntr
 			envVars: ['AWS_ACCESS_KEY_ID'], // SDK reads the rest from the AWS chain
 			defaultModel: 'anthropic.claude-opus-4-7-v1:0',
 			requiresApiKey: true,
+			constructible: false,
 		},
 		http: {
 			id: 'http',
@@ -96,6 +122,7 @@ export const PROVIDER_REGISTRY: Readonly<Record<ProviderId, ProviderRegistryEntr
 			envVars: [],
 			defaultModel: 'gpt-4o',
 			requiresApiKey: true,
+			constructible: false,
 		},
 	},
 )
@@ -109,3 +136,24 @@ export const ALL_PROVIDER_IDS: readonly ProviderId[] = Object.freeze([
 	'bedrock',
 	'http',
 ] as const)
+
+/**
+ * The one sentence every refusal of an unbuildable provider uses.
+ *
+ * Written once because it is said in four places — the chain validator, the
+ * picker, `ensureRegistered` and `constructProvider` — and four wordings of one
+ * fact read as four problems. It names who refused, why, and the two things the
+ * operator can actually do, per `docs/conventions/refuse-do-not-degrade.md`.
+ *
+ * "This build of namzu" and not "namzu": the driver exists, and telling someone
+ * their provider is unsupported when the truth is that this package does not
+ * depend on it yet sends them to the wrong place with the wrong bug report.
+ */
+export function unsupportedProviderMessage(id: string): string {
+	const entry = (PROVIDER_REGISTRY as Record<string, ProviderRegistryEntry | undefined>)[id]
+	const label = entry?.label ?? id
+	const usable = ALL_PROVIDER_IDS.filter((other) => PROVIDER_REGISTRY[other].constructible).join(
+		', ',
+	)
+	return `${label} ("${id}") is not available in this build of namzu — it has no driver bundled, so no session can use it. Pick one of: ${usable}. Following it is tracked in cogitave/namzu#257.`
+}

--- a/packages/cli/src/tui/Picker.tsx
+++ b/packages/cli/src/tui/Picker.tsx
@@ -16,6 +16,7 @@ import {
 	PROVIDER_REGISTRY,
 	type ProviderId,
 	type ProviderRegistryEntry,
+	unsupportedProviderMessage,
 } from '../integrations/providers/index.js'
 import { type ModelListing, describeProviderModels, verifyCredential } from './agent.js'
 import { describeDisposition, keyLooksUsable, maskKey, sessionCredential } from './credential-entry.js'
@@ -204,6 +205,15 @@ export function Picker({
 			const current = detected[cursor]
 			if (!current) {
 				setErrorHint('No provider available.')
+				return
+			}
+			// Detected, and still not choosable. The row stays visible on purpose
+			// — see the list below — so this is the only place that can decline
+			// it, and declining with the reason is the point: accepting would
+			// write the choice to preferences and hand the operator a session
+			// that refuses to start.
+			if (!current.entry.constructible) {
+				setErrorHint(unsupportedProviderMessage(current.entry.id))
 				return
 			}
 			// Ask the provider what it has, then show the model step. The list is
@@ -409,16 +419,36 @@ function ProviderRow({
 	const cursor = selected ? '›' : ' '
 	const number = `${index + 1}.`
 	const label = detected.entry.label
-	const sourceLabel = describeSource(detected)
+	// What was found stays what is shown. A provider this build cannot construct
+	// is still genuinely on the machine, and replacing "local · localhost:1234"
+	// with the refusal would hide the discovery that makes the refusal make
+	// sense. The reason goes in the source column, where the row says what namzu
+	// knows about it.
+	const usable = detected.entry.constructible
+	const sourceLabel = usable
+		? describeSource(detected)
+		: `${describeSource(detected)} · unavailable in this build`
 	const currentMark = isCurrent ? '  ← current' : ''
 	return (
 		<Box>
 			<Text color={selected ? theme.border.focus : theme.text.muted}>{cursor} </Text>
 			<Text color={theme.text.muted}>{number} </Text>
-			<Text color={selected ? theme.border.focus : theme.text.primary} bold={selected}>
+			<Text
+				color={
+					usable
+						? selected
+							? theme.border.focus
+							: theme.text.primary
+						: theme.text.muted
+				}
+				bold={usable && selected}
+				dimColor={!usable}
+			>
 				{label.padEnd(28)}
 			</Text>
-			<Text color={theme.text.muted}>{sourceLabel}</Text>
+			<Text color={usable ? theme.text.muted : theme.status.warn} dimColor={!usable}>
+				{sourceLabel}
+			</Text>
 			{isCurrent ? <Text color={theme.accent.system}>{currentMark}</Text> : null}
 		</Box>
 	)

--- a/packages/cli/src/tui/__tests__/model-picker-draws.test.tsx
+++ b/packages/cli/src/tui/__tests__/model-picker-draws.test.tsx
@@ -17,6 +17,7 @@ import { render } from 'ink-testing-library'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { DetectedProvider } from '../../integrations/providers/index.js'
+
 import type { ModelListing } from '../agent.js'
 import { Picker } from '../Picker.js'
 
@@ -27,12 +28,20 @@ const DEFAULT_MODEL = 'a-default-model'
 function detected(): DetectedProvider[] {
 	return [
 		{
+			// `constructible` is not decoration here. The picker now reads it
+			// before accepting a row, and this literal did not carry it — so it
+			// arrived as `undefined`, the refusal read that as "cannot build", and
+			// seven cases in this file went red at once against a provider that
+			// works perfectly in production. A fixture missing a field the code
+			// under test reads is a system that does not ship
+			// (`docs/conventions/fixture-must-match-production.md`).
 			entry: {
 				id: 'openai',
 				label: 'A Provider',
 				defaultModel: DEFAULT_MODEL,
 				requiresApiKey: true,
 				envVars: ['A_KEY'],
+				constructible: true,
 			},
 			source: { kind: 'env', envName: 'A_KEY' },
 			apiKey: 'not-a-real-key',
@@ -176,5 +185,69 @@ describe('while the list is still loading', () => {
 		await flush()
 		expect(lastFrame()).toContain('Model One')
 		unmount()
+	})
+})
+
+/**
+ * A provider this build cannot construct is shown and cannot be chosen.
+ *
+ * This is the surface #257 is really about: the operator did nothing wrong —
+ * they picked from a list namzu put in front of them — and got an exception.
+ * Detection is honest (the server IS running, the credential IS there), so the
+ * row stays; what changes is that pressing enter refuses instead of saving a
+ * choice that cannot start a session.
+ */
+describe('a detected provider with no bundled driver', () => {
+	function unbuildable(): DetectedProvider[] {
+		return [
+			{
+				entry: {
+					id: 'lmstudio',
+					label: 'A Local Server',
+					defaultModel: DEFAULT_MODEL,
+					requiresApiKey: false,
+					envVars: [],
+					constructible: false,
+				},
+				source: { kind: 'probe', url: 'http://localhost:1234/v1/models' },
+				alternatives: [],
+			} as unknown as DetectedProvider,
+		]
+	}
+
+	it('refuses the selection and says why, instead of accepting it', async () => {
+		const { stdin, lastFrame, onSubmit } = open({ detected: unbuildable() })
+		await flush()
+
+		stdin.write('\r')
+		await flush()
+
+		// Not submitted is the half that matters: accepting would write the
+		// choice to preferences, and the next launch would refuse it.
+		expect(onSubmit).not.toHaveBeenCalled()
+		expect(lastFrame()).toMatch(/not available in this build/)
+	})
+
+	it('still lists the row, because the discovery behind it was true', async () => {
+		// Excluding it would leave an operator who has only this provider staring
+		// at "No providers detected", which is false — namzu found it and
+		// declined it. A refusal that presents as an absence is not a refusal.
+		const { lastFrame } = open({ detected: unbuildable() })
+		await flush()
+
+		expect(lastFrame()).toContain('A Local Server')
+		expect(lastFrame()).toMatch(/unavailable in this build/)
+	})
+
+	it('does not refuse a provider whose driver IS bundled', async () => {
+		// The preservation half. A refusal that fired for everyone would pass the
+		// two cases above and break every session namzu can actually run.
+		const { stdin, lastFrame } = open()
+		await flush()
+
+		stdin.write('\r')
+		await flush()
+
+		expect(lastFrame()).not.toMatch(/not available in this build/)
 	})
 })

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -46,7 +46,6 @@ import {
 	buildMemoryTools,
 	getBuiltinTools,
 	query,
-	resolveProviderCapabilities,
 } from '@namzu/sdk'
 
 import { join } from 'node:path'
@@ -60,7 +59,6 @@ import {
 } from '../integrations/mcp/servers.js'
 import {
 	type DetectedProvider,
-	type MemberCapabilities,
 	PROVIDER_REGISTRY,
 	type Preferences,
 	type ProviderChoice,
@@ -80,6 +78,7 @@ import {
 	readPreferences,
 	resolveChainCapabilities,
 	unresolvedMembers,
+	unsupportedProviderMessage,
 } from '../integrations/providers/index.js'
 import { createSubagentRuntime } from '../integrations/subagents/runtime.js'
 import { composeMemoryPrompt, readMemory } from '../memory/store.js'
@@ -809,7 +808,7 @@ function constructProvider(
 			return provider
 		}
 		default:
-			throw new Error(`provider "${id}" is not yet wired to ProviderRegistry`)
+			throw new Error(unsupportedProviderMessage(id))
 	}
 }
 


### PR DESCRIPTION
Closes #257.

## The issue offers two options and both rest on a false premise

#257 asks: wire them, or refuse them earlier. Both assume the only thing missing is a `switch` arm. One measurement says otherwise — **`packages/cli/package.json` does not depend on `@namzu/lmstudio`, `@namzu/bedrock` or `@namzu/http`.** No arm could import them.

That also makes them three different problems, not one:

| | discovered? | a CLI dependency? | cost to bundle | constructible from registry data? |
|---|---|---|---|---|
| `lmstudio` | **yes**, local probe | no | a third-party SDK | yes — the `ollama` shape |
| `bedrock` | **yes**, ambient `AWS_ACCESS_KEY_ID` | no | a large cloud SDK | yes — credentials resolve from the AWS chain |
| `http` | **no** — no env vars, no probe | no | none | **no** — `baseURL` is required and nothing supplies one |

So "offered by the picker" is false for `http`; it can only be reached by hand-editing preferences. Its registry comment reserves it "for an explicit `/provider` flow that lets the user enter a base URL + key" — `/provider` exists and only *prints* the current provider. It is a placeholder for an unbuilt feature sitting in a structure four other consumers read as truth.

`bedrock` has a second defect I did not fix: detection files an AWS access key **id** as `apiKey`, and the driver takes an `{accessKeyId, secretAccessKey}` pair the CLI never has. It lives in `discover.ts`, which another agent holds.

## Which end is wrong: the offering end — and the refusal was worse than the issue says

Whether a driver is installed is a **static fact known at build time**. Letting construction succeed and failing at *use* would spend the picker, the model listing, the preferences write and a run's setup to report something knowable before a row was drawn.

But the sharper finding is what the existing refusal does. A saved unbuildable primary reaches `createAgentSession`, returns `emptySession(...)`, and `App` sets phase `unhealthy` — **a disabled composer where `/model` cannot be typed**. The message was:

> provider "lmstudio" is not wired yet; pick another or wait for support

on the one screen that will not let them pick another. A refusal whose advice cannot be followed is a dead end wearing one.

So the refusal moves to where it routes somewhere. `describeInvalidChain` declines an unbuildable **primary** when preferences are read, which returns `needs-repick`, which lands the operator in the picker with the reason printed above it.

## Deliberately asymmetric

A **fallback** naming one is *not* refused. #283 already drops it from the chain with a notice and the session runs on the primary the operator has; refusing the whole file over a spare would take a working session away — the opposite of the trade the notice makes. The issue's "the chain validator rejects a member naming one" is right for the head and wrong for the tail, and both directions are pinned by tests.

## The picker keeps the row

Excluding it was considered and rejected. An operator whose only local server is one of these would then read `No providers detected` — which is false. namzu found it and declined it, and a refusal that presents as an absence is not a refusal. The row is listed with `unavailable in this build`, and enter is declined with the reason and the providers that do work.

## Two harness failures, both worth more than the code

**A mutation reported "killed nothing" and had never applied.** My `sed` used four tabs where the file has three. `mutation-check-every-test` warns that the harness itself can lie; this is that, and the tell was a result that contradicted a defect I could see in the diff.

**The first drift guard could not fail.** It iterated a list *derived from* `constructible` — so flipping a flag simply removed that id from the loop, and the mutation restoring the original defect passed. Caught only by re-running the mutation against the guard rather than trusting that the assertions looked reasonable.

## Test contention, measured rather than papered over

The corrected guard drove `ensureRegistered` for all seven ids, pulling four driver module graphs through vite's transform in one worker. That starved `app-draft-survives`, which polls for a frame on real wall-clock: **371ms alone, 3469ms under the full suite, against a 3000ms ceiling.**

Widening that neighbour's budget **did not work** — it consumed whatever ceiling it was given (10s → 10477ms, 12s → 12472ms) and still failed two runs in three. So I removed the cause instead: `constructible` is now checked against **`package.json`'s dependency list**, which is not a proxy for the truth but *is* the truth, plus one real registration witness. The neighbour's test is untouched in this PR, and the full suite ran green three times consecutively.

## Mutations

| # | Mutation | Killed by |
|---|---|---|
| M17 | drop the read-time refusal | 3 |
| M18 | widen the refusal to the whole chain | 3 — the asymmetry cases |
| M19 | a flag claims a driver this build has not got | 2 |
| M20 | the picker accepts an unbuildable row | **nothing**, until the picker test existed |

M20 is the useful one: the surface #257 is actually about had no test at all, and only the mutation said so.

## Gate

`pnpm build && pnpm typecheck && pnpm lint && pnpm test` all exit 0 — sdk 330 files / 2938 passed / 7 skipped, cli 65 files / 623 passed / 3 skipped. `scripts/audit-external-names.mjs` exits 0. `verify-public-surface.mjs` reports the surface intact.

**`pnpm docs:check` is red, and it is red on `main` too** — `alternation-unmounts-state.md` names `tui/App.tsx` as its `resource:` and #282 changed that file after #278 wrote the doc. It blocks every PR, it is not from this branch, and re-establishing that document is a judgement about #282's work rather than mine.

## Not done

**No dependencies added.** Bundling `lmstudio` is small; `bedrock` puts a large cloud SDK in every install. That is a supply-chain decision with a real cost and it is the owner's. The refusal is correct either way, and wiring one later is a flag flip plus a switch arm, held in agreement by a test that reads the dependency list.
