### PR TITLE
fix(cli)!: run-stream stops substituting a history nobody asked for

### DIFF
--- a/.changeset/a-named-conversation-is-not-substituted.md
+++ b/.changeset/a-named-conversation-is-not-substituted.md
@@ -1,0 +1,39 @@
+---
+'@namzu/cli': major
+---
+
+**`run-stream --session <key>` no longer answers against a history you did not
+ask for, and no longer ends on a bare `done` when it failed to save the turn.**
+
+Two bare `catch` blocks at opposite ends of the same command, both of which
+produced an ordinary success.
+
+## What breaks
+
+**A conversation that cannot be opened now stops the run.** Given `--session`,
+if the store cannot be reached — an unwritable `.namzu`, a corrupt map file —
+`run-stream` emits an `error` event and runs nothing. It used to fall through to
+the stateless path, which takes prior turns from **stdin**, so a caller who named
+a conversation got a turn composed against a different history, or none, and
+`exit 0`.
+
+*If you relied on that fallback:* drop `--session`. That asks for the stateless
+run explicitly, which is the only way the command can tell the two apart.
+
+It is a refusal rather than a warning-and-continue because the command cannot say
+what was lost. A key is created on first use, so a fresh key legitimately has no
+prior turns — and the failure is precisely what stopped it finding out which case
+it was in. "Could not look" is not "there was nothing there."
+
+## Also
+
+**A turn that could not be saved now says so**, as a `notice` on the event
+stream, naming the reason and the consequence: `history` for that session will
+not include the turn and the next turn will not have it as context. The run still
+succeeds and still exits 0 — the reply is complete and a host treating this as a
+failed turn would be wrong. It was previously swallowed, which made a later
+`namzu history` look broken with nothing connecting it to a write minutes
+earlier.
+
+`notice` is an existing event kind on this stream, already used for the config
+notices a few lines above the same handler.

--- a/docs/cli/headless.md
+++ b/docs/cli/headless.md
@@ -1,7 +1,7 @@
 ---
 title: Headless runs
 description: namzu run and namzu run-stream — one prompt, no terminal. Shared options, the working directory, exit codes, and the NDJSON event stream.
-last_updated: 2026-08-07
+last_updated: 2026-08-09
 status: current
 related_packages: ["@namzu/cli"]
 ---
@@ -176,6 +176,29 @@ namzu history --session <key> [--cwd <path>]
 `history` prints the conversation's user and assistant messages as a JSON array.
 An empty array means the session exists and has no messages — it is not an
 error.
+
+### When the store will not cooperate
+
+**A conversation that cannot be opened stops the run.** If `--session` is given
+and the store cannot be reached — an unwritable `.namzu`, a corrupt map file —
+`run-stream` emits an `error` event and runs nothing. It does not quietly fall
+back to the stateless path, because that path takes prior turns from stdin: a
+caller who named a conversation would get an answer composed against a different
+history, or none, reported as an ordinary success.
+
+It cannot be a warning-and-continue either, because the command cannot say what
+was lost. A key is created on first use, so a fresh key legitimately has no
+prior turns — and the failure is exactly what stopped it finding out which case
+it is in. If you want the turn to run regardless, drop `--session`; that asks
+for the stateless run explicitly.
+
+**A turn that cannot be saved is reported and not fatal.** If the reply streamed
+but appending it to the store failed, the run finishes normally and emits a
+`notice` naming the reason and the consequence: `history` for that session will
+not include the turn, and the next turn will not have it as context. It is a
+`notice` rather than an `error` because the run genuinely succeeded — a host
+treating it as a failed turn would be wrong — but silence here is what made a
+later `history` look broken with nothing to connect it to.
 
 ## Exit codes
 

