### PR TITLE
fix(cli): the default model is current, and says whose default it is

### DIFF
--- a/.changeset/the-default-model-catches-up.md
+++ b/.changeset/the-default-model-catches-up.md
@@ -1,0 +1,41 @@
+---
+'@namzu/cli': major
+---
+
+The default model is current again, and says whose default it is
+
+**namzu's default Claude model changes from `claude-opus-4-7` to
+`claude-opus-5`** for the Anthropic provider, and from
+`anthropic/claude-opus-4-7` to `anthropic/claude-opus-5` for OpenRouter. Two
+generations had passed. Nothing errored — a run simply happened on an older
+model than the operator had any reason to expect, which is why it went unnoticed.
+
+**To keep the old model**, pick it in `/model`, or set it in
+`~/.namzu/preferences.json`:
+
+```json
+{"version": 3, "providers": [{"id": "anthropic", "model": "claude-opus-4-7"}]}
+```
+
+A saved preference already wins over this constant, so anyone who has chosen a
+model is unaffected.
+
+**The picker now labels it `(namzu default)` rather than `(default)`.** It was
+described in the code as "the provider's own default", which it never was — this
+is a value namzu picks, it goes stale between provider releases, and an operator
+choosing from that list deserves to know it is a choice rather than an
+endorsement.
+
+Resolving the default at runtime was considered and rejected: it would buy a
+network call, a cache, and a staleness question on every launch, and the offline
+path is exactly where this defect would come back invisibly. The constant stays,
+with the obligation to re-check it at each provider release written where the
+constant is defined.
+
+The Bedrock default is **left unchanged and marked unverified.** That driver
+speaks the Converse API, whose ids are date-stamped
+(`<vendor>.<model>-<yyyymmdd>-v<n>:0`); the current value carries the version
+suffix but no date, so it fits neither that shape nor the newer bare alias.
+Nobody here has a credential to establish which the endpoint accepts, and a
+fabricated date would look authoritative while being a guess. That provider has
+no bundled driver in this build in any case, so the value is unreachable today.

--- a/packages/cli/src/integrations/providers/registry.ts
+++ b/packages/cli/src/integrations/providers/registry.ts
@@ -30,7 +30,22 @@ export interface ProviderRegistryEntry {
 	 * discoverer issues a HEAD/GET and treats 2xx as "available".
 	 */
 	readonly probeUrl?: string
-	/** Default model when the user does not pick one in the picker. */
+	/**
+	 * Default model when the user does not pick one in the picker.
+	 *
+	 * **These are namzu's picks, not the provider's, and they go stale.** A
+	 * hardcoded default fails silently: nothing errors, the run just happens on
+	 * an older model than the operator assumes, and only a reader who already
+	 * knows the current generation would notice. One sat two generations behind
+	 * for exactly that reason.
+	 *
+	 * Resolving them at runtime was considered and refused: it buys a network
+	 * call, a cache, and a staleness question on every launch, and the offline
+	 * path is where this defect would reappear invisibly. So the constant stays
+	 * and the obligation is stated instead — **re-check these at every provider
+	 * model release.** The picker labels the value as namzu's default so an
+	 * operator can see it is a choice rather than a recommendation.
+	 */
 	readonly defaultModel: string
 	/** Does this provider require an apiKey? `false` for purely local. */
 	readonly requiresApiKey: boolean
@@ -65,7 +80,7 @@ export const PROVIDER_REGISTRY: Readonly<Record<ProviderId, ProviderRegistryEntr
 			// variant, then claude-code's OAuth env (often present when the user
 			// has claude-code installed).
 			envVars: ['ANTHROPIC_API_KEY', 'ANTHROPIC_TOKEN', 'CLAUDE_CODE_OAUTH_TOKEN'],
-			defaultModel: 'claude-opus-4-7',
+			defaultModel: 'claude-opus-5',
 			requiresApiKey: true,
 			constructible: true,
 		},
