### PR TITLE
feat(sdk): a redaction is not a tool failure

### DIFF
--- a/.changeset/a-redaction-is-not-a-failure.md
+++ b/.changeset/a-redaction-is-not-a-failure.md
@@ -1,0 +1,39 @@
+---
+'@namzu/sdk': minor
+---
+
+**A tool result can now be sanitized without being reported as a failure.**
+`PluginHookResult` gains `{ action: 'replace', output, content? }` for
+`post_tool_use`.
+
+The substitution seam already existed and was typed as a failure channel: the
+only way a hook could change what the model sees was `action: 'error'`, which
+prefixes `Error: ` and sets the error flag. So redacting a credential out of a
+**successful** result was delivered to the model as a tool failure — and a model
+told a call failed routes around it, retrying it or reporting to the user that
+it did not work. Redaction was reachable and unusable.
+
+`error` says the call went wrong. `replace` says the call went right and the
+model may not see all of it:
+
+- the error flag follows the **tool**, not the hook, so a successful call stays
+  successful and a failed one stays failed even if a hook rewrites its message;
+- no `Error: ` prefix;
+- **rich content survives**, because the common case is redacting text from a
+  result whose image is unaffected. A hook that needs the blocks gone passes
+  `content: []` — and a hook redacting a secret that also appears in an image
+  must, since the replace cannot inspect what it is preserving.
+
+`modify` was not reused: it carries `input` and belongs to the pre-call hooks,
+so one action would have meant two things depending on where it was returned.
+`replace` is rejected on `pre_tool_use` and on the lifecycle events — loudly,
+because a hook author who returned it there meant to redact something and would
+otherwise watch the secret go through.
+
+**Minor rather than major**, deliberately, and here is the reasoning to
+overrule if you disagree: `PluginHookResult` is a type plugin authors
+**produce** and the SDK consumes, so widening it cannot break an author's
+switch — there is nothing for them to switch over. That is the opposite
+direction from the `RunEvent` widening in 12.0.0, which went major because
+consumers map every member exhaustively. The four exhaustive switches the
+compiler named for this change are all inside this package.

--- a/docs/sdk/integrations/plugins.md
+++ b/docs/sdk/integrations/plugins.md
@@ -205,6 +205,39 @@ Hook events currently available:
 - `iteration_start`
 - `iteration_end`
 
+### Sanitizing a tool result without failing the call
+
+A `post_tool_use` hook returns `{ action: 'replace', output }` to change what the model sees while the call still stands as successful:
+
+```ts
+{
+  event: 'post_tool_use',
+  handler: async ({ toolResult }) => {
+    const cleaned = redact(toolResult.output)
+    return cleaned === toolResult.output
+      ? { action: 'continue' }
+      : { action: 'replace', output: cleaned }
+  },
+}
+```
+
+This is the difference between the two substitution actions:
+
+| | `error` | `replace` |
+| --- | --- | --- |
+| model sees | `Error: <message>` | your `output`, verbatim |
+| `isError` | `true` | follows the tool — `false` on a successful call |
+| rich content | dropped | **preserved** |
+
+Before `replace` existed the only way to change an output was `error`, so redacting a credential arrived at the model as a **tool failure** — and a model told a call failed routes around it, retrying it or reporting to the user that it did not work.
+
+Two rules worth knowing:
+
+- **Rich content survives a replace.** The common case is redacting text from a result whose image is unaffected. A hook that needs the blocks gone passes `content: []` — and a hook redacting a secret that *also* appears in an image must, because the replace cannot inspect what it is preserving.
+- **A replace cannot promote a failure.** A tool that returned `success: false` stays an error even if a hook rewrites its message. The tool decides whether the work happened; the hook decides what may be shown.
+
+`replace` is rejected on `pre_tool_use` — there is no result to replace yet — and on the lifecycle events, loudly rather than silently, so a hook author who meant to redact something finds out instead of watching the secret go through.
+
 ### What a model-call hook is shown
 
 `pre_llm_call` carries `context.request` — the call the run is about to make — and `post_llm_call` carries `context.response`:

