### PR TITLE
feat(sdk)!: a delegated agent's structured answer reaches its caller

### DIFF
--- a/.changeset/a-structured-answer-reaches-its-caller.md
+++ b/.changeset/a-structured-answer-reaches-its-caller.md
@@ -1,0 +1,45 @@
+---
+'@namzu/sdk': major
+---
+
+**A delegated agent's structured output now reaches its caller.** A supervisor
+that fanned out to five schema-configured specialists received five *strings* —
+the model had to re-parse prose it had just caused to be serialized, and the
+host got no typed handle on any child's answer.
+
+Nothing was missing from the runtime. `Run.structuredOutput` has carried the
+parsed, validated value throughout, and the eval harness reads it correctly;
+every ergonomic boundary above it dropped the value three lines from its
+caller. This connects them:
+
+- **`BaseAgentResult.structuredOutput`** — archetype results carry the value,
+  so `ReactiveAgent.run()` no longer returns `result?: string` and nothing else.
+- **`runAgent` can ask for a schema.** It never forwarded the config, so the
+  most convenient way into the kernel was the one way that could not produce a
+  typed answer. The validated value comes back on `RunAgentResult.structuredOutput`.
+- **Both delegation surfaces return the object.** `Agent` and `create_task`
+  each prefer the child's structured answer over its prose. Both, because the
+  last time a rule lived at one delegation site only, `create_task` shipped
+  without the success check `Agent` already had.
+- **It survives a reload.** `run.json` now persists `structuredOutput`, so a run
+  fetched by id still has the thing it was run for.
+
+**What is major: `run.result` now holds the serialized structured value.**
+Previously the structured exit deliberately did not set it, and result
+resolution walks back from the message tail and stops at the first
+non-assistant message — so a structured run, whose last assistant turn is a tool
+call rather than prose, kept whatever text an *earlier* turn happened to
+produce. A host reading `run.result` got a sentence from the middle of the run
+presented as its answer.
+
+The other two options are worse. Leaving it is a stale value read as a fact,
+which is the defect. Clearing it makes a run that plainly answered report no
+answer, so a host testing `if (run.result)` concludes nothing was produced.
+Serializing is also what every text-shaped consumer needed anyway — the
+transcript, `Run.result`, and both delegation tools handing a child's answer to
+a parent model — and doing it once, where the value is known, replaces three
+slightly different serializations.
+
+**If you relied on the old behaviour**, read `run.messages` for the model's last
+prose; `run.result` on a structured run is now `JSON.stringify(structuredOutput)`.
+Runs without a schema are unchanged.

--- a/docs/sdk/tools/README.md
+++ b/docs/sdk/tools/README.md
@@ -333,7 +333,28 @@ const run = await runToCompletion(
 )
 
 run.structuredOutput // { verdict, findings } — already validated
