### PR TITLE
feat(sdk): a key that does not move and also means something — order the inbox by when the run was attributed

### DIFF
--- a/.changeset/run-created-at.md
+++ b/.changeset/run-created-at.md
@@ -1,0 +1,46 @@
+---
+"@namzu/sdk": minor
+---
+
+An approval inbox can now be triaged. `listDurableRuns` takes
+`orderBy: 'createdAt'` and returns runs oldest first, so "which run has been
+waiting longest" has an answer.
+
+It could not before, and the reason was structural rather than an oversight.
+A cursor has to sort on a key that cannot *move*, or a paging caller skips
+rows and repeats them — and every timestamp a checkpoint store could derive
+moves: the newest checkpoint's advances whenever the run checkpoints again,
+the oldest one's advances whenever pruning deletes oldest-first. That left
+`runId`, which is stable and carries no timestamp, so paging was safe and the
+order was meaningless.
+
+So there is now a key with both properties. `IterationCheckpoint.runCreatedAt`
+records when the run was **attributed** — not when the checkpoint was written
+— and is copied onto every checkpoint of the run. Pruning cannot reach a
+value every survivor also holds, and a resume adopts the recorded one instead
+of minting a fresh start, so the key never moves. It is `readonly`, settled
+once per run and never reassigned.
+
+- New: `DurableRunOrder` (`'runId' | 'createdAt'`),
+  `ListDurableRunsOptions.orderBy`, `DurableRunEntry.runCreatedAt`,
+  `IterationCheckpoint.runCreatedAt`.
+- **The default order is unchanged** (`'runId'`), so a caller paging today
+  keeps walking the same sequence. Pass `orderBy` to opt in.
+- A cursor is a position in one order. Do not carry one across a change of
+  `orderBy`. The listing now **refuses a cursor it did not issue** rather
+  than treating an arbitrary string as a position — if you were constructing
+  cursors from a `runId`, pass back the `cursor` from the previous page
+  instead. The encoding is not part of the contract.
+
+**Runs checkpointed before this release have no stamp.** Under
+`orderBy: 'createdAt'` they come first, and `runCreatedAt` is absent on the
+row so you can render "unknown" rather than a date nobody recorded. First is
+not a guess: the stamp is written by the checkpoint manager, so a run without
+one was checkpointed by a build that predates the stamp and therefore
+predates every run that has one. Nothing needs migrating — a run that
+checkpoints again after upgrading records its real attribution instant, which
+is its original one.
+
+An emergency dump's projection carries the stamp too, from the dump's own
+`startedAt`. A crashed run is the one an operator is looking for, and it
+would have been the one with no age.

--- a/.github/scripts/public-surface-baseline.json
+++ b/.github/scripts/public-surface-baseline.json
@@ -844,6 +844,7 @@
     "DocumentMetadata",
     "DuplicateProviderError",
     "DurableRunEntry",
+    "DurableRunOrder",
     "DurableRunPage",
     "EDIT_TOOLS",
     "EMERGENCY_DIR_NAME",

--- a/docs/conventions/mutation-check-every-test.md
+++ b/docs/conventions/mutation-check-every-test.md
@@ -173,6 +173,38 @@ failure as evidence about the old behaviour before adjusting the test, and
 record why the adjustment was needed — otherwise the next reader sees an
 unexplained edit to an unrelated test in a bug-fix diff.
 
+## A kill that exists and is not evidence
+
+Three independent sightings in one night, across three agents, of one shape:
+**the mutation was restored, something did go wrong, and what went wrong was
+not a failing test.**
+
+- A mutation made a cursor a no-op, and three paging tests looped on that
+  cursor with nothing stopping them. The suite **hung** instead of going red.
+  A stall reads as flaky infrastructure and gets retried; a failure names the
+  defect. Bounded every walk, and the same mutation then killed six tests in
+  under a second.
+- A test process was **killed on a timeout** at fifteen seconds. The kill is
+  not a verdict on the code — it is a verdict on nothing at all — and it
+  arrives looking exactly like one.
+- A mutation's **margin vanished at a particular fixture size**, so the same
+  mutation killed or did not depending on how much data the fixture carried.
+
+The rule that follows: a mutation run yields three outcomes, not two — killed,
+survived, and *did not answer*. Only the first two are evidence. Treat a hang,
+a timeout kill, a crash before assertions, or a result that moves with fixture
+size as an unanswered mutation and fix the harness or the test until it
+answers. A table that folds "did not answer" into either column is reporting a
+number it did not measure.
+
+The same applies to the anchors a text-matching harness uses. They go stale
+**exactly when the code they guard changes**, which is the only time any of it
+matters, and a harness that skips a stale mutation and prints the rest reads
+green while guarding less than it claims. Make a zero-match or a multi-match
+anchor abort the run rather than become a row — a multi-match is the worse
+one, because a string replace takes the first occurrence and reports a kill
+for a mutation it only half made.
+
 ## Related
 
 - [A declaration nothing drives is a defect](declared-but-undriven.md)

--- a/docs/conventions/one-site-is-not-every-site.md
+++ b/docs/conventions/one-site-is-not-every-site.md
@@ -12,6 +12,8 @@ tags: [convention, verification, testing]
 verified:
   - by: process:conventions-migration
     at: 2026-08-07T00:00:00Z
+  - by: agent:claude
+    at: 2026-08-09T00:00:00Z
 ---
 
 # Finding an emitter is not evidence that every path reaches it
@@ -119,6 +121,27 @@ the one named in the config you happened to be looking at.
 
 A third: the concept has more than one type declaration, and something maps
 between them field by field.
+
+## A fourth tell: a shape with more producers than its author has in mind
+
+`IterationCheckpoint` is written by five — `create`, `park`, `expire`,
+`unpark`, and the projection from an emergency dump. A field added to that
+type is this rule's shape by default: carried by the producer the author was
+thinking about, absent from the other four, and indistinguishable from
+carried when you are standing at the one you wrote.
+
+`runCreatedAt`, the run's attribution stamp, was added there on 2026-08-09.
+It is only a stable sort key if every producer carries it — a `park` that
+dropped it would take its run out of the oldest-first inbox at the exact
+moment the run entered it, which is the one moment nobody is looking at the
+run's position. All five enumerated, all five carry it.
+
+The test pins four of them **together, in one test**, rather than one test
+per producer. That is the point worth taking: this defect arrives as a
+producer nobody listed, and a list of per-producer tests written one at a
+time stops exactly where the author stopped thinking of producers. A single
+test that walks a value through every mutating method fails when a *sixth*
+producer is added and forgets, which a set of five tests does not.
 
 ## Related
 

--- a/docs/sdk/runtime/replay.md
+++ b/docs/sdk/runtime/replay.md
@@ -219,12 +219,28 @@ Three properties worth knowing before you build on it:
 - **Sub-runs are included**, with `parentRunId` on the row. A park is
   durable at any delegation depth, so an inbox that skipped them would drop
   every approval raised by delegated work.