--- a/packages/sdk/src/runtime/query/__tests__/a-redaction-is-not-a-failure.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/a-redaction-is-not-a-failure.test.ts
@@ -1,0 +1,196 @@
+/**
+ * A tool result can be sanitized without the call being reported as failed.
+ *
+ * The substitution seam existed and was typed as a failure channel: the only
+ * way a `post_tool_use` hook could change what the model sees was
+ * `action: 'error'`, which prefixes `Error: ` and sets the error flag. So
+ * redacting a credential out of a SUCCESSFUL result arrived at the model as a
+ * tool failure — and a model told a call failed routes around it: retries it,
+ * or reports to the user that it did not work.
+ *
+ * Every assertion here reads the `ToolCallOutcome` the executor produces,
+ * because that is what becomes the `tool_result` the model actually receives.
+ * Asserting that the hook ran, or that the manager returned the action, would
+ * pass against every version of this defect.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { ToolRegistry } from '../../../registry/tool/execute.js'
+import { ActivityStore } from '../../../store/activity/memory.js'
+import type { ToolCall } from '../../../types/message/index.js'
+import type { PluginHookResult } from '../../../types/plugin/index.js'
+import { ToolExecutor } from '../executor.js'
+
+const SECRET = 'sk-live-11112222333344445555'
+const REDACTED = 'token: [redacted]'
+
+function toolsThatReturn(result: {
+	success: boolean
+	output: string
+	content?: unknown
+}): ToolRegistry {
+	const tools = new ToolRegistry()
+	tools.register({
+		name: 'fetch_config',
+		description: 'Returns configuration.',
+		inputSchema: z.object({}),
+		execute: async () => result as never,
+	})
+	return tools
+}
+
+/**
+ * A plugin manager stub that returns one hook result for `post_tool_use`.
+ *
+ * Only the shape the executor consumes: it calls `executeHooks(event, ctx,
+ * emit)` and reads the array back. A fuller fake would be a second
+ * implementation of the manager to keep in agreement with the first.
+ */
+function managerReturning(event: string, results: PluginHookResult[]) {
+	return {
+		async executeHooks(e: string) {
+			return e === event ? results : []
+		},
+	} as never
+}
+
+function call(): ToolCall {
+	return {
+		id: 'call_1',
+		type: 'function',
+		function: { name: 'fetch_config', arguments: '{}' },
+	} as ToolCall
+}
+
+async function runWith(
+	tools: ToolRegistry,
+	hookResults: PluginHookResult[],
+): Promise<{ output: string; isError?: boolean; content?: unknown }> {
+	const stub = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }
+	const logger = { ...stub, child: () => ({ ...stub, child: () => stub }) }
+	const executor = new ToolExecutor(
+		{
+			tools,
+			runId: 'run_redact' as never,
+			workingDirectory: process.cwd(),
+			permissionMode: 'auto',
+			env: {},
+			abortSignal: new AbortController().signal,
+			pluginManager: managerReturning('post_tool_use', hookResults),
+		} as never,
+		new ActivityStore(
+			'run_redact' as never,
+			{
+				enabled: true,
+				trackToolCalls: true,
+			} as never,
+		),
+		(async () => {}) as never,
+		logger as never,
+	)
+
+	const batch = await executor.executeBatch({
+		id: 'r',
+		model: 'm',
+		message: { role: 'assistant', content: null, toolCalls: [call()] },
+		finishReason: 'tool_calls',
+		usage: {
+			promptTokens: 0,
+			completionTokens: 0,
+			totalTokens: 0,
+			cachedTokens: 0,
+			cacheWriteTokens: 0,
+		},
+	} as never)
+	const outcome = batch.results[0]
+	if (!outcome) throw new Error('the executor produced no outcome')
+	return outcome
+}
+
+describe('a post-tool hook that replaces the output', () => {
+	it('does not report the successful call as an error', async () => {
+		const outcome = await runWith(toolsThatReturn({ success: true, output: SECRET }), [
+			{ action: 'replace', output: REDACTED },
+		])
+
+		// The three halves of the defect, each asserted. The `Error:` check is
+		// the one that fails against a fix which cleared the flag and left the
+		// prefix — the model reads the text, not the field.
+		expect(outcome.isError).toBeFalsy()
+		expect(outcome.output).toBe(REDACTED)
+		expect(outcome.output).not.toContain('Error:')
+	})
+
+	it('keeps the secret out of what the model is given', async () => {
+		// The point of the feature, stated as the property rather than as the
+		// mechanism: whatever else happens, the credential is not in the result.
+		const outcome = await runWith(toolsThatReturn({ success: true, output: SECRET }), [
+			{ action: 'replace', output: REDACTED },
+		])
+
+		expect(outcome.output).not.toContain(SECRET)
+	})
+
+	it('preserves an image block the redaction did not touch', async () => {
+		// A screenshot beside a redacted line is still a screenshot. Dropping it
+		// was the old behaviour for every override, and it made the model reason
+		// as though the tool had returned text only.
+		const image = [{ type: 'image', data: 'AAAA', mimeType: 'image/png' }]
+		const outcome = await runWith(
+			toolsThatReturn({ success: true, output: SECRET, content: image }),
+			[{ action: 'replace', output: REDACTED }],
+		)
+
+		expect(outcome.content).toBeDefined()
+	})
+
+	it('drops content when the hook replaces it explicitly', async () => {
+		// The escape hatch for a secret that is also in the image. `content: []`
+		// is a decision the hook made, not an omission.
+		const image = [{ type: 'image', data: 'AAAA', mimeType: 'image/png' }]
+		const outcome = await runWith(
+			toolsThatReturn({ success: true, output: SECRET, content: image }),
+			[{ action: 'replace', output: REDACTED, content: [] }],
+		)
+
+		expect(outcome.content).toEqual([])
+	})
+})
+
+describe('the failure channel still reports failures', () => {
+	it('an error override keeps the flag and the prefix', async () => {
+		// The preservation case. A change that made every override succeed would
+		// pass every test above and silently turn real failures into successes.
+		const outcome = await runWith(toolsThatReturn({ success: true, output: 'fine' }), [
+			{ action: 'error', message: 'policy violation' },
+		])
+
+		expect(outcome.isError).toBe(true)
+		expect(outcome.output).toContain('Error:')
+		expect(outcome.output).toContain('policy violation')
+	})
+
+	it('an error override still drops rich content', async () => {
+		const image = [{ type: 'image', data: 'AAAA', mimeType: 'image/png' }]
+		const outcome = await runWith(
+			toolsThatReturn({ success: true, output: 'fine', content: image }),
+			[{ action: 'error', message: 'policy violation' }],
+		)
+
+		expect(outcome.content).toBeUndefined()
+	})
+
+	it('a tool that genuinely failed stays failed through a replace', async () => {
+		// A hook may sanitize an error message too, and doing so must not
+		// promote the call to a success — the tool, not the hook, decides
+		// whether the work happened.
+		const outcome = await runWith(toolsThatReturn({ success: false, output: SECRET }), [
+			{ action: 'replace', output: REDACTED },
+		])
+
+		expect(outcome.isError).toBe(true)
+		expect(outcome.output).toBe(REDACTED)
+	})
+})

