### PR TITLE
fix(cli): a menu is not a credential check

### DIFF
--- a/.changeset/a-menu-is-not-a-probe.md
+++ b/.changeset/a-menu-is-not-a-probe.md
@@ -1,8 +1,48 @@
+---
+'@namzu/sdk': minor
+'@namzu/cli': minor
+'@namzu/anthropic': minor
+'@namzu/openrouter': minor
+'@namzu/openai': minor
+'@namzu/ollama': minor
+---
 
+A wrong API key is no longer reported as working
 
-The four driver packages are `minor` rather than `patch`: each gains a
-method it did not have. A patch is a backward-compatible bug fix, and added
-functionality is a minor whatever the size of the diff. Anthropic's earns it
-twice over - its listing now returns the live catalogue where it previously
-returned the same three hardcoded entries to every caller, so the value every
-existing caller receives changes.
+Typing a key into the picker ran a check that could not fail for two providers.
+Measured against deliberately invalid keys, both said the key was good.
+
+**With an OpenRouter key, any string at all passed.** A typo, the wrong
+clipboard entry, a revoked key — all were accepted and reported as verified. The
+check listed the model catalogue and treated a successful list as a passed
+check, and OpenRouter's catalogue endpoint does not authenticate, so it answered
+the same way whatever was sent. Nothing was wrong with that driver's listing; a
+catalogue was simply never evidence about a key.
+
+**With an Anthropic key, a real rejection was discarded.** The listing caught
+the `401` and returned a hardcoded three-model list, which the check read as
+success — so the truth existed, was thrown away, and was replaced by something
+that looked like an answer.
+
+A credential check is now a separate, declared capability. A driver that
+declares no probe is reported as **not checked**, never as verified, so a driver
+added in future cannot silently inherit a check it does not perform. Anthropic,
+OpenRouter, OpenAI and Ollama declare one; OpenRouter's asks about the key
+rather than the catalogue.
+
+Refusal and doubt stay distinct. A `401` means the key is genuinely refused; a
+timeout or a DNS failure means nothing was learned, and is reported that way —
+telling someone on a broken connection to rotate a working key is a different
+error, not a smaller one.
+
+**Anthropic's model listing also never once ran.** The SDK method was pulled out
+of its namespace and called bare, so it lost `this`, threw a `TypeError` on
+every call, and was swallowed by the same catch — the hardcoded models were not
+a fallback but the only answer the method could give. It now calls the live
+endpoint, and falls back only when that genuinely fails.
+
+The four driver packages are `minor` rather than `patch`: each gains a method
+it did not have, and added functionality is a minor whatever the size of the
+diff. Anthropic's earns it twice over, because its listing now returns the live
+catalogue where it previously returned the same three hardcoded entries to every
+caller - so the value every existing caller receives changes.

--- a/.changeset/a-menu-is-not-a-probe.md
+++ b/.changeset/a-menu-is-not-a-probe.md
@@ -1,42 +1,8 @@
----
-'@namzu/sdk': minor
-'@namzu/cli': minor
-'@namzu/anthropic': patch
-'@namzu/openrouter': patch
-'@namzu/openai': patch
-'@namzu/ollama': patch
----
 
-A wrong API key is no longer reported as working
 
