### PR TITLE
fix(cli): the key that stops the turn is on the screen that governs it

### DIFF
--- a/.changeset/the-key-that-stops-it.md
+++ b/.changeset/the-key-that-stops-it.md
@@ -1,0 +1,22 @@
+---
+'@namzu/cli': patch
+---
+
+**The permission prompt names `Ctrl+C`, and says why it is different from `n`.**
+
+`n` and `Esc` decline the tool call and the turn **continues** — the agent is
+told, and tries something else. `Ctrl+C` declines and **stops the turn**. Two
+different decisions, and the prompt listed only the first.
+
+So the only key that stops namzu was the one an operator could not see from the
+screen that governs it. Someone who wanted it to stop pressed `n`, watched it
+carry on with a different approach, and had nothing on that screen to tell them
+otherwise; the distinction existed only in the documentation.
+
+The prompt now lists all four keys, grouped by outcome, on two lines — at four
+keys a single line wraps mid-key on a narrow terminal, and this is the box you
+read while deciding. The status-bar hint keeps its compact three-key echo, which
+is budget-constrained by construction and shares a line with the working
+directory, the provider and the model.
+
+No behaviour changed. `Ctrl+C` has always done this.

--- a/docs/cli/tools.md
+++ b/docs/cli/tools.md
@@ -133,10 +133,15 @@ An unrecognized tool is treated as needing consent. That direction is deliberate
 | Key | Decision |
 | --- | --- |
 | `y` | Approve this batch. |
-| `n` (or `Esc`) | Reject — the model is told you declined and can adapt. |
 | `a` | Approve this and everything else for the rest of the session. |
+| `n` (or `Esc`) | Decline — the model is told, and **the turn continues**; it can adapt and try something else. |
+| `Ctrl+C` | Decline **and stop the turn**. |
 
-`Ctrl+C` at the prompt rejects and aborts the turn.
+The last two are not the same decision, and the prompt says so on screen rather
+than only here. Declining with `n` leaves the agent working: it will pick another
+approach, which is usually what you want when one particular call was wrong. If
+you want namzu to stop, `Ctrl+C` is the key — pressing `n` and waiting is how
+that goes wrong.
 
 **`Enter` does not approve.** It used to, and it no longer does. The prompt
 arrives on the agent's schedule rather than yours: the composer stays editable

--- a/packages/cli/src/tui/PermissionOverlay.tsx
+++ b/packages/cli/src/tui/PermissionOverlay.tsx
@@ -56,24 +56,45 @@ export function PermissionOverlay({ toolCalls }: PermissionOverlayProps) {
 					</Box>
 				))}
 			</Box>
-			<Box>
+			{/* Every key that decides this prompt, and what each one decides.
+			    `Ctrl+C` was missing, and it is the only one with a DIFFERENT
+			    outcome: `n` and `esc` decline this batch and the turn carries on
+			    trying something else, while `Ctrl+C` ends the turn. So someone
+			    who wanted namzu to stop pressed `n`, watched it continue, and had
+			    no way to learn otherwise from this screen — the distinction was
+			    written down only in `docs/cli/tools.md`.
+
+			    Two rows rather than one: at four keys the line wraps on a narrow
+			    terminal and wraps mid-key, and this is the box an operator reads
+			    while deciding. Grouped by outcome, so the reading is "these two
+			    let it continue, this one does not" rather than a list of four
+			    equals. The status bar keeps the compact three-key echo — it is
+			    budget-constrained by construction and this box is on screen
+			    whenever it applies. */}
+			<Box flexDirection="column">
 				<Text color={theme.text.muted}>
 					<Text color={theme.status.ok} bold>
 						y
 					</Text>{' '}
 					approve ·{' '}
-					<Text color={theme.status.error} bold>
-						n
-					</Text>{' '}
-					reject ·{' '}
 					<Text color={theme.accent.user} bold>
 						a
 					</Text>{' '}
-					approve all for this session ·{' '}
+					approve all for this session
+				</Text>
+				<Text color={theme.text.muted}>
+					<Text color={theme.status.error} bold>
+						n
+					</Text>{' '}
+					or{' '}
 					<Text color={theme.status.error} bold>
 						esc
 					</Text>{' '}
-					reject
+					decline, and the agent tries something else ·{' '}
+					<Text color={theme.status.error} bold>
+						ctrl+c
+					</Text>{' '}
+					decline and stop the turn
 				</Text>
 			</Box>
 		</Box>

