### PR TITLE
fix(cli): /tools answers for the moment it is asked

### DIFF
--- a/.changeset/tools-reads-the-live-roster.md
+++ b/.changeset/tools-reads-the-live-roster.md
@@ -1,0 +1,18 @@
+---
+'@namzu/cli': patch
+---
+
+**`/tools` lists the tools the agent can call now, not the ones it could call
+when the session opened.**
+
+Some tools register during the first turn rather than at connect — the agent's
+own task tools are the ones that do it today. `/tools` was answering from a list
+captured before that happened, so those tools were missing from it for the whole
+session.
+
+The visible symptom was two commands disagreeing on one screen: `/permissions`
+reads the roster live and would name a tool as never-prompted that `/tools` did
+not list at all, which reads as namzu having invented a tool name.
+
+The connect line (`Connected to … · N tools`) is unchanged and still reports the
+count at connect time, because it describes a connection that has just happened.

--- a/docs/cli/tools.md
+++ b/docs/cli/tools.md
@@ -1,7 +1,7 @@
 ---
 title: Tools & permission
 description: Builtin tools, agent memory + task tools, deferred tools and search_tools, how a tool call is decided, the permissions file, the safety gate, and bypass mode.
-last_updated: 2026-08-05
+last_updated: 2026-08-09
 status: current
 related_packages: ["@namzu/cli", "@namzu/sdk"]
 ---
@@ -35,6 +35,8 @@ The agent can lay out a multi-step plan with the task tools. New tasks appear in
 A **deferred** tool is registered but not offered to the model directly: it costs a name in the prompt rather than a full JSON schema, and the model loads it when it needs it by calling `search_tools`. That keeps per-turn token cost flat as the tool count grows.
 
 In a namzu session the task tools above are the deferred set — they are registered when the session opens a task store, and `search_tools` is mounted alongside them so the model can reach them.
+
+They register during the **first turn**, not at connect. So `Connected to … · N tools` does not count them — it reports what was callable at the moment it connected — while `/tools` and `/permissions` are asked later and answer for the moment you ask. Running one turn and then `/tools` is the reliable way to see the full roster.
 
 A sub-agent runs without a task store, so it has nothing deferred, and `search_tools` is not mounted there at all: a tool whose only possible answer is "nothing matched" costs a turn to discover that.
 

