### PR TITLE
feat(cli)!: tool output you can read in full, by name

### DIFF
--- a/.changeset/expand-instead-of-a-key.md
+++ b/.changeset/expand-instead-of-a-key.md
@@ -1,0 +1,44 @@
+---
+'@namzu/cli': major
+---
+
+**`/expand` reads a collapsed tool output in full. `Ctrl+O` is deprecated and
+stops expanding anything.**
+
+Tool diffs and command output collapse to six lines. The hint under them now
+names the command that reopens them — `… +6 lines · /expand 3` — and `/expand`
+with no argument takes the most recent one. The full text arrives as a new entry
+below, so the collapsed one stays where it was.
+
+## What breaks
+
+**1. `Ctrl+O` no longer expands anything.** It is still bound: pressing it prints
+the reason and points at `/expand`, so nobody meets a dead key.
+
+Be clear about what it did, because it was not nothing. It was advertised as
+toggling full expansion for everything, and for output already on screen it was
+inert — finalized entries are printed once to the terminal's own scrollback and
+never redrawn, which is what keeps a long session bounded and native scrolling
+and selection working across the whole conversation. But pressing it *before* a
+tool finished did have an effect: the result, when it arrived, printed in full.
+That behaviour is removed. It required deciding you wanted the output before you
+could see that it had been truncated, and nothing on screen ever mentioned it.
+
+*To keep the old behaviour:* there is no flag for it. Run the tool, then
+`/expand`, which reaches output the key never could.
+
+**2. `expand` is now a reserved command name.** If you have a user-defined
+command at `~/.namzu/commands/expand.md` or `./.namzu/commands/expand.md`, the
+built-in takes the name and yours stops running — in the TUI and in `namzu run`
+/ `run-stream` alike. Rename the file, and `/help` will report it as shadowed
+until you do.
+
+## Also in this change
+
+- The collapse hint carries a number, and only bodies that actually truncate get
+  one. A body short enough to print whole advertises nothing and takes no number.
+- The blank-row estimate that decides where the composer sits now counts the
+  collapsed body under a tool call, the blank row between entries, and the width
+  the body really renders at. It previously measured each entry by its first line
+  alone, so a six-line tool result counted as nothing — in the direction that
+  pushes the composer off the bottom of the screen.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -34,13 +34,13 @@ rather than treating it as prompt text, so `namzu run --format json "…"` exits
 - **Remembers across sessions.** User facts in `~/.namzu/USER.md` / `MEMORY.md` are injected every turn; the agent also keeps its own structured memory. See [Memory](./memory.md).
 - **Resumes past conversations.** Every conversation is saved. `/resume` continues a previous one in this folder from the TUI; `namzu run --continue` and `--resume <id>` do the same from a script. Neither ever silently starts a fresh conversation when the one you asked for cannot be reopened.
 - **Loads skills on demand.** Author `SKILL.md` capability docs and activate them per session. See [Skills](./skills.md).
-- **Polished TUI.** Markdown-rendered replies, collapsible tool diffs (Ctrl+O), slash-command autocomplete, message queuing, and paste handling. See [The TUI](./tui.md).
+- **Polished TUI.** Markdown-rendered replies, tool diffs that collapse to a numbered hint you can reopen with `/expand`, slash-command autocomplete, message queuing, and paste handling. See [The TUI](./tui.md).
 
 ## Documentation map
 
 | Page | What it covers |
 | --- | --- |
-| [The TUI](./tui.md) | Header, transcript/composer, slash commands + autocomplete, queuing, `/resume`, Ctrl+O, interrupting |
+| [The TUI](./tui.md) | Header, transcript/composer, slash commands + autocomplete, queuing, `/resume`, `/expand`, interrupting |
 | [Headless runs](./headless.md) | `run` and `run-stream`, their shared options, `--cwd`, permission modes, resuming, exit codes, the NDJSON event stream |
 | [Providers & credentials](./providers.md) | How credentials are discovered, the first-run picker, switching providers |
 | [Tools & permission](./tools.md) | Builtin + memory + task tools, deferred tools and `search_tools`, how a call is decided, permission modes, the safety gate, bypass mode |

--- a/docs/cli/tui.md
+++ b/docs/cli/tui.md
@@ -1,7 +1,7 @@
 ---
 title: The TUI
-description: Launching namzu, the transcript and composer, slash commands, message queuing, /resume, and interrupting a running turn.
-last_updated: 2026-08-07
+description: Launching namzu, the transcript and composer, slash commands, message queuing, /resume, /expand, and interrupting a running turn.
+last_updated: 2026-08-09
 status: current
 related_packages: ["@namzu/cli"]
 ---
