### PR TITLE
docs(conventions): two ways an assertion goes loose

### DIFF
--- a/docs/conventions/a-check-that-cannot-fail.md
+++ b/docs/conventions/a-check-that-cannot-fail.md
@@ -1,13 +1,13 @@
 ---
 uid: namzu.conventions.a-check-that-cannot-fail
 title: A check that cannot fail is worse than no check
-description: A guard placed where its condition can never be false protects nothing, and it teaches the next reader that the checks in this file are decoration — so the one that matters gets skimmed too.
+description: A guard placed where its condition can never be false protects nothing, and it teaches the next reader that the checks here are decoration — so the one that matters gets skimmed too. The same shape reaches assertions, where a matcher can accept the value it exists to reject.
 type: Convention
 diataxis: explanation
 owner: cogitave/namzu
 status: active
 timestamp: 2026-08-04T00:00:00Z
-lastReviewed: 2026-08-07
+lastReviewed: 2026-08-09
 resource: packages/cli/src/integrations/subagents/runtime.ts
 tags: [convention, verification, code-review]
 ---
@@ -48,9 +48,53 @@ The same rule catches a test that cannot fail. A test whose assertion holds
 under the bug it was written for is the same object: something that looks like
 a check and is not.
 
+## The loose matcher
+
+Amended 2026-08-09.
+
+The forms above are about *placement* — a guard in a spot its condition cannot
+reach, a test driving a path the defect is not on. There is a third door, and it
+is the quietest, because the placement is right and the path is right:
+
+**the assertion is written with a matcher loose enough to accept the very value
+it exists to reject.**
+
+`toContain(old)` cannot detect a change that only **adds around** `old`. If the
+new value contains the old one as a substring — appended, prefixed, or wrapped —
+the assertion passes on both, so it is not an assertion about the change at all.
+It has been met twice in this repository, once from each direction:
+
+- **Prefixed.** A model with no explicit setting was marked `(default)`, which
+  reads as the provider's current default and is in fact namzu's own pick out of
+  a table compiled into the release. Corrected to `(namzu default)`. The test
+  asserting the marker used `toContain('(default)')` — and `(namzu default)`
+  contains `(default)`, so the test passed identically before and after. It
+  could not have told the two apart in either direction.
+- **Appended.** `toContain('/agents')` was meant to prove a command is listed in
+  `/help`. It survives renaming the command to `/agentsXX`, because that
+  contains it. The fix was to anchor on the whole entry — `/\/agents\s/` — since
+  `/help` pads the name and a real entry is the name followed by whitespace.
+
+## The tell, and the test for it
+
+You are asserting on a string, and the change you are pinning **lengthens** it.
+That is the moment.
+
+Ask: *is the old value a substring of the new one?* If it is, a substring
+matcher proves nothing, and mutation will not tell you — the mutation runs, the
+suite stays green, and green is exactly what a passing mutation-restore looks
+like when the test is sound. This is the one failure the mutation loop reports
+as "kills nothing" when the truth is "cannot kill anything".
+
+The fix is always the same: assert the **whole** phrase, or anchor it. Prefer
+matching what a reader would see in full — the complete marker, the complete
+line — over the fragment that happens to be distinctive today.
+
 ## Related
 
 - [Mutate every test](mutation-check-every-test.md) — how you establish that a
-  check can fail, rather than arguing that it can.
+  check can fail, rather than arguing that it can. The loose matcher above is
+  the case mutation cannot report, which is why it is written down here as a
+  shape to recognise before you run one.
 - [An optional dependency may degrade a feature, never a check](an-optional-dependency-may-not-degrade-a-check.md)
   — a guard that cannot fail because its precondition was defaulted away.

--- a/docs/conventions/index.md
+++ b/docs/conventions/index.md
@@ -37,13 +37,15 @@ Read the rule that matches what you are about to change before you change it.
 ### Tests that prove something
 
 - [Mutate every test](mutation-check-every-test.md) — and a unit test on a
-  helper never proves the caller invokes it.
+  helper never proves the caller invokes it. A kill by one unit is the fixture
+  discriminating, not the code.
 - [A test can be sound and still be about the wrong thing](sound-about-the-wrong-thing.md)
   — right path, wrong observer, wrong moment. A live run is not exempt.
 - [A fixture unlike production tests a system that does not ship](fixture-must-match-production.md)
   — the defect lives in a branch an empty listener set never enters.
 - [A check that cannot fail is worse than no check](a-check-that-cannot-fail.md)
-  — it teaches the next reader that the checks here are decoration.
+  — it teaches the next reader that the checks here are decoration. Includes the
+  loose matcher: `toContain(old)` cannot see a change that only adds around it.
 
 ### Reading the evidence
 

--- a/docs/conventions/mutation-check-every-test.md
+++ b/docs/conventions/mutation-check-every-test.md
@@ -1,13 +1,13 @@
 ---
 uid: namzu.conventions.mutation-check-every-test
 title: Mutate every test, and never trust a helper test to prove its caller
