### PR TITLE
feat(sdk)!: the turn that answers is a step

### DIFF
--- a/.changeset/the-answering-turn-is-a-step.md
+++ b/.changeset/the-answering-turn-is-a-step.md
@@ -1,0 +1,46 @@
+---
+'@namzu/sdk': major
+---
+
+**The turn that produces the answer is now in the step ledger.** It was not.
+`if (forceFinalize || !hasToolCalls)` broke out of the loop before
+`recordStep`, so the ledger held only turns that called tools — and a run's
+last turn is its most expensive, because it carries the whole conversation as
+its prompt.
+
+**Why this is a fix and not a redefinition.** `StepResult` is documented as
+"what one iteration of the agent loop did" and `stepNumber` as "1-based,
+matching `iteration` on the run events". Every skipped turn emitted
+`iteration_completed` with its number, so the events said iteration N happened
+and `steps` had no entry N. The invariant was already false; nobody had chosen
+"turns that called tools" as a meaning.
+
+Measured on a two-iteration run — one tool call, then an answer — **220 of 330
+tokens belonged to no step**, and the unattributed share grows with context
+length. A text-only run, which is the commonest shape there is, produced an
+empty ledger.
+
+**What changes for you.** `run.steps.length` gains one entry for every run that
+ends by answering, and `onStepFinish` fires once more per run. Nothing stops
+compiling; the values change:
+
+- **If you compare step counts across this version, they shift by one.** A
+  recorded baseline is not comparable — `stepBudgetScorer` in the eval harness
+  is the in-tree example, and its own note says it exists because extra turns
+  are "very visible on the bill". It was undercounting the bill by exactly the
+  most expensive turn, so its new number is the correct one.
+- **Trajectory scorers are unaffected.** The added step has no tool calls, so
+  `steps.flatMap(s => s.toolCalls)` is unchanged.
+- **`stopWhen`, `stepCountIs` and `hasToolCall` are unaffected in-run.** The
+  predicate is consulted only after a tool batch, and the answering turn ends
+  the loop before it.
+
+Also recorded now: the auto-continued turn after an output cutoff, the
+structured-output re-prompt, and an answer handed back by `reviewAnswer`. All
+three spend a turn and none of them left a trace.
+
+**Still not steps:** side calls. Compaction verification, the advisory
+executor and the retry after an empty completion spend tokens inside an
+iteration without being one, so they reach `run.tokenUsage` and no step. A run
+that makes them reconciles short by exactly their cost. Attributing those needs
+a record that is not a step, which is a separate change.

--- a/docs/sdk/runtime/loop-control.md
+++ b/docs/sdk/runtime/loop-control.md
@@ -100,6 +100,19 @@ stays at zero and the limit never trips.
 `Run.steps` carries one `StepResult` per iteration, and `onStepFinish`
 fires as each completes.
 
