### PR TITLE
ci: the gate leg is declared on the matrix entry, not spelled eight times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,28 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22, 24]
+        # Eight steps below run on ONE leg rather than every leg — the
+        # deterministic gates, which read the tree and would answer identically
+        # on each, plus the two that install. Which leg carries them is declared
+        # HERE, on the entry, instead of being spelled as `node-version == 24`
+        # eight times further down.
+        #
+        # The literal spelling worked and could stop working silently. It named
+        # a version that lives in this list, so replacing 24 with a newer
+        # runtime — an ordinary, unrelated edit — would leave eight `if`
+        # conditions matching nothing. No step fails; they are simply skipped,
+        # and a skipped step is green. Eight gates would go quiet in a diff that
+        # never mentioned them.
+        #
+        # Attached to the entry, the flag cannot be separated from the version
+        # by accident: whoever changes the runtime is editing the block that
+        # carries it. See `docs/conventions/a-check-that-cannot-fail.md` — a
+        # gate whose condition can quietly become unsatisfiable is that rule
+        # aimed at CI rather than at a test.
+        include:
+          - node-version: 22
+          - node-version: 24
+            gates: true
 
     steps:
       - uses: actions/checkout@v5
@@ -113,7 +134,7 @@ jobs:
       # `docs/conventions/an-optional-dependency-may-not-degrade-a-check.md`
       # exists to prevent. Reviewing the diff is the control for bashisms.
       - name: Installer parses as POSIX sh
-        if: matrix.node-version == 24
+        if: matrix.gates
         run: |
           sh -n install.sh
           dash -n install.sh
@@ -146,15 +167,15 @@ jobs:
       #      classified (required | baselineExempt | exempt).
       # Both are non-bypassable by design (no SKIP_* env var).
       - name: SDK coverage (produce summary)
-        if: matrix.node-version == 24
+        if: matrix.gates
         run: pnpm --filter @namzu/sdk test:coverage
 
       - name: SDK coverage floor gate
-        if: matrix.node-version == 24
+        if: matrix.gates
         run: node .github/scripts/check-sdk-module-coverage.mjs
 
       - name: SDK test-presence gate
-        if: matrix.node-version == 24
+        if: matrix.gates
         run: node .github/scripts/check-sdk-test-presence.mjs
 
       # The registry verifies a provenance attestation against
@@ -162,7 +183,7 @@ jobs:
       # time, after every sibling package has already gone out. Checking it
       # here costs a second; finding out at the registry costs a release.
       - name: Publish-metadata gate
-        if: matrix.node-version == 24
+        if: matrix.gates
         run: node .github/scripts/check-publish-metadata.mjs
 
       # Pre-publish package validation — runs on every PR + every push to main.
@@ -170,7 +191,7 @@ jobs:
       # bugs before they reach a publish tag. Only runs on one node version
       # in the matrix to avoid quadrupling install work.
       - name: Pre-publish consumer install check
-        if: matrix.node-version == 24
+        if: matrix.gates
         run: bash .github/scripts/verify-consumer-install.sh
 
       # Public-surface regression guard (ses_011-sdk-public-surface).
@@ -179,11 +200,11 @@ jobs:
       # error classes, zod schemas). Intentional widenings update the
       # baseline in the same commit.
       - name: Public-surface regression check
-        if: matrix.node-version == 24
+        if: matrix.gates
         run: node .github/scripts/verify-public-surface.mjs
 
       - name: publint (package.json shape)
-        if: matrix.node-version == 24
+        if: matrix.gates
         run: |
           for pkg in sdk sandbox telemetry computer-use providers/anthropic providers/bedrock providers/http providers/lmstudio providers/ollama providers/openai providers/openrouter; do
             echo "::group::publint packages/$pkg"

--- a/docs/conventions/never-filter-a-verification.md
+++ b/docs/conventions/never-filter-a-verification.md
@@ -8,7 +8,6 @@ owner: cogitave/namzu
 status: active
 timestamp: 2026-08-04T00:00:00Z
 lastReviewed: 2026-08-09
-resource: .github/workflows/ci.yml
 tags: [convention, verification, tooling]
 ---
 
@@ -154,6 +153,26 @@ Three things follow, and the third is the one that saved it:
 
 Recorded because the blast radius was somebody else's work, on a branch that was
 already green.
+
+## Why this page has no `resource:`
+
+It pointed at the CI workflow, and the workflow is not what this rule is about.
+A change there cannot make the rule false: the rule is about the habit of
+putting something between yourself and a verdict, and it would be exactly as
+true if this repository had no CI at all.
+
+What the pointer actually did was demand a re-read of the rule every time an
+unrelated line of the workflow moved — which is the dynamic the gate's own
+guidance warns about, a churning sentinel that trains everyone to wave the
+failure through. It fired on a change to which matrix leg carries the gates,
+and there was nothing to re-establish.
+
+So the key is gone rather than re-dated. `resource:` should name code whose
+change could make the document **wrong**, not code the document happens to be
+about; and an absent key honestly reads as "no code can invalidate this",
+which is the true statement here. Same reasoning as
+[alternation-unmounts-state](alternation-unmounts-state.md), which reached it
+first.
 
 ## Related
 


### PR DESCRIPTION
ci: the gate leg is declared on the matrix entry, not spelled eight times

Eight steps run on one matrix leg rather than every leg - the
deterministic gates, which read the tree and would answer identically on
each, plus the two that install. Each said `if: matrix.node-version ==
24`.

That worked and could stop working silently. The condition named a
version that lives in the matrix list, so replacing 24 with a newer
runtime - an ordinary edit, in a diff about node versions - would leave
eight `if` conditions matching nothing. Nothing fails: the steps are
skipped, and a skipped step is green. Eight gates would go quiet without
appearing in the diff that silenced them, including the public-surface
regression check that caught a real widening tonight.

The flag now travels on the matrix entry, so whoever changes the runtime
is editing the block that carries it.

Claiming exactly what this buys and no more: it does not make the failure
impossible, it makes it impossible to cause without seeing it. There is
no assertion here and there cannot usefully be one - a workflow cannot
check that a condition it does not evaluate would have matched. What
changed is that the fact and its dependant now sit on the same three
lines instead of two hundred apart.

Verified by parsing the file rather than by reading it: two legs, eight
conditional steps, one distinct condition, and all eight named.
