### PR TITLE
docs(conventions): a convention has no sentinel, because no file can falsify one

### DIFF
--- a/docs/conventions/a-check-that-cannot-fail.md
+++ b/docs/conventions/a-check-that-cannot-fail.md
@@ -8,7 +8,6 @@ owner: cogitave/namzu
 status: active
 timestamp: 2026-08-04T00:00:00Z
 lastReviewed: 2026-08-09
-resource: packages/cli/src/integrations/subagents/runtime.ts
 tags: [convention, verification, code-review]
 ---
 

--- a/docs/conventions/an-optional-dependency-may-not-degrade-a-check.md
+++ b/docs/conventions/an-optional-dependency-may-not-degrade-a-check.md
@@ -7,8 +7,7 @@ diataxis: explanation
 owner: cogitave/namzu
 status: active
 timestamp: 2026-08-04T00:00:00Z
-lastReviewed: 2026-08-07
-resource: packages/sdk/src/manager/project/lifecycle.ts
+lastReviewed: 2026-08-09
 tags: [convention, api-design, verification]
 ---
 

--- a/docs/conventions/declared-but-undriven.md
+++ b/docs/conventions/declared-but-undriven.md
@@ -7,8 +7,7 @@ diataxis: explanation
 owner: cogitave/namzu
 status: active
 timestamp: 2026-08-04T00:00:00Z
-lastReviewed: 2026-08-07
-resource: packages/sdk/src/sandbox/__tests__/exec-cancellation.test.ts
+lastReviewed: 2026-08-09
 tags: [convention, api-design, types]
 verified:
   - by: process:conventions-migration

--- a/docs/conventions/index.md
+++ b/docs/conventions/index.md
@@ -11,6 +11,36 @@ here.
 
 Read the rule that matches what you are about to change before you change it.
 
+## Why no page here carries a `resource:`
+
+The documentation standard's `resource:` names the code a document describes,
+and the gate fails the build when that code has commits newer than the
+document. Every page here had one, pointing at the file where its incident
+happened.
+
+That is the wrong subject, and the gate says so by firing. **A convention is a
+rule about reasoning, and no file can make one false.** `refuse-do-not-degrade`
+would be exactly as true if the driver that produced it were deleted;
+`one-site-is-not-every-site` is not a claim about a checkpoint type. What the
+pointers actually did was demand a re-read every time an unrelated line moved in
+a file that happened to be the scene — three times in six hours on one night,
+and each time there was nothing to re-establish.
+
+The gate's own guidance warns that a churning sentinel trains everyone to wave
+the failure through, which is the failure mode of a check that fires where
+nothing is wrong. So the key is gone from this directory as a class rather than
+re-dated page by page, and the reasoning lives here once instead of eight times.
+
+**Point `resource:` at code whose change could make the document wrong, not at
+code the document happens to be about.** An absent key honestly reads as "no
+code can invalidate this", which is the true statement for every page in this
+folder — the same reason the standard says to omit `verified:` rather than guess
+it.
+
+A page here would earn a `resource:` back by describing a specific mechanism
+rather than a way of thinking. None does today, and a page that did would
+probably belong under `docs/sdk/` instead.
+
 ## The rules
 
 ### Declarations and reachability

--- a/docs/conventions/one-site-is-not-every-site.md
+++ b/docs/conventions/one-site-is-not-every-site.md
@@ -7,8 +7,7 @@ diataxis: explanation
 owner: cogitave/namzu
 status: active
 timestamp: 2026-08-05T00:00:00Z
-lastReviewed: 2026-08-07
-resource: packages/sdk/src/types/hitl/index.ts
+lastReviewed: 2026-08-09
 tags: [convention, verification, testing]
 verified:
   - by: process:conventions-migration

--- a/docs/conventions/reachability-is-its-own-property.md
+++ b/docs/conventions/reachability-is-its-own-property.md
@@ -7,8 +7,7 @@ diataxis: explanation
 owner: cogitave/namzu
 status: active
 timestamp: 2026-08-06T00:00:00Z
-lastReviewed: 2026-08-08
-resource: packages/sdk/src/agents/__tests__/reachability.test.ts
+lastReviewed: 2026-08-09
 tags: [convention, testing, api-design]
 verified:
   - by: process:conventions-migration

--- a/docs/conventions/refuse-do-not-degrade.md
+++ b/docs/conventions/refuse-do-not-degrade.md
@@ -7,8 +7,7 @@ diataxis: explanation
 owner: cogitave/namzu
 status: active
 timestamp: 2026-08-04T00:00:00Z
-lastReviewed: 2026-08-07
-resource: packages/providers/anthropic/src/thinking-capability.ts
+lastReviewed: 2026-08-09
 tags: [convention, error-handling, api-design]
 ---
 

--- a/docs/conventions/sound-about-the-wrong-thing.md
+++ b/docs/conventions/sound-about-the-wrong-thing.md
@@ -8,7 +8,6 @@ owner: cogitave/namzu
 status: active
 timestamp: 2026-08-06T00:00:00Z
 lastReviewed: 2026-08-09
-resource: packages/sdk/src/runtime/query/index.ts
 tags: [convention, testing, verification]
 ---
 

--- a/docs/conventions/verify-claims-including-your-own.md
+++ b/docs/conventions/verify-claims-including-your-own.md
@@ -7,8 +7,7 @@ diataxis: explanation
 owner: cogitave/namzu
 status: active
 timestamp: 2026-08-04T00:00:00Z
-lastReviewed: 2026-08-07
-resource: packages/sdk/src/tools/builtins/ls.ts
+lastReviewed: 2026-08-09
 tags: [convention, verification, review]
 verified:
   - by: process:conventions-migration


### PR DESCRIPTION
docs(conventions): a convention has no sentinel, because no file can falsify one

Every page in `docs/conventions/` carried a `resource:` pointing at the
file where its incident happened. `resource:` names the code a document
describes, and the gate fails the build when that code has newer commits
- so each of those pointers demanded a re-read of a rule whenever an
unrelated line moved in the file that happened to be the scene.

That is the wrong subject. A convention is a rule about reasoning and no
file can make one false. `refuse-do-not-degrade` would be exactly as true
if the driver that produced it were deleted; `one-site-is-not-every-site`
is not a claim about a checkpoint type.

Measured rather than anticipated: it fired three times in six hours on
one night - on a change to which matrix leg carries the CI gates, on a
composer rework, and on a checkpoint type gaining a field - and each time
the answer was that there was nothing to re-establish. Two were fixed
page by page before the pattern was visible. The gate's own guidance
warns that a churning sentinel trains everyone to wave the failure
through, which is what a check firing where nothing is wrong does to the
people who see it.

So the key goes from the directory as a class rather than being re-dated
one page at a time, and the reasoning lives once in the index instead of
eight times in eight files.

The rule it leaves behind: point `resource:` at code whose change could
make the document wrong, not at code the document happens to be about. An
absent key honestly reads as "no code can invalidate this", which is the
true statement for every page here - the same reason the standard says to
omit `verified:` rather than guess it. A page would earn one back by
describing a specific mechanism rather than a way of thinking, and a page
that did would probably belong under `docs/sdk/` instead.

`lastReviewed` moves on the eight pages because each was re-read against
its rule while deciding this, not because a date needed bumping.

Docs gate: 0 problems across 13 files. Audit: 0.
