### PR TITLE
fix(cli): discovery lists what it can use, and says what it asks

### DIFF
--- a/.changeset/discovery-says-what-it-asks.md
+++ b/.changeset/discovery-says-what-it-asks.md
@@ -1,0 +1,30 @@
+---
+'@namzu/cli': patch
+---
+
+**Credential discovery now states what it asks, and still lists only what it can
+use.**
+
+The `discoverProviders` header said it asks "three questions in order" and then
+listed two. The omitted one was the Keychain read — the question that takes a
+secret off the machine, so the one a reader most needs to see. It now lists
+three, in execution order (environment variable, Keychain, local probe), and
+states plainly that **the Keychain path is macOS-only**: on Windows and Linux
+there are exactly two doors, and a credential kept only in the OS credential
+store is not found. That is a gap rather than a nuance, and it is now written
+where someone reading the file will meet it.
+
+**A local provider whose server is not running is still not listed**, and the
+dead branch that proposed listing it is removed. Membership in the discovery
+list means "usable right now", and that is a contract two readers depend on: the
+`providers.chain` doctor check reads presence itself as the verdict for a
+provider that needs no key, and the session's chain builder applies no
+credential test to a local one. An entry for a down server would report it
+`reachable` and build it into the chain, failing on the day it was supposed to
+rescue a run. The operator-facing intent behind that branch already exists in
+the picker's empty state, which names both local servers and their ports and
+says to start one.
+
+No behaviour changes: the removed branch had an empty body, guarded by a
+condition (`!opts.skipProbes === false`) that did not mean what the comment
+above it said. Closes #258.

--- a/docs/cli/providers.md
+++ b/docs/cli/providers.md
@@ -50,6 +50,10 @@ namzu scans these sources, in order, and offers whatever it finds:
 
 If nothing is found, namzu shows the picker in an empty state explaining exactly which environment variable to set (or to start Ollama), then restart.
 
+**The Keychain path is macOS-only.** On Windows and Linux there are exactly two doors: an environment variable, or a reachable local server. A credential kept only in your OS credential store is not found on those platforms.
+
+**A local server that is not running is not listed.** Appearing in the list means namzu can use that provider *right now* — `namzu doctor` reads presence itself as "reachable" for a provider that needs no key, and the chain builder will build a member from it. An entry for a server that is down would make both of those wrong. The empty-state screen above is where you are told a local server is an option, and it names both ports.
+
 ## The picker
 
 On first run, or after `/model`, the picker lists each detected provider with its source label (for example `keychain · Claude Code-credentials`, `env · ANTHROPIC_API_KEY`, `local · localhost:11434`). Use `↑`/`↓` to navigate, `Enter` to accept, `Esc` to cancel. Your choice is saved to `~/.namzu/preferences.json` and reused on the next launch.

--- a/packages/cli/src/integrations/providers/discover.ts
+++ b/packages/cli/src/integrations/providers/discover.ts
@@ -3,11 +3,50 @@
  *
  * For each entry in `PROVIDER_REGISTRY`, ask three questions in order:
  *   1. Is one of its env vars set in `process.env`?
- *   2. Is the probe URL (if any) reachable right now?
+ *   2. Is there an OAuth credential in the login Keychain? (macOS only, and
+ *      only `anthropic` consumes it.)
+ *   3. Is the probe URL (if any) reachable right now?
+ *
+ * The header used to say "three" and list two, and the one it omitted was the
+ * Keychain — the question that reads a secret off the machine, so the one a
+ * reader most needs to see. A count that disagrees with its own list is the
+ * tell that the list stopped being maintained; in a file about credentials that
+ * is worth more than a typo.
+ *
+ * **The Keychain path is macOS-only and that is a gap, not a nuance.**
+ * `readAgentKeychainCredential` returns `null` on any other platform before it
+ * looks at anything, so on Windows and Linux exactly two doors exist: an
+ * environment variable, and a reachable local server. An operator whose
+ * credential lives in their OS credential store gets no help from namzu there.
  *
  * The first positive answer per provider wins; subsequent sources are
  * recorded as "also available from" so the picker can show alternatives
  * (e.g. anthropic via env, also reachable as a local server).