@@ -82,7 +97,7 @@ export const PROVIDER_REGISTRY: Readonly<Record<ProviderId, ProviderRegistryEntr
 			label: 'OpenRouter',
 			envVars: ['OPENROUTER_API_KEY'],
 			defaultBaseUrl: 'https://openrouter.ai/api/v1',
-			defaultModel: 'anthropic/claude-opus-4-7',
+			defaultModel: 'anthropic/claude-opus-5',
 			requiresApiKey: true,
 			constructible: true,
 		},
@@ -110,6 +125,15 @@ export const PROVIDER_REGISTRY: Readonly<Record<ProviderId, ProviderRegistryEntr
 			id: 'bedrock',
 			label: 'AWS Bedrock',
 			envVars: ['AWS_ACCESS_KEY_ID'], // SDK reads the rest from the AWS chain
+			// UNVERIFIED, and left as-is deliberately. This driver talks to the
+			// Converse API, whose ids are date-stamped and version-suffixed
+			// (`<vendor>.<model>-<yyyymmdd>-v<n>:0`). This value carries the
+			// suffix but no date, so it matches that shape and the newer bare
+			// alias equally badly. Nobody here has a credential to prove which
+			// the endpoint accepts, and inventing a date would be a fabricated
+			// id that looks authoritative — so it is recorded rather than
+			// guessed at. Unreachable today in any case: `constructible: false`
+			// means this build cannot construct the driver at all.
 			defaultModel: 'anthropic.claude-opus-4-7-v1:0',
 			requiresApiKey: true,
 			constructible: false,

--- a/packages/cli/src/tui/__tests__/model-picker-draws.test.tsx
+++ b/packages/cli/src/tui/__tests__/model-picker-draws.test.tsx
@@ -92,12 +92,12 @@ describe('the model step', () => {
 		unmount()
 	})
 
-	it('offers the provider default alongside the listed models', async () => {
+	it('offers the namzu default alongside the listed models', async () => {
 		const { lastFrame, stdin, unmount } = open()
 		stdin.write('\r')
 		await flush()
 		expect(lastFrame()).toContain(DEFAULT_MODEL)
-		expect(lastFrame()).toContain('(default)')
+		expect(lastFrame()).toContain('(namzu default)')
 		unmount()
 	})
 

--- a/packages/cli/src/tui/model-choices.test.ts
+++ b/packages/cli/src/tui/model-choices.test.ts
@@ -26,7 +26,11 @@ describe('modelStep', () => {
 			],
 		})
 		expect(step.choices.map((c) => c.id)).toEqual(['a', DEFAULT])
-		expect(step.choices.find((c) => c.id === DEFAULT)?.note).toBe('(default)')
+		// Says whose default it is. `(default)` read as the provider's
+		// recommendation, which it never was — namzu picks this value, it goes
+		// stale between provider releases, and an operator choosing from this
+		// list deserves to know it is a choice rather than an endorsement.
+		expect(step.choices.find((c) => c.id === DEFAULT)?.note).toBe('(namzu default)')
 		expect(step.choices.filter((c) => c.id === DEFAULT)).toHaveLength(1)
 	})
 

--- a/packages/cli/src/tui/model-choices.ts
+++ b/packages/cli/src/tui/model-choices.ts
@@ -8,7 +8,7 @@
  *
  * ## The default is always offered
  *
- * Every branch returns at least the provider's `defaultModel`. A screen that
+ * Every branch returns at least namzu's `defaultModel` for the provider. A screen that
  * can end with nothing selectable is a dead end for someone who came here to
  * get on with a task, and the default is exactly the value they would have got
  * by not visiting this step.
@@ -27,7 +27,7 @@ import type { ModelListing } from './agent.js'
 export interface ModelChoice {
 	readonly id: string
 	readonly label: string
-	/** Shown beside the row. `(default)` for the provider's own default. */
+	/** Shown beside the row. `(namzu default)` for the value namzu picks. */
 	readonly note?: string
 }
 
