### PR TITLE
fix(cli): say whose default a model is

### DIFF
--- a/.changeset/say-whose-default-it-is.md
+++ b/.changeset/say-whose-default-it-is.md
@@ -1,0 +1,26 @@
+---
+'@namzu/cli': patch
+---
+
+**`namzu doctor` now marks an unpinned model `(namzu default)` instead of
+`(default)`, and the picker's notices stop calling it the provider's.**
+
+A chain member that omits `model` gets a value out of namzu's own registry — a
+table compiled into the release. It is resolved at launch but never refreshed
+from the provider, so between releases it can name a model the provider has
+superseded.
+
+Every surface that showed that value called it "the default" or "its default",
+which reads as the provider's current one. It sends an operator who did not
+expect the model to go looking at the provider, where there is nothing to find.
+The thing to do is give that member an explicit `model`, and the surfaces now
+say so:
+
+- `namzu doctor`'s chain readout prints `<model> (namzu default)`.
+- The `/model` picker's four "could not list" notices say "showing namzu's pick
+  for it" rather than "showing its default" — they sat beside a row already
+  labelled `(namzu default)` and contradicted it.
+- `docs/cli/providers.md` no longer says an omitted `model` "tracks the default".
+  It does not track anything; it moves when you upgrade namzu.
+
+If you parse `namzu doctor` output, the marker string changed.

--- a/docs/cli/providers.md
+++ b/docs/cli/providers.md
@@ -1,7 +1,7 @@
 ---
 title: Providers & credentials
 description: How namzu discovers LLM credentials, the first-run provider picker, and switching providers.
-last_updated: 2026-08-08
+last_updated: 2026-08-09
 status: current
 related_packages: ["@namzu/cli", "@namzu/anthropic", "@namzu/openai", "@namzu/openrouter", "@namzu/ollama"]
 ---
@@ -107,7 +107,9 @@ Run `/model` inside the TUI to re-open the picker at any time. The new choice is
 }
 ```
 
-The order is yours to declare, and the file is meant to be read and edited directly — you do not need to launch the TUI to see it. Index 0 is the **primary**. A member that omits `model` uses that provider's registry default, resolved at launch, so it tracks the default instead of pinning whatever it was on the day you wrote it.
+The order is yours to declare, and the file is meant to be read and edited directly — you do not need to launch the TUI to see it. Index 0 is the **primary**.
+
+**A member that omits `model` gets namzu's own default for that provider**, from a table compiled into the release. It is resolved at launch, but it is not *refreshed* at launch: nothing asks the provider what its current default is, so the value moves only when you upgrade namzu, and between releases it can name a model the provider has superseded. If you care which model a member runs, give it an explicit `model`. Omitting it is the right choice when you want whatever namzu currently considers sensible, and the wrong one if you read it as tracking the provider.
 
 When the primary cannot serve a turn, namzu moves to the next member and carries on — see [When a member cannot serve](#when-a-member-cannot-serve).
 
@@ -121,13 +123,15 @@ If any of those fail, namzu names the offending position (`primary provider`, `f
 
 ### Seeing the chain
 
-`namzu doctor` prints it in order, one line per member, each carrying that member's position, label, the model it will use — marked `(default)` when it came from the registry rather than from your file — and whether a credential was found:
+`namzu doctor` prints it in order, one line per member, each carrying that member's position, label, the model it will use — marked `(namzu default)` when it came from namzu's registry rather than from your file — and whether a credential was found:
 
 ```
 providers.chain  2 providers configured, in order:
                  1. primary · <label> · <model> · credential found
-                 2. fallback 1 · <label> · <model> (default) · NO CREDENTIAL
+                 2. fallback 1 · <label> · <model> (namzu default) · NO CREDENTIAL
 ```
+
+The label names whose choice it is on purpose. A model marked this way is one namzu picked, not one the provider reported, and nothing refreshes it between releases — so a member showing a model you did not expect is fixed by giving that member an explicit `model`, not by looking for the setting at the provider.
 
 A fallback with no credential is a **warning**, not a failure — your primary still runs, so you are not blocked. A primary with no credential is a failure, because no run can start.
 

--- a/docs/cli/tui.md
+++ b/docs/cli/tui.md
@@ -89,9 +89,12 @@ list:
 | *does not publish a model list* | this driver has no listing capability |
 | *could not list models: …* | it errored, with its own reason |
 