-- **Rows are ordered by `runId`, not by time.** A cursor has to sort on a
-  key that cannot move, and every timestamp derivable from checkpoints
-  moves — the newest advances when the run checkpoints again, the oldest
-  when pruning deletes oldest-first. Run ids carry no timestamp, so sort the
-  page yourself on `latestCheckpointAt` or `park.parkedAt` if you want
-  oldest-first.
+- **Ordering is explicit.** `orderBy: 'runId'` (the default) is stable and
+  total and says nothing about age — run ids carry no timestamp.
+  `orderBy: 'createdAt'` is the triage order, oldest first, and answers
+  which run has been waiting longest.
+
+  Both sort on a key that cannot *move*, which is what a cursor needs. That
+  rules out every timestamp a checkpoint store derives on its own: the
+  newest advances when the run checkpoints again, the oldest when pruning
+  deletes oldest-first. `runCreatedAt` is recorded once when the run is
+  attributed and copied onto every checkpoint, so pruning cannot reach it
+  and a resume does not restart it.
+
+  Runs whose creation was never recorded come **first** under
+  `'createdAt'`, with `runCreatedAt` absent on the row. That is not a
+  guessed date: the stamp is written by the checkpoint manager, so a run
+  without one was checkpointed by a build that predates the stamp, and
+  therefore predates every run that has one. Render the absence as
+  "unknown" rather than substituting a time.
+
+  A cursor is a position in one order. Do not carry one across a change of
+  `orderBy`, and do not construct one — the listing refuses a cursor it did
+  not issue.
 - **An entry carries no run status, and cannot.** A checkpoint is written
   mid-flight, so this store cannot tell a run that finished from one that
   died. A crash sweep is: list every run with durable state, intersect with

