### PR TITLE
fix(cli): Ctrl+V says what happened when there is nothing to paste

### DIFF
--- a/.changeset/ctrl-v-says-what-happened.md
+++ b/.changeset/ctrl-v-says-what-happened.md
@@ -1,0 +1,25 @@
+---
+'@namzu/cli': patch
+---
+
+Ctrl+V says what happened when there is no image to paste
+
+The status bar advertises `Ctrl+V to attach`. Pressing it read the clipboard,
+attached an image if it found one, and otherwise did nothing at all — no chip,
+no message, no error.
+
+So three quite different situations produced one identical silence: you have not
+copied an image; this machine has no clipboard tool installed; the key was never
+wired up. The operator's next move differs in each — copy an image, install a
+tool, or stop pressing the key — and the screen gave them nothing to choose
+with.
+
+Each outcome now says which it was, and a missing tool names what to install
+(`xclip` on X11, `wl-clipboard` on Wayland). The success path stays quiet,
+because the attachment chip is already the report.
+
+The reason had to be recovered before it could be shown: the clipboard reader
+returned a bare `null` for every failure, and on Linux a missing `xclip` and an
+empty clipboard are indistinguishable after the fact — both come back from the
+shell as a non-zero exit. It now checks whether any reader exists before
+attempting the read, and returns which of the two it found.

--- a/packages/cli/src/integrations/clipboard/image.ts
+++ b/packages/cli/src/integrations/clipboard/image.ts
@@ -4,9 +4,9 @@
  * Terminals don't deliver pasted image bytes over stdin, so we shell out to
  * the platform clipboard tool, write the image to a temp PNG, and read it
  * back as base64. macOS uses `osascript` (`«class PNGf»`); Linux tries
- * `xclip` then `wl-paste`; Windows uses PowerShell. Non-throwing — any
- * failure (no image on the clipboard, tool missing) returns `null`.
- *
+ * `xclip` then `wl-paste`; Windows uses PowerShell. Non-throwing — every
+ * failure comes back as a {@link ClipboardRead} saying which failure it was,
+ * so the composer can tell the operator something other than nothing.
  */
 
 import { execFileSync } from 'node:child_process'
@@ -21,23 +21,71 @@ export interface ClipboardImage {
 	readonly mediaType: 'image/png'
 }
 
+/**
+ * What a clipboard read found, and when it found nothing, why.
+ *
+ * The reason is the whole point of this type. A single `null` for every outcome
+ * left the composer with nothing to say, so `Ctrl+V` with no image behaved
+ * exactly like `Ctrl+V` on a machine with no clipboard tool installed, which in
+ * turn behaved exactly like a key that was never wired up. Three quite
+ * different situations, one silence — and the operator's next move differs in
+ * each: copy an image, install a tool, or stop pressing the key.
+ */
+export type ClipboardRead =
+	| { readonly kind: 'image'; readonly image: ClipboardImage }
+	/** A tool ran and the clipboard held no image. */
+	| { readonly kind: 'empty' }
+	/** Nothing on this machine can read an image off the clipboard. */
+	| { readonly kind: 'unavailable'; readonly detail: string }
+
 const TIMEOUT_MS = 5_000
 