-Typing a key into the picker ran a check that could not fail for two providers.
-Measured against deliberately invalid keys, both said the key was good.
-
-**With an OpenRouter key, any string at all passed.** A typo, the wrong
-clipboard entry, a revoked key — all were accepted and reported as verified. The
-check listed the model catalogue and treated a successful list as a passed
-check, and OpenRouter's catalogue endpoint does not authenticate, so it answered
-the same way whatever was sent. Nothing was wrong with that driver's listing; a
-catalogue was simply never evidence about a key.
-
-**With an Anthropic key, a real rejection was discarded.** The listing caught
-the `401` and returned a hardcoded three-model list, which the check read as
-success — so the truth existed, was thrown away, and was replaced by something
-that looked like an answer.
-
-A credential check is now a separate, declared capability. A driver that
-declares no probe is reported as **not checked**, never as verified, so a driver
-added in future cannot silently inherit a check it does not perform. Anthropic,
-OpenRouter, OpenAI and Ollama declare one; OpenRouter's asks about the key
-rather than the catalogue.
-
-Refusal and doubt stay distinct. A `401` means the key is genuinely refused; a
-timeout or a DNS failure means nothing was learned, and is reported that way —
-telling someone on a broken connection to rotate a working key is a different
-error, not a smaller one.
-
-**Anthropic's model listing also never once ran.** The SDK method was pulled out
-of its namespace and called bare, so it lost `this`, threw a `TypeError` on
-every call, and was swallowed by the same catch — the hardcoded models were not
-a fallback but the only answer the method could give. It now calls the live
-endpoint, and falls back only when that genuinely fails.
+The four driver packages are `minor` rather than `patch`: each gains a
+method it did not have. A patch is a backward-compatible bug fix, and added
+functionality is a minor whatever the size of the diff. Anthropic's earns it
+twice over - its listing now returns the live catalogue where it previously
+returned the same three hardcoded entries to every caller, so the value every
+existing caller receives changes.

--- a/.changeset/a-menu-is-not-a-probe.md
+++ b/.changeset/a-menu-is-not-a-probe.md
@@ -1,0 +1,42 @@
+---
+'@namzu/sdk': minor
+'@namzu/cli': minor
+'@namzu/anthropic': patch
+'@namzu/openrouter': patch
+'@namzu/openai': patch
+'@namzu/ollama': patch
+---
+
+A wrong API key is no longer reported as working
+
+Typing a key into the picker ran a check that could not fail for two providers.
+Measured against deliberately invalid keys, both said the key was good.
+
+**With an OpenRouter key, any string at all passed.** A typo, the wrong
+clipboard entry, a revoked key — all were accepted and reported as verified. The
+check listed the model catalogue and treated a successful list as a passed
+check, and OpenRouter's catalogue endpoint does not authenticate, so it answered
+the same way whatever was sent. Nothing was wrong with that driver's listing; a
+catalogue was simply never evidence about a key.
+
+**With an Anthropic key, a real rejection was discarded.** The listing caught
+the `401` and returned a hardcoded three-model list, which the check read as
+success — so the truth existed, was thrown away, and was replaced by something
+that looked like an answer.
+
+A credential check is now a separate, declared capability. A driver that
+declares no probe is reported as **not checked**, never as verified, so a driver
+added in future cannot silently inherit a check it does not perform. Anthropic,
+OpenRouter, OpenAI and Ollama declare one; OpenRouter's asks about the key
+rather than the catalogue.
+
+Refusal and doubt stay distinct. A `401` means the key is genuinely refused; a
+timeout or a DNS failure means nothing was learned, and is reported that way —
+telling someone on a broken connection to rotate a working key is a different
+error, not a smaller one.
+
+**Anthropic's model listing also never once ran.** The SDK method was pulled out
+of its namespace and called bare, so it lost `this`, threw a `TypeError` on
+every call, and was swallowed by the same catch — the hardcoded models were not
+a fallback but the only answer the method could give. It now calls the live
+endpoint, and falls back only when that genuinely fails.