-description: A passing test proves nothing until you have watched it fail. Break the thing it covers and confirm that that test, and not a neighbour, goes red — then read the whole run, not the summary line.
+description: A passing test proves nothing until you have watched it fail. Break the thing it covers, confirm that that test and not a neighbour goes red, then read the whole run rather than the summary line — and read the margin, because a kill by one unit is the fixture discriminating and not the code.
 type: Convention
 diataxis: explanation
 owner: cogitave/namzu
 status: active
 timestamp: 2026-08-04T00:00:00Z
-lastReviewed: 2026-08-07
+lastReviewed: 2026-08-09
 tags: [convention, testing, verification]
 ---
 
@@ -120,6 +120,41 @@ read.
 A skip is a result to look at, not a rounding error. Platform-gated with the
 reason written in the file is fine; a contract test skipped for want of a
 credential is a hole wearing a green summary.
+
+## A kill has a size, and one unit is not a kill
+
+Amended 2026-08-09.
+
+"The mutation killed it" is not the whole result. **By how much** is part of it,
+and when the margin is one unit the fixture is doing the discriminating rather
+than the code.
+
+A test asserted that the composer stops being padded down the screen once an
+expanded tool body fills the viewport. It measured the longest run of blank rows
+in the frame and required it under 4. Mutating the caller to stop measuring tool
+bodies produced **4** — a kill, by one row.
+
+That is a coin toss dressed as evidence. The terminal height was 24, and at 24
+the live furniture and safety margin leave so little budget that the *unmeasured*
+transcript also comes out barely padded: both answers were pressed against the
+same floor and the assertion's threshold happened to fall between them. A
+slightly taller live region, a slightly different safety constant, or a fixture
+one row longer, and the same defect passes.
+
+At 40 rows the two answers separate properly — **20 against 4** — because there
+is room for the wrong estimate to be wrong in. Nothing about the code changed;
+the fixture stopped compressing the difference.
+
+**So: record the numbers, not the verdict.** `expected 20 to be less than 4` is
+evidence. `expected 4 to be less than 4` is a warning that the next person to
+touch an unrelated constant will silently turn this test into decoration. If a
+mutation kills by a hair, re-size the fixture until the two answers are far
+apart, and if they will not separate, the assertion is measuring the wrong
+quantity.
+
+This is the quantitative sibling of the fixture rule below: there, the setup
+never reaches the defect's branch; here, it reaches it and then squeezes the
+result until the difference will not fit.
 
 ## The inverse: a test whose green depended on the defect
 


### PR DESCRIPTION
Two mutation results from tonight, promoted. Both are **new doors on rules that already exist** rather than new rules, which is why they are amendments and not files.

## 1. The loose matcher → `a-check-that-cannot-fail.md`

`toContain('(default)')` is satisfied by `(namzu default)` — the exact string the assertion existed to demand instead. It passed identically before and after the change it was written to pin, in both directions.

Generalised: **`toContain(old)` cannot detect a change that only adds around `old`** — appended, prefixed, or wrapped. Met twice in this repository, once from each direction:

- **Prefixed** — `(default)` → `(namzu default)` (#309). The new value contains the old.
- **Appended** — `toContain('/agents')` survives renaming the command to `/agentsXX`. Already noted in a test file; now it has a home.

**Why it belongs beside "a check that cannot fail" and not beside "mutate every test":** mutation *cannot report it*. The restore runs, the suite stays green, and green is exactly what a sound test looks like under a passing restore. It is the one failure the mutation loop reads as "kills nothing" when the truth is "cannot kill anything" — so it has to be recognised before the mutation, not after.

The tell is stated as a question you can actually ask: **you are asserting on a string and the change lengthens it — is the old value a substring of the new one?**

## 2. The margin of a kill → `mutation-check-every-test.md`

"It died" is not the whole result. **By how much** is part of it, and a margin of one unit means the *fixture* is discriminating rather than the code.

The spacer test killed its mutation **4 against 4** on a 24-row terminal. At 24 rows the live furniture and the safety margin press both answers against the same floor, and the assertion's threshold happened to fall between them — a coin toss dressed as evidence. At 40 rows the same code separates **20 against 4**, because there is room for the wrong estimate to be wrong in.

Rule: record the numbers, not the verdict. `expected 20 to be less than 4` is evidence; `expected 4 to be less than 4` is a warning that the next person to move an unrelated constant turns this test into decoration with nothing to show for it. If the answers will not separate, the assertion is measuring the wrong quantity.

Positioned as the quantitative sibling of `fixture-must-match-production.md`: there the setup never reaches the defect's branch; here it reaches it and then squeezes the result until the difference will not fit.

## Also

`docs/conventions/index.md` gains a clause for each, so both are findable from the catalogue rather than only from inside the file.

## Checks

Docs-only, so the four that can say anything about it:

| Gate | |
| --- | --- |
| `pnpm docs:check` | pass — 0 problems across 13 checked files |
| `node scripts/audit-external-names.mjs` | pass |
| `pnpm typecheck` | pass (unaffected; no source touched) |
| `pnpm lint` | pass (unaffected) |

`pnpm build` and `pnpm test` are unaffected by a docs-only diff and were last read green on `main` at `643746e7`. Naming that rather than pasting a stale count, since a number I did not re-measure for this diff is worth less than saying I did not.

Both `description` fields were rewritten twice to land inside the gate's 75–300 character window — the gate caught them at 310 and 302, which is the check doing its job.