-In every one of those cases the provider's default is still offered and
-selectable, so the step is never a dead end. The default is marked `(default)`
-wherever it appears.
+In every one of those cases a model is still offered and selectable, so the step
+is never a dead end. That model is marked **`(namzu default)`** wherever it
+appears, and the label is precise: it is namzu's own choice for the provider,
+not something the provider told us. Nothing refreshes it between releases, so if
+it is not the model you expected, set `model` on that entry in
+`~/.namzu/preferences.json` rather than looking for the setting at the provider.
 
 Your choice is written to `~/.namzu/preferences.json` as the primary entry's
 `model`, and it is what the next turn is sent with. See

--- a/packages/cli/src/doctor/checks/__tests__/chain.test.ts
+++ b/packages/cli/src/doctor/checks/__tests__/chain.test.ts
@@ -54,10 +54,15 @@ describe('the provider chain check', () => {
 		expect(message).toContain('a-model')
 	})
 
-	it('shows the registry default for a member that pinned no model', async () => {
+	it('says WHOSE default a member that pinned no model gets', async () => {
+		// `(namzu default)`, not `(default)`. The value is namzu's registry entry,
+		// and a bare "default" reads as the provider's current one — which sends
+		// an operator looking at the wrong place when the model is not what they
+		// expected. Asserted as the whole phrase for that reason: `(default)`
+		// alone is a substring of it and would pass either way.
 		writePrefs({ version: 3, providers: [{ id: 'anthropic' }] })
 		const r = await check({ ANTHROPIC_API_KEY: 'x' })
-		expect(r.message ?? '').toContain('(default)')
+		expect(r.message ?? '').toContain('(namzu default)')
 	})
 
 	it('WARNS when only a fallback is unusable — the primary still runs', async () => {

--- a/packages/cli/src/doctor/checks/chain.ts
+++ b/packages/cli/src/doctor/checks/chain.ts
@@ -118,7 +118,12 @@ export async function describeProviderChain(
 	for (const [index, member] of members.entries()) {
 		const entry = PROVIDER_REGISTRY[member.id]
 		const position = index === 0 ? 'primary' : `fallback ${index}`
-		const model = member.model ?? `${entry.defaultModel} (default)`
+		// `(namzu default)`, not `(default)`. The value comes from namzu's own
+		// provider registry, and a bare "default" reads as the provider's current
+		// one — so an operator seeing a model they did not expect concludes the
+		// provider changed it, when the thing to do is pin `model` on this member.
+		// The picker already says it this way; this line is the same value.
+		const model = member.model ?? `${entry.defaultModel} (namzu default)`
 		const det = detected.find((d) => d.entry.id === member.id)
 		const usable = entry.requiresApiKey ? Boolean(det?.apiKey) : Boolean(det)
 		if (!usable) {

--- a/packages/cli/src/tui/model-choices.test.ts
+++ b/packages/cli/src/tui/model-choices.test.ts
@@ -81,6 +81,25 @@ describe('modelStep', () => {
 			expect(step.notice).toContain('HTTP 503')
 		})
 
+		it('never tells the operator the fallback is the provider’s own default', () => {
+			// The row is labelled `(namzu default)` because it is namzu's pick out
+			// of its own registry. These four sentences sit beside that label and
+			// said "showing ITS default" — contradicting it on the same screen,
+			// and pointing an operator who did not expect this model at the
+			// provider instead of at `preferences.json`, which is where they can
+			// actually change it.
+			for (const listing of [
+				{ kind: 'timeout' },
+				{ kind: 'unsupported' },
+				{ kind: 'ok', models: [] },
+				{ kind: 'failed', reason: 'x' },
+			] as const) {
+				const notice = modelStep(DEFAULT, listing).notice ?? ''
+				expect(notice, JSON.stringify(listing)).not.toMatch(/its default|the provider's default/i)
+				expect(notice, JSON.stringify(listing)).toContain("namzu's pick")
+			}
+		})
+
 		it('always leaves the default selectable', () => {
 			for (const listing of [
 				{ kind: 'timeout' },

--- a/packages/cli/src/tui/model-choices.ts
+++ b/packages/cli/src/tui/model-choices.ts
@@ -63,19 +63,27 @@ export function modelStep(
 		initialIndex: 0,
 	})
 
+	// "namzu's pick", never "its default", in all four. The row beside these
+	// sentences is labelled `(namzu default)` because the value comes from
+	// namzu's registry and not from the provider — and these said the opposite
+	// on the same screen. It changes what an operator does about a model they
+	// did not expect: whose default it is decides whether they go looking at the
+	// provider, or pin `model` on this member in `preferences.json`.
 	if (listing.kind === 'unsupported') {
-		return fallback('This provider does not publish a model list. Showing its default.')
+		return fallback("This provider does not publish a model list. Showing namzu's pick for it.")
 	}
 	if (listing.kind === 'timeout') {
 		// Deliberately not "no models". The provider may have hundreds; it just
 		// did not answer inside 3s, and that is a retryable condition.
-		return fallback('The provider did not answer in time. Showing its default — try again to list.')
+		return fallback(
+			"The provider did not answer in time. Showing namzu's pick for it — try again to list.",
+		)
 	}
 	if (listing.kind === 'failed') {
-		return fallback(`Could not list models: ${listing.reason}. Showing the default.`)
+		return fallback(`Could not list models: ${listing.reason}. Showing namzu's pick for it.`)
 	}
 	if (listing.models.length === 0) {
-		return fallback('The provider returned no models. Showing its default.')
+		return fallback("The provider returned no models. Showing namzu's pick for it.")
 	}
 
 	// A real list. Make sure the default is in it and marked, because a list


### PR DESCRIPTION
The prose pass. There is no gate on wording, so the gate used was: **for every sentence changed, name what a reader would do differently.** Sentences that failed it were left alone, and those are listed too — the restraint is the harder half.

Everything that changed turned out to be **one claim in four places**.

## The claim

A chain member that omits `model` gets `entry.defaultModel` — a hardcoded constant per provider in `registry.ts`, compiled into the release. It is resolved at launch and never refreshed from the provider, so between releases it can name a model the provider has superseded. #294 corrected the picker's row label to `(namzu default)` for exactly this reason. Three sibling surfaces kept the old wording.

| Where | Said | Now |
| --- | --- | --- |
| `doctor` chain readout | `<model> (default)` | `<model> (namzu default)` |
| `/model` picker, 4 notices | "Showing **its** default" | "Showing **namzu's pick** for it" |
| `docs/cli/tui.md` | "marked `(default)`" | the marker that is actually on screen |
| `docs/cli/providers.md` | "**tracks the default** instead of pinning whatever it was on the day you wrote it" | what it does |

**The reader action.** Whose default it is decides where someone goes when the model is not the one they expected: the provider's settings, where there is nothing to find, or `model` on that chain member, where there is.

**The picker one is a contradiction on a single screen.** The notice says "showing its default" and the row immediately beside it is labelled `(namzu default)`.

**The `providers.md` one is backwards, not merely vague.** It told operators that omitting `model` keeps them current. Omitting it pins them to whatever the release shipped — so the sentence produces the behaviour a reader was trying to avoid. This is the one I would most want reviewed.

## What I did not change, and why

The gate cuts both ways. Three sentences looked wrong and survived it.

- **`Agent is not ready yet — give it a moment.`** Reads like bad advice for a session with no provider, where waiting never helps. Traced it instead of rewriting it: the only producer of `hasProvider: false` is `emptySession`, which requires an `errorHint`, so this `??` fallback is reachable only when `session` is `null` — the probing case, where waiting is exactly right. **Correct as written.**
- **`Conversation history is unavailable in this folder.`** Says nothing a reader can act on. But the cause was swallowed by a bare `catch` in `ensureSessions`, so naming a likely one would be a guess — and guessing is the defect. Making it useful is a code change, not a wording change.
- **The `/tools` empty-roster sentence** ("the agent session may still be connecting") is also a guess, and it sits in lines #306 rewrites. Left to avoid a conflict; flagged there.

## Mutation table

| Mutation | Died |
| --- | --- |
| doctor label back to `(default)` | 1 — "says WHOSE default a member that pinned no model gets" |
| the four notices back to "its default" | 1 — "never tells the operator the fallback is the provider's own default" |

**No mutation killed nothing.**

The doctor assertion was also strengthened while there: it matched `(default)`, which is a **substring of** `(namzu default)` and would have passed either way. It now matches the whole phrase.

## Checks — all six

| Gate | |
| --- | --- |
| `pnpm build` | pass |
| `pnpm typecheck` | pass |
| `pnpm lint` | pass (2 pre-existing warnings in `__fixtures__/temp-dir.ts`, untouched) |
| `pnpm test` | pass — cli 665 passed / 3 skipped |
| `node scripts/audit-external-names.mjs` | pass |
| `pnpm docs:check` | pass — 0 problems across 13 checked files |