--- a/packages/cli/src/__tests__/a-command-file-reaches-the-turn.test.ts
+++ b/packages/cli/src/__tests__/a-command-file-reaches-the-turn.test.ts
@@ -59,7 +59,7 @@ function writeCommand(name: string, body: string): void {
 
 function context(userCommands: SlashContext['userCommands']): SlashContext {
 	return {
-		availableTools: [],
+		availableTools: () => [],
 		providerSummary: 'mock (mock)',
 		modelSummary: 'mock-model',
 		usage: null,

--- a/packages/cli/src/__tests__/mcp-servers-reach-the-session.test.ts
+++ b/packages/cli/src/__tests__/mcp-servers-reach-the-session.test.ts
@@ -137,7 +137,7 @@ describe('a tool server declared in namzu.config.json', () => {
 			expect(session.mcpConnected).toEqual([{ name: 'tickets', toolCount: 1 }])
 			// The load-bearing one. Connecting and adapting is not the feature —
 			// the model has to be able to see and call it.
-			expect(session.toolNames).toContain('mcp_tickets_create')
+			expect(session.toolNames()).toContain('mcp_tickets_create')
 		} finally {
 			await session.close()
 		}
@@ -154,9 +154,9 @@ describe('a tool server declared in namzu.config.json', () => {
 			mcpServers: { tickets: { command: process.execPath, args: [server] } },
 		})
 		try {
-			expect(session.toolNames).toContain('bash')
-			expect(session.toolNames).toContain('read')
-			expect(session.toolNames).toContain('mcp_tickets_create')
+			expect(session.toolNames()).toContain('bash')
+			expect(session.toolNames()).toContain('read')
+			expect(session.toolNames()).toContain('mcp_tickets_create')
 		} finally {
 			await session.close()
 		}
@@ -171,7 +171,7 @@ describe('a tool server declared in namzu.config.json', () => {
 		try {
 			expect(session.mcpConnected).toEqual([])
 			expect(session.mcpFailed.map((f) => f.name)).toEqual(['tickets'])
-			expect(session.toolNames.some((n) => n.startsWith('mcp_'))).toBe(false)
+			expect(session.toolNames().some((n) => n.startsWith('mcp_'))).toBe(false)
 		} finally {
 			await session.close()
 		}
@@ -183,7 +183,7 @@ describe('a tool server declared in namzu.config.json', () => {
 		try {
 			expect(session.mcpConnected).toEqual([])
 			expect(session.mcpFailed).toEqual([])
-			expect(session.toolNames.some((n) => n.startsWith('mcp_'))).toBe(false)
+			expect(session.toolNames().some((n) => n.startsWith('mcp_'))).toBe(false)
 		} finally {
 			await session.close()
 		}

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -303,7 +303,12 @@ export function App({ ctx }: AppProps) {
 				setPhase('ready')
 				pushMessage(
 					'system',
-					`Connected to ${s.providerSummary}${s.modelSummary ? ` · ${s.modelSummary}` : ''} · ${s.toolNames.length} tools`,
+					// Counted here, at connect. The number is deliberately the one true
+					// at this moment rather than the one that will be true after the
+					// first turn registers the deferred tools — a line reporting that a
+					// connection just happened should describe the connection that just
+					// happened. `/tools` is the present-tense question and asks later.
+					`Connected to ${s.providerSummary}${s.modelSummary ? ` · ${s.modelSummary}` : ''} · ${s.toolNames().length} tools`,
 				)
 				// Before the rest: a limitation the operator accepted once and has
 				// been living with since is the thing they are least likely to
@@ -409,7 +414,9 @@ export function App({ ctx }: AppProps) {
 			: 0
 
 	const slashCtx: SlashContext = {
-		availableTools: session?.toolNames ?? [],
+		// Called when `/tools` renders, not read here — the same shape, and the
+		// same reason, as `neverPrompted` below.
+		availableTools: () => session?.toolNames() ?? [],
 		providerSummary: session?.providerSummary ?? null,
 		modelSummary: session?.modelSummary ?? null,
 		// The same state the status bar reads, unformatted. `/cost` prints exact

--- a/packages/cli/src/tui/__fixtures__/agent-session.ts
+++ b/packages/cli/src/tui/__fixtures__/agent-session.ts
@@ -39,7 +39,7 @@ export function fakeAgentSession(overrides: Partial<AgentSession> = {}): AgentSe
 		hasProvider: true,
 		providerSummary: 'mock',
 		modelSummary: 'mock-model',
-		toolNames: [],
+		toolNames: () => [],
 		errorHint: null,
 		instructionFiles: [],
 		skippedInstructionFiles: [],

--- a/packages/cli/src/tui/__tests__/app-draft-survives.test.tsx
+++ b/packages/cli/src/tui/__tests__/app-draft-survives.test.tsx
@@ -56,7 +56,7 @@ vi.mock('../agent.js', async (importOriginal) => {
 			hasProvider: true,
 			providerSummary: 'a-provider',
 			modelSummary: 'a-model',
-			toolNames: ['bash'],
+			toolNames: () => ['bash'],
 			errorHint: null,
 			instructionFiles: [],
 			skippedInstructionFiles: [],

--- a/packages/cli/src/tui/__tests__/app-permission-keys.test.tsx
+++ b/packages/cli/src/tui/__tests__/app-permission-keys.test.tsx
@@ -90,7 +90,7 @@ vi.mock('../agent.js', async (importOriginal) => {
 				hasProvider: true,
 				providerSummary: 'a-provider',
 				modelSummary: 'a-model',
-				toolNames: ['bash'],
+				toolNames: () => ['bash'],
 				errorHint: null,
 				instructionFiles: [],
 				skippedInstructionFiles: [],

--- a/packages/cli/src/tui/__tests__/app-picker-exits.test.tsx
+++ b/packages/cli/src/tui/__tests__/app-picker-exits.test.tsx
@@ -73,7 +73,7 @@ vi.mock('../agent.js', async (importOriginal) => {
 			hasProvider: true,
 			providerSummary: 'a-provider',
 			modelSummary: 'a-model',
-			toolNames: [],
+			toolNames: () => [],
 			errorHint: null,
 			instructionFiles: [],
 			skippedInstructionFiles: [],

--- a/packages/cli/src/tui/__tests__/ctrl-v-says-what-happened.test.tsx
+++ b/packages/cli/src/tui/__tests__/ctrl-v-says-what-happened.test.tsx
@@ -52,7 +52,7 @@ vi.mock('../agent.js', async (importOriginal) => {
 			hasProvider: true,
 			providerSummary: 'a-provider',
 			modelSummary: 'a-model',
-			toolNames: [],
+			toolNames: () => [],
 			errorHint: null,
 			instructionFiles: [],
 			skippedInstructionFiles: [],

--- a/packages/cli/src/tui/__tests__/deferred-tool-discovery.test.ts
+++ b/packages/cli/src/tui/__tests__/deferred-tool-discovery.test.ts
@@ -101,7 +101,7 @@ describe('search_tools is mounted only where a deferred roster exists', () => {
 
 		// The session opens a task store, so query() defers the task tools and
 		// the search has a roster.
-		expect(session.toolNames).toContain('search_tools')
+		expect(session.toolNames()).toContain('search_tools')
 
 		expect(
 			capturedBuildTools,

--- a/packages/cli/src/tui/__tests__/expand-emits-a-row.test.tsx
+++ b/packages/cli/src/tui/__tests__/expand-emits-a-row.test.tsx
@@ -78,7 +78,7 @@ vi.mock('../agent.js', async (importOriginal) => {
 			hasProvider: true,
 			providerSummary: 'a-provider',
 			modelSummary: 'a-model',
-			toolNames: ['bash'],
+			toolNames: () => ['bash'],
 			errorHint: null,
 			instructionFiles: [],
 			skippedInstructionFiles: [],

--- a/packages/cli/src/tui/__tests__/tools-and-permissions-agree.test.ts
+++ b/packages/cli/src/tui/__tests__/tools-and-permissions-agree.test.ts
@@ -1,0 +1,148 @@
+/**
+ * `/tools` and `/permissions` answer from the same roster, at the same moment.
+ *
+ * The kernel registers some tools DEFERRED, inside the first `query()` — the
+ * task tools are the ones that exist today — so a session's roster is not final
+ * when the session is built. `promptExemptTools` was made a function for exactly
+ * that reason, and its docstring in `agent.ts` says so in as many words.
+ *
+ * `toolNames` sat one field above it and stayed a captured array. So the command
+ * whose entire job is to answer "what can this agent call" answered from a list
+ * taken before some of them existed, while the command two along read the
+ * registry live. On the same screen, with nothing to indicate a difference:
+ * `/permissions` naming a tool as never-prompted, and `/tools` not listing that
+ * tool at all.
+ *
+ * This asserts the CONTRAST rather than either half, per
+ * `docs/conventions/one-site-is-not-every-site.md`: a test that only checked
+ * `/tools` against a session built in a test would pass, because in a test
+ * nothing registers late unless the test makes it. So the test makes it — the
+ * mocked `query` registers into the same registry object the real one is handed,
+ * which is the actual mechanism and not a re-enactment of it.
+ */
+
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ToolRegistry } from '@namzu/sdk'
+
+import { removeTempDir } from '../../__fixtures__/temp-dir.js'
+import type { DetectedProvider, Preferences } from '../../integrations/providers/index.js'
+
+/** A tool that appears only once a turn has started, as the task tools do. */
+const DEFERRED_TOOL = {
+	name: 'late_arrival',
+	description: 'registered during the turn, not before it',
+	inputSchema: { type: 'object' as const, properties: {} },
+	// Declared read-only, so `/permissions` will name it too. That is what makes
+	// the two commands comparable: one roster, two readings of it.
+	isReadOnly: () => true,
+	execute: async () => ({ success: true, output: '' }),
+}
+
+vi.mock('@namzu/sdk', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@namzu/sdk')>()
+	return {
+		...actual,
+		// The real `query` registers the task tools into the registry it is
+		// handed. This does the same thing with one tool of its own, so the
+		// session under test experiences a late registration through the real
+		// wiring rather than through a poke at its internals.
+		query: (args: { tools: ToolRegistry }) => {
+			args.tools.register([DEFERRED_TOOL as never])
+			return (async function* () {})()
+		},
+	}
+})
+
+vi.mock('../../integrations/subagents/runtime.js', () => ({
+	createSubagentRuntime: async () => ({
+		gateway: {} as unknown,
+		agentTool: {
+			name: 'Agent',
+			description: 'stub',
+			inputSchema: { type: 'object', properties: {} },
+			execute: async () => ({ success: true, output: '' }),
+		},
+		allowedAgentIds: [],
+	}),
+}))
+
+let workDir: string
+
+beforeEach(() => {
+	workDir = mkdtempSync(join(tmpdir(), 'namzu-roster-'))
+})
+
+afterEach(() => {
+	removeTempDir(workDir)
+})
+
+const prefs = {
+	version: 3,
+	providers: [{ id: 'anthropic' }],
+	subagents: { active: [] },
+} as Preferences
+
+function detectedAnthropic(): DetectedProvider[] {
+	return [
+		{
+			entry: {
+				id: 'anthropic',
+				label: 'Anthropic',
+				defaultModel: 'claude-sonnet-4-5',
+				requiresApiKey: true,
+				envVars: ['ANTHROPIC_API_KEY'],
+			},
+			source: 'env',
+			apiKey: 'sk-ant-not-a-real-key',
+			alternatives: [],
+		} as unknown as DetectedProvider,
+	]
+}
+
+describe('the roster a session reports', () => {
+	it('grows when a turn registers a tool, rather than staying as it was built', async () => {
+		const { createAgentSession } = await import('../agent.js')
+		const session = await createAgentSession(prefs, detectedAnthropic(), { cwd: workDir })
+		expect(session.hasProvider).toBe(true)
+
+		expect(session.toolNames(), 'a tool existed before its turn ran').not.toContain('late_arrival')
+
+		// Run a turn. The mocked query registers into the session's registry, as
+		// the real one does for the task tools.
+		for await (const _ of session.send([{ role: 'user', content: 'go' } as never])) {
+			// drain
+		}
+
+		expect(session.toolNames(), 'the roster was captured when the session was built').toContain(
+			'late_arrival',
+		)
+	})
+
+	it('is the same roster the exempt list is read from', async () => {
+		// The contrast. `promptExemptTools` has always read the registry live;
+		// the defect was that `toolNames` did not, so the two commands could
+		// describe different sets of tools with nothing to say which was current.
+		//
+		// A tool named as never-prompted but absent from the tool list is not a
+		// small inconsistency: `/permissions` exists to tell an operator what
+		// runs without asking, and a name they cannot find in `/tools` reads as
+		// a tool namzu invented.
+		const { createAgentSession } = await import('../agent.js')
+		const session = await createAgentSession(prefs, detectedAnthropic(), { cwd: workDir })
+
+		for await (const _ of session.send([{ role: 'user', content: 'go' } as never])) {
+			// drain
+		}
+
+		const listed = session.toolNames()
+		for (const exempt of session.promptExemptTools()) {
+			expect(listed, `/permissions names "${exempt}" and /tools does not list it`).toContain(exempt)
+		}
+		// And the deferred one is in both, so the loop above is not vacuous.
+		expect(session.promptExemptTools()).toContain('late_arrival')
+	})
+})

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -212,7 +212,24 @@ export interface AgentSession {
 	readonly hasProvider: boolean
 	readonly providerSummary: string | null
 	readonly modelSummary: string | null
-	readonly toolNames: readonly string[]
+	/**
+	 * Every tool this session can call, by name, read at call time.
+	 *
+	 * A FUNCTION, for the reason stated one field down about `promptExemptTools`
+	 * and reached here late: the roster is not final when the session is built.
+	 * The task tools register deferred inside the first `query()`, so a value
+	 * captured at construction names a set the operator never had — and `/tools`,
+	 * whose entire job is to answer "what can this thing call", was reading
+	 * exactly that captured value while `/permissions`, one command over, read
+	 * the registry live. The two could disagree on the same screen: the exempt
+	 * roster naming `task_create` as never-prompted, and the tool list not
+	 * showing `task_create` at all.
+	 *
+	 * The connect line calls it at connect time and gets the same number it
+	 * always did — the deferred tools genuinely are not registered yet at that
+	 * moment, and a line about what just happened should say what was true then.
+	 */
+	readonly toolNames: () => readonly string[]
 	readonly errorHint: string | null
 	/**
 	 * Absolute paths of the `AGENTS.md` files whose text is in this session's
@@ -576,7 +593,6 @@ export async function createAgentSession(
 	} catch {
 		// Sub-agents unavailable this session — non-fatal.
 	}
-	const activeToolNames = registry.getCallableTools().map((t) => t.name)
 	// Task store → query registers task_create / task_update / task_list as
 	// DEFERRED tools and emits task_created/task_updated, so the agent can track
 	// a plan for the current request. Tasks are run-scoped.
@@ -585,6 +601,10 @@ export async function createAgentSession(
 	// the roster it searches. They are registered inside query(), after this
 	// function returns, which is why the connect line reports no count of them —
 	// counting here would mean restating query's registration order in the CLI.
+	//
+	// It is also why `toolNames` below reads the registry rather than a list
+	// captured on this line. The count at connect time is unchanged; what
+	// changes is that asking again later gets a later answer.
 	const taskStore: TaskStore = new DiskTaskStore({
 		baseDir: join(cwd, '.namzu'),
 		defaultRunId: 'run_namzu-cli' as RunId,
@@ -597,7 +617,10 @@ export async function createAgentSession(
 		hasProvider: true,
 		providerSummary: entry.label,
 		modelSummary: model,
-		toolNames: activeToolNames,
+		// Reads the same registry object the deferred registration mutates, at
+		// call time — the pair of `promptExemptTools` below, and for the same
+		// reason.
+		toolNames: () => registry.getCallableTools().map((t) => t.name),
 		agentIds: allowedAgentIds,
 		instructionFiles: projectInstructions.files.map((f) => f.path),
 		skippedInstructionFiles: projectInstructions.skipped,
@@ -1659,7 +1682,7 @@ function emptySession(errorHint: string): AgentSession {
 		hasProvider: false,
 		providerSummary: null,
 		modelSummary: null,
-		toolNames: [],
+		toolNames: () => [],
 		// No provider, so no runtime was built and there is nothing to delegate
 		// to — the same reason `toolNames` is empty.
 		agentIds: [],

--- a/packages/cli/src/tui/slashCommands.test.ts
+++ b/packages/cli/src/tui/slashCommands.test.ts
@@ -32,7 +32,7 @@ function permissions(over: Partial<SlashContext['permissions']> = {}): SlashCont
  */
 function context(over: Partial<SlashContext> = {}): SlashContext {
 	return {
-		availableTools: [],
+		availableTools: () => [],
 		providerSummary: null,
 		modelSummary: null,
 		usage: null,
@@ -47,7 +47,7 @@ function context(over: Partial<SlashContext> = {}): SlashContext {
 const ctx: SlashContext = context()
 
 const ctxWithTools: SlashContext = context({
-	availableTools: ['Bash', 'Read', 'Edit'],
+	availableTools: () => ['Bash', 'Read', 'Edit'],
 	providerSummary: 'anthropic-personal (anthropic)',
 	modelSummary: 'claude-opus-4-7',
 })

--- a/packages/cli/src/tui/slashCommands.ts
+++ b/packages/cli/src/tui/slashCommands.ts
@@ -58,7 +58,18 @@ export type SlashAction =
 	| { kind: 'none' }
 
 export interface SlashContext {
-	readonly availableTools: readonly string[]
+	/**
+	 * Every tool the agent can call, read when the command runs.
+	 *
+	 * A function, and it is the same function `neverPrompted` below already is,
+	 * for the same reason — see the note there. It was an array, captured when
+	 * the session was built, which is before the task tools register. So the
+	 * command whose entire job is "what can this thing call" answered from a
+	 * snapshot taken too early, while `/permissions` two commands down read the
+	 * registry live. On the same screen, `/permissions` could name a tool as
+	 * never-prompted that `/tools` did not list at all.
+	 */
+	readonly availableTools: () => readonly string[]
 	readonly providerSummary: string | null
 	readonly modelSummary: string | null
 	/**
@@ -213,14 +224,20 @@ export const SLASH_COMMANDS: readonly SlashCommand[] = [
 	{
 		name: 'tools',
 		description: 'List tools the agent can call.',
-		action: (ctx) => ({
-			kind: 'message',
-			role: 'system',
-			content:
-				ctx.availableTools.length === 0
-					? 'No tools registered yet — the agent session may still be connecting.'
-					: `Registered tools (${ctx.availableTools.length}):\n  ${ctx.availableTools.join('\n  ')}`,
-		}),
+		action: (ctx) => {
+			// Asked now, not when the session was built. Some of these register
+			// during the first turn, so a list captured earlier is a list of what
+			// was callable then — and this command is asked in the present tense.
+			const tools = ctx.availableTools()
+			return {
+				kind: 'message',
+				role: 'system',
+				content:
+					tools.length === 0
+						? 'No tools registered yet — the agent session may still be connecting.'
+						: `Registered tools (${tools.length}):\n  ${tools.join('\n  ')}`,
+			}
+		},
 	},
 	{
 		name: 'remember',


### PR DESCRIPTION
**The seventh instance of the defect this queue is about: a surface reporting something it did not actually read.**

`/tools` — the command whose entire job is to answer "what can this agent call" — answered from a list captured when the session was built. Some tools register during the first turn (the agent's own task tools do it today), so for the whole session they were missing from it.

## The evidence, and why it is uncomfortable

`agent.ts` computed the roster at build time and shipped it as a frozen array:

```ts
const activeToolNames = registry.getCallableTools().map((t) => t.name)   // :596
…
toolNames: activeToolNames,                                             // :600
promptExemptTools: () => promptExemptToolNames(registry),               // :617
```

Seventeen lines apart, the same registry object, read two different ways. And the live one carries a docstring that states the reason in plain words:

> Resolved per call rather than snapshotted, because the roster changes after this module has run — the task tools are registered deferred inside `query()`, and tool servers connect during startup, so anything computed eagerly would be answering about a registry that no longer exists.

That was written for `promptExemptTools` and not carried across to the field above it. `docs/conventions/one-site-is-not-every-site.md` is about exactly this shape.

## What the operator sees

Two commands disagreeing on one screen, with nothing to say which is current: `/permissions` naming a tool as never-prompted that `/tools` does not list at all. That reads as namzu having invented a tool name.

## The connect line is deliberately unchanged

`Connected to … · N tools` still counts at connect. It reports a connection that has just happened, and the deferred tools genuinely are not registered at that moment. `docs/cli/tools.md` now says so, because "the number in the connect line is smaller than `/tools`" is otherwise a puzzle.

## The test

It asserts the **contrast**, not either half, for the reason the convention gives: a test of `/tools` alone passes in a suite where nothing registers late. So the test makes something register late through the real wiring — the mocked `query` writes into the same registry object the real one is handed, which is the actual mechanism rather than a re-enactment of it.

The failure message is the operator-visible symptom, not a field name:

```
/permissions names "late_arrival" and /tools does not list it
```

## Mutation table

| Mutation | Died |
| --- | --- |
| `toolNames` re-frozen to a build-time snapshot | 2 — both tests, one naming the growth and one naming the disagreement |

**No mutation killed nothing.**

## Rebased on `main`

Originally two commits. The second fixed a wall-clock race in `app-draft-survives.test.tsx` — its mock ended the turn after a fixed 120ms, so "is the turn still running when Esc arrives" was a question about machine load. That went red on this branch independently of the change, which is what established it as the test's problem rather than either change's.

**That commit is dropped**, because #305 landed the identical edit first. Verified before dropping rather than assumed: `main`'s copy of the file carries the `addEventListener('abort'` line. So this PR is now one commit.

The rebase also pulled in #305's new `<App>` harness, whose session mock still had `toolNames: ['bash']`. Typecheck caught it — the second time in this branch that the compiler finished a signature change grep could not, and here grep could not have, because the file did not exist on the branch when the grep ran.

## Checks — all six

| Gate | |
| --- | --- |
| `pnpm build` | pass |
| `pnpm typecheck` | pass |
| `pnpm lint` | pass (2 pre-existing warnings in `__fixtures__/temp-dir.ts`, untouched) |
| `pnpm test` | pass — cli 667 passed / 3 skipped |
| `node scripts/audit-external-names.mjs` | pass |
| `pnpm docs:check` | pass — 0 problems across 13 checked files |
