### PR TITLE
chore(release): a version that never shipped says so, and the check that would have caught it

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -71,12 +71,30 @@ Cuts new versions of publishable packages via [Changesets](https://github.com/ch
 
 3. Verify CI is green on the Version Packages PR. The pre-merge `consumer install`, `publint`, and `@arethetypeswrong/cli` steps in `.github/workflows/ci.yml` catch peer-range drift and package-shape defects before publish.
 
-4. Merge the PR to `main`. The `.github/workflows/release.yml` workflow triggers automatically:
+4. **Confirm the PR is not stale: every changeset on `main` must appear in its diff.**
+
+   ```bash
+   git ls-tree origin/main --name-only .changeset/   # minus README.md and config.json
+   gh pr diff <n> --name-only | grep '^\.changeset/'
+   ```
+
+   A changeset on `main` that the PR does not consume means the PR was computed
+   before that changeset landed — merge it and the version numbers it wrote are
+   spent on a state that no longer exists. The workflow then re-versions instead
+   of publishing and opens a fresh PR, so nothing is lost, but the bump has
+   already been written: `@namzu/cli` `4.4.0` exists in the CHANGELOG and on no
+   registry for exactly this reason.
+
+   This happens whenever a feature PR is merged shortly before the version PR.
+   Waiting for the version PR to *exist* is not enough — it already existed; it
+   was out of date. Check what it consumes, not that it is there.
+
+5. Merge the PR to `main`. The `.github/workflows/release.yml` workflow triggers automatically:
    - Runs the full install + build + lint + typecheck + test pipeline.
    - Runs the pre-publish consumer-install check (`.github/scripts/verify-consumer-install.sh`) against the packed tarballs.
    - Invokes `pnpm changeset publish` — publishes every bumped package to npm with provenance, creates Git tags (`@namzu/<pkg>@<version>`), and GitHub Releases.
 
-5. Monitor `https://github.com/cogitave/namzu/actions` for the release run. Confirm each published package appears on npm under its expected dist-tag.
+6. Monitor `https://github.com/cogitave/namzu/actions` for the release run. **Confirm each published package appears on npm under its expected dist-tag by asking npm, not by reading the workflow's exit status** — `npm view <pkg> version` against the version in `package.json` on `main`. A release run can succeed without publishing: if it re-versions instead, it exits green and opens a PR. Green means the run did what it decided to do, not that a package shipped.
 </procedure_phase_2>
 
 ## Hard rules
@@ -86,6 +104,7 @@ Cuts new versions of publishable packages via [Changesets](https://github.com/ch
 - Never invoke `npm publish` or `pnpm publish` directly. The release workflow is the authority, and it runs `changeset publish`.
 - Never skip hooks (`--no-verify`, `--no-gpg-sign`) during a release commit.
 - Never merge a "Version Packages" PR if CI is red on it — the red gate is catching a real publish-time regression.
+- Never merge a "Version Packages" PR that does not consume every changeset on `main` (Phase 2, step 4). Its existence is not evidence of its currency.
 - Peer range widening / narrowing happens via Changesets config (`___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange`). Do not hand-edit peer ranges in `package.json` files unless the change is a policy decision being ratified in a session (e.g., the original `>=0.1.6 <1.0.0` policy set in ses_012).
 - NPM Trusted Publisher is configured via OIDC (provenance). Do not add an `NPM_TOKEN` secret unless switching to classic auth.
 </hard_rules>

--- a/docs/conventions/never-filter-a-verification.md
+++ b/docs/conventions/never-filter-a-verification.md
@@ -7,7 +7,7 @@ diataxis: explanation
 owner: cogitave/namzu
 status: active
 timestamp: 2026-08-04T00:00:00Z
-lastReviewed: 2026-08-07
+lastReviewed: 2026-08-09
 resource: .github/workflows/ci.yml
 tags: [convention, verification, tooling]
 ---
@@ -115,6 +115,45 @@ The same rule pointed at a tool rather than a filter. Two from one session:
 Both were caught by re-running through the real command and reading *why* it
 failed. A mutation that "passes" tells you nothing until you have seen the
 assertion in the failure output.
+
+## The door where nothing is read at all
+
+Every incident above has someone reading the wrong thing. This one has nobody
+reading anything, and it did the most damage.
+
+A one-line correction to a changeset was applied by a script that read the file
+from the API, edited the text, and wrote it back. The read expression contained a
+parse error. The error printed. **The script kept going**, built the new content
+out of nothing, and the write succeeded — truncating another agent's changeset to
+a single paragraph and taking its frontmatter, and with it every version
+declaration in the pull request, out of the file. The write reported success
+because it did exactly what it was told.
+
+The shell in use does not stop on an error by default. So a step that failed and
+a step that succeeded look identical to the step after them, and a script is a
+gate only if something in it refuses to continue. Nothing here refused.
+
+This is the rule's limit case. The others say *read the verdict*; this one says
+**there has to be a verdict at all**. A sequence of commands where failure does
+not stop the sequence is not a check that was misread — it is a check that was
+never taken.
+
+Three things follow, and the third is the one that saved it:
+
+1. **Make failure stop the sequence**, explicitly, in any shell that does not do
+   it for you. One step per command is better than a clever one-liner precisely
+   because the boundary between steps is where the stopping happens.
+2. **Never write a file from data you have not seen.** Build the new content,
+   look at it, then write. Here the intended content had a frontmatter block; one
+   glance would have ended it.
+3. **Verify against the store you wrote to.** The file was read back from the
+   remote and compared byte-for-byte against what was intended, which is how the
+   damage was found within a minute rather than at the next release. Reading back
+   what you just wrote is cheap and it is the only check that cannot be satisfied
+   by the write's own report.
+
+Recorded because the blast radius was somebody else's work, on a branch that was
+already green.
 
 ## Related
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -86,6 +86,20 @@
 
 ## 4.4.0
 
+> **This version was never published.** `4.3.1` is followed on the registry by
+> `4.4.1`; there is no `4.4.0` to install, and this section is kept rather than
+> deleted because the work below did ship — inside `4.4.1`.
+>
+> What happened: the release PR that produced these version numbers had been
+> computed before the changeset for `4.4.1` landed on `main`, so merging it
+> bumped versions against a state that was already stale. The release workflow
+> declined to publish and opened a fresh version PR instead, which is the
+> correct behaviour and is why nothing was lost — but the bump had already been
+> written, so this number was spent without ever reaching npm.
+>
+> The precondition that prevents it is now in the release skill: before merging
+> a version PR, every changeset present on `main` must appear in that PR's diff.
+
 ### Minor Changes
 
 - 3eed8a0: **A provider namzu cannot build is no longer offered as if it could.** Three


### PR DESCRIPTION
chore(release): a version that never shipped says so, and the check that would have caught it

`@namzu/cli` 4.4.0 is in the CHANGELOG and on no registry. The release PR
that wrote those numbers had been computed before the next changeset
landed on main, so merging it bumped versions against a stale state. The
workflow then declined to publish and opened a fresh version PR, which is
correct and is why nothing was lost - but the bump was already written,
so the number was spent without reaching npm.

A changelog entry for a version nobody can install is the failure this
repository keeps removing, one register down: a record that reads as a
fact and is not one. The section stays, because the work in it shipped -
inside 4.4.1 - and it now says both of those things.

The precondition goes into the release skill as its own step: before
merging a version PR, every changeset present on main must appear in that
PR's diff. Waiting for the version PR to exist is not enough. It existed;
it was out of date.

The monitoring step gains the same correction one layer out: confirm a
publish by asking npm, not by reading the workflow's exit status. A
release run that re-versions instead of publishing exits green. Green
means the run did what it decided to do, not that a package shipped -
which is how this was nearly missed a second time.

And `never-filter-a-verification` gains the door where nothing is read at
all. A script correcting one line of a changeset hit a parse error, the
error was non-fatal, the script continued with empty data, and the write
that followed truncated another agent's changeset and took its
frontmatter - every version declaration in an open PR - with it. Every
earlier instance in that file has someone reading the wrong thing; this
one has nobody reading anything, and it did the most damage. A sequence
of commands where failure does not stop the sequence is not a check that
was misread. It is a check that was never taken.

Restored from git and verified by reading the file back from the remote
and comparing byte-for-byte, which is why it was found in a minute rather
than at the next release.