--- a/packages/sdk/src/runtime/query/executor.ts
+++ b/packages/sdk/src/runtime/query/executor.ts
@@ -144,6 +144,20 @@ export interface ToolExecutorConfig {
 	repairToolCall?: RepairToolCall
 }
 
+/**
+ * What a `post_tool_use` hook decided to show the model instead.
+ *
+ * `isError` is the field this type exists for. The override used to be a bare
+ * string, so the executor had no way to tell "the call failed" from "the call
+ * succeeded and the model may not see all of it" — and it assumed the first,
+ * which turned every redaction into a reported tool failure.
+ */
+interface PostToolOverride {
+	readonly output: string
+	readonly isError: boolean
+	readonly content?: ToolResultContent
+}
+
 type PreToolHookOutcome =
 	| { kind: 'continue'; input: unknown }
 	| { kind: 'skip'; input: unknown; output: string }
@@ -708,10 +722,14 @@ export class ToolExecutor {
 
 		const postOverride = post.override
 		if (postOverride !== null) {
-			output = postOverride
+			output = postOverride.output
 		}
 
-		const effectiveIsError = !result.success || postOverride !== null
+		// A failed call, or an override that says the call failed. A `replace`
+		// says the opposite, and reading it as a failure is what made redaction
+		// unusable: the model was told a successful call had gone wrong, and
+		// routed around it.
+		const effectiveIsError = !result.success || (postOverride?.isError ?? false)
 
 		if (this.workingStateManager) {
 			extractFromToolResult(this.workingStateManager, toolName, output, effectiveIsError)
@@ -756,17 +774,31 @@ export class ToolExecutor {
 			...(budgeted.spillPath ? { outputSpillPath: budgeted.spillPath } : {}),
 		})
 
+		const resolveContent = (): { content?: ToolResultContent } => {
+			if (postOverride?.content !== undefined) {
+				return { content: this.budgetContent(postOverride.content, toolName) }
+			}
+			if (postOverride?.isError) return {}
+			if (budgeted.truncated || result.content === undefined) return {}
+			return { content: this.budgetContent(result.content, toolName) }
+		}
+
 		return {
 			toolCallId: toolCall.id,
 			toolName,
 			output,
 			isError: effectiveIsError,
-			// A plugin override replaces what the model sees, and a spilled
-			// preview is no longer the tool's own payload — neither may carry
-			// rich content through.
-			...(result.content !== undefined && postOverride === null && !budgeted.truncated
-				? { content: this.budgetContent(result.content, toolName) }
-				: {}),
+			// Rich content follows the override's own decision.
+			//
+			// An ERROR override drops it: the payload is no longer the tool's,
+			// and shipping an image beside a failure message describes something
+			// the model was just told did not happen. A spilled preview drops it
+			// for the same reason.
+			//
+			// A REPLACE keeps it, because the common case is redacting text from
+			// a result whose image is unaffected — and a hook that needs it gone
+			// says so with `content`, which wins over both.
+			...resolveContent(),
 		}
 	}
 