--- a/packages/cli/src/commands/__tests__/a-named-conversation-is-not-substituted.test.ts
+++ b/packages/cli/src/commands/__tests__/a-named-conversation-is-not-substituted.test.ts
@@ -1,0 +1,209 @@
+/**
+ * `run-stream --session <key>` never answers against a different history than
+ * the one it was given, and never claims to have saved a turn it did not.
+ *
+ * Two failures at opposite ends of the same command, both of which used to be
+ * a bare `catch` and an ordinary success.
+ *
+ * **Before the turn.** Opening the conversation set `cli = null` on any error
+ * and fell through to reading prior turns from STDIN — so a caller who named a
+ * conversation got a confident answer composed against somebody else's history,
+ * or none, reported as exit 0. `run.ts` already refuses the equivalent, and
+ * says why in the source: someone who asked for a specific conversation and got
+ * a new one that looks the same finds out several turns later, having already
+ * acted on it.
+ *
+ * It cannot be softened to a warning-and-continue, because the command cannot
+ * say what was lost. `resolveConversation` CREATES the key on first use, so a
+ * fresh key legitimately has no prior turns — and the failure is precisely what
+ * stopped it finding out which case it is in. "Could not look" is not "there
+ * was nothing there."
+ *
+ * **After the turn.** The append that makes `history --session` correct was
+ * wrapped in `catch {}` marked `// non-fatal`. Non-fatal is right; silent is
+ * not. It is the one failure here that makes a LATER command wrong — the stream
+ * ends `done`, the process exits 0, and `history` then comes back missing a
+ * turn the user watched arrive, with nothing connecting the two.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+	appendMessages,
+	openSessions,
+	resolveConversation,
+} from '../../integrations/sessions/store.js'
+import { fakeAgentSession } from '../../tui/__fixtures__/agent-session.js'
+import { runStreamCommand } from '../run-stream.js'
+import type { CommandContext } from '../types.js'
+
+vi.mock('../../integrations/sessions/store.js', () => ({
+	openSessions: vi.fn(async () => ({}) as never),
+	resolveConversation: vi.fn(async () => 'conv-1' as never),
+	loadConversation: vi.fn(async () => []),
+	appendMessages: vi.fn(async () => undefined),
+}))
+
+vi.mock('../../integrations/trust/store.js', () => ({
+	isTrusted: () => true,
+	trustDir: () => {},
+}))
+
+vi.mock('../../tui/agent.js', () => ({
+	probeAgentSession: vi.fn(async () => ({
+		preferences: { version: 2, provider: 'anthropic', subagents: { active: [] } },
+		needsRepickReason: null,
+		detected: [],
+	})),
+	createAgentSession: vi.fn(async () =>
+		fakeAgentSession({
+			providerSummary: 'stub',
+			modelSummary: 'stub',
+			// A reply the operator watches arrive. It is what makes the silent
+			// persistence failure a lie rather than merely a gap: the words were
+			// on screen, so the turn plainly happened.
+			send: async function* () {
+				yield { kind: 'delta', text: 'an answer' } as never
+			},
+		}),
+	),
+}))
+
+const ctx = { config: {} } as unknown as CommandContext
+
+function capture(): { lines: string[]; restore: () => void } {
+	const lines: string[] = []
+	const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+		lines.push(String(chunk))
+		return true
+	})
+	return { lines, restore: () => spy.mockRestore() }
+}
+
+async function run(rawArgs: string[]): Promise<string> {
+	const { lines, restore } = capture()
+	try {
+		await runStreamCommand.handler({ rawArgs, ctx } as never)
+	} finally {
+		restore()
+	}
+	return lines.join('')
+}
+
+/**
+ * Restored in `afterEach`; see below for why it is set at all.
+ */
+let stdinWasTTY: boolean | undefined
+
+beforeEach(() => {
+	// A terminal, so the stateless path reads nothing and returns at once.
+	//
+	// This is about the QUALITY of the failure, not about convenience. With the
+	// refusal mutated away the command falls through to reading prior turns from
+	// stdin, and under vitest stdin is an inherited pipe that never ends — so the
+	// three tests below "died" by 15-second timeout rather than by assertion.
+	// A timeout is a poor kill: it is slow, it says "hung" instead of "answered
+	// against a history nobody asked for", and it is a flake waiting for a loaded
+	// CI box. It is also an artifact of the harness — a host piping NDJSON closes
+	// its end, so production does not hang here either.
+	stdinWasTTY = process.stdin.isTTY
+	Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+	vi.mocked(openSessions).mockClear()
+	vi.mocked(resolveConversation).mockClear()
+	vi.mocked(appendMessages).mockClear()
+	vi.mocked(openSessions).mockImplementation(async () => ({}) as never)
+	vi.mocked(resolveConversation).mockImplementation(async () => 'conv-1' as never)
+	vi.mocked(appendMessages).mockImplementation(async () => undefined)
+})
+
+afterEach(() => {
+	Object.defineProperty(process.stdin, 'isTTY', { value: stdinWasTTY, configurable: true })
+	vi.restoreAllMocks()
+})
+
+describe('when the named conversation cannot be opened', () => {
+	it('refuses, instead of answering against whatever stdin held', async () => {
+		vi.mocked(openSessions).mockImplementation(async () => {
+			throw new Error('EACCES: permission denied')
+		})
+
+		const out = await run(['--session', 'nightly-build', 'what did we decide?'])
+
+		expect(out, 'the failure was not reported').toContain('"kind":"error"')
+		expect(out, 'did not name the conversation that was asked for').toContain('nightly-build')
+		expect(out, "did not carry the store's own reason").toContain('EACCES')
+		// The refusal is the point: no turn may have run.
+		expect(out, 'the model answered anyway, against a history nobody asked for').not.toContain(
+			'an answer',
+		)
+	})
+
+	it('tells the caller how to get the turn they wanted', async () => {
+		// A refusal an operator cannot act on is a dead end. Running stateless is
+		// a legitimate thing to want; it just has to be asked for.
+		vi.mocked(openSessions).mockImplementation(async () => {
+			throw new Error('EACCES')
+		})
+
+		expect(await run(['--session', 'k', 'hi'])).toContain('--session')
+	})
+
+	it('still ends the stream, so a host scanning stdout is not left hanging', async () => {
+		// The NDJSON contract is that every run ends with `done`, refusals
+		// included.
+		vi.mocked(openSessions).mockImplementation(async () => {
+			throw new Error('EACCES')
+		})
+
+		expect(await run(['--session', 'k', 'hi'])).toContain('"kind":"done"')
+	})
+})
+
+describe('when the turn cannot be saved', () => {
+	it('says so, rather than ending on an unqualified done', async () => {
+		vi.mocked(appendMessages).mockImplementation(async () => {
+			throw new Error('ENOSPC: no space left on device')
+		})
+
+		const out = await run(['--session', 'nightly-build', 'hello'])
+
+		expect(out, 'the reply did not stream').toContain('an answer')
+		expect(out, 'the failed write was silent').toContain('not saved')
+		expect(out, "did not carry the store's own reason").toContain('ENOSPC')
+	})
+
+	it('names the consequence, not just the fault', async () => {
+		// "Could not persist" does not tell a host that its OWN later reads are
+		// now incomplete, which is the part that costs something.
+		vi.mocked(appendMessages).mockImplementation(async () => {
+			throw new Error('ENOSPC')
+		})
+
+		const out = await run(['--session', 'k', 'hello'])
+
+		expect(out).toContain('history')
+		expect(out).toContain('context')
+	})
+
+	it('is a notice and not an error, because the run did succeed', async () => {
+		// A host that treated this as a failed run would be wrong: the reply is
+		// complete and correct. Only the record of it is missing.
+		vi.mocked(appendMessages).mockImplementation(async () => {
+			throw new Error('ENOSPC')
+		})
+
+		const out = await run(['--session', 'k', 'hello'])
+
+		expect(out).toContain('"kind":"notice"')
+		expect(out, 'a successful run was reported as an error').not.toContain('"kind":"error"')
+	})
+
+	it('says nothing when the save succeeded, so the notice means something', async () => {
+		// The other half. A notice printed either way is noise, and a host would
+		// learn to ignore it.
+		const out = await run(['--session', 'k', 'hello'])
+
+		expect(out).toContain('an answer')
+		expect(out, 'reported a failure on the success path').not.toContain('not saved')
+	})
+})