+ *
+ * ## Membership means "usable right now", and two consumers depend on that
+ *
+ * A provider appears in the returned list only when a source actually answered.
+ * That is not merely a description of the loop — it is the contract the readers
+ * are built on, and it is why this function does NOT return a local provider
+ * whose server is down:
+ *
+ *  - the `providers.chain` doctor check reads presence itself as the verdict
+ *    for a provider that needs no key (`requiresApiKey ? apiKey : Boolean(det)`),
+ *    so an unreachable entry would make it print `reachable` for a dead server;
+ *  - the session's chain builder applies no credential test to a local
+ *    provider, so an unreachable entry would be built into the chain and fail
+ *    on the day it was supposed to rescue a run.
+ *
+ * `DetectionSource` has no way to say "found, not usable" either — every
+ * variant asserts a working source.
+ *
+ * A dead branch here used to propose the opposite: list a local provider whose
+ * probe failed, so the picker could show `(not running)` and the operator would
+ * know they could start the server. It was removed rather than built, because
+ * the operator-facing half of that idea already exists somewhere better — the
+ * picker's empty state names both local servers and their ports and says to
+ * start one — while the machine-facing half would have made the two readers
+ * above lie. See cogitave/namzu#258.
  *
  * Discovery is non-throwing. Network probes have short timeouts. The
  * picker can render immediately and refine if discovery completes later.
@@ -115,15 +154,6 @@ export async function discoverProviders(
 				...(oauth ? { oauth } : {}),
 				alternatives: sources.slice(1),
 			})
-			continue
-		}
-		// Probe-only providers (Ollama, LM Studio): include even when probe
-		// fails so the picker can show "(not running)" and the user knows
-		// they could start the server. Local providers with no apiKey need
-		// only the URL to be addressable.
-		if (!entry.requiresApiKey && entry.probeUrl && !opts.skipProbes === false) {
-			// `skipProbes === true` reaches this branch; surface as not-detected,
-			// no row in the picker, so user isn't confused by phantom entries.
 		}
 	}
 	return detected


### PR DESCRIPTION
Closes #258. Split out of #287 — that PR merged while this half was still in progress, so this is the same commit re-homed on current `main` with its own changeset.

#258 is #257's question from the other side. #257 is *"the picker offers something that cannot be constructed"*; #258 is *"the picker does not offer something that could be started"*. Both ask what a row in that list means, which is why they were decided together.

## The header lied about itself

It said "ask three questions in order" and listed **two**. The omitted one was the Keychain read — the question that takes a secret off the machine, so the one a reader most needs to see. A count that disagrees with its own list is the tell that the list stopped being maintained, and in a file about credentials that is worth more than a typo.

It now lists three, in real execution order (environment variable → Keychain → local probe). The old text also had the order wrong by implication: the Keychain question sits *between* the two that were documented, not after them.

**The Keychain path is macOS-only, and that is now stated as a gap.** `readAgentKeychainCredential` returns `null` on any other platform before it looks at anything, so on Windows and Linux exactly two doors exist. An operator whose credential lives in their OS credential store gets no help from namzu there. No Windows path is built — that decision has not been made.

## The unreachable local provider stays unlisted, which is not the answer I was pointed at

The suggestion from outside was that an unreachable local provider *should* be offered with its state named, since the operator can act on that and cannot act on an unbuildable one. Two measurements from inside the code say otherwise.

**1. The feature already exists, and says more than the proposed row would.** The picker's empty state names both local servers *with their ports* and tells the operator to start one. That screen is shown to exactly the person the dead comment was written for. A `(not running)` row would be a weaker version of something already delivered.

**2. Building it would have made two readers lie.** Membership in the discovery list means "usable right now", and that is a contract rather than a description of the loop:

- the `providers.chain` doctor check reads presence *itself* as the verdict for a provider that needs no key — `requiresApiKey ? Boolean(det?.apiKey) : Boolean(det)` — so an unreachable entry would print `reachable` for a dead server;
- the session's chain builder applies no credential test to a local provider at all, so an unreachable entry would be built into the chain and fail on the day it was supposed to rescue a run.

`DetectionSource` has no variant meaning "found, not usable" either. Every variant asserts a working source, so the value would have had to travel as a lie through a type that cannot express it.

So the empty `if` is deleted rather than filled. Its condition was `!opts.skipProbes === false` — a negation of a negation meaning "skipProbes is truthy", which has nothing to do with the sentence above it — and its body contained a comment stating the *opposite* of the comment three lines earlier: one said list the provider so the picker can show `(not running)`, the other said "no row in the picker". The empty body implemented the second. The file documented a feature, its own reversal, and shipped neither.

The `continue` above it becomes unnecessary once the branch is gone, and is removed rather than kept as a no-op.

## Why there is no new test

The deletion is inert by construction — the removed body was empty — and `discover.test.ts` already pins the behaviour it would have changed: *"does not include ollama when its probe fails"*. A mutation against removing an empty block has nothing to catch, and adding a near-duplicate of an existing assertion would be noise rather than evidence.

## Gate

`pnpm build && pnpm typecheck && pnpm lint` clean; `pnpm --filter @namzu/cli test` — 66 files / 629 passed / 3 skipped. `scripts/audit-external-names.mjs` exits 0.