+**One step per iteration, including the turn that answers.** That turn used to
+be missing: the loop broke out before recording it, so a run's most expensive
+turn — the one carrying the whole conversation as its prompt — was absent, and
+a text-only run produced an empty ledger. The same held for an auto-continued
+turn, a structured-output re-prompt and a rejected answer.
+
+So `sum(steps[].usage)` now equals `run.tokenUsage`, and `steps[].stepNumber`
+matches the `iteration` on the run events, which is what `StepResult` always
+claimed. The one exception is a **side call** — compaction verification, the
+advisory executor, the retry after an empty completion. Those spend tokens
+inside an iteration without being one; they reach `run.tokenUsage` and no step,
+so a run that makes them reconciles short by exactly their cost.
+
 ```ts
 query({
   // …
@@ -146,10 +159,6 @@ end, absent when the configured one served throughout.
 
 Two limits worth knowing before you build on this:
 
-- **Only tool-calling turns are recorded.** The turn that produces the final
-  answer ends the loop before a step is written, so it is not in `steps`. On a
-  chain that falls over and answers immediately, `run.metadata.servingProvider`
-  is the only record of the swap.
 - **The built-in store writes `metadata`, not `steps`.** `run.json` carries
   `servingProvider`; per-step provenance reaches you on the returned `Run`, so
   persist that if you need it.

--- a/packages/sdk/src/runtime/query/__tests__/every-iteration-is-a-step.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/every-iteration-is-a-step.test.ts
@@ -1,0 +1,249 @@
+/**
+ * One step per iteration, including the turn that produces the answer.
+ *
+ * `StepResult` is documented as "what one iteration of the agent loop did" and
+ * `stepNumber` as "1-based, matching `iteration` on the run events". Both were
+ * false for the last turn of every run: `if (forceFinalize || !hasToolCalls)`
+ * broke out before `recordStep`, so the events said iteration N happened and
+ * the ledger had no entry N.
+ *
+ * The assertions here are about the LEDGER as a whole rather than about one
+ * field, because the defect was never a wrong value — it was an absence, and an
+ * absence is only visible against a total. Reconciliation against
+ * `run.tokenUsage` is the sharpest form: it cannot pass by accident, and it is
+ * the thing a host actually needs when it asks what a run cost.
+ */
+
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { removeTempDirs } from '../../../__fixtures__/temp-dir.js'
+import { MockLLMProvider } from '../../../provider/mock.js'
+import { ToolRegistry } from '../../../registry/tool/execute.js'
+import type { SessionId, TenantId } from '../../../types/ids/index.js'
+import { createUserMessage } from '../../../types/message/index.js'
+import type { RunEvent } from '../../../types/run/index.js'
+import type { ProjectId, ThreadId } from '../../../types/session/ids.js'
+import { drainQuery } from '../index.js'
+
+function registerEcho(tools: ToolRegistry): void {
+	tools.register({
+		name: 'echo',
+		description: 'Echo the text back.',
+		inputSchema: z.object({}),
+		execute: async () => ({ success: true, output: 'ok' }),
+	})
+}
+
+function baseParams(
+	provider: MockLLMProvider,
+	tools: ToolRegistry,
+	workingDirectory: string,
+	maxIterations = 4,
+) {
+	return {
+		provider,
+		tools,
+		runConfig: {
+			model: 'run-model',
+			timeoutMs: 5_000,
+			tokenBudget: 100_000,
+			maxIterations,
+			maxResponseTokens: 256,
+		},
+		agentId: 'agent_step',
+		agentName: 'Step Agent',
+		workingDirectory,
+		sessionId: 'ses_step' as SessionId,
+		threadId: 'thd_step' as ThreadId,
+		projectId: 'prj_step' as ProjectId,
+		tenantId: 'tnt_step' as TenantId,
+		retry: false as const,
+	}
+}
+
+describe('every iteration leaves a step', () => {
+	let workdirs: string[] = []
+
+	afterEach(async () => {
+		await removeTempDirs(workdirs)
+		workdirs = []
+	})
+
+	async function mkWorkdir(): Promise<string> {
+		const dir = await mkdtemp(join(tmpdir(), 'namzu-step-'))
+		workdirs.push(dir)
+		return dir
+	}
+
+	it('reconciles the ledger with the run total, which it never did before', async () => {
+		// The answering turn is the expensive one — it carries the whole
+		// conversation as its prompt — so this is scripted with the second turn
+		// costing twice the first. Before this change the ledger held 110 of 330
+		// tokens and nothing said so.
+		const provider = new MockLLMProvider({
+			turns: [
+				{
+					toolCalls: [{ id: 'c1', name: 'echo', rawArguments: '{}' }],
+					usage: { promptTokens: 100, completionTokens: 10, totalTokens: 110 },
+				},
+				{
+					text: 'the answer',
+					usage: { promptTokens: 200, completionTokens: 20, totalTokens: 220 },
+				},
+			],
+		})
+		const tools = new ToolRegistry()
+		registerEcho(tools)
+
+		const run = await drainQuery({
+			...baseParams(provider, tools, await mkWorkdir()),
+			messages: [createUserMessage('hello')],
+		})
+
+		const steps = run.steps ?? []
+		const ledger = steps.reduce((total, s) => total + s.usage.totalTokens, 0)
+
+		expect(ledger).toBe(run.tokenUsage.totalTokens)
+		// Named as well as summed: a ledger that reconciled while attributing
+		// everything to one step would satisfy the line above.
+		expect(steps.map((s) => s.usage.totalTokens)).toEqual([110, 220])
+	})
+
+	it('numbers steps to match the iteration events, which is what the type promises', async () => {
+		const provider = new MockLLMProvider({
+			turns: [
+				{ toolCalls: [{ id: 'c1', name: 'echo', rawArguments: '{}' }] },
+				{ toolCalls: [{ id: 'c2', name: 'echo', rawArguments: '{}' }] },
+				{ text: 'done' },
+			],
+		})
+		const tools = new ToolRegistry()
+		registerEcho(tools)
+		const events: RunEvent[] = []
+
+		const run = await drainQuery(
+			{
+				...baseParams(provider, tools, await mkWorkdir()),
+				messages: [createUserMessage('hello')],
+			},
+			(e) => {
+				events.push(e)
+			},
+		)
+
+		// Read off the EVENTS, not off a constant. `stepNumber` documents itself
+		// against them, so the events are the other party to the contract, and a
+		// hand-written `[1, 2, 3]` would pass even if both drifted together.
+		const iterations = events
+			.filter((e) => e.type === 'iteration_completed')
+			.map((e) => (e as { iteration: number }).iteration)
+
+		expect(run.steps?.map((s) => s.stepNumber)).toEqual(iterations)
+	})
+
+	it('records the answering turn with its content and finish reason', async () => {
+		const provider = new MockLLMProvider({
+			turns: [
+				{ toolCalls: [{ id: 'c1', name: 'echo', rawArguments: '{}' }] },
+				{ text: 'the final answer' },
+			],
+		})
+		const tools = new ToolRegistry()
+		registerEcho(tools)
+
+		const run = await drainQuery({
+			...baseParams(provider, tools, await mkWorkdir()),
+			messages: [createUserMessage('hello')],
+		})
+
+		const last = run.steps?.at(-1)
+		expect(last?.content).toBe('the final answer')
+		expect(last?.toolCalls).toEqual([])
+		// The turn that ends the run is the one a reader most wants to find, and
+		// it is the one that was missing.
+		expect(last?.finishReason).toBe('stop')
+	})
+
+	it('gives a text-only run one step rather than none', async () => {
+		// The commonest shape there is: a question, an answer, no tools. It used
+		// to produce an empty ledger on a run that plainly did something.
+		const provider = new MockLLMProvider({ turns: [{ text: 'just an answer' }] })
+
+		const run = await drainQuery({
+			...baseParams(provider, new ToolRegistry(), await mkWorkdir(), 2),
+			messages: [createUserMessage('hello')],
+		})
+
+		expect(run.steps).toHaveLength(1)
+		expect(run.steps?.[0]?.content).toBe('just an answer')
+	})
+
+	it('reports each step to `onStepFinish`, including the last', async () => {
+		// The callback is the live half of the ledger and it is fed from the same
+		// site, so a fix that only filled `run.steps` would leave a host watching
+		// steps go by and never seeing the one that mattered.
+		const provider = new MockLLMProvider({
+			turns: [{ toolCalls: [{ id: 'c1', name: 'echo', rawArguments: '{}' }] }, { text: 'done' }],
+		})
+		const tools = new ToolRegistry()
+		registerEcho(tools)
+		const seen: number[] = []
+
+		await drainQuery({
+			...baseParams(provider, tools, await mkWorkdir()),
+			onStepFinish: (step: { stepNumber: number }) => {
+				seen.push(step.stepNumber)
+			},
+			messages: [createUserMessage('hello')],
+		})
+
+		expect(seen).toEqual([1, 2])
+	})
+})
+
+/**
+ * The branch that had no step is not only the LAST turn.
+ *
+ * Auto-continuation, the structured-output re-prompt and an answer-review
+ * rejection all reach it and then `continue` — each spending a turn's tokens on
+ * an iteration that emits its own `iteration_completed`. That is why the record
+ * is taken at the top of the branch rather than beside the `break` at its end:
+ * recording only the terminal turn would leave these three exactly as they
+ * were, and they are the turns a host reviewing a re-prompt loop most wants to
+ * count.
+ */
+describe('an iteration that loops back is still a step', () => {
+	let workdirs: string[] = []
+
+	afterEach(async () => {
+		await removeTempDirs(workdirs)
+		workdirs = []
+	})
+
+	it('records the rejected answer as well as the accepted one', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'namzu-step-'))
+		workdirs.push(dir)
+		const provider = new MockLLMProvider({
+			turns: [{ text: 'first attempt' }, { text: 'second attempt' }],
+		})
+		let asked = 0
+
+		const run = await drainQuery({
+			...baseParams(provider, new ToolRegistry(), dir),
+			// Rejected once, then accepted. Both turns are iterations; neither
+			// called a tool.
+			reviewAnswer: async () => {
+				asked++
+				return asked === 1 ? { accept: false, feedback: 'try again' } : { accept: true }
+			},
+			messages: [createUserMessage('hello')],
+		})
+
+		expect(asked).toBe(2)
+		expect(run.steps?.map((s) => s.content)).toEqual(['first attempt', 'second attempt'])
+	})
+})

--- a/packages/sdk/src/runtime/query/__tests__/provider-chain-provenance.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/provider-chain-provenance.test.ts
@@ -211,13 +211,17 @@ describe('the run record names the member that served', () => {
 			messages: [createUserMessage('hello')],
 		})
 
+		// Four steps for four iterations, including the answering turn — which
+		// is the one whose provenance nothing could see before it became a step.
 		expect(run.steps?.map((s) => s.servedBy?.providerId)).toEqual([
 			'primary',
+			fallback.id,
 			fallback.id,
 			fallback.id,
 		])
 		expect(run.steps?.map((s) => s.servedBy?.model)).toEqual([
 			'primary-model',
+			'fallback-model',
 			'fallback-model',
 			'fallback-model',
 		])
@@ -269,9 +273,19 @@ describe('the run record names the member that served', () => {
 			messages: [createUserMessage('hello')],
 		})
 
-		expect(run.steps?.map((s) => s.model)).toEqual(['primary-model', 'cheap-model'])
+		// The third entry is the answering turn, which asked for the run's model
+		// because `prepareStep` only overrode step 2.
+		expect(run.steps?.map((s) => s.model)).toEqual([
+			'primary-model',
+			'cheap-model',
+			'primary-model',
+		])
 		// And the same correction reaches the provenance, because a member
 		// declared without a model serves whatever the step asked for.
-		expect(run.steps?.map((s) => s.servedBy?.model)).toEqual(['primary-model', 'cheap-model'])
+		expect(run.steps?.map((s) => s.servedBy?.model)).toEqual([
+			'primary-model',
+			'cheap-model',
+			'primary-model',
+		])
 	})
 })

--- a/packages/sdk/src/runtime/query/iteration/index.ts
+++ b/packages/sdk/src/runtime/query/iteration/index.ts
@@ -609,6 +609,62 @@ export class IterationOrchestrator {
 							)
 						}
 
+						// This iteration gets a step too.
+						//
+						// It did not, and the ledger's own contract said it should:
+						// `StepResult` is documented as "what one iteration of the
+						// agent loop did" and `stepNumber` as "1-based, matching
+						// `iteration` on the run events". Every path below emits
+						// `iteration_completed` with this iteration's number, and
+						// none of them recorded a step — so the events said
+						// iteration N happened and `steps` had no entry N. The
+						// invariant was not a definition anyone chose; it was
+						// already false.
+						//
+						// What it cost: measured on a two-iteration run, one tool
+						// call then an answer, 220 of 330 tokens belonged to no
+						// step. That is not a rounding error and it is structurally
+						// the worst turn to lose — the answering turn carries the
+						// largest prompt, so the unattributed share GROWS with
+						// context length.
+						//
+						// Recorded HERE, at the top of the branch, rather than at
+						// each of its exits. Every path out of this block is a
+						// `continue`, a `break` or a `return`, so one call covers
+						// the terminal answer, the forced-final summary, the
+						// auto-continuation, the structured-output re-prompt and the
+						// answer-review rejection — all of which spend a turn's
+						// tokens. Placing it at the exits instead would be five call
+						// sites to keep in agreement, and the one added later would
+						// be the one that got missed.
+						//
+						// No tool results, because this branch is defined by their
+						// absence. `toolExecutionMs` is 0 for the same reason.
+						//
+						// A step is an ITERATION'S MAIN TURN, and side calls are
+						// still not steps — the compaction verifier, the advisory
+						// executor, and the empty-completion retry a few lines below
+						// all spend tokens inside an iteration without being one.
+						// Their usage reaches `run.tokenUsage` and no step, so the
+						// ledger reconciles with the run total for a run that makes
+						// no side calls and undercounts by exactly those calls for a
+						// run that does. That residual is named rather than fixed
+						// here: attributing a side call needs a record that is not a
+						// step, which is a different claim.
+
+						this.recordStep({
+							stepNumber: iterationNum,
+							model: stepModel,
+							servedBy,
+							messageId,
+							response,
+							toolResults: [],
+							toolExecutionMs: 0,
+							startedAt: stepStartedAt,
+							usageBefore,
+							costBefore,
+						})
+
 						const hasContent =
 							response.message.content !== null && response.message.content.length > 0
 


### PR DESCRIPTION
The turn that produces the answer was not in the step ledger. `if (forceFinalize || !hasToolCalls)` broke out of the loop before `recordStep`, and a run's last turn is its most expensive — it carries the whole conversation as its prompt.

## Measured first: is this a gap, or a definition?

You asked me to establish what a step currently *means* before designing, because if the ledger is defined as "turns that called tools" then adding the final turn changes what every consumer counts. **It is a gap, and the type says so itself.**

`StepResult` is documented as *"what one iteration of the agent loop did"*, and `stepNumber` as *"1-based, matching `iteration` on the run events"*. Every skipped turn emits `iteration_completed` carrying its iteration number. So the events said iteration N happened and `steps` had no entry N — the documented invariant was already false. Nobody chose "turns that called tools" as a meaning; it was the accidental shape of one `break`.

What it cost, measured on a two-iteration run — one tool call, then an answer, with usage scripted per turn:

```
iterations: 2      stepCount: 1      stepNumbers: [1]
ledger total: 110  run total: 330    unattributed: 220
```

**Two thirds of the tokens belonged to no step**, and the unattributed share *grows* with context length, because the missing turn is the one carrying the largest prompt. A text-only run — a question and an answer, the commonest shape there is — produced an entirely empty ledger.

## Every consumer, and what actually moves

| Consumer | Effect |
|---|---|
| trajectory — `steps.flatMap(s => s.toolCalls)` in `evalRunFromRun` | **none**; the added step has no tool calls |
| `stopWhen`, `stepCountIs`, `hasToolCall` | **none in-run**; the predicate is consulted only after a tool batch, and the answering turn ends the loop before it |
| `stepBudgetScorer` — `run.steps.length` | **+1 per run that ends by answering** |
| `onStepFinish` | fires once more per run |

The a2a and sse `steps` mappers are *plan* steps, not this ledger — unaffected.

So exactly one consumer's number changes, and **it was wrong in the direction it exists to measure**: its own note says it matters because extra turns are "very visible on the bill", and it was undercounting the bill by precisely the most expensive turn.

## Why major

Nothing stops compiling. `run.steps.length` and the `onStepFinish` count change on essentially every run, with no compiler to say so — a shipped value moving silently is exactly what the bump is for. The changeset says plainly that recorded step counts are not comparable across this boundary.

## Recorded at the top of the branch, not beside its `break`

That placement is what also picks up three turns nobody had noticed were missing: the **auto-continued** turn after an output cutoff, the **structured-output re-prompt**, and an **answer handed back** by `reviewAnswer`. Each spends a turn's tokens, emits its own `iteration_completed`, and left no trace.

Recording at the exits instead would have been five call sites to keep in agreement, and the one added later is the one that gets missed.

## Still not steps, deliberately

A step is an **iteration's main turn**. Side calls — compaction verification, the advisory executor, the retry after an empty completion — spend tokens inside an iteration without being one. Their usage reaches `run.tokenUsage` and no step, so the ledger reconciles exactly for a run that makes none and undercounts by their cost for a run that does. That residual is named in the code, the docs and the changeset rather than papered over: attributing a side call needs a record that is *not* a step, which is a different claim and the next item on my queue.

## Mutations

| # | Mutation | Killed by |
|---|---|---|
| M21 | suppress the new record | **7** — all 5 new cases plus the 2 provenance tests |
| M22 | move the record to the terminal `break` | **1** — exactly the loop-back case |

M22 is the one that earns the placement. It leaves the five straightforward cases green and fails only the answer-review rejection, which is what proves the claim is specifically about the `continue` paths rather than about the last turn.

Two pre-existing provenance tests also changed, by gaining the answering turn — that is the consumer impact of this change, demonstrated by the repo's own suite rather than argued.

The reconciliation test reads `run.tokenUsage` rather than a constant, and the numbering test reads the iteration numbers **off the emitted events** rather than a hand-written `[1, 2, 3]` — `stepNumber` documents itself against those events, so they are the other party to the contract, and a literal would pass even if both drifted together.

## Gate

All six: `pnpm build`, `pnpm typecheck`, `pnpm lint` clean; `pnpm test` exit 0 — sdk 331 files / 2944 passed / 7 skipped, cli 67 files / 634 passed / 3 skipped, no unhandled rejections. `scripts/audit-external-names.mjs` exits 0. `verify-public-surface.mjs` reports the surface intact. `pnpm docs:check` reports 0 problems across 13 files.
