### PR TITLE
ci: the leg name stays the leg name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,17 @@ permissions:
 
 jobs:
   check:
-    name: Build & Test
+    # Named explicitly so the check is called `Build & Test (24)` and not
+    # `Build & Test (24, true)`. Left implicit, a matrix job's name is composed
+    # from EVERY value in its entry, so the `gates` flag added beside the
+    # version leaked into the check's identity — and a check's name is what a
+    # ruleset pins when someone makes it required. That would put a required
+    # check one unrelated matrix edit away from naming nothing, which is the
+    # same silent-unsatisfiable shape the flag itself was introduced to remove.
+    #
+    # Pinning the name to the version alone means a future matrix dimension is
+    # free to arrive without renaming the check.
+    name: Build & Test (${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
A matrix job's display name is composed from every value in its entry unless the job sets one. The `gates` flag I added beside the node version in #303 leaked into the check's identity: **`Build & Test (24)` became `Build & Test (24, true)`**.

A check's name is what a ruleset pins when someone makes it required. Leaving it composed would put a future required check one unrelated matrix edit away from naming nothing — the same silently-unsatisfiable shape the flag was introduced to remove, moved from the step condition to the check name.

No ruleset pins it today; I checked before deciding this was worth a PR rather than an issue. It is worth it because the cost is one line now and a confusing outage later.

Pinned to the version alone, so a future matrix dimension can arrive without renaming the check.