--- a/packages/cli/src/commands/run-stream.ts
+++ b/packages/cli/src/commands/run-stream.ts
@@ -168,8 +168,29 @@ export const runStreamCommand: CommandDef = {
 				cli = await openSessions(cwd)
 				conversationId = await resolveConversation(cli, sessionKey)
 				prior = await loadConversation(cli, conversationId as never)
-			} catch {
-				cli = null // persistence unavailable — run stateless rather than fail
+			} catch (err) {
+				// Refused, not run stateless.
+				//
+				// This used to set `cli = null` and fall through to the branch
+				// below, which reads prior turns from STDIN — so a caller who named
+				// a conversation got a turn answered against a different history,
+				// or none, reported as an ordinary success. `run.ts` already
+				// refuses the equivalent, in those words: someone who asked for a
+				// specific conversation and got a new one that looks the same finds
+				// out several turns later, having already acted on it.
+				//
+				// It cannot be softened into a warning, because we cannot say what
+				// was lost. `resolveConversation` creates the key on first use, so
+				// a fresh key legitimately has no prior turns — and the failure is
+				// exactly what stopped us finding out which case this is. "Could
+				// not look" is not "there was nothing there."
+				//
+				// In band, like every other failure here, because that is what the
+				// host reads. No session has been built at this point in the flow,
+				// so there is nothing to close on the way out.
+				return fail(
+					`could not open conversation "${sessionKey}": ${err instanceof Error ? err.message : String(err)}. Nothing ran, because continuing the wrong history is worse than not continuing. Drop --session to run this turn stateless.`,
+				)
 			}
 		}
 		if (!cli) {
@@ -271,6 +292,22 @@ export const runStreamCommand: CommandDef = {
 		// Persist the turn so a later `history --session <key>` (and the next
 		// turn's context) sees it. Best-effort — a store failure must not lose
 		// the reply the user already saw stream.
+		//
+		// Best-effort is about not FAILING, not about staying quiet. This used to
+		// swallow the error entirely, and it is the one failure here that makes a
+		// LATER command wrong: the stream ends `done`, the process exits 0, and a
+		// host has every reason to believe the turn is stored. Then
+		// `history --session` comes back missing a turn the user watched arrive,
+		// and the next turn's context silently lacks it — with nothing, anywhere,
+		// connecting that to a write that failed minutes earlier.
+		//
+		// So it is said, on the same channel and in the same shape as the config
+		// notices forty lines above, and for the reason written there: a host UI
+		// is the caller with no human watching, and its own event kind rather
+		// than an `error` because the run did succeed and a host treating this as
+		// a failure would be wrong. The consequence is named, not just the fault,
+		// because "could not persist" alone does not tell a host that its own
+		// later reads are now incomplete.
 		if (cli && conversationId) {
 			try {
 				const assistant: Message = {
@@ -279,8 +316,11 @@ export const runStreamCommand: CommandDef = {
 					timestamp: Date.now(),
 				} as Message
 				await appendMessages(cli, conversationId as never, [userMessage, assistant])
-			} catch {
-				// non-fatal
+			} catch (err) {
+				write({
+					kind: 'notice',
+					message: `this turn was not saved: ${err instanceof Error ? err.message : String(err)}. The reply above is complete, but history for this session will not include it and the next turn will not have it as context.`,
+				})
 			}
 		}
 


### PR DESCRIPTION
The run/error surfaces, swept with the through-line question. **Two more, at opposite ends of one command, both producing an ordinary success.**

`run.ts` came out clean: its one bare `catch` (`:327`) deliberately delegates reporting to `resolveResume`, with a comment saying so, and `resolveResume` refuses rather than starting fresh.

## 1. A named conversation was substituted, silently

```ts
// run-stream.ts:171, before
} catch {
  cli = null // persistence unavailable — run stateless rather than fail
}
```

`cli = null` falls through to the branch below, which reads prior turns **from stdin**. So `run-stream --session nightly-build "what did we decide?"` against an unwritable `.namzu` answered against a *different* history — or none — and exited 0, with a `done` event and no indication that the conversation it named was never opened.

`run.ts:336-340` already refuses the equivalent, and writes down the reason:

> Refused, never silently started fresh. Someone who asked for a specific conversation and got a new one that looks the same finds out several turns later, having already acted on it.

**Third time tonight that the correct reasoning was already in the tree, close by, and simply not applied** (after `promptExemptTools` in #306 and the `(namzu default)` label in #309).

### Why refusal, not warn-and-continue

Because the command cannot say what was lost. `resolveConversation` **creates** the key on first use, so a fresh key legitimately has no prior turns — and the failure is exactly what stopped it finding out which case it is in. *"Could not look" is not "there was nothing there."* Same distinction the credential probe draws between `unverifiable` and `verified`.

A caller who wants the stateless run can ask for it: drop `--session`.

## 2. A turn that failed to save said nothing

```ts
} catch {
  // non-fatal
}
```

Non-fatal is right. Silent is not. This is the one failure here that makes a **later command wrong**: the stream ends `done`, the process exits 0, and `namzu history --session <key>` then returns a transcript missing a turn the operator watched arrive — with nothing joining the two events.

It now emits a `notice`, naming the reason *and the consequence*, because "could not persist" alone does not tell a host that its own later reads are incomplete. `notice` is an existing kind on this stream, used forty lines above for config notices under a comment that already makes the argument:

> "Printed on every launch" has to reach a host UI too, or the one caller with no human watching is the one that never hears it. Its own event kind rather than an `error`: the run is proceeding, and a host that treats this as a failure would be wrong.

Same channel, same argument, not applied.

## Mutation table

| Mutation | Died |
| --- | --- |
| stateless fallback restored | 2 — "refuses, instead of answering against whatever stdin held"; "tells the caller how to get the turn they wanted" |
| persistence `notice` removed | 3 — says so / names the consequence / is a notice not an error |

**Two preservation cases correctly survived each mutation** and are worth naming, because a mutation that fails everything says the tests are coupled: "still ends the stream" survives the first (a stateless run also ends `done`), and "says nothing when the save succeeded" survives the second.

### A mutation whose kill was the wrong *shape*

Restoring the stateless fallback killed all three refusal tests — **by 15-second timeout**. The mutated path calls `readStdin()`, and under vitest stdin is an inherited pipe that never ends, so the tests hung instead of asserting.

A timeout is a poor kill: slow, it reports "hung" rather than "answered against a history nobody asked for", and it is a flake waiting for a loaded CI box. It is also an unfaithful fixture — a host piping NDJSON closes its end, so production does not hang there either. Setting `process.stdin.isTTY` makes the kill land in **8ms** with the real message:

```
expected '{"kind":"delta","text":"an answer"}\n…' to contain '"kind":"error"'
```

That is the model answering, which is the defect stated exactly. Same lesson as the margin rule in #313, arriving from a third direction: **the kill existed, and its shape was still not evidence.**

## Bump

`major`. A script calling `run-stream --session <key>` on a machine where the store is unreachable used to exit 0; it now emits an `error` event. That is backward-incompatible for a consumer regardless of the fact that its previous success was wrong, and the changeset says what to do instead.

## Checks — all six

| Gate | |
| --- | --- |
| `pnpm build` | pass |
| `pnpm typecheck` | pass |
| `pnpm lint` | pass (2 pre-existing warnings in `__fixtures__/temp-dir.ts`, untouched) |
| `pnpm test` | pass — cli 672 passed / 3 skipped, 71 files |
| `node scripts/audit-external-names.mjs` | pass |
| `pnpm docs:check` | pass — 0 problems across 13 checked files |