--- a/packages/cli/src/tui/__tests__/a-menu-is-not-a-probe.test.ts
+++ b/packages/cli/src/tui/__tests__/a-menu-is-not-a-probe.test.ts
@@ -1,0 +1,68 @@
+/**
+ * A credential check answers about the credential, not about a catalogue.
+ *
+ * `verifyCredential` used to ask `listModels` and read a successful list as a
+ * passed check. Two drivers proved that wrong in different ways, and both
+ * reported a deliberately invalid key as verified:
+ *
+ * - one caught a real `401` and returned its hardcoded catalogue, so the truth
+ *   existed and was discarded;
+ * - one has no fallback and is entirely honest about its menu — its listing
+ *   endpoint simply does not authenticate, so ANY string returned the real
+ *   catalogue.
+ *
+ * The second is why the fix is a separate, declared probe rather than a rule
+ * about writing `listModels` more carefully: no amount of care in a menu makes
+ * it a probe.
+ *
+ * These are unit tests over the classifier and the declaration rule. That the
+ * shipped drivers reject a real bad key was measured separately, against live
+ * 401s from each vendor, and cannot be asserted here without a network.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { isCredentialRejection } from '../agent.js'
+
+describe('isCredentialRejection', () => {
+	it('treats an explicit 401 or 403 as the server refusing the key', () => {
+		expect(isCredentialRejection(Object.assign(new Error('nope'), { status: 401 }))).toBe(true)
+		expect(isCredentialRejection(Object.assign(new Error('nope'), { status: 403 }))).toBe(true)
+		expect(isCredentialRejection(Object.assign(new Error('nope'), { statusCode: 401 }))).toBe(true)
+	})
+
+	it('does not treat other statuses as a refusal', () => {
+		// A 500 or a 429 says nothing about whether the key is good.
+		expect(isCredentialRejection(Object.assign(new Error('boom'), { status: 500 }))).toBe(false)
+		expect(isCredentialRejection(Object.assign(new Error('slow down'), { status: 429 }))).toBe(
+			false,
+		)
+	})
+
+	it('does not treat a transport failure as a bad key', () => {
+		// The direction that matters most. Telling an operator on broken wifi to
+		// rotate a working credential is a different lie, not a smaller one.
+		expect(isCredentialRejection(new TypeError('fetch failed'))).toBe(false)
+		expect(isCredentialRejection(new Error('getaddrinfo ENOTFOUND api.example.com'))).toBe(false)
+		expect(isCredentialRejection(new Error('connect ETIMEDOUT'))).toBe(false)
+	})
+
+	it('reads the message only when no status is present', () => {
+		// Drivers that surface a plain Error still have to be classifiable.
+		expect(isCredentialRejection(new Error('401 authentication_error'))).toBe(true)
+		expect(isCredentialRejection(new Error('Invalid API key'))).toBe(true)
+		// And a status that IS present wins over a message that happens to
+		// contain a number, so a 500 whose body quotes "401" is not a refusal.
+		expect(
+			isCredentialRejection(Object.assign(new Error('upstream said 401'), { status: 500 })),
+		).toBe(false)
+	})
+
+	it('says nothing was learned when it cannot tell', () => {
+		// The fail-safe direction: an unrecognised failure is unverifiable, not
+		// rejected, because only one of those sends someone to rotate a key.
+		expect(isCredentialRejection(new Error('something went wrong'))).toBe(false)
+		expect(isCredentialRejection(null)).toBe(false)
+		expect(isCredentialRejection(undefined)).toBe(false)
+	})
+})

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -914,7 +914,8 @@ function describeError(err: unknown): string {
  * working key into a rotation request.
  */
 export function isCredentialRejection(err: unknown): boolean {
-	const status = (err as { status?: unknown; statusCode?: unknown } | null)?.status ??
+	const status =
+		(err as { status?: unknown; statusCode?: unknown } | null)?.status ??
 		(err as { statusCode?: unknown } | null)?.statusCode
 	if (status === 401 || status === 403) return true
 	if (typeof status === 'number') return false

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -879,11 +879,48 @@ export async function verifyCredential(
 	id: ProviderId,
 	det: DetectedProvider,
 ): Promise<{ kind: 'verified' } | { kind: 'unverifiable' } | { kind: 'rejected'; reason: string }> {
-	const listing = await describeProviderModels(id, det)
-	if (listing.kind === 'ok') return { kind: 'verified' }
-	if (listing.kind === 'unsupported') return { kind: 'unverifiable' }
-	if (listing.kind === 'timeout') return { kind: 'unverifiable' }
-	return { kind: 'rejected', reason: listing.reason.slice(0, 200) }
+	try {
+		await ensureRegistered(id)
+		const provider = constructProvider(id, det, det.entry.defaultModel)
+		// Declared, never inferred. A driver without a probe is unverifiable —
+		// including one added years from now by someone who never reads this.
+		// Falling back to the listing here is precisely the defect: it reported a
+		// wrong key as verified for two drivers, one because a 401 was swallowed
+		// behind a hardcoded catalogue and one because its listing endpoint does
+		// not authenticate at all.
+		if (typeof provider.probeCredential !== 'function') return { kind: 'unverifiable' }
+		await provider.probeCredential()
+		return { kind: 'verified' }
+	} catch (err) {
+		// The server answered and said no, versus nothing was learned. Collapsing
+		// these would tell an operator on broken wifi to rotate a key that is fine.
+		if (isCredentialRejection(err)) {
+			return { kind: 'rejected', reason: describeError(err).slice(0, 200) }
+		}
+		return { kind: 'unverifiable' }
+	}
+}
+
+function describeError(err: unknown): string {
+	return err instanceof Error ? err.message : String(err)
+}
+
+/**
+ * Whether the server rejected the credential, as opposed to never being reached.
+ *
+ * Reads a status off the error where a driver supplies one, and falls back to
+ * the message. The fallback is deliberately narrow: an unrecognised failure is
+ * treated as "nothing was learned", which is the direction that cannot turn a
+ * working key into a rotation request.
+ */
+export function isCredentialRejection(err: unknown): boolean {
+	const status = (err as { status?: unknown; statusCode?: unknown } | null)?.status ??
+		(err as { statusCode?: unknown } | null)?.statusCode
+	if (status === 401 || status === 403) return true
+	if (typeof status === 'number') return false
+	return /\b(401|403|unauthorized|forbidden|invalid[ _-]?api[ _-]?key|authentication)\b/i.test(
+		describeError(err),
+	)
 }
 
 /**

--- a/packages/cli/src/tui/credential-entry.test.ts
+++ b/packages/cli/src/tui/credential-entry.test.ts
@@ -96,8 +96,13 @@ describe('describeDisposition', () => {
 	})
 
 	it('does not claim a check it did not perform', () => {
+		// Asserts the CLAIM, not the sentence. The wording moved from "offers no
+		// way to check it" to "could not confirm it", because `unverifiable` now
+		// covers two things: a driver that declares no credential probe, and one
+		// whose probe could not be reached. The old phrase asserted the first and
+		// would be false for a probe that timed out.
 		const unverifiable = describeDisposition(entry, { kind: 'unverifiable' })
-		expect(unverifiable).toContain('no way to check it')
+		expect(unverifiable).toContain('NOT checked')
 		expect(unverifiable).not.toContain('accepted the key')
 
 		const verified = describeDisposition(entry, { kind: 'verified' })

--- a/packages/cli/src/tui/credential-entry.ts
+++ b/packages/cli/src/tui/credential-entry.ts
@@ -100,10 +100,14 @@ export function describeDisposition(
 	const checked =
 		verification.kind === 'verified'
 			? `${entry.label} accepted the key.`
-			: // Said plainly rather than implied. A driver with no cheap check
-				// cannot confirm a key without spending a turn, and claiming it is
-				// good would be inventing a verification that did not happen.
-				`Key accepted. ${entry.label} offers no way to check it without a request, so the first message will be the test.`
+			: // Said plainly rather than implied. Claiming a key is good would be
+				// inventing a verification that did not happen — and this now covers
+				// two ways of not happening: a driver that declares no credential
+				// probe at all, and one whose probe could not be reached. The old
+				// wording asserted the first ("offers no way to check it"), which
+				// would be false for a probe that timed out. Neither is a bad key,
+				// and neither is a checked one.
+				`Key accepted, but NOT checked — ${entry.label} could not confirm it just now, so the first message will be the test.`
 
 	return `${checked}\nHeld in memory for this session only — it is not written anywhere. ${durable}`
 }

--- a/packages/providers/anthropic/src/client.ts
+++ b/packages/providers/anthropic/src/client.ts
@@ -1025,11 +1025,16 @@ export class AnthropicProvider implements LLMProvider {
 			const clientLike = this.client as unknown as {
 				models?: { list?: (opts: { limit: number }) => Promise<unknown> }
 			}
-			const listFn = clientLike.models?.list
-			if (typeof listFn !== 'function') {
+			const models = clientLike.models
+			if (typeof models?.list !== 'function') {
 				return this.knownModels()
 			}
-			const page = (await listFn({ limit: 100 })) as {
+			// Called ON the namespace, not pulled out and invoked bare. Detached,
+			// it lost `this` and the SDK's own `this._client` read threw a
+			// TypeError on EVERY call — which the catch below swallowed, so this
+			// listing never once reached the network and the hardcoded models
+			// were not a fallback but the only answer this method could give.
+			const page = (await models.list({ limit: 100 })) as {
 				data?: Array<{ id?: string; display_name?: string; type?: string }>
 			}
 			const data = page?.data ?? []
@@ -1064,11 +1069,14 @@ export class AnthropicProvider implements LLMProvider {
 		const clientLike = this.client as unknown as {
 			models?: { list?: (opts: { limit: number }) => Promise<unknown> }
 		}
-		const listFn = clientLike.models?.list
-		if (typeof listFn !== 'function') {
+		const models = clientLike.models
+		if (typeof models?.list !== 'function') {
 			throw new Error('This SDK version cannot list models, so the key cannot be checked here.')
 		}
-		await listFn({ limit: 1 })
+		// Called ON the namespace. Pulling the method into a bare variable and
+		// invoking it loses `this`, and the SDK reads `this._client` — which is
+		// how the sibling `listModels` came to never execute at all.
+		await models.list({ limit: 1 })
 	}
 
 	private knownModels(): ModelInfo[] {

--- a/packages/providers/anthropic/src/client.ts
+++ b/packages/providers/anthropic/src/client.ts
@@ -1049,6 +1049,28 @@ export class AnthropicProvider implements LLMProvider {
 		}
 	}
 
+	/**
+	 * Ask the API whether this credential works, and let the answer through.
+	 *
+	 * The same call `listModels` makes, without the `catch` that turns a real
+	 * `401` into a hardcoded catalogue. That fallback is right for a menu and
+	 * fatal for a probe: it reported an invalid key as working, because the
+	 * failure it swallowed was the entire answer.
+	 *
+	 * An SDK too old to expose `models.list` throws rather than passing, so the
+	 * caller reports unverifiable — nothing was asked, so nothing is known.
+	 */
+	async probeCredential(): Promise<void> {
+		const clientLike = this.client as unknown as {
+			models?: { list?: (opts: { limit: number }) => Promise<unknown> }
+		}
+		const listFn = clientLike.models?.list
+		if (typeof listFn !== 'function') {
+			throw new Error('This SDK version cannot list models, so the key cannot be checked here.')
+		}
+		await listFn({ limit: 1 })
+	}
+
 	private knownModels(): ModelInfo[] {
 		return [
 			{

--- a/packages/providers/ollama/src/client.ts
+++ b/packages/providers/ollama/src/client.ts
@@ -233,6 +233,16 @@ export class OllamaProvider implements LLMProvider {
 		}
 	}
 
+	/**
+	 * A local server takes no credential, so this establishes reachability
+	 * rather than authorisation — which is the whole of what "does this work?"
+	 * can mean here. Declared so the answer comes from the driver rather than
+	 * from a listing call that happened to throw.
+	 */
+	async probeCredential(): Promise<void> {
+		await this.client.list()
+	}
+
 	async listModels(): Promise<ModelInfo[]> {
 		const resp = await this.client.list()
 		return resp.models.map((m) => ({

--- a/packages/providers/openai/src/client.ts
+++ b/packages/providers/openai/src/client.ts
@@ -362,6 +362,17 @@ export class OpenAIProvider implements LLMProvider {
 		}
 	}
 
+	/**
+	 * Declared even though this driver's listing already fails correctly on a
+	 * bad key. The check is a declared capability rather than something inferred
+	 * from whether a menu happened to throw, so a driver that answers the
+	 * question has to say so — otherwise it is reported unverifiable, which is
+	 * the honest default and would be a regression here.
+	 */
+	async probeCredential(): Promise<void> {
+		await this.client.models.list()
+	}
+
 	async listModels(): Promise<ModelInfo[]> {
 		const page = await this.client.models.list()
 		return page.data.map((m) => ({

--- a/packages/providers/openrouter/src/client.ts
+++ b/packages/providers/openrouter/src/client.ts
@@ -292,6 +292,31 @@ export class OpenRouterProvider implements LLMProvider {
 		}
 	}
 
+	/**
+	 * Ask about the KEY, not about the catalogue.
+	 *
+	 * `listModels` here is already honest — it has no fallback and returns
+	 * exactly what the server sent. It is still useless as a credential check,
+	 * because `/models` does not authenticate: any string whatsoever, including
+	 * a typo or a revoked key, came back with the full catalogue and was
+	 * reported as verified. Nothing was wrong with the menu; the menu was simply
+	 * never evidence about the key.
+	 *
+	 * `/key` is the endpoint that answers the question actually being asked. It
+	 * requires the credential and returns its metadata, so a 401 here means the
+	 * key is genuinely refused.
+	 */
+	async probeCredential(): Promise<void> {
+		const response = await fetch(`${this.baseUrl}/key`, { headers: this.getHeaders() })
+		if (!response.ok) {
+			const err = new Error(`Credential check failed: ${response.status}`) as Error & {
+				status?: number
+			}
+			err.status = response.status
+			throw err
+		}
+	}
+
 	async listModels(): Promise<ModelInfo[]> {
 		const response = await fetch(`${this.baseUrl}/models`, {
 			headers: this.getHeaders(),

--- a/packages/sdk/src/types/provider/interface.ts
+++ b/packages/sdk/src/types/provider/interface.ts
@@ -38,6 +38,41 @@ export interface LLMProvider {
 
 	listModels?(): Promise<ModelInfo[]>
 
+	/**
+	 * Establish whether this credential actually works. Resolves if it does,
+	 * throws if it does not.
+	 *
+	 * Separate from `listModels` because the two answer different questions, and
+	 * conflating them is a defect measured rather than imagined. `listModels`
+	 * builds a MENU: "what can I offer this operator to choose from?" — a stale
+	 * hardcoded list is a degraded but legitimate answer, since someone offline
+	 * still has to pick a model. This builds a PROBE: "did this key work?" — and
+	 * for that a list is not a degraded answer, it is no answer, because it
+	 * arrives whether the key is right, wrong, expired or never sent.
+	 *
+	 * Two drivers proved a menu cannot stand in for a probe, and they failed
+	 * differently. One caught a real `401` and returned its hardcoded catalogue,
+	 * so the truth existed and was thrown away. The other has no fallback at all
+	 * and is entirely honest about its menu — its listing endpoint simply does
+	 * not authenticate, so ANY string returned the real catalogue. That second
+	 * case is why this is a separate method rather than a rule about writing
+	 * `listModels` more carefully: no amount of care in a menu makes it a probe.
+	 *
+	 * The probe is per-driver by nature — one has an authenticated call whose
+	 * failure is real, another needs a different endpoint than its menu — so it
+	 * is DECLARED, never inferred. A driver that does not implement this is
+	 * reported as unverifiable, never as verified, and that has to hold for the
+	 * driver nobody has written yet: inheriting a generic path silently is how
+	 * this defect returns.
+	 *
+	 * Throw so the caller can tell the two failures apart. A rejection from the
+	 * server (`401`/`403`) means the credential is genuinely bad; anything else
+	 * — a timeout, DNS, a proxy — means nothing was learned, and reporting that
+	 * as a bad key would tell an operator on broken wifi to go and rotate a
+	 * credential that is fine.
+	 */
+	probeCredential?(): Promise<void>
+
 	healthCheck?(): Promise<boolean>
 
 	/**


### PR DESCRIPTION
Typing a key into the picker ran a check that **could not fail** for two providers. Measured against deliberately invalid keys, both reported the key as good.

## What was measured, live

| driver | before | after |
|---|---|---|
| **anthropic** | `ok` (3 models) → **verified** | **rejected** (real 401) |
| **openrouter** | `ok` (400 models) → **verified** | **rejected** (401 from `/key`) |
| openai | failed → rejected | rejected |
| ollama | failed → rejected | **unverifiable** (fetch failed — nothing learned) |

Invalid keys, real network calls, through the built `dist`. No real credential was read or printed.

## The two failures are opposites, and the second decides the design

**OpenRouter's listing is entirely honest** — no fallback, exactly what the server sent. Its catalogue endpoint simply **does not authenticate**, so any string at all came back with 400 real models and was reported verified. A typo, the wrong clipboard entry, a revoked key.

**Anthropic's caught a real `401`** and returned a hardcoded list, so the truth existed and was discarded.

That pair kills the tempting fix on the merits: making `listModels` honest cannot work, because OpenRouter's already is. **No amount of care in a menu makes it a probe.**

## The fix: a declared capability, never inferred

`probeCredential?()` on the provider interface. A driver that does not declare one is reported **not checked**, never verified.

Declared rather than inferred on purpose — inferring it from whether a listing happened to throw is exactly how a driver written next year silently inherits a check it never performs, which is the shape of `declared-but-undriven`. OpenRouter's probe asks about the *key* (`/key`), not the catalogue.

**Refusal and doubt stay apart.** A `401` is a rejection; a timeout or DNS failure is unverifiable — telling someone on a broken connection to rotate a working key is a different error, not a smaller one.

## A third finding, larger than the one I set out to fix

Diagnosing why anthropic came out `unverifiable` rather than `rejected` exposed this:

```ts
const listFn = clientLike.models?.list
await listFn({ limit: 100 })      // called BARE — `this` is lost
```

The SDK reads `this._client`, so it threw a `TypeError` on **every** call — swallowed by the same catch. **Anthropic's live model listing has never once executed.** The hardcoded three models were not a fallback for failure; they were the only answer the method could produce, with a valid key or without one.

Three layers, each concealing the one beneath: a dead code path, masked by a fallback, read as a passed credential check.

## Tests

Unit tests over the classifier, including the direction that matters most — a transport failure must **not** read as a bad key. The end-to-end claim (each shipped driver rejects a real bad key) was measured against live 401s and cannot be asserted without a network; that is stated in the test file rather than faked.

One existing test changed, and why is worth reading: it pinned the *sentence* `"no way to check it"` rather than the claim behind it, and that sentence became false for one of the two ways a check can be missing (a declared probe that could not be reached). The claim it protects — never assert a check that did not happen — is now asserted directly.

## What only you can confirm

Whether `unverifiable` reads clearly enough on the credential screen. It says the key was accepted but **not checked**, and why. I have not seen it at human speed in a real terminal.

## Checks

All six: `pnpm build` 0 · `pnpm typecheck` 0 · `audit-external-names` 0 · `check-docs` 0 · `pnpm test` 0 (cli 634 passed, 3 skipped) · `pnpm lint` 0.