-export function readClipboardImage(): ClipboardImage | null {
+export function readClipboardImage(): ClipboardRead {
+	const unavailable = clipboardUnavailable()
+	if (unavailable !== null) return { kind: 'unavailable', detail: unavailable }
 	const file = join(tmpdir(), `namzu-clip-${Date.now()}.png`)
 	try {
-		if (!saveClipboardImageTo(file)) return null
+		if (!saveClipboardImageTo(file)) return { kind: 'empty' }
 		const buf = readFileSync(file)
-		if (buf.length === 0) return null
-		return { data: buf.toString('base64'), mediaType: 'image/png' }
+		if (buf.length === 0) return { kind: 'empty' }
+		return { kind: 'image', image: { data: buf.toString('base64'), mediaType: 'image/png' } }
 	} catch {
-		return null
+		return { kind: 'empty' }
 	} finally {
 		try {
 			rmSync(file, { force: true })
 		} catch {
 			// best-effort cleanup
 		}
+	}
+}
+
+/**
+ * Why this machine cannot read a clipboard image at all, or `null` if it can.
+ *
+ * Checked before attempting the read, because afterwards the two are
+ * indistinguishable: a missing `xclip` and an empty clipboard both come back
+ * from `/bin/sh` as a non-zero exit. The macOS and Windows tools ship with the
+ * OS, so only Linux needs the probe.
+ */
+function clipboardUnavailable(): string | null {
+	switch (platform()) {
+		case 'darwin':
+		case 'win32':
+			return null
+		case 'linux': {
+			try {
+				execFileSync('/bin/sh', ['-c', 'command -v xclip || command -v wl-paste'], {
+					timeout: TIMEOUT_MS,
+					stdio: ['ignore', 'ignore', 'ignore'],
+				})
+				return null
+			} catch {
+				return 'install xclip (X11) or wl-clipboard (Wayland)'
+			}
+		}
+		default:
+			return `no clipboard reader is known for ${platform()}`
 	}
 }
 

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -1075,6 +1075,7 @@ export function App({ ctx }: AppProps) {
 								// the composer's clear.
 								escapeInterrupts={state === 'thinking' || state === 'tool'}
 								onSubmit={handleSubmit}
+								onNotice={(text) => pushMessage('system', text)}
 								userCommands={userCommands}
 								history={history}
 							/>

--- a/packages/cli/src/tui/Composer.tsx
+++ b/packages/cli/src/tui/Composer.tsx
@@ -43,6 +43,15 @@ export interface ComposerProps {
 	 * what it is for when nothing more urgent is happening.
 	 */
 	readonly escapeInterrupts?: boolean
+	/**
+	 * Say something to the operator that is not a message to the agent.
+	 *
+	 * The composer has no transcript of its own, so without this a key it
+	 * advertises can fail with nowhere to report it. Optional so the component
+	 * stays usable in isolation, but a caller that omits it re-creates the
+	 * silence this exists to end.
+	 */
+	readonly onNotice?: (text: string) => void
 }
 
 const MAX_SUGGESTIONS = 6
@@ -56,6 +65,7 @@ export function Composer({
 	userCommands = [],
 	hidden = false,
 	escapeInterrupts = false,
+	onNotice,
 }: ComposerProps) {
 	const [value, setValue] = useState<string>('')
 	const [historyIndex, setHistoryIndex] = useState<number>(-1)
@@ -163,9 +173,20 @@ export function Composer({
 				return
 			}
 			// Ctrl+V: pull an image off the clipboard and hold it as an attachment.
+			//
+			// Every outcome says something. The status bar advertises this key, so
+			// a press that produces no chip and no words is indistinguishable from
+			// a key that was never wired up — and the operator's next move differs
+			// per reason: copy an image, install a tool, or stop pressing it.
 			if (key.ctrl && input === 'v') {
-				const img = readClipboardImage()
-				if (img) setImages((p) => [...p, img])
+				const read = readClipboardImage()
+				if (read.kind === 'image') {
+					setImages((p) => [...p, read.image])
+				} else if (read.kind === 'empty') {
+					onNotice?.('No image on the clipboard. Copy one, then press Ctrl+V.')
+				} else {
+					onNotice?.(`Cannot read images from the clipboard here — ${read.detail}.`)
+				}
 				return
 			}
 			if (key.ctrl || key.meta) return

--- a/packages/cli/src/tui/__tests__/app-draft-survives.test.tsx
+++ b/packages/cli/src/tui/__tests__/app-draft-survives.test.tsx
@@ -141,7 +141,10 @@ async function turnRunningWithDraft(draft: string) {
 	harness.stdin.write('go')
 	await tick(20)
 	harness.stdin.write('\r')
-	await tick(40)
+	// Wait for the turn to actually start rather than assuming 40ms is enough.
+	// The mock streams "working" as its first delta, so its arrival is the
+	// signal that the submit was processed and the composer is free again.
+	await frameShows(harness.lastFrame, 'working')
 	harness.stdin.write(draft)
 	await frameShows(harness.lastFrame, draft)
 	expect(harness.lastFrame(), 'the draft never reached the composer').toContain(draft)

--- a/packages/cli/src/tui/__tests__/app-trust-gate.test.tsx
+++ b/packages/cli/src/tui/__tests__/app-trust-gate.test.tsx
@@ -94,6 +94,14 @@ afterEach(() => {
 	vi.restoreAllMocks()
 })
 
+/** Wait for the durable trust write, or give up. */
+async function trustedWithin(timeoutMs = 3_000): Promise<void> {
+	const started = performance.now()
+	while (trusted.length === 0 && performance.now() - started < timeoutMs) {
+		await tick(20)
+	}
+}
+
 /** Move the stubbed clock past the settle window. */
 function settle(): void {
 	nowMs += APPROVAL_SETTLE_MS + 1
@@ -102,8 +110,20 @@ function settle(): void {
 async function gateOnScreen() {
 	const harness = render(<App ctx={ctx} />)
 	mounted.push(harness)
-	await tick(60)
+	// Poll for the gate, then let its effects flush. The effect that stamps when
+	// the gate appeared runs after the commit that draws it, and the settle
+	// window is measured from that stamp — so pressing a key in the gap between
+	// "drawn" and "stamped" is measured against no stamp at all and refused.
+	// A fixed wait here made that gap load-dependent.
+	const started = performance.now()
+	while (
+		!(harness.lastFrame() ?? '').includes('Do you trust') &&
+		performance.now() - started < 3_000
+	) {
+		await tick(20)
+	}
 	expect(harness.lastFrame(), 'the trust gate never appeared').toContain('Do you trust')
+	await tick(60)
 	return harness
 }
 
@@ -137,7 +157,10 @@ describe('the trust gate', () => {
 
 		settle()
 		stdin.write('y')
-		await tick(200)
+		// Polled, not slept. A fixed wait here passed alone and failed inside the
+		// full parallel run — the same transform-load cliff this suite has met
+		// before, and a flake in the waiting rather than in what is asserted.
+		await trustedWithin()
 
 		expect(trusted).toEqual(['C:/a/folder'])
 	})

--- a/packages/cli/src/tui/__tests__/ctrl-v-says-what-happened.test.tsx
+++ b/packages/cli/src/tui/__tests__/ctrl-v-says-what-happened.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Ctrl+V reports its outcome, including the outcomes that are not an image.
+ *
+ * The status bar advertises `Ctrl+V to attach`. The handler read the clipboard,
+ * attached an image if it found one, and otherwise did nothing at all — no
+ * chip, no message, no error. So "you have not copied an image", "this machine
+ * has no clipboard tool installed", and "this key was never wired up" were the
+ * same observable event, and the operator's next move is different in each.
+ *
+ * These drive a rendered `<App>` rather than the component alone, because the
+ * composer has no transcript of its own: whether the reason reaches the screen
+ * depends on the caller passing `onNotice`, which a component test cannot see.
+ */
+
+import { render } from 'ink-testing-library'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Preferences } from '../../integrations/providers/index.js'
+import type { AgentEvent, AgentSession } from '../agent.js'
+import type { TuiContext } from '../types.js'
+
+const PREFS: Preferences = { version: 3, providers: [{ id: 'openai' }], subagents: { active: [] } }
+
+/** What the mocked clipboard returns for the next read. */
+let clipboard: import('../../integrations/clipboard/image.js').ClipboardRead = { kind: 'empty' }
+
+vi.mock('../../integrations/clipboard/image.js', () => ({
+	readClipboardImage: () => clipboard,
+}))
+
+vi.mock('../../integrations/trust/store.js', () => ({ isTrusted: () => true, trustDir: () => {} }))
+vi.mock('../../integrations/updates.js', () => ({ checkUpdates: async () => [] }))
+vi.mock('../../integrations/sessions/store.js', () => ({
+	openSessions: async () => ({ tenantId: 't' }),
+	startConversation: async () => 'conv',
+	appendMessages: async () => {},
+	listRecent: async () => [],
+	loadConversation: async () => [],
+}))
+vi.mock('../../user-commands/store.js', () => ({ discoverUserCommands: () => [] }))
+
+vi.mock('../agent.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../agent.js')>()
+	return {
+		...actual,
+		probeAgentSession: async () => ({
+			preferences: PREFS,
+			needsRepickReason: null,
+			detected: [],
+		}),
+		createAgentSession: async (): Promise<AgentSession> => ({
+			hasProvider: true,
+			providerSummary: 'a-provider',
+			modelSummary: 'a-model',
+			toolNames: [],
+			errorHint: null,
+			instructionFiles: [],
+			skippedInstructionFiles: [],
+			mcpConnected: [],
+			mcpFailed: [],
+			agentIds: [],
+			configNotices: [],
+			close: async () => {},
+			approvalLatched: () => false,
+			promptExemptTools: () => [],
+			send: async function* (): AsyncIterable<AgentEvent> {
+				yield { kind: 'done', stopReason: 'end_turn' } as AgentEvent
+			},
+		}),
+	}
+})
+
+const { App } = await import('../App.js')
+
+const ctx: TuiContext = { cwd: '/w', version: '0.0.0-test' }
+const tick = (ms = 40) => new Promise((r) => setTimeout(r, ms))
+const mounted: { unmount: () => void }[] = []
+
+async function frameShows(
+	lastFrame: () => string | undefined,
+	text: string,
+	timeoutMs = 3_000,
+): Promise<void> {
+	const started = performance.now()
+	while (!(lastFrame() ?? '').includes(text) && performance.now() - started < timeoutMs) {
+		await tick(20)
+	}
+}
+
+beforeEach(() => {
+	clipboard = { kind: 'empty' }
+})
+
+afterEach(() => {
+	for (const h of mounted) h.unmount()
+	mounted.length = 0
+	vi.restoreAllMocks()
+})
+
+async function ready() {
+	const harness = render(<App ctx={ctx} />)
+	mounted.push(harness)
+	await frameShows(harness.lastFrame, 'Type a message')
+	await tick(60)
+	return harness
+}
+
+describe('Ctrl+V with nothing to paste', () => {
+	it('says the clipboard holds no image, rather than doing nothing', async () => {
+		clipboard = { kind: 'empty' }
+		const { stdin, lastFrame } = await ready()
+
+		stdin.write('\x16') // Ctrl+V
+		await frameShows(lastFrame, 'No image on the clipboard')
+
+		expect(lastFrame(), 'the key was silent').toContain('No image on the clipboard')
+	})
+
+	it('names what is missing when the machine cannot read the clipboard at all', async () => {
+		// A different situation with a different fix, so it gets a different
+		// sentence: nothing the operator copies will help until a tool exists.
+		clipboard = { kind: 'unavailable', detail: 'install xclip (X11) or wl-clipboard (Wayland)' }
+		const { stdin, lastFrame } = await ready()
+
+		stdin.write('\x16')
+		await frameShows(lastFrame, 'Cannot read images')
+
+		const frame = lastFrame() ?? ''
+		expect(frame).toContain('Cannot read images')
+		expect(frame, 'did not say what to install').toContain('xclip')
+		expect(frame, 'blamed an empty clipboard for a missing tool').not.toContain(
+			'No image on the clipboard',
+		)
+	})
+})
+
+describe('Ctrl+V with an image', () => {
+	it('attaches it and says nothing, because the chip is the report', async () => {
+		clipboard = { kind: 'image', image: { data: 'AAAA', mediaType: 'image/png' } }
+		const { stdin, lastFrame } = await ready()
+
+		stdin.write('\x16')
+		await frameShows(lastFrame, 'Image #1')
+
+		const frame = lastFrame() ?? ''
+		expect(frame).toContain('Image #1')
+		expect(frame, 'reported a failure on the success path').not.toContain('No image')
+	})
+})


### PR DESCRIPTION
The status bar advertises `Ctrl+V to attach`. Pressing it read the clipboard, attached an image if it found one, and **otherwise did nothing at all** — no chip, no message, no error.

So three quite different situations produced one identical silence:

| What actually happened | What the operator should do |
|---|---|
| You have not copied an image | Copy one |
| This machine has no clipboard tool installed | Install `xclip` / `wl-clipboard` |
| The key was never wired up | Stop pressing it |

The next move differs in every row, and the screen gave them nothing to choose with. **An advertised key that fails silently is indistinguishable from one that does not exist.**

## The reason had to be recovered before it could be shown

`readClipboardImage()` returned a bare `null` for every failure — so there was no reason to report even if the composer had wanted to.

And on Linux the two cases are **indistinguishable after the fact**: a missing `xclip` and an empty clipboard both come back from `/bin/sh` as a non-zero exit. So the check moved to *before* the read — the only point at which they can still be told apart. macOS and Windows ship their tool with the OS, so only Linux needs the probe.

Each outcome now says which it was, and a missing tool names what to install. **The success path stays quiet** — the attachment chip is already the report, and a message beside it would be noise.

## Reporting needed a channel

The composer has no transcript of its own, so it takes an `onNotice` callback rather than growing one. Optional, so the component stays usable in isolation — and documented as re-creating this exact silence if a caller omits it.

That the caller actually passes it is the reachability half, asserted against a rendered `<App>`: a component test cannot see whether the reason reaches a screen.

## Mutation-checked

| Mutation | Result |
|---|---|
| restore the silence (the original defect) | both notice tests die; the success test survives |
| `App` drops the `onNotice` wiring | both notice tests die |

## Two more fixed waits removed — and these had stopped being flakes

`app-trust-gate` and `app-draft-survives` were failing **consistently**, not intermittently, as the suite grew.

The trust-gate one is worth naming: the gate stamps *when it appeared* in an effect that runs after the commit that draws it, and the settle window is measured from that stamp. A key pressed in the gap between "drawn" and "stamped" is measured against **no stamp at all** and correctly refused. A fixed wait made that gap load-dependent; polling for the frame and letting effects flush closes it.

**Four consecutive full runs clean** after the change.

## Checks

All six: `pnpm build` 0 · `pnpm typecheck` 0 · `audit-external-names` 0 · `check-docs` 0 · `pnpm test` 0 (four runs; cli 637 passed, 3 skipped) · `pnpm lint` 0.

## What only you can confirm

Whether the wording lands at the moment it appears. `No image on the clipboard. Copy one, then press Ctrl+V.` is what an operator sees mid-task, and I have not seen it in a real terminal.