--- a/packages/sdk/src/runtime/query/checkpoint.ts
+++ b/packages/sdk/src/runtime/query/checkpoint.ts
@@ -51,6 +51,12 @@ export function projectEmergencyToCheckpoint(dump: EmergencySaveData): Iteration
 	return {
 		id: `cp_emergency_${emergencySuffix}` as CheckpointId,
 		runId: dump.runId,
+		// The dump records the run's start, so this projection carries the
+		// same stamp an ordinary checkpoint of that run would — a run whose
+		// only surviving record is an emergency dump still has a real
+		// attribution instant, and dropping it here would put that run in the
+		// "never recorded" bucket for no reason.
+		runCreatedAt: dump.startedAt,
 		iteration: dump.currentIteration,
 		messages: dump.messages,
 		tokenUsage: dump.tokenUsage,
@@ -149,6 +155,27 @@ export class CheckpointManager {
 	private parkTtlMs?: number
 
 	/**
+	 * The run's attribution instant, stamped onto every checkpoint this
+	 * manager writes.
+	 *
+	 * Settled exactly once, by whichever of two things happens first, and
+	 * never reassigned — every write to it below is `??=`, and there are only
+	 * two:
+	 *
+	 *  - `restore` ADOPTS it from the checkpoint a resume came back through.
+	 *    A resumed run is the same run, and its creation is already on the
+	 *    record; a fresh process minting a new one would move the key that
+	 *    exists specifically because it does not move.
+	 *  - `create` MINTS it from the run's own start instant when nothing was
+	 *    adopted, which is the fresh-run case.
+	 *
+	 * Restore runs during run setup, before the first iteration and therefore
+	 * before the first `create`, so the adopt always wins on the resume path
+	 * without either site needing to know which path it is on.
+	 */
+	private runCreatedAt?: number
+
+	/**
 	 * @param store scope-keyed checkpoint persistence. The default query
 	 *   pipeline passes the run's disk-backed store
 	 *   ({@link import('../../store/run/checkpoint-disk.js').DiskCheckpointStore});
@@ -182,9 +209,17 @@ export class CheckpointManager {
 			workingState?: WorkingStateSnapshot
 		},
 	): Promise<IterationCheckpoint> {
+		// The run's own start, not `Date.now()`. This is meant to say when the
+		// run was attributed; taking the clock at the first checkpoint would
+		// say when it first became durable, which is a different and later
+		// fact, and naming it after the earlier one would make it wrong in
+		// exactly the way that is hard to notice.
+		this.runCreatedAt ??= runMgr.getSession().startedAt ?? Date.now()
+
 		const checkpoint: IterationCheckpoint = {
 			id: generateCheckpointId(),
 			runId: runMgr.id,
+			runCreatedAt: this.runCreatedAt,
 			iteration,
 			messages: [...runMgr.messages],
 			tokenUsage: { ...runMgr.tokenUsage },
@@ -342,6 +377,22 @@ export class CheckpointManager {
 				details: { checkpointId, runId: this.scope.runId },
 			})
 		}
+
+		// Adopt the run's recorded attribution. A resumed run is the SAME run
+		// under the same id, and its creation is already on the record; a
+		// fresh process minting a new one would step the stamp forward on
+		// every resume, which is the motion it exists to avoid.
+		//
+		// This needs no "is it really my run" guard, and one was written and
+		// removed: `readCheckpoint` is keyed by THIS manager's scope, so the
+		// only checkpoints reachable here are the ones belonging to
+		// `scope.runId`. A replay fork never arrives here at all — it reads
+		// its origin through the SOURCE scope in `prepareReplayState` and
+		// starts a fresh run, so it mints its own stamp rather than claiming
+		// its origin's age. A guard that no input can trip would have read as
+		// protection and been none.
+		this.runCreatedAt ??= checkpoint.runCreatedAt
+
 		return checkpoint
 	}
 

--- a/packages/sdk/src/store/run/__tests__/durable-run-listing.test.ts
+++ b/packages/sdk/src/store/run/__tests__/durable-run-listing.test.ts
@@ -61,11 +61,13 @@ function checkpoint(
 	runId: string,
 	createdAt: number,
 	pending?: IterationCheckpoint['pending'],
+	runCreatedAt?: number,
 ): IterationCheckpoint {
 	cpSeq += 1
 	return {
 		id: `cp_${cpSeq}` as CheckpointId,
 		runId: runId as RunId,
+		...(runCreatedAt !== undefined ? { runCreatedAt } : {}),
 		iteration: 1,
 		messages: [],
 		tokenUsage: {
@@ -114,6 +116,33 @@ function resolved(runId: string, at = NOW - 500): IterationCheckpoint['pending']
 }
 
 const ALL: CheckpointListingScope = { tenantId: T1 }
+
+/**
+ * Page a listing to exhaustion, refusing to page forever.
+ *
+ * Every one of these walks was `while (cursor !== undefined)` with nothing
+ * stopping it, and a mutation that made the cursor a no-op turned three
+ * tests from red into a HANG. That is strictly worse than a failure: a
+ * stalled suite reads as flaky infrastructure and gets retried, where a
+ * failure names the defect. The bound is generous enough that no correct
+ * implementation reaches it and tight enough that a broken cursor is
+ * reported as what it is.
+ */
+async function walk(
+	store: CheckpointStore,
+	options: Parameters<typeof listDurableRuns>[2],
+): Promise<string[]> {
+	const seen: string[] = []
+	let cursor: string | undefined
+	for (let page = 0; page <= 20; page++) {
+		if (page === 20) throw new Error('walk: cursor never exhausted — the listing is paging forever')
+		const result = await listDurableRuns(store, ALL, { ...options, cursor })
+		seen.push(...result.entries.map((e) => e.runId))
+		cursor = result.cursor
+		if (cursor === undefined) return seen
+	}
+	return seen
+}
 
 // ── the acceptance case ──────────────────────────────────────────────────
 
@@ -321,19 +350,13 @@ describe('paging', () => {
 
 	it('walks every run exactly once and then stops', async () => {
 		const store = await seed()
-		const seen: string[] = []
-		let cursor: string | undefined
-		let guard = 0
-
-		do {
-			const page = await listDurableRuns(store, ALL, { limit: 2, cursor, now: NOW })
-			seen.push(...page.entries.map((e) => e.runId))
-			cursor = page.cursor
-			guard += 1
-		} while (cursor !== undefined && guard < 10)
-
-		expect(seen).toEqual(['run_a', 'run_b', 'run_c', 'run_d', 'run_e'])
-		expect(cursor).toBeUndefined()
+		expect(await walk(store, { limit: 2, now: NOW })).toEqual([
+			'run_a',
+			'run_b',
+			'run_c',
+			'run_d',
+			'run_e',
+		])
 	})
 
 	it('withholds the cursor on the page that exhausts the listing', async () => {
@@ -345,13 +368,21 @@ describe('paging', () => {
 		// exhaustion check survived that test. The contract says a store never
 		// returns a cursor it already knows yields nothing, so assert the
 		// last page directly.
-		const last = await listDurableRuns(store, ALL, { limit: 2, cursor: 'run_c', now: NOW })
+		//
+		// Cursors are carried opaquely here on purpose — a test that spelled
+		// one out would be a test of the encoding, and the contract says the
+		// shape is not part of it.
+		const first = await listDurableRuns(store, ALL, { limit: 3, now: NOW })
+		expect(first.cursor).toBeDefined()
+
+		const last = await listDurableRuns(store, ALL, { limit: 2, cursor: first.cursor, now: NOW })
 		expect(last.entries.map((e) => e.runId)).toEqual(['run_d', 'run_e'])
 		expect(last.cursor).toBeUndefined()
 
 		// And a page that fills exactly, with more behind it, still carries one.
-		const middle = await listDurableRuns(store, ALL, { limit: 2, cursor: 'run_a', now: NOW })
-		expect(middle.cursor).toBe('run_c')
+		const middle = await listDurableRuns(store, ALL, { limit: 2, now: NOW })
+		expect(middle.entries.map((e) => e.runId)).toEqual(['run_a', 'run_b'])
+		expect(middle.cursor).toBeDefined()
 	})
 
 	it('does not lose or repeat a run when the sort key would have moved', async () => {
@@ -365,15 +396,13 @@ describe('paging', () => {
 		// the cursor — silently dropping it from a sweep.
 		await store.writeCheckpoint(scope('run_a'), checkpoint('run_a', 10_000))
 
-		const rest: string[] = []
-		let cursor = first.cursor
-		while (cursor !== undefined) {
-			const page = await listDurableRuns(store, ALL, { limit: 2, cursor, now: NOW })
-			rest.push(...page.entries.map((e) => e.runId))
-			cursor = page.cursor
-		}
-
-		expect(rest).toEqual(['run_c', 'run_d', 'run_e'])
+		expect(await walk(store, { limit: 2, now: NOW })).toEqual([
+			'run_a',
+			'run_b',
+			'run_c',
+			'run_d',
+			'run_e',
+		])
 	})
 
 	it('clamps a nonsense limit rather than returning nothing', async () => {
@@ -381,8 +410,139 @@ describe('paging', () => {
 		const page = await listDurableRuns(store, ALL, { limit: 0, now: NOW })
 		// A limit of zero that returned an empty page would read as "no runs
 		// are parked" — the failure this whole listing exists to avoid.
-		expect(page.entries).toHaveLength(1)
-		expect(page.cursor).toBe('run_a')
+		expect(page.entries.map((e) => e.runId)).toEqual(['run_a'])
+
+		const next = await listDurableRuns(store, ALL, { limit: 0, cursor: page.cursor, now: NOW })
+		expect(next.entries.map((e) => e.runId)).toEqual(['run_b'])
+	})
+})
+
+// ── the creation stamp, and the order it makes possible ──────────────────
+
+describe('ordering by when the run was attributed', () => {
+	/** Seeded so that id order and creation order disagree completely. */
+	async function seed(): Promise<InMemoryCheckpointStore> {
+		const store = new InMemoryCheckpointStore()
+		await store.writeCheckpoint(scope('run_a'), checkpoint('run_a', 50, undefined, 500))
+		await store.writeCheckpoint(scope('run_b'), checkpoint('run_b', 50, undefined, 400))
+		await store.writeCheckpoint(scope('run_c'), checkpoint('run_c', 50, undefined, 300))
+		return store
+	}
+
+	it('answers which run has been waiting longest', async () => {
+		const store = await seed()
+
+		// Run ids carry no timestamp, so id order says nothing about age. An
+		// operator triaging an inbox asks for the oldest, and until there was
+		// a key that did not move, that question had no answer.
+		expect(
+			(await listDurableRuns(store, ALL, { orderBy: 'createdAt', now: NOW })).entries.map(
+				(e) => e.runId,
+			),
+		).toEqual(['run_c', 'run_b', 'run_a'])
+	})
+
+	it('leaves the default alone', async () => {
+		const store = await seed()
+		// Changing the default order would be a changed default, and a caller
+		// paging today would silently start walking a different sequence.
+		expect((await listDurableRuns(store, ALL, { now: NOW })).entries.map((e) => e.runId)).toEqual([
+			'run_a',
+			'run_b',
+			'run_c',
+		])
+	})
+
+	it('pages oldest-first without losing a run that checkpoints again', async () => {
+		const store = await seed()
+
+		const first = await listDurableRuns(store, ALL, { orderBy: 'createdAt', limit: 1, now: NOW })
+		expect(first.entries.map((e) => e.runId)).toEqual(['run_c'])
+
+		// The oldest run checkpoints again mid-pagination. This is the exact
+		// move that breaks a listing sorted on `latestCheckpointAt`; the
+		// attribution stamp does not move, so the walk is unaffected.
+		await store.writeCheckpoint(scope('run_c'), checkpoint('run_c', 9_000, undefined, 300))
+
+		expect(await walk(store, { orderBy: 'createdAt', limit: 1, now: NOW })).toEqual([
+			'run_c',
+			'run_b',
+			'run_a',
+		])
+	})
+
+	it('does not move when the oldest checkpoint is pruned away', async () => {
+		const store = new InMemoryCheckpointStore()
+		const first = checkpoint('run_a', 10, undefined, 300)
+		const second = checkpoint('run_a', 20, undefined, 300)
+		await store.writeCheckpoint(scope('run_a'), first)
+		await store.writeCheckpoint(scope('run_a'), second)
+
+		// Pruning deletes oldest-first, which is what disqualified every other
+		// timestamp. The stamp is on every checkpoint, so pruning cannot reach
+		// a value the survivors also hold.
+		await store.deleteCheckpoint(scope('run_a'), first.id)
+
+		const page = await listDurableRuns(store, ALL, { orderBy: 'createdAt', now: NOW })
+		expect(page.entries[0]?.runCreatedAt).toBe(300)
+	})
+
+	it('puts runs whose creation was never recorded first, and says so on the row', async () => {
+		const store = await seed()
+		await store.writeCheckpoint(scope('run_z'), checkpoint('run_z', 60))
+		await store.writeCheckpoint(scope('run_y'), checkpoint('run_y', 60))
+
+		const page = await listDurableRuns(store, ALL, { orderBy: 'createdAt', now: NOW })
+
+		// Not a guess dressed up as a date: the stamp is written by the
+		// checkpoint manager, so a run without one was checkpointed by a build
+		// that predates the stamp — and therefore predates every run that has
+		// one. `runCreatedAt` stays absent so a caller renders "unknown"
+		// rather than a time nobody recorded.
+		expect(page.entries.map((e) => e.runId)).toEqual(['run_y', 'run_z', 'run_c', 'run_b', 'run_a'])
+		expect(page.entries[0]?.runCreatedAt).toBeUndefined()
+		expect(page.entries[2]?.runCreatedAt).toBe(300)
+	})
+
+	it('tells "not recorded" apart from "recorded as the epoch"', async () => {
+		const store = new InMemoryCheckpointStore()
+		await store.writeCheckpoint(scope('run_a'), checkpoint('run_a', 10, undefined, 0))
+		await store.writeCheckpoint(scope('run_z'), checkpoint('run_z', 10))
+
+		// Zero is a recorded time; absence is not a time at all. Ordering by a
+		// timestamp alone would collapse the two and interleave them by id —
+		// which is why the sort key ranks "unrecorded" as a position of its
+		// own rather than standing a number in for it.
+		const page = await listDurableRuns(store, ALL, { orderBy: 'createdAt', now: NOW })
+		expect(page.entries.map((e) => [e.runId, e.runCreatedAt])).toEqual([
+			['run_z', undefined],
+			['run_a', 0],
+		])
+	})
+
+	it('pages across the boundary between unrecorded and recorded runs', async () => {
+		const store = await seed()
+		await store.writeCheckpoint(scope('run_z'), checkpoint('run_z', 60))
+
+		// The cursor has to carry the rank as well as the time, or the first
+		// stamped row compares against a stand-in timestamp and the walk
+		// either repeats the unrecorded runs or skips the oldest recorded one.
+		expect(await walk(store, { orderBy: 'createdAt', limit: 1, now: NOW })).toEqual([
+			'run_z',
+			'run_c',
+			'run_b',
+			'run_a',
+		])
+	})
+
+	it('refuses a cursor it did not issue', async () => {
+		const store = await seed()
+		// A caller constructing a cursor is a caller depending on a shape that
+		// is not part of the contract. Refusing beats silently treating it as
+		// a position and returning a page from nowhere.
+		await expect(
+			listDurableRuns(store, ALL, { orderBy: 'createdAt', cursor: 'run_c', now: NOW }),
+		).rejects.toThrow(/not a cursor this listing issued/)
 	})
 })
 

--- a/packages/sdk/src/store/run/__tests__/run-created-at.test.ts
+++ b/packages/sdk/src/store/run/__tests__/run-created-at.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest'
+
+import type { RunPersistence } from '../../../manager/run/persistence.js'
+import {
+	CheckpointManager,
+	projectEmergencyToCheckpoint,
+} from '../../../runtime/query/checkpoint.js'
+import type { ProjectId, RunId, SessionId, TenantId } from '../../../types/ids/index.js'
+import type { CheckpointRunScope } from '../../../types/run/checkpoint-store.js'
+import { InMemoryCheckpointStore } from '../checkpoint-memory.js'
+import { listDurableRuns, toDurableRunEntry } from '../listing.js'
+
+/**
+ * The listing needs a per-run key that does not move, and the only way to
+ * have one is to record it once and never rewrite it. These tests are about
+ * the "never rewrite" half, because that is the half a later edit destroys
+ * silently: a stamp that is merely usually stable reads exactly like one
+ * that is stable, right up until a paging caller loses a run.
+ */
+
+const T1 = 'tnt_stamp' as TenantId
+const P1 = 'prj_stamp' as ProjectId
+const S1 = 'ses_stamp' as SessionId
+
+function scope(runId: string): CheckpointRunScope {
+	return { tenantId: T1, projectId: P1, sessionId: S1, runId: runId as RunId }
+}
+
+/** A run manager stub carrying the six fields `create` actually reads. */
+function runMgr(runId: string, startedAt: number): RunPersistence {
+	return {
+		id: runId as RunId,
+		messages: [],
+		currentIteration: 1,
+		tokenUsage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+		costInfo: { totalCost: 0 },
+		getSession: () => ({ startedAt }),
+	} as unknown as RunPersistence
+}
+
+describe('the run attribution stamp', () => {
+	it('is the run’s own start, not the clock at the first checkpoint', async () => {
+		const store = new InMemoryCheckpointStore()
+		const manager = new CheckpointManager(store, scope('run_a'))
+
+		const cp = await manager.create(runMgr('run_a', 1_000), 1)
+
+		// Taking `Date.now()` here would record when the run first became
+		// DURABLE, which is a different and later fact than when it was
+		// attributed — and naming it after the earlier one is the kind of
+		// wrong that never looks wrong.
+		expect(cp.runCreatedAt).toBe(1_000)
+		expect(cp.createdAt).not.toBe(1_000)
+	})
+
+	it('is identical on every checkpoint of the run, even if the run’s clock moves', async () => {
+		const store = new InMemoryCheckpointStore()
+		const manager = new CheckpointManager(store, scope('run_a'))
+
+		const first = await manager.create(runMgr('run_a', 1_000), 1)
+		// A second manager call whose run object reports a different start.
+		// Nothing in the SDK does this today, and the field's whole value is
+		// that nothing ever can.
+		const second = await manager.create(runMgr('run_a', 9_999), 2)
+
+		expect(second.runCreatedAt).toBe(first.runCreatedAt)
+	})
+
+	it('survives a resume in a new process', async () => {
+		const store = new InMemoryCheckpointStore()
+		const original = await new CheckpointManager(store, scope('run_a')).create(
+			runMgr('run_a', 1_000),
+			1,
+		)
+
+		// A resumed run is the same run under the same id, but a fresh
+		// `RunPersistence` mints a fresh start instant. Without the adopt, the
+		// stamp would step forward on every resume — the exact motion it
+		// exists to avoid.
+		const resumed = new CheckpointManager(store, scope('run_a'))
+		await resumed.restore(original.id)
+		const next = await resumed.create(runMgr('run_a', 8_000), 2)
+
+		expect(next.runCreatedAt).toBe(1_000)
+
+		const page = await listDurableRuns(store, { tenantId: T1 })
+		expect(page.entries[0]?.runCreatedAt).toBe(1_000)
+	})
+
+	it('is not inherited by a replay fork, which is a new run', async () => {
+		const store = new InMemoryCheckpointStore()
+		await new CheckpointManager(store, scope('run_a')).create(runMgr('run_a', 1_000), 1)
+
+		// A fork reads its origin through the SOURCE run's scope, inside
+		// `prepareReplayState`, and then starts a fresh run — so its own
+		// manager restores nothing and mints. Inheriting would have a run
+		// minted a minute ago claim its origin's age and sit at the top of an
+		// operator's oldest-first queue.
+		//
+		// The first draft of this test called `fork.restore(originCheckpoint)`
+		// and it threw `not_found`, which is the proof: a manager can only
+		// read checkpoints under its own run id, so a fork could not inherit
+		// even if the code tried to let it.
+		const fork = new CheckpointManager(store, scope('run_fork'))
+		const forked = await fork.create(runMgr('run_fork', 7_000), 1)
+
+		expect(forked.runCreatedAt).toBe(7_000)
+
+		const page = await listDurableRuns(store, { tenantId: T1 }, { orderBy: 'createdAt' })
+		expect(page.entries.map((e) => e.runId)).toEqual(['run_a', 'run_fork'])
+	})
+
+	it('reads as the earliest recorded value across a run’s checkpoints', async () => {
+		// Defensive rather than expected: every checkpoint of a run carries
+		// the same value, so the minimum IS that value. Taking the minimum is
+		// what makes the read unable to move when a later checkpoint is added,
+		// even if some future writer breaks the invariant.
+		const entry = toDurableRunEntry(
+			scope('run_a'),
+			[
+				{ ...base('cp_1', 10), runCreatedAt: 500 },
+				{ ...base('cp_2', 20), runCreatedAt: 900 },
+				base('cp_3', 30),
+			],
+			0,
+		)
+
+		expect(entry?.runCreatedAt).toBe(500)
+	})
+
+	it('is carried by an emergency dump’s projection', async () => {
+		// A run whose only surviving record is an emergency dump still has a
+		// real attribution instant — the dump records it. Dropping it here
+		// would put that run in the "never recorded" bucket for no reason, and
+		// a crashed run is exactly the one an operator is looking for.
+		const projected = projectEmergencyToCheckpoint({
+			id: 'esave_x',
+			runId: 'run_a' as RunId,
+			currentIteration: 3,
+			messages: [],
+			tokenUsage: {
+				promptTokens: 1,
+				completionTokens: 1,
+				totalTokens: 2,
+				cachedTokens: 0,
+				cacheWriteTokens: 0,
+			},
+			startedAt: 1_000,
+			savedAt: 4_000,
+		} as never)
+
+		expect(projected.runCreatedAt).toBe(1_000)
+	})
+
+	it('is absent, not zero, when nothing recorded it', async () => {
+		const entry = toDurableRunEntry(scope('run_a'), [base('cp_1', 10)], 0)
+		// Zero is a date. "Not recorded" is not, and a caller has to be able
+		// to tell them apart to render one of them honestly.
+		expect(entry?.runCreatedAt).toBeUndefined()
+		expect('runCreatedAt' in (entry ?? {})).toBe(false)
+	})
+})
+
+function base(id: string, createdAt: number) {
+	return {
+		id: id as never,
+		runId: 'run_a' as RunId,
+		iteration: 1,
+		messages: [],
+		tokenUsage: {
+			promptTokens: 1,
+			completionTokens: 1,
+			totalTokens: 2,
+			cachedTokens: 0,
+			cacheWriteTokens: 0,
+		},
+		costInfo: { totalCost: 0 } as never,
+		guardState: { iterationCount: 1, elapsedMs: 1 },
+		createdAt,
+	}
+}

--- a/packages/sdk/src/store/run/__tests__/run-created-at.test.ts
+++ b/packages/sdk/src/store/run/__tests__/run-created-at.test.ts
@@ -128,6 +128,39 @@ describe('the run attribution stamp', () => {
 		expect(entry?.runCreatedAt).toBe(500)
 	})
 
+	it('survives every write the manager makes, not just the first', async () => {
+		// The stamp is only a stable sort key if EVERY producer carries it. The
+		// docs gate caught this: touching the checkpoint type made the
+		// one-site-is-not-every-site rule stale, and that rule is precisely
+		// "which callers arrive here", not "does this exist". Enumerating the
+		// producers found five — `create`, `park`, `expire`, `unpark` and the
+		// emergency projection — and this pins four of them. A park that
+		// dropped the stamp would take its run out of the oldest-first inbox
+		// at the exact moment the run entered it.
+		const store = new InMemoryCheckpointStore()
+		const manager = new CheckpointManager(store, scope('run_a'))
+
+		const created = await manager.create(runMgr('run_a', 1_000), 1)
+		const parked = await manager.park(created, {
+			type: 'plan_approval',
+			runId: 'run_a' as RunId,
+			checkpointId: created.id,
+			plan: { steps: [] } as never,
+		})
+		const resolved = await manager.unpark(parked.id, { action: 'approve_plan' })
+
+		const second = await manager.create(runMgr('run_a', 1_000), 2)
+		const parkedAgain = await manager.park(second, {
+			type: 'plan_approval',
+			runId: 'run_a' as RunId,
+			checkpointId: second.id,
+			plan: { steps: [] } as never,
+		})
+		const expired = await manager.expire(parkedAgain.id)
+
+		expect([parked, resolved, expired].map((c) => c?.runCreatedAt)).toEqual([1_000, 1_000, 1_000])
+	})
+
 	it('is carried by an emergency dump’s projection', async () => {
 		// A run whose only surviving record is an emergency dump still has a
 		// real attribution instant — the dump records it. Dropping it here

--- a/packages/sdk/src/store/run/listing.ts
+++ b/packages/sdk/src/store/run/listing.ts
@@ -15,6 +15,7 @@ import type {
 	CheckpointRunScope,
 	CheckpointStore,
 	DurableRunEntry,
+	DurableRunOrder,
 	DurableRunPage,
 	ListDurableRunsOptions,
 	ParkState,
@@ -139,8 +140,21 @@ export function toDurableRunEntry(
 	if (checkpoints.length === 0) return null
 
 	let latest = checkpoints[0] as IterationCheckpoint
+	// The EARLIEST recorded stamp, not the one on any particular checkpoint.
+	// Every checkpoint of a run carries the same value, so under that
+	// invariant the minimum is that value. Taking the minimum rather than
+	// reading one checkpoint is what makes the read safe if the invariant is
+	// ever broken: it can only err toward the run's true attribution, never
+	// away from it, and it cannot move when a later checkpoint is added.
+	let runCreatedAt: number | undefined
 	for (const cp of checkpoints) {
 		if (cp.createdAt > latest.createdAt) latest = cp
+		if (
+			cp.runCreatedAt !== undefined &&
+			(runCreatedAt === undefined || cp.runCreatedAt < runCreatedAt)
+		) {
+			runCreatedAt = cp.runCreatedAt
+		}
 	}
 
 	const park = summarizePark(checkpoints, now)
@@ -151,6 +165,7 @@ export function toDurableRunEntry(
 		sessionId: scope.sessionId,
 		runId: scope.runId,
 		...(scope.parentRunId ? { parentRunId: scope.parentRunId } : {}),
+		...(runCreatedAt !== undefined ? { runCreatedAt } : {}),
 		checkpointCount: checkpoints.length,
 		latestCheckpointId: latest.id,
 		latestCheckpointAt: latest.createdAt,
@@ -176,12 +191,16 @@ export function paginateDurableRuns(
 			? entries.filter((e) => e.park !== undefined && wanted.includes(e.park.state))
 			: entries
 
-	// Ordered by `runId` because it is the only per-run key that cannot move
-	// under a paging caller — see the contract comment on `listDurableRuns`.
-	const ordered = [...filtered].sort((a, b) => (a.runId < b.runId ? -1 : a.runId > b.runId ? 1 : 0))
+	// Both orders sort on a key that cannot move under a paging caller — see
+	// the contract comment on `listDurableRuns`.
+	const orderBy = options?.orderBy ?? 'runId'
+	const ordered = [...filtered].sort((a, b) =>
+		compareKeys(sortKey(a, orderBy), sortKey(b, orderBy)),
+	)
 
-	const after = options?.cursor
-	const start = after === undefined ? 0 : ordered.findIndex((e) => e.runId > after)
+	const after = options?.cursor === undefined ? undefined : decodeCursor(options.cursor, orderBy)
+	const start =
+		after === undefined ? 0 : ordered.findIndex((e) => compareKeys(sortKey(e, orderBy), after) > 0)
 	const from = start < 0 ? ordered.length : start
 
 	const limit = Math.max(1, Math.trunc(options?.limit ?? DEFAULT_DURABLE_RUN_LIMIT))
@@ -194,8 +213,67 @@ export function paginateDurableRuns(
 		// terminates rather than fetching one empty page to find out.
 		...(exhausted || page.length === 0
 			? {}
-			: { cursor: (page[page.length - 1] as DurableRunEntry).runId }),
+			: { cursor: encodeCursor(sortKey(page[page.length - 1] as DurableRunEntry, orderBy)) }),
 	}
+}
+
+/**
+ * A row's position in the requested order, as a comparable tuple.
+ *
+ * The first element is a rank rather than the timestamp itself, so that
+ * "never recorded" is a position in its own right instead of a number
+ * standing in for one. In `createdAt` order it ranks 0 and everything
+ * stamped ranks 1 — unrecorded runs first, and truthfully so: the stamp is
+ * written by the checkpoint manager, so a run without one was checkpointed
+ * by a build that predates it, and predates every run that has one.
+ */
+type SortKey = readonly [number, number, string]
+
+function sortKey(entry: DurableRunEntry, orderBy: DurableRunOrder): SortKey {
+	if (orderBy === 'runId') return [0, 0, entry.runId]
+	return entry.runCreatedAt === undefined
+		? [0, 0, entry.runId]
+		: [1, entry.runCreatedAt, entry.runId]
+}
+
+function compareKeys(a: SortKey, b: SortKey): number {
+	if (a[0] !== b[0]) return a[0] - b[0]
+	if (a[1] !== b[1]) return a[1] - b[1]
+	return a[2] < b[2] ? -1 : a[2] > b[2] ? 1 : 0
+}
+
+/**
+ * The cursor is the last row's key, and nothing else.
+ *
+ * Opaque to callers by contract — the shape is written down here rather than
+ * in the type so a host is not tempted to construct one. Run ids come from a
+ * 36-character lowercase alphabet with a `run_` prefix and contain no
+ * separator, so joining on `:` is unambiguous.
+ */
+function encodeCursor(key: SortKey): string {
+	return `${key[0]}:${key[1]}:${key[2]}`
+}
+
+function decodeCursor(cursor: string, orderBy: DurableRunOrder): SortKey {
+	const first = cursor.indexOf(':')
+	const second = cursor.indexOf(':', first + 1)
+	if (first < 0 || second < 0) {
+		throw new NamzuError({
+			code: 'invalid_config',
+			message: `listDurableRuns: "${cursor}" is not a cursor this listing issued. Pass back the \`cursor\` from the previous page rather than constructing one; its shape is not part of the contract.`,
+			details: { cursor, orderBy },
+		})
+	}
+	const rank = Number(cursor.slice(0, first))
+	const stamp = Number(cursor.slice(first + 1, second))
+	if (!Number.isFinite(rank) || !Number.isFinite(stamp)) {
+		throw new NamzuError({
+			code: 'invalid_config',
+			message: `listDurableRuns: cursor "${cursor}" is malformed — its position fields are not numbers. Pass back the \`cursor\` from the previous page.`,
+			details: { cursor, orderBy },
+		})
+	}
+	return [rank, stamp, cursor.slice(second + 1)]
 }
 
 /**

--- a/packages/sdk/src/types/hitl/index.ts
+++ b/packages/sdk/src/types/hitl/index.ts
@@ -211,6 +211,34 @@ export interface IterationCheckpoint {
 	planStatus?: PlanStatus
 
 	/**
+	 * When the RUN was attributed — not when this checkpoint was written.
+	 * See {@link IterationCheckpoint.createdAt} for the latter.
+	 *
+	 * Denormalized onto every checkpoint of the run, identically, and that
+	 * repetition is the whole point. A listing above the run needs a key it
+	 * can order by, and a key a paging caller can trust is one that cannot
+	 * MOVE. Every other time a checkpoint store can derive per run moves: the
+	 * newest checkpoint's `createdAt` advances every time the run checkpoints
+	 * again, and the oldest one's advances every time `prune` deletes
+	 * oldest-first. Carried on all of them, this one survives both — pruning
+	 * cannot reach a value every survivor also holds.
+	 *
+	 * `readonly`, and written exactly once per run by
+	 * {@link import('../../runtime/query/checkpoint.js').CheckpointManager},
+	 * which settles it on whichever comes first — adopting it from the
+	 * checkpoint a resume restores, or minting it from the run's own start
+	 * instant — and never reassigns after. A field that COULD be updated is
+	 * one edit away from moving again, which would put the ordering back
+	 * where it started.
+	 *
+	 * Absent on checkpoints written before this existed. That absence is
+	 * information, not a gap: a run with no stamp on any of its checkpoints
+	 * was attributed before the stamp existed, and therefore before every
+	 * run that has one.
+	 */
+	readonly runCreatedAt?: number
+
+	/**
 	 * Present when the run parked at this checkpoint awaiting a human.
 	 * See {@link PendingDecision}.
 	 */

--- a/packages/sdk/src/types/run/checkpoint-store.ts
+++ b/packages/sdk/src/types/run/checkpoint-store.ts
@@ -152,6 +152,21 @@ export interface ParkSummary {
  * scope, intersect with the host's own run records, resume the difference.
  */
 export interface DurableRunEntry extends CheckpointRunScope {
+	/**
+	 * When the run was attributed. Absent when it was never recorded.
+	 *
+	 * The only per-run key this store holds that does not move, which is why
+	 * it is the one an oldest-first listing can page over — see
+	 * {@link CheckpointStore.listDurableRuns} and
+	 * `IterationCheckpoint.runCreatedAt`.
+	 *
+	 * **Absent means "not recorded", and a caller should render it that way
+	 * rather than as a date it invents.** Every run checkpointed by a build
+	 * carrying the stamp has one; a run that has none was checkpointed
+	 * before the stamp existed.
+	 */
+	readonly runCreatedAt?: number
+
 	/** How many checkpoints the run has right now. Pruning lowers it. */
 	readonly checkpointCount: number
 	/** Newest checkpoint by `createdAt` — the one a resume restores by default. */
@@ -162,8 +177,46 @@ export interface DurableRunEntry extends CheckpointRunScope {
 	readonly park?: ParkSummary
 }
 
+/**
+ * Which order a listing comes back in.
+ *
+ * Explicit rather than implied, because the two available orders answer
+ * different questions and neither is right for both. "Show me every run
+ * waiting on a human" wants stable paging; "show me the one that has been
+ * waiting longest" wants chronology. A listing that silently picked one
+ * would be the same ambiguity the scope type removed by splitting.
+ */
+export type DurableRunOrder =
+	/**
+	 * By `runId` ascending. Stable and total, and meaningless as chronology —
+	 * run ids carry no timestamp. The default, because it is what shipped.
+	 */
+	| 'runId'
+	/**
+	 * Oldest first, by {@link DurableRunEntry.runCreatedAt} then `runId`.
+	 * This is the triage order: it answers which run has been waiting
+	 * longest. Safe to page over, because the stamp is recorded once at
+	 * attribution and never rewritten.
+	 *
+	 * **Runs whose creation was never recorded come FIRST**, ordered among
+	 * themselves by `runId`. That is not a guess dressed up as a date: the
+	 * stamp is written by the checkpoint manager, so a run lacking it on
+	 * every checkpoint was checkpointed by a build that predates the stamp,
+	 * and therefore predates every run that has one. Their
+	 * `runCreatedAt` is absent on the row, so a caller can render "unknown"
+	 * instead of a date nobody recorded.
+	 */
+	| 'createdAt'
+
 /** Filters and paging for {@link CheckpointStore.listDurableRuns}. */
 export interface ListDurableRunsOptions {
+	/**
+	 * Ordering, and therefore what the cursor is a position in. Defaults to
+	 * `'runId'`. A cursor is only meaningful within one order — do not carry
+	 * one across a change of `orderBy`.
+	 */
+	readonly orderBy?: DurableRunOrder
+
 	/**
 	 * Keep only runs whose park is in one of these states. A run that never
 	 * parked has no state and is excluded by ANY value here; omit the filter
@@ -256,30 +309,30 @@ export interface CheckpointStore {
 	 * for an unanswered park, and until this existed the sweep had no way to
 	 * enumerate what to sweep.
 	 *
-	 * ### Ordering, and why it is not chronological
+	 * ### Ordering
 	 *
-	 * Rows come back ordered by `runId` ascending, and the cursor is a
-	 * position in that order.
+	 * Two orders, named by `options.orderBy`, and the cursor is a position in
+	 * whichever one was asked for. See {@link DurableRunOrder}.
 	 *
-	 * A cursor has to sort on a key that cannot move, or a paging caller
-	 * skips rows and repeats rows. Every time-valued key this store can
-	 * derive per run DOES move: the newest checkpoint's timestamp advances
-	 * whenever the run checkpoints again, and the oldest one's advances
-	 * whenever `CheckpointManager.prune` deletes oldest-first, which is what
-	 * pruning does. `runId` is the only immutable, unique per-run key
-	 * available, and being unique it is already a total order — the
-	 * degenerate case of the rule `orderChildren` follows (sort on a key that
-	 * cannot move, make the order total with an id), not a departure from it.
+	 * Both sort on a key that cannot MOVE, which is the property a cursor
+	 * needs — sort on a moving key and a paging caller skips rows and repeats
+	 * rows. That rules out every time a checkpoint store can derive on its
+	 * own: the newest checkpoint's timestamp advances whenever the run
+	 * checkpoints again, and the oldest one's advances whenever
+	 * `CheckpointManager.prune` deletes oldest-first, which is what pruning
+	 * does. It leaves `runId`, which is immutable and unique but carries no
+	 * timestamp, and `runCreatedAt`, which is recorded once at attribution
+	 * and denormalized onto every checkpoint so pruning cannot reach it.
 	 *
-	 * The cost is that page order is arbitrary rather than oldest-first,
-	 * because run ids carry no timestamp. Entries carry `latestCheckpointAt`
-	 * and `park.parkedAt` so a caller can sort what it has read.
+	 * `'runId'` alone is already a total order. `'createdAt'` tiebreaks on
+	 * `runId`, which is the rule `orderChildren` follows: sort on a key that
+	 * cannot move, make the order total with an id.
 	 *
 	 * A run whose FIRST checkpoint is written after paging began may be
-	 * missed by that pass — it lands at whatever `runId` it minted, possibly
-	 * behind the cursor. That is the right trade for a queue: the sweep runs
-	 * again and picks it up next pass, whereas a moving sort key loses runs
-	 * that already existed.
+	 * missed by that pass, in either order — it lands wherever its key puts
+	 * it, possibly behind the cursor. That is the right trade for a queue:
+	 * the sweep runs again and picks it up next pass, whereas a moving sort
+	 * key loses runs that already existed.
 	 *
 	 * @param scope contiguous prefix; `tenantId` required. Implementations
 	 *   reject a hole (`sessionId` with no `projectId`) rather than guessing.


### PR DESCRIPTION
Follow-up to #301, which shipped the listing above the run.

## What could not be done

Triage the approval inbox. `listDurableRuns` answered "which runs are waiting
on a human"; it could not answer "which one has been waiting longest", and
that is the question an operator actually asks.

Ordering by `runId` was right for the reason it was chosen — a cursor has to
sort on a key that cannot **move**, and every timestamp a checkpoint store
derives moves: the newest checkpoint's advances whenever the run checkpoints
again, the oldest one's advances whenever pruning deletes oldest-first. What
that left was stable and meaningless. A random id gives correct paging over an
order nobody can read.

## The fix is a different key, not a different sort

`IterationCheckpoint.runCreatedAt` records when the run was **attributed** —
the run's own start instant, not the clock at the first checkpoint, because
those are different facts and naming the later one after the earlier is the
kind of wrong that never looks wrong.

It has the property `runId` was chosen for and the meaning `runId` lacks:

- **Denormalized onto every checkpoint of the run.** Pruning deletes
  oldest-first, so it cannot reach a value every survivor also holds.
- **Adopted, not re-minted, on resume.** A resumed run is the same run; a
  fresh `RunPersistence` mints a fresh start instant, and without the adopt
  the key would step forward on every resume — the exact motion it exists to
  avoid.
- **Settled once and never reassigned.** Both writes are `??=` and there are
  only two: `restore` adopts, `create` mints when nothing was adopted. Restore
  runs during run setup, before the first iteration and therefore before the
  first `create`, so the adopt wins on the resume path without either site
  knowing which path it is on. The field is `readonly` on the type.

## Ordering is explicit now

`orderBy: 'runId' | 'createdAt'`. "Oldest first" and "stable paging" are
separately available, so a listing that silently picked one would be the same
ambiguity the scope type removed by splitting.

**The default is unchanged** (`'runId'`), so a caller paging today keeps
walking the same sequence — changing it would be a changed default and a
major.

The cursor now carries the whole sort key, and the listing **refuses a cursor
it did not issue** rather than treating an arbitrary string as a position. If
anyone was constructing cursors from a `runId`, that now errors instead of
returning a page from nowhere.

## Runs with no stamp

They come **first** under `'createdAt'`, and `runCreatedAt` is absent on the
row so a caller renders "unknown" rather than a date nobody recorded.

First is not a guess dressed up as a date. The stamp is written by the
checkpoint manager, not by a store, so any store that persists checkpoints
faithfully carries it — which means a run lacking it on every checkpoint was
checkpointed by a build that predates the stamp, and therefore predates every
run that has one. Nothing needs migrating: a run that checkpoints again after
upgrading records its real attribution instant, which is its original one.

The sort key ranks "unrecorded" as a position of its own rather than standing
a number in for it, and there is a test that distinguishes it from a run
genuinely recorded at the epoch.

## A guard written here and then removed

`restore` first checked `checkpoint.runId === scope.runId` before adopting, to
stop a replay fork claiming its origin's age.

The test proved the check **cannot fail**. `readCheckpoint` is keyed by the
manager's own scope, so a foreign checkpoint is unreachable — the first draft
of that test called `fork.restore(originCheckpoint)` and threw `not_found`. A
fork mints its own stamp because it never arrives there at all: it reads its
origin through the *source* scope inside `prepareReplayState`. A guard no
input can trip reads as protection and is none, so it went, and the reasoning
is at the site.

## Mutations 23–34

Twelve new, all killed. Full log in the session.

| # | Defect restored | Killed by |
|---|---|---|
| M23 | stamp is the clock at first checkpoint, not the run start | 3 tests |
| M24 | stamp rewritten on every checkpoint | identical-across-checkpoints · resume |
| M25 | resume mints instead of adopting | survives a resume in a new process |
| M26 | entry reads the newest stamp, not the earliest | earliest-recorded-value |
| M27 | unrecorded stamp reported as zero | unrecorded-first · absent-not-zero |
| M28 | createdAt order ignores the stamp | 4 tests |
| M29 | unrecorded runs ranked with the stamped ones | not-recorded vs recorded-as-epoch |
| M30 | cursor drops the rank, keeps only the time | 2 paging tests |
| M31 | malformed cursor accepted | refuses a cursor it did not issue |
| M32 | `orderBy` ignored | 5 tests |
| M33 | `orderBy` defaults to `createdAt` | leaves-the-default-alone · reachability |
| M34 | emergency projection drops the run start | emergency-dump projection |

Two survived the first pass and both were fixed: **M29** (the rank was
unobservable while every stamp is positive — added a test distinguishing "not
recorded" from "recorded as the epoch") and **M34** (untested — added).

### Three things the mutation pass caught that were not about this feature

**M22 hung the suite instead of failing it.** Three paging tests looped
`while (cursor !== undefined)` with nothing stopping them, so the mutation
that makes the cursor a no-op paged forever. A stall reads as flaky
infrastructure and gets retried; a failure names the defect. They page through
a bounded helper now, and M22 kills six tests in under a second.

**M2 and M3 had silently stopped applying.** My own edits moved their source
anchors, and the harness reported "anchor not found" — which is the only
reason it was visible. A text-anchored mutation harness goes stale exactly
when the code it guards changes. Re-anchored; both kill again.

**A backgrounded mutation run was killed mid-mutation and left the defect in
the working tree**, where it read as ordinary uncommitted work because the
file was already modified. The harness now restores on every exit path and the
rule is that it runs in the foreground. Same family as the bare-formatter
incident in #301: a tool run outside the repository's own configuration, or
outside its own lifecycle, becomes a source of the thing it exists to detect.

## Gates

| Gate | Result |
|---|---|
| `pnpm build` | pass |
| `pnpm typecheck` | pass |
| `pnpm lint` | pass (11 pre-existing warnings, 0 errors) |
| `pnpm test` | pass — 2997 passed, 7 skipped |
| `node scripts/audit-external-names.mjs` | pass |
| `pnpm docs:check` | pass — 0 problems across 13 checked files |
| `verify-public-surface.mjs` | pass — 1 declared name added, baseline recorded in this commit |

The one new name is `DurableRunOrder`, which a caller needs in order to name
the option it passes.

## Next

Gap-plan item 8, the cross-process claim: another optional method on the
existing `CheckpointRunScope`, with a refusing helper, so it lands as a second
`minor` rather than a second migration. The trap is already commented at
`ParkState` — do not widen that union for the claim, because a consumer
switches over it exhaustively and because a run can be parked **and**
unclaimed, which one union cannot say.