@@ -47,7 +47,7 @@ export interface ModelStep {
 /**
  * Build the model step for one provider.
  *
- * @param defaultModel The provider's own default, always offered.
+ * @param defaultModel namzu's default for this provider, always offered.
  * @param listing What asking the provider produced.
  * @param currentModel The model in force now, if any — so re-opening the picker
  *   starts on what is already selected rather than resetting to the default.
@@ -58,7 +58,7 @@ export function modelStep(
 	currentModel?: string,
 ): ModelStep {
 	const fallback = (notice: string): ModelStep => ({
-		choices: [{ id: defaultModel, label: defaultModel, note: '(default)' }],
+		choices: [{ id: defaultModel, label: defaultModel, note: '(namzu default)' }],
 		notice,
 		initialIndex: 0,
 	})
@@ -89,11 +89,11 @@ export function modelStep(
 		choices.push({
 			id: m.id,
 			label: m.name,
-			...(m.id === defaultModel ? { note: '(default)' } : {}),
+			...(m.id === defaultModel ? { note: '(namzu default)' } : {}),
 		})
 	}
 	if (!seen.has(defaultModel)) {
-		choices.unshift({ id: defaultModel, label: defaultModel, note: '(default)' })
+		choices.unshift({ id: defaultModel, label: defaultModel, note: '(namzu default)' })
 	}
 
 	const wanted = currentModel ?? defaultModel


### PR DESCRIPTION
namzu's default Claude model was **two generations behind**, and nothing failed because of it. A run simply happened on an older model than the operator had reason to expect. A stale default produces no error, no warning, and no symptom — only a reader who already knows the current generation would notice, which is exactly why it sat.

## What changes for a caller

**Anthropic:** `claude-opus-4-7` → `claude-opus-5`
**OpenRouter:** `anthropic/claude-opus-4-7` → `anthropic/claude-opus-5`

To keep the old model, pick it in `/model`, or set it in `~/.namzu/preferences.json`:

```json
{"version": 3, "providers": [{"id": "anthropic", "model": "claude-opus-4-7"}]}
```

A saved preference already wins over this constant, so anyone who has chosen a model is unaffected.

The id was verified against the current model reference rather than written from memory — an id from recall is the same class of mistake as the one being fixed.

## No runtime resolution, and why

Considered and refused. It buys a network call, a cache, a staleness question on every launch, and an offline path — and **the offline path is precisely where this defect would return, invisibly, having cost all of that.**

So the constant stays, and the obligation is written where the constant is defined: re-check at each provider release. Pretending the fix is permanent is how it went stale the first time.

## Found on the way — the same defect in different clothes

The picker labelled the value `(default)`, and the code called it *"the provider's own default"*.

It is neither. **namzu picks it**, it goes stale between provider releases, and an operator choosing from that list was being shown an endorsement nobody had given. It reads `(namzu default)` now, across all three call sites, with both tests updated.

## Bedrock: unverified, and that is a stronger statement than it sounds

I could not test it, but I could narrow it without a credential. The driver imports `ConverseCommand` from `@aws-sdk/client-bedrock-runtime` — the **legacy** Bedrock integration, whose ids are date-stamped and version-suffixed (`<vendor>.<model>-<yyyymmdd>-v<n>:0`).

The registry value `anthropic.claude-opus-4-7-v1:0` carries the version suffix but **no date**, so it fits neither that shape nor the newer bare-alias scheme.

That is enough to say the value is wrong. It is **not** enough to say what is right — the correct date-stamped id is a fact I cannot establish here, and a fabricated date would read as authoritative while being invented. So it is recorded in place, unchanged, with the evidence in a comment. The provider has no bundled driver in this build (`constructible: false`), so nothing can reach the value today.

## Checks

All six, exit codes captured before filtering: `pnpm build` 0 · `pnpm typecheck` 0 · `audit-external-names` 0 · `check-docs` 0 · `pnpm test` 0 (run twice; cli 634 passed, 3 skipped) · `pnpm lint` 0.

Three tests needed updating for the `(namzu default)` label — two assertions and one test name. They asserted the old string, not a behaviour, so the change is cosmetic in each case.