--- a/packages/cli/src/tui/__tests__/app-permission-keys.test.tsx
+++ b/packages/cli/src/tui/__tests__/app-permission-keys.test.tsx
@@ -275,13 +275,46 @@ describe('the permission prompt', () => {
 		const { lastFrame } = await promptOpenWithDraftInFlight()
 		const frame = lastFrame() ?? ''
 
-		expect(frame).toContain('y')
-		expect(frame).toContain('reject')
-		expect(frame).toContain('approve all')
-		expect(frame).toContain('esc')
+		// Asserted as whole phrases the OVERLAY produces, not as bare letters.
+		// The previous version of this test used `toContain('y')`, which is
+		// satisfied by any frame containing the letter y — including every frame
+		// this component has ever rendered — and `toContain('reject')`, which the
+		// status bar's own hint satisfies from the other side of the screen. Two
+		// assertions that could not fail, guarding the advertisement that four
+		// separate fixes tonight were about.
+		expect(frame).toContain('approve all for this session')
+		expect(frame).toContain('the agent tries something else')
 		// The advertisement is the contract the handler is held to. `enter` must
 		// not appear, because Enter no longer does anything here.
 		expect(frame.toLowerCase()).not.toContain('enter')
+	})
+
+	it('names the key that stops the turn, and says that it is different', async () => {
+		// `n`/`esc` decline this batch and the agent carries on trying something
+		// else; `ctrl+c` declines AND ends the turn. Two outcomes, and only the
+		// first was on the screen — so an operator who wanted namzu to stop
+		// pressed `n`, watched it continue, and had no way to learn otherwise
+		// from the box they were reading. The distinction was written down only
+		// in `docs/cli/tools.md`.
+		const { lastFrame } = await promptOpenWithDraftInFlight()
+		const frame = lastFrame() ?? ''
+
+		expect(frame.toLowerCase(), 'the key that stops the turn is unnamed').toContain('ctrl+c')
+		expect(frame, 'named the key without naming what makes it different').toContain(
+			'stop the turn',
+		)
+	})
+
+	it('ctrl+c does what the overlay now says it does', async () => {
+		// The other half, and the reason the line above is allowed to claim it:
+		// an advertisement is only worth adding if the key behaves that way. The
+		// batch is declined AND the turn is aborted, where `n` declines only.
+		const { stdin } = await promptOpenWithDraftInFlight()
+
+		stdin.write('\x03')
+		await decisionSettles()
+
+		expect(decisions).toEqual([{ kind: 'reject', feedback: 'User interrupted.' }])
 	})
 })
 


### PR DESCRIPTION
The last surface where a documented behaviour was unreachable from the screen that governs it.

## The gap

`docs/cli/tools.md` draws a distinction the prompt did not:

| Key | Outcome |
| --- | --- |
| `n` / `Esc` | Decline — the model is told, **and the turn continues**. It tries something else. |
| `Ctrl+C` | Decline **and stop the turn**. |

The overlay listed `y` · `n` · `a` · `esc`. So the only key that stops namzu was the one an operator could not see from the box they are reading while deciding. Someone who wanted it to stop pressed `n`, watched it carry on with a different approach, and had nothing on that screen to tell them otherwise.

**This is the fifth instance of the pattern tonight**: the correct answer already written down, near where it was needed, not applied. The other four were `promptExemptTools` seventeen lines below the field that needed it (#306), the `(namzu default)` label two columns from the sentence contradicting it (#309), and `run.ts` refusing the equivalent plus the `notice` event kind forty lines above the handler that needed it (#314).

## What changed

All four keys, **grouped by outcome rather than listed as equals**, so it reads as "these two let it continue, this one does not":

```
y approve · a approve all for this session
n or esc decline, and the agent tries something else · ctrl+c decline and stop the turn
```

Two rows and not one: at four keys a single line wraps mid-key on a narrow terminal, and this is the box being read at the moment a decision is made.

**The status-bar hint is deliberately untouched.** It keeps the compact three-key echo. It is budget-constrained by construction — it shares a line with the working directory, the provider and the model, and yielding order among those was the subject of a fix earlier tonight — and this box is on screen whenever it applies.

`docs/cli/tools.md` moves `Ctrl+C` **into** the decision table it was sitting below, and names the consequence of getting it wrong. A list of the decisions with one decision outside it is the same defect, smaller.

**No behaviour changed.** `Ctrl+C` has always done this (`App.tsx`, the prompt branch).

## Two assertions that could not fail, found on the way past

The existing harness guarded this advertisement with:

```ts
expect(frame).toContain('y')        // satisfied by any frame containing the letter y
expect(frame).toContain('reject')   // satisfied by the STATUS BAR, on the other side of the screen
```

Neither can fail. The second is the more interesting one: the test reads the whole frame, so it could not tell whether the *overlay* advertised anything at all — a reachability hole, not just a loose matcher. Both now assert whole phrases only the overlay produces. This is the rule ratified in #313 a few hours ago meeting a test written before it.

## Mutation table

| Mutation | Died |
| --- | --- |
| `ctrl+c` dropped from the overlay | 1 — "names the key that stops the turn…" on its first assertion |
| `ctrl+c` named, but `stop the turn` → `reject` | 1 — the same test, on its second assertion |
| `ctrl+c` branch removed from the prompt handler | 1 — "ctrl+c does what the overlay now says it does" |

**No mutation killed nothing.** The second and third are the point: an advertisement is only worth adding if the key behaves that way, so the claim is pinned from both ends — the words, and the decision they describe.

## Checks — all six

| Gate | |
| --- | --- |
| `pnpm build` | pass |
| `pnpm typecheck` | pass |
| `pnpm lint` | pass (2 pre-existing warnings in `__fixtures__/temp-dir.ts`, untouched) |
| `pnpm test` | pass — cli 676 passed / 3 skipped, 72 files |
| `node scripts/audit-external-names.mjs` | pass |
| `pnpm docs:check` | pass — 0 problems across 13 checked files |