@@ -919,6 +951,11 @@ export class ToolExecutor {
 						output: `Error: ${result.message}`,
 					}
 				case 'retry':
+				// There is no result to replace yet. Rejecting loudly beats
+				// silently ignoring it: a hook author who returned this here
+				// meant to redact something and would otherwise watch the secret
+				// go through.
+				case 'replace':
 					throw new Error(
 						`Plugin hook pre_tool_use returned unsupported action '${result.action}' for tool ${toolName}`,
 					)
@@ -1120,21 +1157,32 @@ export class ToolExecutor {
 		toolName: string,
 		input: unknown,
 		toolResult: ToolResult,
-	): Promise<{ override: string | null; retry: boolean }> {
+	): Promise<{ override: PostToolOverride | null; retry: boolean }> {
 		if (!this.config.pluginManager) return { override: null, retry: false }
 		const results = await this.config.pluginManager.executeHooks(
 			'post_tool_use',
 			{ runId: this.config.runId, toolName, toolInput: input, toolResult },
 			this.emitEvent,
 		)
-		let override: string | null = null
+		let override: PostToolOverride | null = null
 		let retry = false
 		for (const result of results) {
 			switch (result.action) {
 				case 'continue':
 					continue
 				case 'error':
-					override = `Error: ${result.message}`
+					override = { output: `Error: ${result.message}`, isError: true }
+					continue
+				// A redaction, not a failure. The call stood; the model is shown
+				// less of it. Rich content survives unless the hook replaced it —
+				// see the variant's own documentation for why that default, and
+				// for what a hook redacting a secret in an image has to do.
+				case 'replace':
+					override = {
+						output: result.output,
+						isError: false,
+						...(result.content !== undefined ? { content: result.content } : {}),
+					}
 					continue
 				// `retry` was a declared variant with no implementation: every
 				// site that consumed it threw. Here it finally means something

--- a/packages/sdk/src/runtime/query/plugin-hooks.ts
+++ b/packages/sdk/src/runtime/query/plugin-hooks.ts
@@ -26,6 +26,7 @@ export function applyLifecycleHookResults(
 			case 'skip':
 			case 'modify':
 			case 'retry':
+			case 'replace':
 				throw new Error(
 					`Plugin hook ${event} returned unsupported action '${result.action}' for a lifecycle event`,
 				)

--- a/packages/sdk/src/types/plugin/index.ts
+++ b/packages/sdk/src/types/plugin/index.ts
@@ -9,7 +9,7 @@ import {
 	PLUGIN_NAME_MAX_LENGTH,
 } from '../../constants/plugin/index.js'
 import type { PluginId, RunId } from '../ids/index.js'
-import type { Message } from '../message/index.js'
+import type { Message, ToolResultContent } from '../message/index.js'
 import type { ToolResult } from '../tool/index.js'
 
 // ---------------------------------------------------------------------------
@@ -191,6 +191,31 @@ export type PluginHookResult =
 	| { action: 'modify'; input: unknown }
 	| { action: 'error'; message: string }
 	| { action: 'retry' }
+	/**
+	 * Replace what the model sees, WITHOUT reporting the call as failed.
+	 *
+	 * The substitution seam already existed and was typed as a failure channel:
+	 * the only way a `post_tool_use` hook could change the output was
+	 * `action: 'error'`, which prefixes `Error: ` and sets the error flag. So
+	 * redacting a credential out of a successful result was delivered to the
+	 * model as a tool failure, and the model routed around a call that had
+	 * worked — retrying it, or reporting to the user that it had failed.
+	 *
+	 * That is the difference this variant exists for. `error` says the call went
+	 * wrong; this says the call went right and the model may not see all of it.
+	 *
+	 * `modify` is not this. It carries `input` and belongs to the pre-call
+	 * hooks, which is why `post_tool_use` rejects it — a result is not an input,
+	 * and reusing the variant would have made one action mean two things
+	 * depending on where it was returned.
+	 *
+	 * Rich content blocks SURVIVE a replace unless `content` is given, because
+	 * the common case is redacting text from a result whose image or resource
+	 * is unaffected. A hook that needs to drop them passes `content: []`, and a
+	 * hook redacting a secret that also appears in an image must — this variant
+	 * cannot inspect what it is preserving.
+	 */
+	| { action: 'replace'; output: string; content?: ToolResultContent }
 
 export function assertPluginHookResult(result: PluginHookResult): asserts result {
 	const action = result.action
@@ -200,6 +225,7 @@ export function assertPluginHookResult(result: PluginHookResult): asserts result
 		case 'modify':
 		case 'error':
 		case 'retry':
+		case 'replace':
 			break
 		default: {
 			const _exhaustive: never = action


### PR DESCRIPTION
Gap-plan item 2, first half. The second half — the connector untrusted envelope — is a separate reachability claim and gets its own PR.

The substitution seam existed and was **typed as a failure channel**. The only way a `post_tool_use` hook could change what the model sees was `action: 'error'`, which prefixes `Error: ` and sets the error flag. So redacting a credential out of a *successful* result arrived at the model as a tool failure — and a model told a call failed routes around it: retries it, or reports to the user that it did not work. The capability was reachable and unusable.

## `error` and `replace` say opposite things

| | `error` | `replace` |
| --- | --- | --- |
| model sees | `Error: <message>` | the hook's `output`, verbatim |
| `isError` | `true` | follows the **tool** |
| rich content | dropped | **preserved** |

The error flag following the tool rather than the hook is the load-bearing part: a successful call stays successful, and a genuinely failed one stays failed even when a hook rewrites its message. The tool decides whether the work happened; the hook decides what may be shown. Both directions have a test.

**Rich content survives a replace.** The common case is redacting text from a result whose image is unaffected, and dropping it was the old behaviour for *every* override — which made the model reason as though the tool had returned text only. A hook that needs the blocks gone passes `content: []`, and a hook redacting a secret that also appears in an image **must**: the replace cannot inspect what it is preserving, and the variant's own documentation says so rather than leaving a reader to discover it.

## `modify` was not reused

It carries `input` and belongs to the pre-call hooks, which is why `post_tool_use` already rejected it as unsupported. Reusing it would have made one action mean two different things depending on where it was returned. `replace` is symmetrically rejected on `pre_tool_use` — there is no result to replace yet — and on the lifecycle events. Loudly, in both cases, because a hook author who returned it there meant to redact something and would otherwise watch the secret go through.

## The bump — a decision to overrule if you disagree

**Minor.** `PluginHookResult` is a type plugin authors **produce** and the SDK consumes, so widening it cannot break an author's switch: there is nothing for them to switch over. That is the opposite direction from the `RunEvent` widening in 12.0.0, which went major because consumers map every member exhaustively and the compiler named three in-tree mappers as proof.

Here the compiler named four exhaustive switches, and **all four are inside this package** — `assertPluginHookResult`, both executor switches, and the lifecycle-event switch. That is the evidence for minor rather than an argument against it: the widening's blast radius is entirely internal.

## Mutations

| # | Mutation | Killed by |
|---|---|---|
| M27 | every override reported as an error again | 1 |
| M28 | an error override stops dropping rich content | 1 |
| M29 | hook-supplied `content` ignored | 1 |

Three mutations, three *distinct* kills — each behaviour is pinned by its own case rather than by one test standing in for the group. Each mutation was verified to have actually applied before the run, after the four-tab/three-tab false negative earlier tonight.

## Gate

All six: `pnpm build`, `pnpm typecheck`, `pnpm lint` clean; `pnpm test` exit 0 — sdk 332 files / 2951 passed / 7 skipped, cli 68 files / 637 passed / 3 skipped. `audit-external-names.mjs` exits 0. `verify-public-surface.mjs` reports the surface intact — `PluginHookResult` was already exported, so a new union member adds no name. `pnpm docs:check` reports 0 problems.

## Left for the second half

- **The connector untrusted envelope.** Treated as a reachability claim, per the ratified rule: a test per inbound surface. One thing already measured while building #299 — a **delegated agent result is already framed** before it reaches the parent model, so that surface is covered and the work is connector paths only. I will still test each rather than trust my own finding.
- **A tool-result variant of the secret-redaction preset**, which needs this variant to exist first.

Neither touches the store contract, so nothing here collides with the agent working item 3.