+run.result           // the same value, serialized
 ```
+
+`run.result` carries `JSON.stringify(structuredOutput)` on a structured run. It used to hold whatever prose an *earlier* turn produced — result resolution walks back from the message tail and stops at the first non-assistant message, and a structured run's last assistant turn is a tool call — so a host reading it got a sentence from the middle of the run presented as the answer. Read `run.messages` if you want the model's last prose.
+
+### It reaches a caller, not just the run
+
+The same value comes back through every boundary above `query()`:
+
+```ts
+// The front door can ask for a schema, and hands the parsed value back.
+const { structuredOutput } = await runAgent({
+  provider, model, prompt,
+  structuredOutput: { schema },
+})
+```
+
+- `BaseAgentResult.structuredOutput` — so an archetype's `run()` returns the object, not only text.
+- **Both delegation surfaces** — `Agent` and `create_task` return a schema-configured child's *object* to the parent, rather than the prose beside it. A supervisor fanning out to specialists gets typed answers instead of strings its model has to re-parse.
+- `run.json` persists it, so a run fetched by id still carries its answer.
+
+A child with no schema is unchanged: its prose is still what the parent receives.
 
 A model that answers in prose instead is re-prompted. If it still will not comply within `maxRetries`, the run settles with `stopReason: 'structured_output_failed'` rather than grinding against `maxIterations` — you get a clear failure instead of an expensive one.
 

--- a/packages/sdk/src/agents/ReactiveAgent.ts
+++ b/packages/sdk/src/agents/ReactiveAgent.ts
@@ -157,6 +157,7 @@ export class ReactiveAgent extends AbstractAgent<ReactiveAgentConfig, ReactiveAg
 			durationMs: Date.now() - startTime,
 			messages: run.messages,
 			result: run.result,
+			structuredOutput: run.structuredOutput,
 			lastError: run.lastError,
 			toolCallCount,
 		}

--- a/packages/sdk/src/agents/__tests__/a-structured-answer-reaches-the-caller.test.ts
+++ b/packages/sdk/src/agents/__tests__/a-structured-answer-reaches-the-caller.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The front door can ask for a schema, and gets the parsed value back.
+ *
+ * `runAgent` never forwarded `structuredOutput`, so the most convenient way
+ * into the kernel was the one way that could not produce a typed answer. The
+ * runtime has parsed and validated these throughout — the eval harness reads
+ * `run.structuredOutput` correctly, which is the proof the value is real and
+ * only the ergonomic boundaries dropped it.
+ *
+ * Driven end-to-end through `runAgent` rather than against the parser: the
+ * parser was never the broken part, and a test on it would pass against every
+ * version of this defect.
+ */
+
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { MockLLMProvider } from '../../provider/mock.js'
+import { ToolRegistry } from '../../registry/tool/execute.js'
+import { runAgent } from '../runAgent.js'
+
+const SCHEMA = z.object({ city: z.string(), degrees: z.number() })
+const ANSWER = { city: 'Ankara', degrees: 21 }
+
+/**
+ * A model that calls the structured-output tool with a valid payload.
+ *
+ * The tool name is the kernel's own constant rather than a literal, so a rename
+ * breaks this test loudly instead of leaving it driving a tool that no longer
+ * exists.
+ */
+async function runWithSchema(workingDirectory: string) {
+	const { STRUCTURED_OUTPUT_TOOL_NAME } = await import('../../tools/builtins/structuredOutput.js')
+	const provider = new MockLLMProvider({
+		turns: [
+			{
+				toolCalls: [
+					{
+						id: 'so1',
+						name: STRUCTURED_OUTPUT_TOOL_NAME,
+						rawArguments: JSON.stringify(ANSWER),
+					},
+				],
+			},
+			{ text: 'done' },
+		],
+	})
+	return runAgent({
+		provider,
+		model: 'm',
+		prompt: 'what is the weather',
+		tools: new ToolRegistry(),
+		workingDirectory,
+		maxIterations: 4,
+		structuredOutput: { schema: SCHEMA },
+	})
+}
+
+describe('runAgent with a schema', () => {
+	it('returns the parsed object, on the result and on the run', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'namzu-so-'))
+		const out = await runWithSchema(dir)
+
+		// Both, because they are two different promises to a caller: `run` is the
+		// durable record and `structuredOutput` is the ergonomic handle that did
+		// not exist. A fix that populated only the run would leave the front door
+		// exactly as unusable as it was.
+		expect(out.run.structuredOutput).toEqual(ANSWER)
+		expect(out.structuredOutput).toEqual(ANSWER)
+	})
+
+	it('puts the serialized answer on `output` instead of stale prose', async () => {
+		// The changed default. `resolveResult` walks back from the message tail
+		// and stops at the first non-assistant message, so a structured run — whose
+		// last assistant turn is a tool call — used to keep whatever text an
+		// earlier turn produced, or nothing at all. Either way the caller read
+		// something that was not the answer.
+		const dir = await mkdtemp(join(tmpdir(), 'namzu-so-'))
+		const out = await runWithSchema(dir)
+
+		expect(out.output).toBe(JSON.stringify(ANSWER))
+		expect(out.run.result).toBe(JSON.stringify(ANSWER))
+	})
+
+	it('leaves `output` as prose when no schema was asked for', async () => {
+		// The preservation half: the serialization must not reach an ordinary run.
+		const dir = await mkdtemp(join(tmpdir(), 'namzu-so-'))
+		const provider = new MockLLMProvider({ turns: [{ text: 'just prose' }] })
+
+		const out = await runAgent({
+			provider,
+			model: 'm',
+			prompt: 'hello',
+			tools: new ToolRegistry(),
+			workingDirectory: dir,
+			maxIterations: 2,
+		})
+
+		expect(out.output).toBe('just prose')
+		expect(out.structuredOutput).toBeUndefined()
+	})
+})

--- a/packages/sdk/src/agents/runAgent.ts
+++ b/packages/sdk/src/agents/runAgent.ts
@@ -5,6 +5,7 @@ import type { Message } from '../types/message/index.js'
 import type { LLMProvider, ReasoningEffort, ThinkingConfig } from '../types/provider/index.js'
 import type { Run, RunEventListener } from '../types/run/index.js'
 import type { Skill } from '../types/skills/index.js'
+import type { StructuredOutputConfig } from '../types/structured-output/index.js'
 import type { ToolRegistryContract } from '../types/tool/index.js'
 import type { VerificationGateConfig } from '../types/verification/index.js'
 import {
@@ -93,6 +94,17 @@ export interface RunAgentOptions extends AgentIdentity {
 	temperature?: number
 
 	/**
+	 * Demand a schema-validated answer instead of prose.
+	 *
+	 * The front door could not ask for one at all: the runtime has supported
+	 * structured output throughout and this function never forwarded the
+	 * config, so the single most convenient way into the kernel was the one way
+	 * that could not produce a typed answer. Present, the validated value comes
+	 * back on {@link RunAgentResult.structuredOutput} and on `run`.
+	 */
+	structuredOutput?: StructuredOutputConfig
+
+	/**
 	 * Extended-thinking request and response-effort level, forwarded on every
 	 * model call.
 	 *
@@ -121,6 +133,16 @@ export interface RunAgentOptions extends AgentIdentity {
 export interface RunAgentResult {
 	/** The model's final text, or `undefined` if it produced none. */
 	readonly output: string | undefined
+
+	/**
+	 * The schema-validated answer, when {@link RunAgentOptions.structuredOutput}
+	 * asked for one and the model produced it.
+	 *
+	 * Mirrors `run.structuredOutput` the way {@link output} mirrors
+	 * `run.result` — the whole point of this shape is that the two answers a
+	 * run can give are reachable without unpacking the run.
+	 */
+	readonly structuredOutput?: unknown
 
 	/** The full run — usage, cost, steps, stop reason, every message. */
 	readonly run: Run
@@ -226,10 +248,11 @@ export async function runAgent(options: RunAgentOptions): Promise<RunAgentResult
 			...(options.signal ? { signal: options.signal } : {}),
 			...(options.skills ? { skills: options.skills } : {}),
 			...(options.verificationGate ? { verificationGate: options.verificationGate } : {}),
+			...(options.structuredOutput ? { structuredOutput: options.structuredOutput } : {}),
 			...identity,
 		},
 		options.listener,
 	)
 
-	return { output: run.result, run, identity }
+	return { output: run.result, structuredOutput: run.structuredOutput, run, identity }
 }

--- a/packages/sdk/src/manager/run/persistence.ts
+++ b/packages/sdk/src/manager/run/persistence.ts
@@ -266,8 +266,36 @@ export class RunPersistence {
 		this.resultOverridden = true
 	}
 
+	/**
+	 * Record the schema-validated answer, and make `result` agree with it.
+	 *
+	 * `result` used to be left alone here, and the consequence was not "empty"
+	 * but "wrong": `resolveResult` walks back from the message tail and stops at
+	 * the first non-assistant message, so a structured run — whose last
+	 * assistant turn is a tool call, not prose — kept whatever text an EARLIER
+	 * turn happened to produce. A host reading `run.result` got a sentence from
+	 * the middle of the run presented as its answer.
+	 *
+	 * Three options, and the other two are worse:
+	 *
+	 *  - leave it: a stale value read as a fact, which is the defect;
+	 *  - clear it: a run that plainly answered reports no answer, so a host
+	 *    testing `if (run.result)` concludes nothing was produced;
+	 *  - serialize the structured value into it, which is what this does.
+	 *
+	 * The serialization is not an invention. Every text-shaped consumer — the
+	 * transcript, `Run.result`, both delegation tools handing a child's answer
+	 * back to a parent model — needs the answer as a string, and each of them
+	 * would otherwise serialize it again, differently. One serialization, at the
+	 * moment the value is known.
+	 *
+	 * Sticky, via `setResult`: `resolveResult` runs again when the run settles,
+	 * and without the override flag it would walk the tail and put the stale
+	 * prose back.
+	 */
 	setStructuredOutput(value: unknown): void {
 		this.run.structuredOutput = value
+		this.setResult(typeof value === 'string' ? value : JSON.stringify(value))
 	}
 
 	/**

--- a/packages/sdk/src/store/run/disk.ts
+++ b/packages/sdk/src/store/run/disk.ts
@@ -136,6 +136,12 @@ export class RunDiskStore {
 			messageCount: run.messages.length,
 		}
 
+		// The schema-validated answer belongs in the durable record for the same
+		// reason `result` does: a run reloaded by id that has lost its answer has
+		// lost the thing it was run for. Written only when present, so a run that
+		// asked for no schema carries no key rather than an explicit `undefined`.
+		if (run.structuredOutput !== undefined) meta.structuredOutput = run.structuredOutput
+
 		if (run.parentRunId) meta.parentRunId = run.parentRunId
 		if (run.depth !== undefined && run.depth > 0) meta.depth = run.depth
 

--- a/packages/sdk/src/tools/coordinator/__tests__/a-delegated-answer-keeps-its-shape.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/a-delegated-answer-keeps-its-shape.test.ts
@@ -1,0 +1,158 @@
+/**
+ * A schema-configured child answers with an OBJECT, and both delegation
+ * surfaces used to hand the parent its prose instead.
+ *
+ * The value was never missing — `Run.structuredOutput` has carried it
+ * throughout, and the eval harness reads it correctly, which is the proof the
+ * parser works and only the ergonomic boundaries drop it. A supervisor fanning
+ * out to five specialists received five strings and had to make the model
+ * re-parse what it had just caused to be serialized.
+ *
+ * Both surfaces are driven because that is this file's whole subject: the
+ * sibling comment in `coordinator/index.ts` records what happened last time a
+ * rule lived at one delegation site only — `create_task` shipped without the
+ * success check that `Agent` already had, because a review caught one site and
+ * nothing carried the answer to the other.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import type { TaskGateway, TaskHandle } from '../../../types/agent/gateway.js'
+import type { TaskId } from '../../../types/ids/index.js'
+import type { ToolContext, ToolDefinition } from '../../../types/tool/index.js'
+import { buildAgentTool } from '../agent.js'
+import { buildCoordinatorTools } from '../index.js'
+
+const taskId = 'task_child' as TaskId
+
+/** The serialized form the child's structured answer must reach the parent as. */
+const SERIALIZED = JSON.stringify({ orderId: 'A-1', refunded: true, amountUsd: 42 })
+
+function makeContext(): ToolContext {
+	return {
+		runId: 'run_parent' as never,
+		workingDirectory: '/tmp/test',
+		abortSignal: new AbortController().signal,
+		env: {},
+		log: () => {},
+	}
+}
+
+/** A child that finished, carrying both a prose result and a structured one. */
+function completedChild(over: Partial<Record<string, unknown>> = {}): TaskHandle {
+	return {
+		taskId,
+		agentId: 'refunds',
+		createdAt: 0,
+		completedAt: 1,
+		state: 'completed',
+		result: {
+			status: 'completed',
+			// Prose the model happened to emit earlier in the child's run. Before
+			// this change it was what the parent received.
+			result: 'I have finished looking into the refund.',
+			structuredOutput: { orderId: 'A-1', refunded: true, amountUsd: 42 },
+			...over,
+		},
+	} as unknown as TaskHandle
+}
+
+function fakeGateway(completed: TaskHandle): TaskGateway {
+	return {
+		async createTask() {
+			return completed
+		},
+		async waitForTask() {
+			return completed
+		},
+		async continueTask() {},
+		cancelTask() {},
+		getTask() {
+			return completed
+		},
+		listTasks() {
+			return [completed]
+		},
+		onTaskCompleted() {
+			return () => {}
+		},
+	}
+}
+
+const AGENT_CONFIG = { workingDirectory: '/tmp/test', allowedAgentIds: ['refunds'] }
+
+describe('the Agent tool returns the child’s structured answer', () => {
+	it('hands the parent the object, not the prose beside it', async () => {
+		const tool = buildAgentTool({
+			gateway: fakeGateway(completedChild()),
+			...AGENT_CONFIG,
+		})
+
+		const out = await tool.execute(
+			{ description: 'refund', prompt: 'refund order A-1', subagent_type: 'refunds' },
+			makeContext(),
+		)
+
+		expect(out.success).toBe(true)
+		// Read INSIDE the untrusted envelope. A delegated answer is framed before
+		// it reaches the parent model — which is correct and predates this change
+		// — so the payload is what this file is about, not the wrapper.
+		expect(out.output).toContain(SERIALIZED)
+		// The prose is not what the parent is told. Asserting its ABSENCE is the
+		// half that fails against the old behaviour — a test that only checked
+		// the object was parseable would pass on a string that contained both.
+		expect(out.output).not.toContain('finished looking into')
+	})
+
+	it('still returns prose for a child with no schema', async () => {
+		// The preservation case. A rule that preferred the structured value
+		// unconditionally would return an empty string for every ordinary child.
+		const tool = buildAgentTool({
+			gateway: fakeGateway(completedChild({ structuredOutput: undefined })),
+			...AGENT_CONFIG,
+		})
+
+		const out = await tool.execute(
+			{ description: 'refund', prompt: 'refund order A-1', subagent_type: 'refunds' },
+			makeContext(),
+		)
+
+		expect(out.success).toBe(true)
+		expect(out.output).toContain('I have finished looking into the refund.')
+	})
+})
+
+describe('the task tools return the child’s structured answer', () => {
+	function taskTool(name: string, completed: TaskHandle): ToolDefinition {
+		const tools = buildCoordinatorTools({
+			gateway: fakeGateway(completed),
+			...AGENT_CONFIG,
+		} as never)
+		const found = tools.find((t) => t.name === name)
+		if (!found) throw new Error(`no ${name} tool in the coordinator set`)
+		return found
+	}
+
+	it('create_task hands the parent the object', async () => {
+		const tool = taskTool('create_task', completedChild())
+
+		const out = await tool.execute(
+			{ agent_id: 'refunds', prompt: 'refund order A-1', description: 'refund' } as never,
+			makeContext(),
+		)
+
+		expect(out.output).toContain(SERIALIZED)
+		expect(out.output).not.toContain('finished looking into')
+	})
+
+	it('create_task still returns prose for a child with no schema', async () => {
+		const tool = taskTool('create_task', completedChild({ structuredOutput: undefined }))
+
+		const out = await tool.execute(
+			{ agent_id: 'refunds', prompt: 'refund order A-1', description: 'refund' } as never,
+			makeContext(),
+		)
+
+		expect(out.output).toContain('I have finished looking into the refund.')
+	})
+})

--- a/packages/sdk/src/tools/coordinator/agent.ts
+++ b/packages/sdk/src/tools/coordinator/agent.ts
@@ -175,12 +175,27 @@ export function buildAgentTool(opts: AgentToolOptions): ToolDefinition {
 			// the other one.
 			const succeeded = taskSucceeded(completed)
 
+			// A schema-configured child answers with an OBJECT, and this used to
+			// hand the parent model the child's prose instead — so a supervisor
+			// fanning out to five specialists got five strings and had to
+			// re-parse what it had just caused to be serialized.
+			//
+			// `structuredOutput` wins over `result` when present, and reading it
+			// first is what makes that true. They agree by construction anyway:
+			// `setStructuredOutput` serializes the value into `result`, so this
+			// preference is about which field is authoritative rather than about
+			// which string is produced.
+			const structured = completed.result?.structuredOutput
 			const resultText =
-				typeof completed.result?.result === 'string'
-					? completed.result.result
-					: completed.result?.result !== undefined
-						? JSON.stringify(completed.result.result)
-						: ''
+				structured !== undefined
+					? typeof structured === 'string'
+						? structured
+						: JSON.stringify(structured)
+					: typeof completed.result?.result === 'string'
+						? completed.result.result
+						: completed.result?.result !== undefined
+							? JSON.stringify(completed.result.result)
+							: ''
 
 			if (!succeeded) {
 				const detail =

--- a/packages/sdk/src/tools/coordinator/index.ts
+++ b/packages/sdk/src/tools/coordinator/index.ts
@@ -288,6 +288,26 @@ function readPositiveIntEnv(key: string, fallback: number): number {
 	return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback
 }
 
+/**
+ * The answer a delegated child produced, as the string a parent model reads.
+ *
+ * One function because two delegation surfaces ask the same question, and the
+ * comment on the other one records what happens when a rule lives at one site
+ * only: create_task shipped without the success check that agent already had.
+ *
+ * A schema-configured child answers with an object. Reading structuredOutput
+ * first is what stops a supervisor receiving prose it then has to re-parse.
+ */
+function delegatedAnswer(
+	result: { structuredOutput?: unknown; result?: string } | undefined,
+): string | undefined {
+	const structured = result?.structuredOutput
+	if (structured !== undefined) {
+		return typeof structured === 'string' ? structured : JSON.stringify(structured)
+	}
+	return result?.result
+}
+
 export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefinition[] {
 	const {
 		gateway,
@@ -614,7 +634,7 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 			// the work had been done.
 			const success = taskSucceeded(completed)
 			const resultText =
-				completed.result?.result ??
+				delegatedAnswer(completed.result) ??
 				completed.result?.lastError ??
 				`Task finished with state: ${failureLabel(completed)}`
 
@@ -744,7 +764,7 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 
 			const success = completed.state === 'completed'
 			const resultText =
-				completed.result?.result ??
+				delegatedAnswer(completed.result) ??
 				completed.result?.lastError ??
 				`Task finished with state: ${completed.state}`
 			return {

--- a/packages/sdk/src/types/agent/base.ts
+++ b/packages/sdk/src/types/agent/base.ts
@@ -186,6 +186,26 @@ export interface BaseAgentResult {
 	durationMs: number
 	messages: Message[]
 	result?: string
+	/**
+	 * The schema-validated answer, when the run was configured to produce one.
+	 *
+	 * `Run.structuredOutput` has carried this all along and every ergonomic
+	 * boundary above it dropped the value three lines from its caller: an
+	 * archetype's result literal did not copy it, `runAgent` did not even
+	 * forward the config that produces it, and both delegation tools handed a
+	 * parent the child's prose. So a supervisor fanning out to five
+	 * schema-configured specialists received five strings and had to make the
+	 * model re-parse what it had just caused to be serialized.
+	 *
+	 * `unknown` rather than a generic, deliberately. The schema lives on the
+	 * run's config and a result type parameter would have to be threaded
+	 * through every archetype, both delegation tools and the task record to
+	 * reach here — and at the delegation boundary the parent does not hold the
+	 * child's schema anyway, so the parameter would be `unknown` again at the
+	 * only place it was wanted. Narrow it at the call site with the schema you
+	 * already have.
+	 */
+	structuredOutput?: unknown
 	lastError?: string
 }
 


### PR DESCRIPTION
Gap-plan item 1 — the highest ratio in the plan, and the plan's own framing is why: **nothing here was missing from the runtime.** `Run.structuredOutput` has carried the parsed, validated value throughout, and the eval harness reads it correctly. Every ergonomic boundary above it dropped the value three lines from its caller.

A supervisor fanning out to five schema-configured specialists received five *strings*. The model had to re-parse prose it had just caused to be serialized, and the host got no typed handle on any child's answer.

## What is now connected

- **`BaseAgentResult.structuredOutput`** — an archetype's `run()` returns the object, not `result?: string` and nothing else.
- **`runAgent` can ask for a schema.** It never forwarded the config, so the most convenient way into the kernel was the one way that could not produce a typed answer. The value comes back on `RunAgentResult.structuredOutput`, mirroring the way `output` mirrors `run.result`.
- **Both delegation surfaces return the object** — `Agent` and `create_task`.
- **`run.json` persists it**, so a run fetched by id still carries the thing it was run for.

Both surfaces, deliberately and with a mutation each. The sibling comment in `coordinator/index.ts` records what happened the last time a rule lived at one delegation site only: `create_task` shipped without the success check `Agent` already had, because a review caught one site and nothing carried the answer to the other.

## The decision the plan flagged and did not make

**`run.result` now holds the serialized structured value.** That is the major.

The structured exit deliberately did not call `setResult`, and result resolution walks back from the message tail and stops at the first non-assistant message. A structured run's last assistant turn is a *tool call*, not prose — so `run.result` kept whatever text an **earlier** turn happened to produce. A host reading it got a sentence from the middle of the run presented as the run's answer.

Three options; the other two are worse:

- **leave it** — a stale value read as a fact, which is the defect itself;
- **clear it** — a run that plainly answered reports no answer, so a host testing `if (run.result)` concludes nothing was produced;
- **serialize it** — which is additionally what every text-shaped consumer needed anyway. The transcript, `Run.result`, and both delegation tools handing a child's answer to a parent model each need the answer as a string; doing it once where the value is known replaces three slightly different serializations.

A caller who wants the model's last prose reads `run.messages`. Runs without a schema are untouched, and a test pins that.

## `unknown`, not a generic

A result type parameter would have to thread through every archetype, both delegation tools and the task record to reach `BaseAgentResult` — and at the delegation boundary the parent does not hold the child's schema, so it would arrive back as `unknown` at the one place it was wanted. Narrow at the call site with the schema you already have.

## Mutations

| # | Mutation | Killed by |
|---|---|---|
| M23 | `Agent` ignores the child's structured answer | 1 — its own case only |
| M24 | the task tools ignore it | 1 — its own case only |
| M25 | the structured exit stops setting `result` | 1 |
| M26 | `runAgent` stops forwarding the config | 2 |

M23 and M24 killing *different* single tests is the result worth reading: it is what proves the two delegation surfaces are independently covered rather than one test standing in for both.

## Found while testing

**A delegated answer is already wrapped in the untrusted envelope** before it reaches the parent model. The tests assert through the wrapper rather than around it. That narrows gap-plan item 2: the envelope work there is needed for **connector** output only, not for agent results.

## Gate

All six: `pnpm build`, `pnpm typecheck`, `pnpm lint` clean; `pnpm test` exit 0 — sdk 333 files / 2951 passed / 7 skipped, cli 68 files / 637 passed / 3 skipped. `audit-external-names.mjs` exits 0. `verify-public-surface.mjs` reports the surface intact. `pnpm docs:check` reports 0 problems.

One process note: a `git checkout … || …` fallback silently landed me on the previous branch, and the CLI suite failed two render-loop tests from that stale base. I checked it against `main` rather than assuming, confirmed `main` already carried the answering-turn change under a different SHA, and re-homed this work on `origin/main`. The two failures were the base, not this change — but the check is the only reason I can say so.