@@ -39,6 +39,7 @@ Type `/` followed by a command — an autocomplete dropdown filters as you type.
 | `/provider` | Show the current provider and model. |
 | `/model` | Choose the provider, then the model. See [Switching model](#switching-model). |
 | `/resume` | Pick a past conversation in this folder to continue. See [Sessions & resume](#sessions--resume). |
+| `/expand [n]` | Print a collapsed tool output in full. See [Expanding tool output](#expanding-tool-output). |
 | `/remember <text>` | Save a fact to durable memory. See [Memory](./memory.md). |
 | `/memory` | Show what namzu remembers. |
 | `/skills` | List available skills. See [Skills](./skills.md). |
@@ -143,6 +144,12 @@ disk is accounted for, and the other commands keep working. A file named after a
 built-in — `help.md` — is likewise listed with its reason rather than silently
 ignored; built-ins always win.
 
+That last point cuts both ways: a name that is free today can become a built-in
+tomorrow, and your file then stops running rather than starting to conflict
+loudly. `/help` is where you find out — a shadowed file is listed with the
+reason. `expand` became a built-in in `@namzu/cli` 6.0.0 and is the only name to
+have done so; rename an `expand.md` you already have.
+
 Files are read when the session starts. After adding one, `/model` or a restart
 picks it up.
 
@@ -190,7 +197,24 @@ A draft you have not sent survives whatever the agent does. If a permission prom
 
 ## Expanding tool output
 
-Tool diffs and command output collapse to a few lines with a `… +N lines (ctrl+o to expand)` hint. Press **Ctrl+O** to toggle full expansion for everything.
+Tool diffs and command output collapse to six lines with a hint that names itself:
+
+```
+⏺ Bash(rg --files-with-matches TODO)
+ ▏ src/agent.ts
+ ▏ src/composer.ts
+ ▏ … +6 lines · /expand 3
+```
+
+`/expand 3` prints that body in full, and `/expand` on its own takes the most recent one. The full text arrives as a **new entry below**, so the collapsed one stays where it was and your scrollback keeps both.
+
+That is the mechanism, not a stylistic choice. Finalized transcript entries are written straight to the terminal's own scrollback and are never redrawn — which is what keeps a long session from growing without bound, and what makes your terminal's native scroll and text selection work over the whole conversation. Nothing can reach back and change an entry that has already been printed, so an expansion has to be something new on the end.
+
+### `Ctrl+O` is deprecated
+
+`Ctrl+O` used to be the way in, and it is still bound: pressing it tells you what to use instead. It no longer expands anything.
+
+It was advertised as toggling full expansion for everything, and against output already on screen it did nothing — for the reason above. Pressing it *before* a tool finished did work, in that the result printed in full when it arrived, but that meant deciding you wanted the output before you could see it had been truncated, and nothing said so. `/expand` reaches output the key never could.
 
 ## Sessions & resume
 

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -43,7 +43,7 @@ import { PermissionOverlay } from './PermissionOverlay.js'
 import { approvalIsDeliberate } from './consent-timing.js'
 import { Picker } from './Picker.js'
 import { type ContextFill, StatusBar } from './StatusBar.js'
-import { Transcript } from './Transcript.js'
+import { Transcript, renderedDetailLines, willCollapse } from './Transcript.js'
 import { createAssistantMessage, createUserMessage } from '@namzu/sdk'
 import {
 	type CliSessions,
@@ -82,6 +82,36 @@ type RunningTool = ActiveTool & {
 	readonly detail?: readonly string[]
 }
 
+/**
+ * Every line the finalized transcript will print, for the spacer to measure.
+ *
+ * Exported so the wiring is testable rather than only typecheckable. The
+ * spacer's own docblock states the asymmetry it depends on: over-count the
+ * content and the composer merely floats, under-count it and the composer is
+ * pushed off the bottom. The caller used to pass each row's `content` alone,
+ * which counted a six-line collapsed tool body as nothing at all — the estimate
+ * ran low by six per tool call, in the direction that costs the usability
+ * rather than the feature. `/expand` makes it acute: a row whose entire
+ * substance is a two-hundred-line body would have been handed over as one line.
+ *
+ * A pending row is excluded because it is not in the static log yet; the
+ * spacer's `liveRows` covers the live region.
+ */
+export function spacerTranscript(messages: readonly TranscriptMessage[]): readonly string[] {
+	const finalized = messages.filter((m) => !m.pending)
+	return finalized.flatMap((m, i) => [
+		// The blank row `MessageRow` puts above every entry but the first and the
+		// `⎿` result rows. One row per entry sounds negligible and is not: forty
+		// entries is forty rows, which on most terminals is the whole viewport.
+		...(i > 0 && m.glyph !== '⎿' ? [''] : []),
+		// Indented by the two-column glyph gutter the content renders beside, so
+		// a long line is measured against the width it actually has.
+		`  ${m.content}`,
+		...renderedDetailLines(m),
+	])
+}
+
+
 export function App({ ctx }: AppProps) {
 	const { exit } = useApp()
 	const [messages, setMessages] = useState<readonly TranscriptMessage[]>([])
@@ -108,7 +138,6 @@ export function App({ ctx }: AppProps) {
 	// Tools currently executing — rendered live (spinner + elapsed) below the
 	// transcript, then committed as static lines on completion.
 	const [activeTools, setActiveTools] = useState<readonly ActiveTool[]>([])
-	const [expanded, setExpanded] = useState<boolean>(false)
 	// Bumped to reset the <Static> transcript log (on /clear and /resume).
 	const [resetKey, setResetKey] = useState<number>(0)
 	// Messages typed while a turn is running — auto-sent when it settles.
@@ -158,9 +187,14 @@ export function App({ ctx }: AppProps) {
 		idRef.current += 1
 		return `m${idRef.current}`
 	}, [])
-
 	// Reset the transcript view: clear the terminal + remount <Static> so its
 	// already-printed lines don't linger above fresh content (/clear, /resume).
+	//
+	// The block numbering resets with it and needs no separate step: the numbers
+	// live on the rows, so emptying `messages` takes them with it. A number that
+	// outlived the row it named would resolve `/expand 3` to output the operator
+	// can no longer see anywhere, which is the failure this surface is being
+	// cleaned of, one layer up.
 	const resetTranscript = useCallback(() => {
 		if (process.stdout.isTTY) process.stdout.write('\x1b[2J\x1b[3J\x1b[H')
 		setResetKey((k) => k + 1)
@@ -179,7 +213,29 @@ export function App({ ctx }: AppProps) {
 			const id = nextId()
 			setMessages((prev) => [
 				...prev,
-				{ id, role, content, pending, glyph, detail, glyphColor, meta },
+				{
+					id,
+					role,
+					content,
+					pending,
+					glyph,
+					detail,
+					glyphColor,
+					meta,
+					// Numbered only if this body will actually be COLLAPSED — the
+					// number exists to be read off a hint, and a body that fits
+					// prints no hint. Numbering every body instead would leave gaps
+					// the operator can see nothing of, make bare `/expand` reprint a
+					// two-line body while the truncated one above it stayed hidden,
+					// and let the out-of-range message quote a count that includes
+					// blocks no hint ever named.
+					//
+					// Derived from `prev` rather than a counter, so the number is a
+					// fact about the transcript rather than a second record of it.
+					...(willCollapse(detail)
+						? { detailRef: prev.filter((m) => m.detailRef !== undefined).length + 1 }
+						: {}),
+				},
 			])
 			return id
 		},
@@ -347,7 +403,7 @@ export function App({ ctx }: AppProps) {
 			? bottomSpacerRows({
 					rows: process.stdout.rows,
 					columns: process.stdout.columns,
-					transcript: messages.filter((m) => !m.pending).map((m) => m.content),
+					transcript: spacerTranscript(messages),
 					liveRows: 10,
 				})
 			: 0
@@ -740,6 +796,89 @@ export function App({ ctx }: AppProps) {
 					case 'resume':
 						void doResume()
 						return
+					case 'expand': {
+						// Resolved INSIDE the updater, against `prev`.
+						//
+						// Not against the `messages` this callback captured: rows arrive
+						// from `applyEvent` while a turn runs, which is exactly when
+						// someone types `/expand`, and a captured array can be a render
+						// behind — so "the most recent one" would sometimes mean the one
+						// before it, and the command would quietly show the wrong output.
+						// `prev` is by definition the latest.
+						//
+						// And against the ROWS, not a parallel index of them. An earlier
+						// draft kept a ref mirroring `{ref, label, lines}` alongside the
+						// rows that already hold all three. That is one concept in two
+						// shapes with a hand-written copy between them — the geometry
+						// `docs/conventions/one-site-is-not-every-site.md` names as the
+						// hardest kind to spot, adopted here to solve a staleness problem
+						// the updater solves without it.
+						//
+						// The id is taken outside so both branches use the same one.
+						const id = nextId()
+						setMessages((prev) => {
+							const blocks = prev.filter((m) => m.detailRef !== undefined)
+							const say = (content: string): TranscriptMessage => ({
+								id,
+								role: 'system',
+								content,
+							})
+							if (blocks.length === 0) {
+								return [
+									...prev,
+									say(
+										'Nothing to expand yet. Tool output longer than six lines collapses with a "… +N lines · /expand n" hint, and that number is what this takes.',
+									),
+								]
+							}
+							const block =
+								slash.which === 'last'
+									? blocks[blocks.length - 1]
+									: blocks.find((m) => m.detailRef === slash.which)
+							if (!block) {
+								// Names the range rather than only refusing: the operator's
+								// next move is to type a different number, and they should
+								// not have to guess which ones exist.
+								return [
+									...prev,
+									say(
+										`No collapsed output numbered ${slash.which}. This conversation has ${
+											blocks.length === 1
+												? 'one, numbered 1'
+												: `${blocks.length}, numbered 1 to ${blocks.length}`
+										}.`,
+									),
+								]
+							}
+							// A NEW row carrying the same lines, flagged to print them all.
+							// Not a mutation of the row that collapsed them: that row was
+							// handed to <Static>, which emits an item once and calls the
+							// render function only for items it has not emitted yet, so
+							// nothing decided now can reach it. Appending is the only
+							// expansion this architecture has.
+							//
+							// The lines travel as `detail` rather than flattened into the
+							// content so the `▏` rule and the +/- diff colouring survive.
+							// An expansion that showed LESS than the collapsed form would
+							// be a strange thing to have asked for.
+							//
+							// It carries no `detailRef` of its own: it is already in full,
+							// so there is nothing for a number to offer, and giving it one
+							// would let `/expand` produce a third copy of the same output.
+							return [
+								...prev,
+								{
+									id,
+									role: 'system',
+									content: `${block.content} — in full (${block.detail?.length ?? 0} lines)`,
+									glyph: '⤢',
+									detail: block.detail,
+									detailExpanded: true,
+								},
+							]
+						})
+						return
+					}
 					case 'prompt':
 						// Deliberately does NOT return: the composed text falls
 						// through to the same queue-or-send below that a typed
@@ -748,6 +887,17 @@ export function App({ ctx }: AppProps) {
 						break
 					case 'none':
 						return
+					default: {
+						// Exhaustive on purpose. Without it a `SlashAction` kind added
+						// and not handled here falls out of the switch into the send
+						// path below — so `/somenewcommand` would be dispatched to the
+						// MODEL as prose, silently, which is both a wrong answer and a
+						// tool call the operator did not ask for. This turns that into
+						// a build failure.
+						const exhaustive: never = slash
+						void exhaustive
+						return
+					}
 				}
 			}
 			// A turn is in flight → queue the message; it auto-sends when idle.
@@ -758,7 +908,7 @@ export function App({ ctx }: AppProps) {
 			}
 			void runTurn(outgoing, images)
 		},
-		[activeSkills, doResume, exit, pushMessage, runTurn, slashCtx, state],
+		[activeSkills, doResume, exit, nextId, pushMessage, runTurn, slashCtx, state],
 	)
 
 	// Drain the queue: when a turn settles (idle) and nothing is running,
@@ -950,9 +1100,30 @@ export function App({ ctx }: AppProps) {
 				pushMessage('system', 'Interrupted.')
 				return
 			}
-			// Ctrl+O toggles expansion of collapsed tool diffs / output.
+			// Ctrl+O is deprecated, still bound, and now says so.
+			//
+			// It was advertised — on every collapsed body — as toggling full
+			// expansion for everything, and in that use it did nothing: finalized
+			// rows go through `<Static>`, which renders `items.slice(index)` and
+			// calls the render function only for items it has not emitted yet, so
+			// output already on screen was beyond its reach.
+			//
+			// It was NOT inert, though, and the difference matters enough to have
+			// changed this design. `<Static>` calls the CURRENT render closure for
+			// each newly appended item, so pressing the key while a tool was
+			// running made that tool's result print in full when it arrived. A
+			// working behaviour — undiscoverable, unadvertised, and the opposite of
+			// what the hint under the row promised: you had to decide you wanted
+			// the output before you had seen that it was truncated.
+			//
+			// So it is not deleted out from under anyone. It stays bound for a
+			// release and answers with the reason and the replacement, which is
+			// more than it gave in the case an operator would actually try it.
 			if (key.ctrl && input === 'o') {
-				setExpanded((e) => !e)
+				pushMessage(
+					'system',
+					'Ctrl+O is deprecated and no longer expands anything. It could never reopen output already on screen — finalized rows are printed once and never redrawn. Use /expand <n>; the number is in the hint under each collapsed body, and /expand on its own takes the most recent.',
+				)
 				return
 			}
 			if (key.ctrl && input === 'c') {
@@ -1023,8 +1194,7 @@ export function App({ ctx }: AppProps) {
 								messages={messages.filter((m) => !m.pending)}
 								pending={messages.find((m) => m.pending) ?? null}
 								state={state}
-								expanded={expanded}
-								resetKey={resetKey}
+																resetKey={resetKey}
 								header={
 									phase === 'ready' ? (
 										<Banner

--- a/packages/cli/src/tui/Transcript.tsx
+++ b/packages/cli/src/tui/Transcript.tsx
@@ -20,8 +20,6 @@ export interface TranscriptProps {
 	/** The in-progress streaming message, re-rendered live below the static log. */
 	readonly pending: TranscriptMessage | null
 	readonly state: 'idle' | 'thinking' | 'tool' | 'awaiting-permission'
-	/** When true, collapsed tool diffs/output are shown in full (Ctrl+O). */
-	readonly expanded: boolean
 	/** Bump to reset the static log (e.g. /clear, /resume). */
 	readonly resetKey: number
 	/**
@@ -45,14 +43,7 @@ type StaticRow =
 			readonly prev: TranscriptMessage | undefined
 	  }
 
-export function Transcript({
-	messages,
-	pending,
-	state,
-	expanded,
-	resetKey,
-	header,
-}: TranscriptProps) {
+export function Transcript({ messages, pending, state, resetKey, header }: TranscriptProps) {
 	const spinner = useSpinner(state !== 'idle')
 
 	// The banner is row 0 so it prints to the very top of scrollback; messages
@@ -75,13 +66,7 @@ export function Transcript({
 					row.kind === 'header' ? (
 						<Box key="header">{header}</Box>
 					) : (
-						<MessageRow
-							key={row.message.id}
-							message={row.message}
-							prev={row.prev}
-							spinner=""
-							expanded={expanded}
-						/>
+						<MessageRow key={row.message.id} message={row.message} prev={row.prev} spinner="" />
 					)
 				}
 			</Static>
@@ -90,7 +75,6 @@ export function Transcript({
 					message={pending}
 					prev={messages[messages.length - 1]}
 					spinner={spinner}
-					expanded={expanded}
 				/>
 			) : null}
 			{messages.length === 0 && !pending ? (
@@ -108,12 +92,10 @@ function MessageRow({
 	message,
 	prev,
 	spinner,
-	expanded,
 }: {
 	readonly message: TranscriptMessage
 	readonly prev: TranscriptMessage | undefined
 	readonly spinner: string
-	readonly expanded: boolean
 }) {
 	const glyph = message.pending ? spinner : (message.glyph ?? glyphForRole(message.role))
 	// The `⎿` tool-result gutter is rendered dim so the call line leads.
@@ -146,22 +128,37 @@ function MessageRow({
 				</Box>
 			</Box>
 			{message.detail && message.detail.length > 0 ? (
-				<DetailBlock lines={message.detail} expanded={expanded} />
+				<DetailBlock
+					lines={message.detail}
+					expanded={message.detailExpanded === true}
+					detailRef={message.detailRef}
+				/>
 			) : null}
 		</Box>
 	)
 }
 
-/** Collapsible tool diff / output, aligned under the content gutter. */
+/**
+ * Collapsible tool diff / output, aligned under the content gutter.
+ *
+ * `expanded` comes from the ROW, not from a view-wide setting, because a
+ * view-wide setting reaches the wrong rows: `<Static>` renders each item once,
+ * calling the CURRENT render function for items it has not emitted yet — so a
+ * flag flipped now applies to rows that have not happened and to none of the
+ * rows on screen. `/expand` therefore pushes a new row with the flag already
+ * set, rather than trying to flip one on a row that has been printed.
+ */
 function DetailBlock({
 	lines,
 	expanded,
+	detailRef,
 }: {
 	readonly lines: readonly string[]
 	readonly expanded: boolean
+	/** The number `/expand` takes for this block, when it has one. */
+	readonly detailRef: number | undefined
 }) {
-	const shown = expanded ? lines : lines.slice(0, COLLAPSE_LINES)
-	const hidden = lines.length - shown.length
+	const { shown, hidden } = splitDetail(lines, expanded)
 	// A dim left rule (`▏`) under the gutter frames the output as a block,
 	// so tool output is visibly not the assistant speaking.
 	const Rule = () => (
@@ -184,11 +181,75 @@ function DetailBlock({
 			{hidden > 0 ? (
 				<Box flexDirection="row">
 					<Rule />
-					<Text color={theme.text.muted}>… +{hidden} lines (ctrl+o to expand)</Text>
+					{/* The hint names its OWN number rather than telling the operator
+					    to find one. Counting collapsed blocks up a scrolled
+					    transcript is work, and a hint that costs work is a hint
+					    that gets ignored. A block with no number cannot be named,
+					    so it says how many lines it is hiding and stops there
+					    rather than printing a command that would not resolve. */}
+					<Text color={theme.text.muted}>
+						… +{hidden} lines{detailRef === undefined ? '' : ` · /expand ${detailRef}`}
+					</Text>
 				</Box>
 			) : null}
 		</Box>
 	)
+}
+
+/**
+ * Whether a body will be truncated, and so will print a hint naming itself.
+ *
+ * Exported because only bodies that actually collapse get a `/expand` number,
+ * and this file owns `COLLAPSE_LINES`. Numbering the rest would produce numbers
+ * no hint ever shows: gaps in the sequence, a bare `/expand` that reprints a
+ * two-line body while the truncated one above it stays hidden, and a
+ * "there are N" message counting blocks the operator was never offered.
+ */
+export function willCollapse(detail: readonly string[] | undefined): boolean {
+	return detail !== undefined && detail.length > COLLAPSE_LINES
+}
+
+/** How much of a body prints, and how much stays behind the hint. */
+function splitDetail(
+	lines: readonly string[],
+	expanded: boolean,
+): { readonly shown: readonly string[]; readonly hidden: number } {
+	const shown = expanded ? lines : lines.slice(0, COLLAPSE_LINES)
+	return { shown, hidden: lines.length - shown.length }
+}
+
+/**
+ * Every line a row's body will occupy, hint row included.
+ *
+ * Exported because the bottom spacer has to estimate how tall a row renders,
+ * and this file is the only place that can answer: it owns `COLLAPSE_LINES` and
+ * whether the hint row exists. The spacer previously measured each row from its
+ * `content` alone, so a six-line collapsed body counted as nothing and the
+ * estimate ran low — which is the direction that pushes the composer off the
+ * screen. A copy of the collapse rule kept over there would put it back the
+ * first time this number changed.
+ */
+export function renderedDetailLines(message: TranscriptMessage): readonly string[] {
+	const lines = message.detail
+	if (!lines || lines.length === 0) return []
+	const { shown, hidden } = splitDetail(lines, message.detailExpanded === true)
+	// Indented by the gutter this block actually renders inside: `paddingLeft={1}`
+	// plus the two-column `▏` rule. Those columns are not available to the text,
+	// so measuring a body line against the full terminal width under-counts how
+	// many rows it wraps to — and under-counting is the direction that pushes the
+	// composer off the screen. The prefix is what the estimator measures, so the
+	// arithmetic is done by making the string the width it really is.
+	const gutter = '   '
+	const body = shown.map((line) => gutter + line)
+	// The hint's real text, `/expand n` included, because that is what wraps.
+	return hidden > 0
+		? [
+				...body,
+				`${gutter}… +${hidden} lines${
+					message.detailRef === undefined ? '' : ` · /expand ${message.detailRef}`
+				}`,
+			]
+		: body
 }
 
 function detailLineColor(line: string): string {

--- a/packages/cli/src/tui/__tests__/a-body-is-counted-and-numbered.test.ts
+++ b/packages/cli/src/tui/__tests__/a-body-is-counted-and-numbered.test.ts
@@ -1,0 +1,119 @@
+/**
+ * A collapsed tool body is measured, and the collapse rule has one owner.
+ *
+ * Two claims, and they are the same claim from opposite ends.
+ *
+ * The bottom spacer decides how many blank rows to put above the composer by
+ * estimating how tall the transcript renders. Its own docblock states the
+ * asymmetry it lives by: over-count the content and the composer merely floats,
+ * under-count it and the composer is pushed off the bottom. The caller passed
+ * each row's `content` and nothing else — so a six-line collapsed tool body was
+ * measured as zero rows, and the estimate ran low by six on every tool call, in
+ * the direction that costs the usability rather than the feature. `/expand`
+ * makes that acute rather than novel: it produces a row whose whole substance
+ * is its body.
+ *
+ * And the count has to come from the renderer, because the renderer is the only
+ * thing that knows how much of a body prints. A copy of `COLLAPSE_LINES` kept
+ * on the measuring side would be correct on the day it was written and silently
+ * wrong the first time the collapse changed — with no failure, because a low
+ * estimate does not throw.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { spacerTranscript } from '../App.js'
+import { renderedDetailLines } from '../Transcript.js'
+import { estimateRenderedLines } from '../bottom-spacer.js'
+import type { TranscriptMessage } from '../types.js'
+
+const body = (n: number) => Array.from({ length: n }, (_, i) => `line-${i + 1}`)
+
+function row(over: Partial<TranscriptMessage> = {}): TranscriptMessage {
+	return { id: 'm1', role: 'tool', content: 'Bash(ls)', ...over }
+}
+
+describe('renderedDetailLines', () => {
+	it('is empty for a row with no body, so an ordinary message costs one row', () => {
+		expect(renderedDetailLines(row())).toEqual([])
+		expect(renderedDetailLines(row({ detail: [] }))).toEqual([])
+	})
+
+	it('counts the hint row, because the hint occupies a row too', () => {
+		// Twelve lines collapse to six plus the hint: seven, not six. Off by one
+		// in the low direction is still the low direction.
+		const lines = renderedDetailLines(row({ detail: body(12) }))
+		expect(lines).toHaveLength(7)
+		expect(lines[6]).toContain('+6 lines')
+	})
+
+	it('gives the hint the text it really prints, command included', () => {
+		// `… +6 lines · /expand 3` is eleven columns longer than `… +6 lines`, and
+		// on a narrow terminal those eleven columns are a second rendered row that
+		// the estimate would not know about.
+		const lines = renderedDetailLines(row({ detail: body(12), detailRef: 3 }))
+		expect(lines[6]).toContain('/expand 3')
+	})
+
+	it('measures a body against the width it has, not the width of the terminal', () => {
+		// The block renders inside a one-column pad plus the two-column `▏` rule,
+		// so three columns are gone before any text. Measuring against the full
+		// width says a 78-character line fits on an 80-column terminal; it does
+		// not, and the missed wrap is a row the estimate never counted.
+		const wide = 'x'.repeat(78)
+		const measured = estimateRenderedLines(renderedDetailLines(row({ detail: [wide] })), 80)
+		expect(measured).toBe(2)
+	})
+
+	it('counts every line of a body that fits, with no hint', () => {
+		// Nothing is hidden, so nothing advertises hiding it.
+		const lines = renderedDetailLines(row({ detail: body(4) }))
+		expect(lines).toHaveLength(4)
+		expect(lines[0]).toContain('line-1')
+	})
+
+	it('counts the whole body of an expanded row', () => {
+		// The row `/expand` pushes. This is the case that would be measured as a
+		// single line by anything reading `content` alone.
+		expect(renderedDetailLines(row({ detail: body(200), detailExpanded: true }))).toHaveLength(200)
+	})
+})
+
+describe('what the spacer is given', () => {
+	it('includes the body under a tool call, not just the line above it', () => {
+		const lines = spacerTranscript([row({ detail: body(12) })])
+		// The call line plus six shown plus the hint.
+		expect(lines).toHaveLength(8)
+		expect(lines[0]).toContain('Bash(ls)')
+	})
+
+	it('counts the blank row between entries', () => {
+		// `MessageRow` puts one above every entry but the first and the `⎿`
+		// results. Forty entries is forty rows — a whole viewport on most
+		// terminals, silently absent from the estimate.
+		const two = spacerTranscript([row({ id: 'a' }), row({ id: 'b' })])
+		expect(two).toHaveLength(3)
+		expect(two[1]).toBe('')
+	})
+
+	it('does not count a gap before a result row, which hugs its call', () => {
+		const hugging = spacerTranscript([row({ id: 'a' }), row({ id: 'b', glyph: '⎿' })])
+		expect(hugging).toHaveLength(2)
+	})
+
+	it('measures an expanded row as the many rows it is', () => {
+		const expanded = row({
+			content: 'Bash(ls) — in full (200 lines)',
+			detail: body(200),
+			detailExpanded: true,
+		})
+		const measured = estimateRenderedLines(spacerTranscript([expanded]), 80)
+		expect(measured).toBeGreaterThan(200)
+	})
+
+	it('leaves out the row still streaming, which is not in the static log yet', () => {
+		// The live region is covered by the spacer's `liveRows`, so counting a
+		// pending row here would count it twice.
+		expect(spacerTranscript([row({ pending: true, detail: body(12) })])).toEqual([])
+	})
+})

--- a/packages/cli/src/tui/__tests__/app-draft-survives.test.tsx
+++ b/packages/cli/src/tui/__tests__/app-draft-survives.test.tsx
@@ -69,9 +69,33 @@ vi.mock('../agent.js', async (importOriginal) => {
 			promptExemptTools: () => ['read'],
 			send: async function* (_messages, opts): AsyncIterable<AgentEvent> {
 				yield { kind: 'delta', text: 'working' } as AgentEvent
+				if (!askPermission) {
+					// The interrupt tests need the turn to STILL BE RUNNING when Esc
+					// arrives, because that is the only state in which Esc is the
+					// interrupt at all — with nothing in flight it is the composer's
+					// own clear, which is the very next test down.
+					//
+					// So the turn ends on the abort rather than on a wall clock. It
+					// used to end after a fixed 120ms, which made "is the turn still
+					// running" a question about how loaded the machine was: under the
+					// full parallel suite the turn finished before the keystroke
+					// landed, Esc cleared the draft as designed, and the failure
+					// reported was "the turn was not interrupted" — a true statement
+					// about a turn that was already over.
+					await Promise.race([
+						new Promise<void>((resolve) => {
+							if (opts?.signal?.aborted) return resolve()
+							opts?.signal?.addEventListener('abort', () => resolve(), { once: true })
+						}),
+						// A backstop so a test that never interrupts cannot hang the
+						// run. It is not the mechanism; if it is what ends a turn,
+						// something above went wrong.
+						new Promise<void>((resolve) => setTimeout(resolve, 10_000)),
+					])
+					return
+				}
 				// Long enough for the test to type into a live composer.
 				await new Promise((r) => setTimeout(r, 120))
-				if (!askPermission) return
 				const req: PermissionRequest = {
 					toolCalls: [{ id: 'c1', name: 'bash', summary: 'rm -rf build', isDestructive: true }],
 				}

--- a/packages/cli/src/tui/__tests__/app-permission-keys.test.tsx
+++ b/packages/cli/src/tui/__tests__/app-permission-keys.test.tsx
@@ -4,8 +4,9 @@
  * This is the first harness that mounts the root component. Everything in
  * `App.tsx`'s key handler was previously unreachable from a test: both existing
  * Ink harnesses render `<Picker>`, so the Ctrl+C ladder, the Esc-interrupt and
- * this prompt had no coverage at all. That gap is why `Ctrl+O` shipped inert and
- * why Enter could approve a tool call while being named on no screen.
+ * this prompt had no coverage at all. That gap is why a key advertised as
+ * expanding tool output shipped able to do nothing, and why Enter could approve
+ * a tool call while being named on no screen.
  *
  * The scenario is the real one rather than a convenient one: a turn is running,
  * the operator is typing a follow-up into the composer (which stays live while

--- a/packages/cli/src/tui/__tests__/expand-emits-a-row.test.tsx
+++ b/packages/cli/src/tui/__tests__/expand-emits-a-row.test.tsx
@@ -1,0 +1,425 @@
+/**
+ * Collapsed tool output can be read in full, and the way it advertises works.
+ *
+ * Finalized rows render through Ink's `<Static>`, which keeps an index of what
+ * it has already emitted, renders `items.slice(index)`, and calls the render
+ * function only for items beyond it. So the key this replaces could not reopen
+ * a body already on screen — measured, with a twelve-line body up: pressing it
+ * produced one further frame whose transcript region was byte-identical.
+ *
+ * It was not inert, though, and getting that wrong is what shaped this file.
+ * `<Static>` calls the CURRENT render closure for each newly appended item, so
+ * pressing the key while a tool was still running made that tool's result print
+ * in full when it arrived — a real behaviour, invisible, and available only to
+ * someone who wanted the output before knowing it would be truncated.
+ *
+ * Either way the expansion has to be a NEW row, which is what `/expand` pushes.
+ * These tests are written against that distinction: the assertion is not "the
+ * hidden lines are visible somewhere" but "a new row appeared containing them,
+ * and the collapsed one is untouched", because the first would also pass for a
+ * design that cannot reach the case anyone actually hits.
+ *
+ * Driven through a rendered `<App>` rather than `<Transcript>` alone, because
+ * every part of this that can go wrong lives in the seam: whether the number in
+ * the hint is the number the command takes, and whether the command reaches a
+ * transcript that is still being written to. A component test sees neither.
+ */
+
+import { render } from 'ink-testing-library'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Preferences } from '../../integrations/providers/index.js'
+import type { AgentEvent, AgentSession } from '../agent.js'
+import type { TuiContext } from '../types.js'
+
+const PREFS: Preferences = { version: 3, providers: [{ id: 'openai' }], subagents: { active: [] } }
+
+vi.mock('../../integrations/trust/store.js', () => ({ isTrusted: () => true, trustDir: () => {} }))
+vi.mock('../../integrations/updates.js', () => ({ checkUpdates: async () => [] }))
+vi.mock('../../integrations/sessions/store.js', () => ({
+	openSessions: async () => ({ tenantId: 't' }),
+	startConversation: async () => 'conv',
+	appendMessages: async () => {},
+	listRecent: async () => [],
+	loadConversation: async () => [],
+}))
+vi.mock('../../user-commands/store.js', () => ({ discoverUserCommands: () => [] }))
+
+/**
+ * Twelve lines, so six collapse and six hide. Distinguishable per line and
+ * per block: an assertion that `line-9` reached the screen must not be
+ * satisfiable by the OTHER block's ninth line, or the test would pass while
+ * `/expand 1` expanded block 2.
+ */
+const CALL_DETAIL = Array.from({ length: 12 }, (_, i) => `call-line-${i + 1}`)
+const RESULT_DETAIL = Array.from({ length: 12 }, (_, i) => `result-line-${i + 1}`)
+
+/**
+ * Short enough to print in full, so it collapses nothing and advertises nothing.
+ *
+ * Three lines rather than seven on purpose: the whole question is whether a body
+ * that never truncates can nonetheless take a number and be picked up by a bare
+ * `/expand`. Set by the second `describe` below.
+ */
+const SHORT_DETAIL = ['short-a', 'short-b', 'short-c']
+/** Whether the mocked turn ends with a short, uncollapsed body. */
+let trailingShortBlock = false
+
+vi.mock('../agent.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../agent.js')>()
+	return {
+		...actual,
+		probeAgentSession: async () => ({
+			preferences: PREFS,
+			needsRepickReason: null,
+			detected: [],
+		}),
+		createAgentSession: async (): Promise<AgentSession> => ({
+			hasProvider: true,
+			providerSummary: 'a-provider',
+			modelSummary: 'a-model',
+			toolNames: ['bash'],
+			errorHint: null,
+			instructionFiles: [],
+			skippedInstructionFiles: [],
+			mcpConnected: [],
+			mcpFailed: [],
+			agentIds: [],
+			configNotices: [],
+			close: async () => {},
+			approvalLatched: () => false,
+			promptExemptTools: () => [],
+			// One tool call producing TWO collapsible bodies — the `⏺` call line
+			// and the `⎿` result. Two is the minimum that can tell a working
+			// lookup from one that always returns the last thing it saw.
+			send: async function* (): AsyncIterable<AgentEvent> {
+				yield {
+					kind: 'tool-start',
+					toolUseId: 'u1',
+					toolName: 'bash',
+					summary: 'ls',
+					detail: CALL_DETAIL,
+				} as AgentEvent
+				await new Promise((r) => setTimeout(r, 10))
+				yield {
+					kind: 'tool-end',
+					toolUseId: 'u1',
+					toolName: 'bash',
+					summary: 'ok',
+					isError: false,
+					detail: RESULT_DETAIL,
+				} as AgentEvent
+				if (trailingShortBlock) {
+					yield {
+						kind: 'tool-start',
+						toolUseId: 'u2',
+						toolName: 'read',
+						summary: 'notes.txt',
+						detail: SHORT_DETAIL,
+					} as AgentEvent
+					await new Promise((r) => setTimeout(r, 10))
+					yield {
+						kind: 'tool-end',
+						toolUseId: 'u2',
+						toolName: 'read',
+						summary: 'ok',
+						isError: false,
+						detail: SHORT_DETAIL,
+					} as AgentEvent
+				}
+				yield { kind: 'done', stopReason: 'end_turn' } as AgentEvent
+			},
+		}),
+	}
+})
+
+const { App } = await import('../App.js')
+
+const ctx: TuiContext = { cwd: '/w', version: '0.0.0-test' }
+const tick = (ms = 40) => new Promise((r) => setTimeout(r, ms))
+const mounted: { unmount: () => void }[] = []
+
+afterEach(() => {
+	for (const h of mounted) h.unmount()
+	mounted.length = 0
+	trailingShortBlock = false
+	vi.restoreAllMocks()
+})
+
+/**
+ * Poll rather than sleep a fixed interval.
+ *
+ * The same load cliff the permission-key harness documents: this suite
+ * transforms TypeScript on the way in, and a fixed wait that passes this file
+ * alone goes red inside the full parallel run — reported as "the output never
+ * arrived" rather than as whatever the test was about.
+ */
+async function frameShows(
+	lastFrame: () => string | undefined,
+	text: string,
+	timeoutMs = 5_000,
+): Promise<void> {
+	const started = performance.now()
+	while (!(lastFrame() ?? '').includes(text) && performance.now() - started < timeoutMs) {
+		await tick(20)
+	}
+}
+
+/** Render, run the turn, and stop with two collapsed bodies on screen. */
+async function twoCollapsedBlocks() {
+	const harness = render(<App ctx={ctx} />)
+	// Registered before the first assertion so a throw still tears down; a
+	// leaked Ink instance turns one real failure into a column of fake ones.
+	mounted.push(harness)
+	// The COMPOSER's placeholder is not readiness — it draws from the first
+	// frame, while the composer stays `disabled` until the session is up, so a
+	// key sent on sight of it is dropped and the turn never runs. The connect
+	// line is the first thing that only exists once `phase === 'ready'`.
+	await frameShows(harness.lastFrame, 'Connected to a-provider')
+	harness.stdin.write('go')
+	await tick(20)
+	harness.stdin.write('\r')
+	await frameShows(harness.lastFrame, 'result-line-6')
+	expect(harness.lastFrame(), 'the turn never produced output').toContain('result-line-6')
+	return harness
+}
+
+/**
+ * The longest run of consecutive blank lines in a frame.
+ *
+ * The bottom spacer is a `<Box height={n} />` and renders as exactly that: n
+ * empty rows above the composer. Nothing else in the layout produces a run of
+ * them, so this is how much padding was inserted.
+ */
+function longestBlankRun(frame: string): number {
+	let best = 0
+	let run = 0
+	for (const line of frame.split('\n')) {
+		run = line.trim().length === 0 ? run + 1 : 0
+		if (run > best) best = run
+	}
+	return best
+}
+
+/** Type a line into the composer and submit it. */
+async function submit(harness: { stdin: { write: (s: string) => void } }, line: string) {
+	// Written separately: Ink delivers one `stdin.write` as ONE keypress, so
+	// `'/expand\r'` arrives with `key.return` false and is taken as pasted text.
+	harness.stdin.write(line)
+	await tick(30)
+	harness.stdin.write('\r')
+}
+
+describe('a collapsed body advertises how to read it', () => {
+	it('names the number the command takes, rather than a key', async () => {
+		const { lastFrame } = await twoCollapsedBlocks()
+
+		const frame = lastFrame() ?? ''
+		// Both blocks hide six lines, and each carries its own number.
+		expect(frame, 'the first body did not name itself').toContain('… +6 lines · /expand 1')
+		expect(frame, 'the second body did not name itself').toContain('… +6 lines · /expand 2')
+		// The removed key must not still be advertised anywhere on the screen.
+		// A key that is gone and still printed is the defect this replaced.
+		expect(frame.toLowerCase(), 'a removed key is still advertised').not.toContain('ctrl+o')
+	})
+})
+
+describe('a body that fits', () => {
+	it('takes no number, so bare /expand still reaches the one that is hidden', async () => {
+		// The turn ends with a three-line body: fully visible, no hint, nothing
+		// concealed. Numbering it anyway would make it "the most recent block",
+		// so bare `/expand` would reprint three lines the operator can already
+		// read while the twelve-line body above stayed truncated — a command that
+		// answers a question nobody asked and leaves the real one unanswered.
+		//
+		// It also puts invisible gaps in the sequence, and makes "this
+		// conversation has N" count blocks no hint ever offered.
+		trailingShortBlock = true
+		const harness = render(<App ctx={ctx} />)
+		mounted.push(harness)
+		await frameShows(harness.lastFrame, 'Connected to a-provider')
+		harness.stdin.write('go')
+		await tick(20)
+		harness.stdin.write('\r')
+		await frameShows(harness.lastFrame, 'short-c')
+
+		const before = harness.lastFrame() ?? ''
+		// Two numbered blocks, and they are the two that truncated.
+		expect(before).toContain('… +6 lines · /expand 1')
+		expect(before).toContain('… +6 lines · /expand 2')
+		expect(before, 'a body that fits was numbered').not.toContain('/expand 3')
+
+		await submit(harness, '/expand')
+		await frameShows(harness.lastFrame, 'result-line-12')
+
+		expect(
+			harness.lastFrame() ?? '',
+			'bare /expand reprinted a body that was already whole',
+		).toContain('result-line-12')
+	})
+})
+
+describe('Ctrl+O, which used to be the way', () => {
+	it('is still bound, and says what to press instead', async () => {
+		// It is not deleted out from under anyone. Advertised for a long time as
+		// toggling full expansion, it never could reopen output already drawn —
+		// but it was not inert either: it pre-armed rows that had not arrived yet.
+		// So it keeps answering, and what it answers is the replacement.
+		const harness = await twoCollapsedBlocks()
+
+		harness.stdin.write('\x0f') // Ctrl+O
+		await frameShows(harness.lastFrame, 'Ctrl+O is deprecated')
+
+		const frame = harness.lastFrame() ?? ''
+		expect(frame, 'the key went back to being silent').toContain('Ctrl+O is deprecated')
+		expect(frame, 'said it was gone without saying what replaced it').toContain('/expand')
+		// And it must not have expanded anything: the whole point is that it
+		// cannot, and a notice plus a silent expansion would be two answers.
+		expect(frame, 'the deprecated key expanded something anyway').not.toContain('result-line-12')
+	})
+})
+
+describe('/expand', () => {
+	it('prints the hidden lines as a NEW row, leaving the collapsed one alone', async () => {
+		const harness = await twoCollapsedBlocks()
+
+		await submit(harness, '/expand 2')
+		await frameShows(harness.lastFrame, 'result-line-12')
+
+		const frame = harness.lastFrame() ?? ''
+		// The lines that were behind the hint are now on screen.
+		expect(frame, 'the hidden lines never appeared').toContain('result-line-12')
+		// And they arrived as a new row that says what it is of, rather than by
+		// the old row changing — which `<Static>` would not have allowed.
+		expect(frame, 'the expansion did not say what it expanded').toContain('in full (12 lines)')
+		// The original row still reads exactly as it did. This is the assertion
+		// that distinguishes emitting from mutating: a design that tried to
+		// re-render the committed row would leave no hint behind.
+		expect(frame, 'the collapsed row was disturbed').toContain('… +6 lines · /expand 2')
+	})
+
+	it('takes the number the hint printed, not the position of the row', async () => {
+		// `/expand 1` must reach the FIRST body. Between the two bodies sit the
+		// user's own row and the tool result line, so anything counting messages
+		// rather than bodies lands somewhere else.
+		const harness = await twoCollapsedBlocks()
+
+		await submit(harness, '/expand 1')
+		await frameShows(harness.lastFrame, 'call-line-12')
+
+		const frame = harness.lastFrame() ?? ''
+		expect(frame, '/expand 1 did not reach the first body').toContain('call-line-12')
+		expect(frame, '/expand 1 expanded the wrong body').not.toContain('result-line-12')
+	})
+
+	it('with no argument takes the most recent body', async () => {
+		const harness = await twoCollapsedBlocks()
+
+		await submit(harness, '/expand')
+		await frameShows(harness.lastFrame, 'result-line-12')
+
+		const frame = harness.lastFrame() ?? ''
+		expect(frame, 'bare /expand did not take the most recent').toContain('result-line-12')
+		expect(frame, 'bare /expand reached back past the most recent').not.toContain('call-line-12')
+	})
+
+	it('says how many there are when asked for one that does not exist', async () => {
+		// Refusing alone would leave the operator guessing at a number, which is
+		// the same cost the numbered hint exists to remove.
+		const harness = await twoCollapsedBlocks()
+
+		await submit(harness, '/expand 9')
+		await frameShows(harness.lastFrame, 'No collapsed output numbered 9')
+
+		const frame = harness.lastFrame() ?? ''
+		expect(frame).toContain('No collapsed output numbered 9')
+		expect(frame, 'refused without saying which numbers exist').toContain('numbered 1 to 2')
+	})
+
+	it('says what produces one when the transcript has none', async () => {
+		// Before any tool has run. An empty result here would read as a broken
+		// command rather than as an empty set.
+		const harness = render(<App ctx={ctx} />)
+		mounted.push(harness)
+		// The COMPOSER's placeholder is not readiness — it draws from the first
+	// frame, while the composer stays `disabled` until the session is up, so a
+	// key sent on sight of it is dropped and the turn never runs. The connect
+	// line is the first thing that only exists once `phase === 'ready'`.
+	await frameShows(harness.lastFrame, 'Connected to a-provider')
+
+		await submit(harness, '/expand')
+		await frameShows(harness.lastFrame, 'Nothing to expand yet')
+
+		expect(harness.lastFrame() ?? '').toContain('Nothing to expand yet')
+	})
+
+	it('forgets the numbers when /clear takes the rows away', async () => {
+		// A number outliving the row it names is this surface's own defect in
+		// miniature: `/expand 1` would print output the operator can no longer
+		// see anywhere, from a conversation they just cleared.
+		const harness = await twoCollapsedBlocks()
+
+		await submit(harness, '/clear')
+		await tick(80)
+		await submit(harness, '/expand 1')
+		await frameShows(harness.lastFrame, 'Nothing to expand yet')
+
+		const frame = harness.lastFrame() ?? ''
+		expect(frame, 'a cleared block was still expandable').toContain('Nothing to expand yet')
+		expect(frame, 'output from a cleared conversation came back').not.toContain('call-line-12')
+	})
+
+	it('stops padding the composer down once the expansion fills the viewport', async () => {
+		// The wiring assertion, and it has to be here rather than on the helper.
+		//
+		// `spacerTranscript` has its own unit tests, and every one of them stays
+		// green if `App` goes back to passing `messages.map(m => m.content)` — the
+		// helper would simply not be called. That is a check that cannot fail
+		// under its own target defect, so this drives the real component and
+		// looks at the real frame.
+		//
+		// What it looks at: the spacer pads blank rows above the composer only
+		// while the transcript is knowably shorter than the terminal. An expanded
+		// twelve-line body on a small terminal is past that point, so the padding
+		// must be gone. If App stops counting bodies, the same transcript measures
+		// a handful of rows and the spacer pads a screenful — pushing the composer
+		// out of view, which is the harm the estimate exists to avoid.
+		const rows = Object.getOwnPropertyDescriptor(process.stdout, 'rows')
+		const columns = Object.getOwnPropertyDescriptor(process.stdout, 'columns')
+		// Forty rows, not twenty-four, and the difference is the point. At 24 the
+		// live furniture and safety margin leave so little budget that the
+		// unmeasured transcript ALSO comes out barely padded, and the test passed
+		// the defect by three rows. A tall terminal is where the two answers
+		// diverge: the real estimate is past the viewport and pads nothing, the
+		// content-only one has room to spare and pads a screenful.
+		Object.defineProperty(process.stdout, 'rows', { value: 40, configurable: true })
+		Object.defineProperty(process.stdout, 'columns', { value: 80, configurable: true })
+		try {
+			const harness = await twoCollapsedBlocks()
+			await submit(harness, '/expand 2')
+			await frameShows(harness.lastFrame, 'result-line-12')
+
+			const blankRun = longestBlankRun(harness.lastFrame() ?? '')
+			expect(blankRun, 'the composer was padded down past a full screen').toBeLessThan(4)
+		} finally {
+			if (rows) Object.defineProperty(process.stdout, 'rows', rows)
+			else Reflect.deleteProperty(process.stdout, 'rows')
+			if (columns) Object.defineProperty(process.stdout, 'columns', columns)
+			else Reflect.deleteProperty(process.stdout, 'columns')
+		}
+	})
+
+	it('refuses an argument that is not a number, instead of expanding something', async () => {
+		const harness = await twoCollapsedBlocks()
+
+		await submit(harness, '/expand 2nd')
+		await frameShows(harness.lastFrame, 'Usage: /expand')
+
+		const frame = harness.lastFrame() ?? ''
+		expect(frame).toContain('Usage: /expand')
+		// `parseInt('2nd')` is 2. A parser that used it would silently expand
+		// block 2 for a typo, which is the quiet-wrong-answer failure this
+		// whole surface is being cleaned of.
+		expect(frame, 'a typo was read as a block number').not.toContain('result-line-12')
+	})
+})

--- a/packages/cli/src/tui/bottom-spacer.ts
+++ b/packages/cli/src/tui/bottom-spacer.ts
@@ -50,7 +50,16 @@ export interface SpacerInput {
 	readonly rows: number | undefined
 	/** Terminal width, for wrapping. `undefined` falls back to 80. */
 	readonly columns: number | undefined
-	/** The finalized transcript lines, as emitted — before ink renders them. */
+	/**
+	 * The finalized transcript lines, as emitted — before ink renders them.
+	 *
+	 * Every line a row will print, including the collapsed body under a tool
+	 * call. The caller used to pass each row's `content` alone, which counted an
+	 * eight-row tool result as one row: the estimate then ran low by seven, and
+	 * the asymmetry above says exactly what running low costs. `/expand` makes a
+	 * row whose whole substance is its body, so a caller that passed content
+	 * alone would hand a two-hundred-line row over as a single line.
+	 */
 	readonly transcript: readonly string[]
 	/** Rows the live region occupies: activity, composer frame, status bar. */
 	readonly liveRows: number

--- a/packages/cli/src/tui/slashCommands.test.ts
+++ b/packages/cli/src/tui/slashCommands.test.ts
@@ -447,6 +447,10 @@ describe('the new commands are reachable', () => {
 			expect(r.content).toMatch(/\/cost\s/)
 			expect(r.content).toMatch(/\/permissions\s/)
 			expect(r.content).toMatch(/\/agents\s/)
+			// `/expand` replaced a key. A key is discoverable by pressing it and a
+			// command is not, so the entry that names it is load-bearing in a way
+			// the others are not.
+			expect(r.content).toMatch(/\/expand\s/)
 		}
 	})
 
@@ -454,5 +458,54 @@ describe('the new commands are reachable', () => {
 		expect(matchSlashCommands('/co').map((c) => c.name)).toContain('cost')
 		expect(matchSlashCommands('/ag').map((c) => c.name)).toContain('agents')
 		expect(matchSlashCommands('/per').map((c) => c.name)).toContain('permissions')
+		expect(matchSlashCommands('/ex').map((c) => c.name)).toContain('expand')
+	})
+})
+
+describe('/expand argument parsing', () => {
+	// This module validates the SHAPE of the argument and nothing else. Whether
+	// block 4 exists is a fact about the transcript, which App owns; putting the
+	// lookup here as well would give one question two answers.
+
+	it('takes the most recent block when given no argument', () => {
+		expect(runSlash('/expand', ctx)).toEqual({ kind: 'expand', which: 'last' })
+	})
+
+	it('passes a number through', () => {
+		expect(runSlash('/expand 3', ctx)).toEqual({ kind: 'expand', which: 3 })
+	})
+
+	it('refuses a number-with-a-suffix rather than reading the digits off it', () => {
+		// `parseInt('2nd')` is 2, so a parser built on it expands block 2 for
+		// what was a typo — and shows the operator output they did not ask for
+		// with nothing to indicate the substitution. `Number` returns NaN, which
+		// is the honest reading of `2nd` as a block number.
+		const r = runSlash('/expand 2nd', ctx)
+		expect(r?.kind).toBe('message')
+		if (r?.kind === 'message') expect(r.content).toContain('Usage: /expand')
+	})
+
+	it('accepts only the spelling a hint can print', () => {
+		// Every one of these is a number JavaScript is happy to parse and no
+		// collapse hint has ever shown. They matter because each turns a typo
+		// into a VALID reference to some other block, which is the silently-wrong
+		// answer this surface exists to remove — `0x10` reaching block 16 is
+		// worse than `0x10` being refused.
+		//
+		// `Number(arg)` with `Number.isInteger` — the first version of this
+		// parser — accepts all four.
+		for (const arg of ['0', '-1', '1.5', '0x10', '1e2', '+3', '3.0', '3 3']) {
+			const r = runSlash(`/expand ${arg}`, ctx)
+			expect(r?.kind, `"${arg}" was accepted as a block number`).toBe('message')
+		}
+	})
+
+	it('is not fussy about the spacing around it', () => {
+		// Refusing `0x10` is about a wrong answer being possible. Extra spaces
+		// cannot produce a wrong answer, and refusing them would be strictness
+		// for its own sake — `parseSlash` splits on runs of whitespace, so this
+		// is already the same argument.
+		expect(runSlash('/expand   3', ctx)).toEqual({ kind: 'expand', which: 3 })
+		expect(runSlash('  /expand 3  ', ctx)).toEqual({ kind: 'expand', which: 3 })
 	})
 })

--- a/packages/cli/src/tui/slashCommands.ts
+++ b/packages/cli/src/tui/slashCommands.ts
@@ -1,9 +1,11 @@
 /**
  * Slash command registry + parser. Pure logic — no React. Unit-tested.
  *
- * A command's `action` returns either a `system` message to push onto the
- * transcript, an `exit` signal, or `void` (no transcript change). The
- * caller (App) maps results onto state.
+ * A command's `action` returns a `SlashAction` — see the union below, which has
+ * grown well past the "message, exit, or nothing" this line used to claim. The
+ * caller (App) maps every kind onto state, and its switch is exhaustive: a kind
+ * added here and not handled there falls out of the switch into the send path
+ * and dispatches the operator's `/command` to the model as prose.
  *
  * `/cost`, `/permissions` and `/agents` are RENDERERS. Every number and rule
  * they print was already computed — the kernel emits usage on its own event,
@@ -12,6 +14,13 @@
  * asks the model, recomputes anything, or reaches past what the session
  * already carries. A command that had to compute its own answer would be a
  * second source for a fact the kernel already owns, and the two would drift.
+ *
+ * `/expand` is the same discipline with the split drawn one step earlier. The
+ * lines it prints were captured when the tool ran and are held on the transcript
+ * row, which this module cannot see and must not: it validates the argument and
+ * hands App a `which`, and App — the only thing that knows what rows exist —
+ * resolves it. Giving this module the transcript to search would put the answer
+ * to "does block 4 exist" in two places at once.
  */
 
 import type { VerificationRule } from '@namzu/sdk'
@@ -28,6 +37,15 @@ export type SlashAction =
 	| { kind: 'list-skills' }
 	| { kind: 'load-skill'; name: string }
 	| { kind: 'resume' }
+	/**
+	 * Print a collapsed tool body in full, as a NEW transcript row.
+	 *
+	 * `which` is the number the collapse hint printed, or `'last'` for the most
+	 * recent one. This module validates the shape of the argument and stops
+	 * there: whether such a block exists is a fact about the transcript, which
+	 * App owns and this module deliberately does not see.
+	 */
+	| { kind: 'expand'; which: number | 'last' }
 	/**
 	 * Drive a turn with text the command composed rather than the user typed.
 	 *
@@ -228,6 +246,34 @@ export const SLASH_COMMANDS: readonly SlashCommand[] = [
 		name: 'resume',
 		description: 'Resume a past conversation in this folder.',
 		action: () => ({ kind: 'resume' }),
+	},
+	{
+		name: 'expand',
+		description: 'Print a collapsed tool output in full: /expand [n].',
+		action: (_ctx, args) => {
+			const arg = args.join(' ').trim()
+			// Bare `/expand` means the most recent one. That is what a person types
+			// the moment output truncates in front of them, and making them read a
+			// number back off the screen first would be a toll on the common case.
+			if (arg.length === 0) return { kind: 'expand', which: 'last' }
+			// Matched as the literal decimal a hint can print, and nothing else.
+			//
+			// `parseInt` would read `2nd` as 2 and expand a block the operator did
+			// not name. `Number` plus `Number.isInteger` fixes that one and still
+			// admits `0x10`, `1e2`, `+3` and `3.0` — four spellings no hint has
+			// ever shown, each of which turns a typo into a valid reference to
+			// some OTHER block. What this accepts is exactly what the screen can
+			// produce, which is the only set with no silently-wrong answer in it.
+			if (!/^[1-9][0-9]*$/.test(arg)) {
+				return {
+					kind: 'message',
+					role: 'system',
+					content:
+						'Usage: /expand [n], where n is the number in the "… +N lines · /expand n" hint under a collapsed tool output. /expand on its own takes the most recent one.',
+				}
+			}
+			return { kind: 'expand', which: Number(arg) }
+		},
 	},
 	{
 		name: 'skill',

--- a/packages/cli/src/tui/types.ts
+++ b/packages/cli/src/tui/types.ts
@@ -21,8 +21,31 @@ export interface TranscriptMessage {
 	readonly glyphColor?: string
 	/** Dim suffix after the content (e.g. a tool's elapsed time). */
 	readonly meta?: string
-	/** Collapsible body under the line (tool diff / output); see Ctrl+O. */
+	/** Collapsible body under the line (tool diff / output). */
 	readonly detail?: readonly string[]
+	/**
+	 * The number this row's collapse hint prints, so `/expand <n>` can name it.
+	 *
+	 * Assigned once, when the row is pushed, and monotone for the life of the
+	 * transcript. Deliberately NOT an index into the message list: system, user
+	 * and assistant rows sit between the ones that carry detail, so an index
+	 * would name a different row every time one of those arrived.
+	 */
+	readonly detailRef?: number
+	/**
+	 * This row prints its whole body, with no collapse and no hint.
+	 *
+	 * A property of the ROW rather than a setting on the view, and that is
+	 * forced rather than chosen. Finalized rows render through Ink's `<Static>`,
+	 * which renders `items.slice(index)` and calls the render function only for
+	 * items it has not emitted yet — so a view-wide "expanded" flag reaches rows
+	 * that have not arrived and no row that has. That is what the key this
+	 * replaced actually did, and why it was worse than useless: it expanded
+	 * output you had not seen and could not touch the output you were looking at.
+	 * The only expansion available to a row already on screen is a NEW row, which
+	 * is what `/expand` pushes and what this flag marks.
+	 */
+	readonly detailExpanded?: boolean
 }
 
 export interface TuiContext {


### PR DESCRIPTION
Collapsed tool bodies now say how to reopen themselves, and `/expand` reopens them.

```
⏺ Bash(rg --files-with-matches TODO)
 ▏ src/agent.ts
 ▏ src/composer.ts
 ▏ … +6 lines · /expand 3
```

`/expand 3` prints that body in full as a **new entry below**; bare `/expand` takes the most recent one. The collapsed entry stays exactly where it was.

## Why a command and not a key

Finalized entries render through Ink's `<Static>`, which keeps an index of what it has emitted, renders `items.slice(index)`, and calls the render function only for items beyond it. Nothing decided now can reach a body already on screen. That is deliberate — it is what keeps a long session bounded (adopted after an out-of-memory incident) and what makes the terminal's own scrollback and text selection work across the whole conversation.

**Measured, not reasoned:** an `<App>` harness with a twelve-line body up, `Ctrl+O` pressed, every frame dumped. One further frame, transcript region byte-identical.

## What the adversarial pass overturned

I first wrote that the key "never did anything" and that "no keystroke could have worked". **The second claim was false and the first was too strong.** `<Static>` calls the *current* render closure for each newly appended item, so pressing `Ctrl+O` while a tool was still running made that tool's result print in full when it arrived. A real behaviour — undiscoverable, unadvertised, and requiring you to want the output before you could see it had been truncated.

Two consequences, both taken rather than argued around:

- The changeset and docs are rewritten to say what it did.
- `AGENTS.md` permits going straight to `major` only for a removal that "provably does nothing — no producer, no reader, no runtime effect". This has a runtime effect, so **the key stays bound** and now prints the reason and the replacement. That is strictly more than it gave in the case an operator would actually try it.

## Also here, because `/expand` makes them load-bearing

- **Only bodies that truncate take a number.** Numbering every body put invisible gaps in the sequence and let a bare `/expand` reprint a whole three-line body while the truncated one above it stayed hidden.
- **The argument is matched as the decimal a hint can print.** `parseInt` reads `2nd` as 2; `Number` + `isInteger` fixes that and still admits `0x10`, `1e2`, `+3`, `3.0` — four spellings no hint shows, each turning a typo into a valid reference to a *different* block.
- **App's slash switch is exhaustive.** Without it an action kind added and not handled falls out of the switch into the send path and dispatches the operator's `/command` to the model as prose. `assertNever` turns that into a build failure.
- **The composer's blank-row estimate counts what renders.** It measured each entry by its first line alone, so a six-line collapsed body counted as zero — the direction that pushes the composer off the bottom. It now counts the body, the blank row between entries, and the three columns the gutter and rule take from each body line. *This is not the blocked spacer item*: `liveRows: 10` versus a variable live region still needs a real terminal, and is untouched.

## Every place `Ctrl+O` was mentioned

Enumerated before anything was changed. `docs/cli/tui.md` ×2, `docs/cli/README.md` ×2, `types.ts`, `Transcript.tsx` ×2, `App.tsx`, one test docblock. `packages/cli/CHANGELOG.md` mentions it three times and is deliberately **not** edited — those entries describe releases that happened.

## Mutation table

Each mutation restores one defect; the tests that die are listed.

| Mutation | Died |
| --- | --- |
| hint drops `· /expand N` | 2 — names the number; leaves the collapsed one alone |
| bare `/expand` takes `blocks[0]` | 1 — with no argument takes the most recent |
| number becomes a row index, not a body number | 3 — names the number; both lookups |
| parser back to `parseInt` | 3 — two parser cases, one rendered-App case |
| expanded row loses `detailExpanded` | 3 — every expansion re-collapses |
| `willCollapse` → `detail.length > 0` | 1 — a body that fits takes no number |
| `renderedDetailLines` drops the hint row | 2 — hint row; what the spacer is given |
| App bypasses `spacerTranscript` | 1 — stops padding once the expansion fills the viewport |
| `resetTranscript` stops clearing (pre-rework design) | 1 — forgets the numbers on `/clear` |
| Ctrl+O notice removed | 1 — is still bound, and says what to press instead |
| `case 'expand'` deleted | **typecheck fails** (the `assertNever`), plus 8 tests |

**A test that could not fail, and how it was caught.** I claimed the spacer unit test "pins the wiring". It does not: every assertion calls the helper directly, so putting App's call site back to `messages.map(m => m.content)` leaves them all green. Replaced with a rendered-`<App>` assertion on the real blank-row count. The first version of *that* was nearly as bad — it killed the mutation 4 vs 4, because at 24 rows the budget is small enough that the unmeasured transcript is also barely padded. At 40 rows the answers diverge properly: 20 vs 4.

## Found and deliberately not fixed here

`/resume` during a running turn does not abort the old loop. Its later events append into the resumed transcript and the old turn persists under the mutated `scope.sessionId`. Pre-existing, unrelated to this change except that those rows now take numbers too.

## Checks — all six

| Gate | |
| --- | --- |
| `pnpm build` | pass |
| `pnpm typecheck` | pass |
| `pnpm lint` | pass (2 pre-existing warnings in `__fixtures__/temp-dir.ts`, untouched) |
| `pnpm test` | pass — cli 664 passed / 3 skipped |
| `node scripts/audit-external-names.mjs` | pass |
| `pnpm docs:check` | pass — 0 problems across 13 checked files |

Also fixed: `app-draft-survives.test.tsx` raced a wall clock. Its mock ended the turn after a fixed 120ms, so "is the turn still running when Esc arrives" was a question about machine load — it went red under the full parallel suite reporting "the turn was not interrupted", which was true of a turn that was already over. The turn now ends on the abort signal.
