### PR TITLE
fix(cli): /resume aborts the turn it interrupts

### DIFF
--- a/.changeset/resume-aborts-the-turn-it-interrupts.md
+++ b/.changeset/resume-aborts-the-turn-it-interrupts.md
@@ -1,0 +1,29 @@
+---
+'@namzu/cli': patch
+---
+
+`/resume` now stops the turn it interrupts, and that turn is saved where it belongs
+
+Selecting a conversation from the `/resume` picker while the agent was working
+left the old turn running. Three things followed, and the last one outlived the
+process:
+
+- its tool rows and reply text kept appending into the resumed transcript, so
+  one conversation's output arrived in the middle of another;
+- a follow-up you had queued for the old conversation was sent to the new one
+  the moment the screen went idle;
+- when it finished, it wrote its messages into the **resumed** conversation's
+  stored history. `namzu` then showed you a turn you never had there, and fed it
+  to the model as context on the next one.
+
+Selecting a conversation now interrupts the running turn first, the same way
+`Esc` does. The interrupted turn is not discarded: it finishes reading its own
+events, its reply so far is written to the conversation it was started in, and
+the transcript says so — a tool call already dispatched is not undone, and the
+line says that too. Cancelling the picker still changes nothing, and a
+conversation that cannot be read now leaves the running turn alone rather than
+stopping it on the way to a failure.
+
+No API changed. If you script against `namzu`'s stored history, note that
+records written by this defect are already on disk and this release does not
+rewrite them.

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -196,6 +196,14 @@ export function App({ ctx }: AppProps) {
 	 * conversation's rows and must keep arriving.
 	 */
 	const conversationGenRef = useRef<number>(0)
+	/**
+	 * Whether a conversation has been chosen and is still being read.
+	 *
+	 * The picker keeps the screen for that interval, and `Esc` stops cancelling:
+	 * the choice is already being acted on, so a press landing here would close
+	 * the picker over a switch that happens anyway.
+	 */
+	const resumeCommittedRef = useRef<boolean>(false)
 	const idRef = useRef<number>(0)
 	const nextId = useCallback(() => {
 		idRef.current += 1
@@ -554,20 +562,37 @@ export function App({ ctx }: AppProps) {
 	 * Nothing is disturbed until the new conversation is actually in hand. A
 	 * read that fails leaves a running turn running where it belongs, exactly as
 	 * cancelling the picker does.
+	 *
+	 * And the picker stays up for the length of the read rather than handing the
+	 * screen back first. A composer that is live over an unsettled switch takes
+	 * a message with nowhere to go: queued against a conversation being left, and
+	 * then either dropped by the interrupt below or sent to a conversation nobody
+	 * addressed it to. The screen should not accept input for a conversation that
+	 * is not decided yet, and a read is usually too fast to see.
 	 */
 	const resumeConversation = useCallback(
 		async (conv: RecentConversation) => {
 			const sessions = sessionsRef.current
 			const scope = scopeRef.current
-			setPhase('ready')
-			if (!sessions || !scope) return
+			if (!sessions || !scope) {
+				setPhase('ready')
+				return
+			}
+			// The operator has committed; `Esc` no longer cancels from here, or a
+			// press landing during the read would leave the picker closed and the
+			// switch happening anyway.
+			resumeCommittedRef.current = true
 			let msgs: Awaited<ReturnType<typeof loadConversation>>
 			try {
 				msgs = await loadConversation(sessions, conv.id)
 			} catch (err) {
+				resumeCommittedRef.current = false
+				setPhase('ready')
 				pushMessage('system', `Could not resume: ${err instanceof Error ? err.message : String(err)}`)
 				return
 			}
+			resumeCommittedRef.current = false
+			setPhase('ready')
 			const restored: TranscriptMessage[] = msgs
 				.filter((m) => m.role === 'user' || m.role === 'assistant')
 				.map((m) => ({
@@ -582,9 +607,14 @@ export function App({ ctx }: AppProps) {
 			scope.sessionId = conv.id // new turns now attribute to the resumed session
 			pushMessage('system', `Resumed: ${conv.title}`)
 			if (interrupted) {
+				// "is being saved", not "is saved". The write has not happened yet —
+				// it runs when the abandoned turn finishes unwinding, which is after
+				// this line — and a surface that reports a result it has not read is
+				// the defect class this whole change is about. If that write fails,
+				// the turn says so itself, in the same words `run-stream` uses.
 				pushMessage(
 					'system',
-					'The turn that was running was interrupted. Its reply so far is saved to the conversation it started in, so it is not in the transcript above. A tool call already dispatched was not undone.',
+					'The turn that was running was interrupted. Its reply so far is being saved to the conversation it started in, so it is not in the transcript above. A tool call already dispatched was not undone.',
 				)
 			}
 		},
@@ -785,10 +815,18 @@ export function App({ ctx }: AppProps) {
 					onPermission: ctx.skipPermissions ? undefined : onPermission,
 					extraSystem: composeSkillsPrompt(activeSkills) ?? undefined,
 				})) {
-					// A turn the operator has left is consumed but not rendered: the
-					// text still accumulates, so the reply persisted into its own
-					// conversation below is whole, and no row from it lands in a
-					// transcript it has nothing to do with.
+					// A turn the operator has left is consumed but not rendered: no row
+					// from it lands in a transcript it has nothing to do with, and its
+					// text keeps accumulating so that what gets saved does not depend
+					// on exactly when the switch happened.
+					//
+					// How much arrives after the switch is a property of the SESSION,
+					// not of this loop. The built-in one checks the signal at the top of
+					// each iteration and returns after a single `error: aborted`, so in
+					// practice very little does. The accumulation is here so a session
+					// that notices later — a different implementation, a generator
+					// parked in a tool call — still saves a whole reply rather than one
+					// truncated at the moment the operator happened to leave.
 					if (stillHere()) applyEvent(event, st)
 					else if (event.kind === 'delta') st.text += event.text
 				}
@@ -822,11 +860,31 @@ export function App({ ctx }: AppProps) {
 				}
 				// Persisted either way, and into the conversation this turn was
 				// started in — captured above, never re-read.
+				//
+				// Best-effort is about not FAILING, not about staying quiet. The
+				// rejection used to be swallowed whole, and it is the one failure here
+				// that makes a LATER surface wrong: `/resume` comes back missing a
+				// turn that was on screen, and the next turn in that conversation
+				// silently lacks it as context, with nothing connecting either to a
+				// write that failed minutes ago. `run-stream` already says this, in
+				// these words and for this reason.
+				//
+				// Said wherever the operator is now, even when that is a different
+				// conversation, because there is no other channel and it is news they
+				// need. Naming the conversation is what keeps it from reading as a
+				// fault of the one in front of them.
 				const sessions = sessionsRef.current
 				if (sessions && destination) {
 					const turn: Message[] = [createUserMessage(text)]
 					if (st.text.trim().length > 0) turn.push(createAssistantMessage(st.text))
-					void appendMessages(sessions, destination, turn).catch(() => {})
+					void appendMessages(sessions, destination, turn).catch((err: unknown) => {
+						pushMessage(
+							'system',
+							`A turn was not saved to conversation ${destination}: ${
+								err instanceof Error ? err.message : String(err)
+							}. That conversation's history will not include it, and its next turn will not have it as context.`,
+						)
+					})
 				}
 			}
 		},
@@ -1162,6 +1220,11 @@ export function App({ ctx }: AppProps) {
 			}
 			// Resume picker owns the keyboard while open.
 			if (phase === 'resume') {
+				// Once a conversation is being read, the keyboard does nothing here.
+				// The choice is already being acted on; a second Enter would start a
+				// second read and an Esc would hand back a screen that is about to be
+				// replaced regardless.
+				if (resumeCommittedRef.current) return
 				if (key.upArrow) setSelectedResume((i) => Math.max(0, i - 1))
 				else if (key.downArrow) setSelectedResume((i) => Math.min(resumeList.length - 1, i + 1))
 				else if (key.return) {

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -182,6 +182,20 @@ export function App({ ctx }: AppProps) {
 	// turns attribute to the resumed conversation.
 	const sessionsRef = useRef<CliSessions | null>(null)
 	const scopeRef = useRef<RunScope | null>(null)
+	/**
+	 * How many times the operator has switched conversations.
+	 *
+	 * `abort()` returns long before the `for await` in `runTurn` unwinds, so an
+	 * abandoned turn keeps producing events for a while after `/resume` has
+	 * already replaced the screen. This counter is what tells those events they
+	 * are late: a turn captures the value at send time and renders nothing once
+	 * it stops matching.
+	 *
+	 * Bumped ONLY by `resumeConversation`. `/clear` resets the transcript too and
+	 * stays in the same conversation — its turn's rows are still that
+	 * conversation's rows and must keep arriving.
+	 */
+	const conversationGenRef = useRef<number>(0)
 	const idRef = useRef<number>(0)
 	const nextId = useCallback(() => {
 		idRef.current += 1
@@ -467,33 +481,6 @@ export function App({ ctx }: AppProps) {
 		}
 	}, [ensureSessions, pushMessage])
 
-	// Load the chosen conversation into the transcript and continue in it.
-	const resumeConversation = useCallback(
-		async (conv: RecentConversation) => {
-			const sessions = sessionsRef.current
-			const scope = scopeRef.current
-			setPhase('ready')
-			if (!sessions || !scope) return
-			try {
-				const msgs = await loadConversation(sessions, conv.id)
-				const restored: TranscriptMessage[] = msgs
-					.filter((m) => m.role === 'user' || m.role === 'assistant')
-					.map((m) => ({
-						id: nextId(),
-						role: m.role as 'user' | 'assistant',
-						content: typeof m.content === 'string' ? m.content : '',
-					}))
-				resetTranscript()
-				setMessages(restored)
-				scope.sessionId = conv.id // new turns now attribute to the resumed session
-				pushMessage('system', `Resumed: ${conv.title}`)
-			} catch (err) {
-				pushMessage('system', `Could not resume: ${err instanceof Error ? err.message : String(err)}`)
-			}
-		},
-		[nextId, pushMessage],
-	)
-
 	// Resolve a pending permission prompt with the user's decision and tear
 	// down the overlay. No-op if nothing is pending.
 	const resolvePermission = useCallback((decision: PermissionDecision) => {
@@ -503,6 +490,106 @@ export function App({ ctx }: AppProps) {
 		setPermission(null)
 		if (resolve) resolve(decision)
 	}, [])
+
+	/**
+	 * Stop the running turn, and hand the screen back in a usable state.
+	 *
+	 * Returns whether there was one to stop, because the caller has different
+	 * things to say in the two cases.
+	 *
+	 * The screen cleanup lives HERE, at the act that decided to stop, rather
+	 * than in the turn's own `finally`. That was safe only while nothing could
+	 * start another turn in between. `/resume` can — the abandoned loop unwinds
+	 * long after the resumed conversation is on screen, and possibly after a
+	 * turn in it has already begun — so a `finally` that resets the composer,
+	 * the active tools and the abort handle would be resetting somebody else's.
+	 *
+	 * The pending permission prompt is settled first. A turn parked on that
+	 * promise never reaches its own `finally` at all, so aborting alone would
+	 * leave it hanging with its reply unsaved. It is the same decision Ctrl+C
+	 * sends at that prompt, for the same reason.
+	 */
+	const interruptTurn = useCallback((): boolean => {
+		if (permissionResolveRef.current) resolvePermission({ kind: 'reject', feedback: 'User interrupted.' })
+		const ac = abortRef.current
+		if (!ac) return false
+		ac.abort()
+		// Dropped now so a second interrupt does not re-abort, and the queue with
+		// it: interrupting means stop, not "run the next one".
+		abortRef.current = null
+		setQueued([])
+		clearActiveTools()
+		setState('idle')
+		return true
+	}, [clearActiveTools, resolvePermission])
+
+	/**
+	 * Load the chosen conversation into the transcript and continue in it.
+	 *
+	 * A turn may still be running when this happens — the composer stays live
+	 * while the agent works, and a slash action is dispatched ahead of the
+	 * message queue — and until this aborted it, three things went wrong at
+	 * once. Its rows appended into the resumed transcript. Its queued follow-ups
+	 * would have run against a conversation nobody asked them of. And, the one
+	 * that outlived the process, its `appendMessages` wrote into the RESUMED
+	 * conversation's durable record, because `sessionId` was mutated on a
+	 * `RunScope` the running loop held the very same object of.
+	 *
+	 * The mutation below stays, and it is the sharing that makes it necessary:
+	 * `createAgentSession` closed over this exact object and spreads it into
+	 * every `query()`, so replacing it here would leave the agent attributing
+	 * every future turn to the conversation the operator has left. `RunScope`
+	 * says as much — `sessionId` is its one non-`readonly` field. What changed is
+	 * on the other side: a turn now fixes its own destination when it starts
+	 * (see `runTurn`), so a shared cursor moving under it can no longer decide
+	 * where it lands.
+	 *
+	 * The abandoned turn is not dropped in silence. It goes on consuming its own
+	 * events, so its reply is whole, and persists into the conversation it
+	 * belongs to; the operator is told that here, because those rows are
+	 * correctly absent from the transcript now in front of them, and a turn that
+	 * vanishes with no account of where it went is the same defect as one that
+	 * lands in the wrong place.
+	 *
+	 * Nothing is disturbed until the new conversation is actually in hand. A
+	 * read that fails leaves a running turn running where it belongs, exactly as
+	 * cancelling the picker does.
+	 */
+	const resumeConversation = useCallback(
+		async (conv: RecentConversation) => {
+			const sessions = sessionsRef.current
+			const scope = scopeRef.current
+			setPhase('ready')
+			if (!sessions || !scope) return
+			let msgs: Awaited<ReturnType<typeof loadConversation>>
+			try {
+				msgs = await loadConversation(sessions, conv.id)
+			} catch (err) {
+				pushMessage('system', `Could not resume: ${err instanceof Error ? err.message : String(err)}`)
+				return
+			}
+			const restored: TranscriptMessage[] = msgs
+				.filter((m) => m.role === 'user' || m.role === 'assistant')
+				.map((m) => ({
+					id: nextId(),
+					role: m.role as 'user' | 'assistant',
+					content: typeof m.content === 'string' ? m.content : '',
+				}))
+			const interrupted = interruptTurn()
+			conversationGenRef.current += 1
+			resetTranscript()
+			setMessages(restored)
+			scope.sessionId = conv.id // new turns now attribute to the resumed session
+			pushMessage('system', `Resumed: ${conv.title}`)
+			if (interrupted) {
+				pushMessage(
+					'system',
+					'The turn that was running was interrupted. Its reply so far is saved to the conversation it started in, so it is not in the transcript above. A tool call already dispatched was not undone.',
+				)
+			}
+		},
+		[interruptTurn, nextId, pushMessage, resetTranscript],
+	)
 
 	// Bridge passed into session.send(): the agent calls this before a
 	// non-read-only tool batch; it parks until the user presses y/n/a.
@@ -677,6 +764,19 @@ export function App({ ctx }: AppProps) {
 			const st = { assistantId: null as string | null, text: '' }
 			const ac = new AbortController()
 			abortRef.current = ac
+			// Where this turn will be saved, and which transcript its rows belong
+			// to. Both fixed HERE, at the one moment they are knowable.
+			//
+			// `/resume` can land between this line and the `finally` below, and
+			// `abort()` returns long before the loop unwinds — so after a mid-turn
+			// switch the finally ALWAYS runs on the far side of it. Reading
+			// `scopeRef.current` down there wrote this turn into whichever
+			// conversation happened to be open when it finished, and that record
+			// outlives the process. A string captured now cannot be reassigned by
+			// anyone.
+			const destination = scopeRef.current?.sessionId ?? null
+			const turnGeneration = conversationGenRef.current
+			const stillHere = (): boolean => conversationGenRef.current === turnGeneration
 			try {
 				for await (const event of session.send(priorForSdk, {
 					signal: ac.signal,
@@ -685,26 +785,48 @@ export function App({ ctx }: AppProps) {
 					onPermission: ctx.skipPermissions ? undefined : onPermission,
 					extraSystem: composeSkillsPrompt(activeSkills) ?? undefined,
 				})) {
-					applyEvent(event, st)
+					// A turn the operator has left is consumed but not rendered: the
+					// text still accumulates, so the reply persisted into its own
+					// conversation below is whole, and no row from it lands in a
+					// transcript it has nothing to do with.
+					if (stillHere()) applyEvent(event, st)
+					else if (event.kind === 'delta') st.text += event.text
 				}
 			} catch (err) {
-				if (st.assistantId) finalizeMessage(st.assistantId)
-				pushMessage('system', `Error: ${err instanceof Error ? err.message : String(err)}`)
+				// Reported only where it means something. In the conversation the
+				// operator has moved on from, this row would be the same misplacement
+				// the generation exists to stop — and it would be the more confusing
+				// half of it, because an abort reads as an error.
+				if (stillHere()) {
+					if (st.assistantId) finalizeMessage(st.assistantId)
+					pushMessage('system', `Error: ${err instanceof Error ? err.message : String(err)}`)
+				}
 			} finally {
-				abortRef.current = null
-				permissionResolveRef.current = null
-				permissionOpenedAtRef.current = null
-				setPermission(null)
-				clearActiveTools()
-				setState('idle')
-				// Persist the turn to the SDK session store (best-effort) so it can
-				// be resumed later. User message + the assistant's reply text.
+				// The screen belongs to the conversation on it, which after a
+				// `/resume` is no longer this turn's. `interruptTurn` already did this
+				// cleanup at the moment it decided to stop; repeating it here would
+				// clear the state of whatever has started since.
+				if (stillHere()) {
+					// Unguarded, and it can be: a second turn cannot start in the
+					// conversation this one is running in — the composer queues instead
+					// — so within one generation this handle is still ours. An
+					// `=== ac` comparison here read as prudence and was a check that
+					// could not fail, which teaches the next reader that the checks
+					// around it are decoration too.
+					abortRef.current = null
+					permissionResolveRef.current = null
+					permissionOpenedAtRef.current = null
+					setPermission(null)
+					clearActiveTools()
+					setState('idle')
+				}
+				// Persisted either way, and into the conversation this turn was
+				// started in — captured above, never re-read.
 				const sessions = sessionsRef.current
-				const scope = scopeRef.current
-				if (sessions && scope) {
+				if (sessions && destination) {
 					const turn: Message[] = [createUserMessage(text)]
 					if (st.text.trim().length > 0) turn.push(createAssistantMessage(st.text))
-					void appendMessages(sessions, scope.sessionId, turn).catch(() => {})
+					void appendMessages(sessions, destination, turn).catch(() => {})
 				}
 			}
 		},
@@ -1101,9 +1223,7 @@ export function App({ ctx }: AppProps) {
 			// Esc interrupts a running turn (Ctrl+C stays reserved for exit). Mirrors
 			// the Ctrl+C interrupt path: abort, drop the queue, one "Interrupted." line.
 			if (key.escape && abortRef.current) {
-				abortRef.current.abort()
-				abortRef.current = null
-				setQueued([])
+				interruptTurn()
 				pushMessage('system', 'Interrupted.')
 				return
 			}
@@ -1135,13 +1255,9 @@ export function App({ ctx }: AppProps) {
 			}
 			if (key.ctrl && input === 'c') {
 				// A turn is running → first Ctrl+C interrupts it, not exits.
-				if (abortRef.current) {
-					abortRef.current.abort()
-					// Drop the ref now so a second Ctrl+C arms exit instead of
-					// re-aborting (which spammed "Interrupted." lines), and clear any
-					// queued messages — interrupting means stop, not "run the next one".
-					abortRef.current = null
-					setQueued([])
+				// Drops the ref, so a second Ctrl+C arms exit instead of re-aborting
+				// (which spammed "Interrupted." lines).
+				if (interruptTurn()) {
 					pushMessage('system', 'Interrupted.')
 					return
 				}

--- a/packages/cli/src/tui/__tests__/resume-abandons-its-turn.test.tsx
+++ b/packages/cli/src/tui/__tests__/resume-abandons-its-turn.test.tsx
@@ -13,11 +13,16 @@
  *      record, because `sessionId` was mutated on a `RunScope` the running loop
  *      held the same object of. That one outlived the process.
  *
- * The fake session deliberately keeps yielding after the abort, because that is
- * what a real one does: `abort()` returns and the `for await` unwinds whenever
- * it gets there. A generator that stopped politely on the signal would make
- * halves 2 and 3 untestable — the window they live in is exactly the interval
- * this fake holds open.
+ * The fake session keeps yielding after the abort, and it is worth being exact
+ * about what that models. `abort()` returns immediately and the `for await`
+ * unwinds whenever it gets there, so the window is real — but the BUILT-IN
+ * session checks the signal at the top of each iteration and returns after one
+ * `error: aborted`, so on that implementation very little arrives in it. This
+ * fake is therefore a session that notices the signal LATE, which is the case
+ * the guards have to hold for and the only one in which they are observable at
+ * all. A generator that stopped politely would close the window and make halves
+ * 2 and 3 untestable; claiming it is what the shipped session does would be a
+ * different error, so it is not claimed.
  *
  * The second test is the other side, and it is the one that was correct only by
  * placement: cancelling the picker must leave everything alone, and nothing
@@ -66,6 +71,16 @@ let abortSeenAtRelease = false
 
 /** Set by a test that wants the conversation read to fail. */
 let loadShouldFail = false
+/** Set by a test that wants the write of the abandoned turn to fail. */
+let appendShouldFail = false
+/** Held by a test that wants the conversation read to take an observable while. */
+let readHeld: Promise<void> | null = null
+let releaseTheRead: () => void = () => {}
+function holdTheRead(): void {
+	readHeld = new Promise<void>((r) => {
+		releaseTheRead = r
+	})
+}
 /** Set by a test that wants the abandoned turn to end by throwing. */
 let throwAtEnd = false
 /** Set by a test that wants the abandoned turn parked on a permission prompt. */
@@ -91,11 +106,13 @@ vi.mock('../../integrations/sessions/store.js', () => ({
 			sessionId,
 			contents: messages.map((m) => (typeof m.content === 'string' ? m.content : '')),
 		})
+		if (appendShouldFail) throw new Error('ENOSPC: no space left on device')
 	},
 	listRecent: async () => [
 		{ id: RESUMED, title: 'An earlier conversation', updatedAt: new Date().toISOString(), count: 2 },
 	],
 	loadConversation: async () => {
+		if (readHeld) await readHeld
 		if (loadShouldFail) throw new Error('DISKUNREADABLE')
 		return [
 			{ role: 'user', content: 'RESTOREDQUESTION', timestamp: 1 },
@@ -139,6 +156,12 @@ vi.mock('../agent.js', async (importOriginal) => {
 				const turn = signals.length
 				signals.push(opts?.signal)
 				const gate = nextGate()
+				// A delta BEFORE the wait, so the turn owns a streaming assistant row
+				// in the transcript that `/resume` then throws away. That is the shape
+				// where a late `appendToMessage` would target an id belonging to the
+				// discarded array and no-op in silence — invisible to a turn whose
+				// first event is a tool call.
+				yield { kind: 'delta', text: `EARLY${turn} ` } as AgentEvent
 				yield {
 					kind: 'tool-start',
 					toolUseId: 'c1',
@@ -181,6 +204,8 @@ beforeEach(() => {
 	signals.length = 0
 	abortSeenAtRelease = false
 	loadShouldFail = false
+	appendShouldFail = false
+	readHeld = null
 	throwAtEnd = false
 	askPermission = false
 	permissionAsked = false
@@ -189,8 +214,9 @@ beforeEach(() => {
 
 afterEach(() => {
 	// Released whatever the test did, so a failing assertion cannot leave a
-	// generator parked forever and take the next file down with it.
+	// generator or a read parked forever and take the next file down with it.
 	for (const g of gates) g.release()
+	releaseTheRead()
 	for (const h of mounted) h.unmount()
 	mounted.length = 0
 	vi.restoreAllMocks()
@@ -290,11 +316,61 @@ describe('/resume while a turn is running', () => {
 			'LEAKEDREPLY0',
 		)
 
+		// The reply the operator watched begin, before the switch, is part of what
+		// is saved — and its row is gone from the screen, so a late write against
+		// its id would be a silent no-op nothing else here would notice.
+		expect(appended[0]?.contents.join(' ')).toContain('EARLY0')
+
 		// 4 — and the operator is told, because those rows are correctly missing
 		// from the transcript they are now looking at.
 		expect(everything, 'the abandoned turn was dropped in silence').toContain(
-			'saved to the conversation it started in',
+			'being saved to the conversation it started in',
 		)
+	})
+
+	it('says so when the abandoned turn could not be saved after all', async () => {
+		// The notice above says the reply is BEING saved, present tense, because
+		// the write has not happened when it is printed. It runs later, detached,
+		// and its rejection used to be swallowed whole — so a resume could promise
+		// a turn was going somewhere and nothing would ever say it did not arrive.
+		// That is the same defect as the one being fixed, one step further on.
+		appendShouldFail = true
+		const harness = await pickerOpenMidTurn()
+
+		harness.stdin.write('\r')
+		await untilFrame(harness, 'RESTOREDANSWER', 'the conversation never loaded')
+		gates[0]?.release()
+		await untilFrame(harness, 'was not saved', 'the failed write was silent')
+
+		const everything = harness.frames.join('\n')
+		// Named, so it does not read as a fault of the conversation on screen.
+		expect(everything, 'did not say which conversation lost the turn').toContain(STARTED_IN)
+		expect(everything, 'named the fault without naming the consequence').toContain('context')
+	})
+
+	it('keeps the picker until the conversation is actually read', async () => {
+		// The composer is live in the `ready` phase, and handing it back before the
+		// read settles gives a message nowhere to go: queued against a conversation
+		// being left, then dropped by the interrupt or sent somewhere nobody
+		// addressed it. Esc stops cancelling for the same interval — the choice is
+		// already being acted on.
+		holdTheRead()
+		const harness = await pickerOpenMidTurn()
+
+		harness.stdin.write('\r')
+		await tick(120)
+		expect(harness.lastFrame(), 'the screen was handed back mid-read').toContain(
+			'Resume a conversation',
+		)
+
+		harness.stdin.write('\x1B')
+		await tick(80)
+		expect(harness.lastFrame(), 'esc cancelled a resume already under way').toContain(
+			'Resume a conversation',
+		)
+
+		releaseTheRead()
+		await untilFrame(harness, 'RESTOREDANSWER', 'the conversation never loaded')
 	})
 
 	it('keeps the abandoned turn from reporting its own failure into the resumed transcript', async () => {

--- a/packages/cli/src/tui/__tests__/resume-abandons-its-turn.test.tsx
+++ b/packages/cli/src/tui/__tests__/resume-abandons-its-turn.test.tsx
@@ -1,0 +1,452 @@
+/**
+ * What `/resume` does to the turn it interrupts — asserted against a rendered
+ * `<App>`.
+ *
+ * The defect this pins had three independent halves, and each needs its own
+ * assertion, because any one of the three fixes makes the other two look
+ * covered:
+ *
+ *   1. the running turn was never aborted at all;
+ *   2. its later events appended into the RESUMED transcript, dated as though
+ *      they belonged there;
+ *   3. its `appendMessages` wrote into the RESUMED conversation's durable
+ *      record, because `sessionId` was mutated on a `RunScope` the running loop
+ *      held the same object of. That one outlived the process.
+ *
+ * The fake session deliberately keeps yielding after the abort, because that is
+ * what a real one does: `abort()` returns and the `for await` unwinds whenever
+ * it gets there. A generator that stopped politely on the signal would make
+ * halves 2 and 3 untestable — the window they live in is exactly the interval
+ * this fake holds open.
+ *
+ * The second test is the other side, and it is the one that was correct only by
+ * placement: cancelling the picker must leave everything alone, and nothing
+ * said so.
+ */
+
+import { render } from 'ink-testing-library'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Preferences } from '../../integrations/providers/index.js'
+import type { AgentEvent, AgentSession } from '../agent.js'
+import type { TuiContext } from '../types.js'
+
+const PREFS: Preferences = { version: 3, providers: [{ id: 'openai' }], subagents: { active: [] } }
+
+/** The conversation the turn is started in, and the one `/resume` moves to. */
+const STARTED_IN = 'conv-started-in'
+const RESUMED = 'conv-resumed'
+
+/** Every `appendMessages` call, with the conversation it named. */
+const appended: Array<{ sessionId: string; contents: string[] }> = []
+
+/**
+ * One gate per turn, standing in for a tool still running.
+ *
+ * Two, because the sharpest case needs a SECOND turn started in the resumed
+ * conversation while the first is still unwinding — the moment where the
+ * abandoned turn's cleanup would reset somebody else's screen.
+ */
+const gates: Array<{ wait: Promise<void>; release: () => void }> = []
+function nextGate() {
+	let release: () => void = () => {}
+	const wait = new Promise<void>((r) => {
+		release = r
+	})
+	const g = { wait, release }
+	gates.push(g)
+	return g
+}
+
+/** Per-turn signals, indexed by the order the turns were started. */
+const signals: Array<AbortSignal | undefined> = []
+
+/** Whether the first turn's signal had been aborted by the time it resumed. */
+let abortSeenAtRelease = false
+
+/** Set by a test that wants the conversation read to fail. */
+let loadShouldFail = false
+/** Set by a test that wants the abandoned turn to end by throwing. */
+let throwAtEnd = false
+/** Set by a test that wants the abandoned turn parked on a permission prompt. */
+let askPermission = false
+/** Whether the first turn has asked, and what it was told. */
+let permissionAsked = false
+const decisions: unknown[] = []
+
+vi.mock('../../integrations/trust/store.js', () => ({
+	isTrusted: () => true,
+	trustDir: () => {},
+}))
+
+vi.mock('../../integrations/updates.js', () => ({
+	checkUpdates: async () => [],
+}))
+
+vi.mock('../../integrations/sessions/store.js', () => ({
+	openSessions: async () => ({ tenantId: 't', root: '/tmp/.namzu' }),
+	startConversation: async () => STARTED_IN,
+	appendMessages: async (_s: unknown, sessionId: string, messages: readonly { content: unknown }[]) => {
+		appended.push({
+			sessionId,
+			contents: messages.map((m) => (typeof m.content === 'string' ? m.content : '')),
+		})
+	},
+	listRecent: async () => [
+		{ id: RESUMED, title: 'An earlier conversation', updatedAt: new Date().toISOString(), count: 2 },
+	],
+	loadConversation: async () => {
+		if (loadShouldFail) throw new Error('DISKUNREADABLE')
+		return [
+			{ role: 'user', content: 'RESTOREDQUESTION', timestamp: 1 },
+			{ role: 'assistant', content: 'RESTOREDANSWER', timestamp: 2 },
+		]
+	},
+}))
+
+vi.mock('../../user-commands/store.js', () => ({
+	discoverUserCommands: () => [],
+}))
+
+vi.mock('../agent.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../agent.js')>()
+	return {
+		...actual,
+		probeAgentSession: async () => ({ preferences: PREFS, needsRepickReason: null, detected: [] }),
+		createAgentSession: async (): Promise<AgentSession> => ({
+			hasProvider: true,
+			providerSummary: 'a-provider',
+			modelSummary: 'a-model',
+			toolNames: () => ['bash'],
+			errorHint: null,
+			instructionFiles: [],
+			skippedInstructionFiles: [],
+			mcpConnected: [],
+			mcpFailed: [],
+			agentIds: [],
+			configNotices: [],
+			close: async () => {},
+			approvalLatched: () => false,
+			promptExemptTools: () => [],
+			// One row before the operator can act, then the wait, then the events
+			// that must land in the right place — or nowhere.
+			//
+			// It goes on yielding AFTER the abort on purpose. That is what a real
+			// one does — `abort()` returns and the loop unwinds whenever it gets
+			// there — and a generator that stopped politely on the signal would
+			// close the very window the other two halves of this defect live in.
+			send: async function* (_messages, opts): AsyncIterable<AgentEvent> {
+				const turn = signals.length
+				signals.push(opts?.signal)
+				const gate = nextGate()
+				yield {
+					kind: 'tool-start',
+					toolUseId: 'c1',
+					toolName: 'bash',
+					summary: `RUNNING${turn}`,
+				} as AgentEvent
+				await gate.wait
+				if (askPermission && turn === 0) {
+					permissionAsked = true
+					const decision = await opts?.onPermission?.({
+						toolCalls: [{ id: 'call-1', name: 'bash', summary: 'rm -rf build', isDestructive: true }],
+					})
+					if (decision) decisions.push(decision)
+				}
+				if (turn === 0) abortSeenAtRelease = opts?.signal?.aborted === true
+				yield {
+					kind: 'tool-end',
+					toolUseId: 'c1',
+					toolName: 'bash',
+					summary: `LEAKEDTOOL${turn}`,
+					isError: false,
+				} as AgentEvent
+				yield { kind: 'delta', text: `LEAKEDREPLY${turn}` } as AgentEvent
+				if (throwAtEnd && turn === 0) throw new Error('TURNBLEWUP')
+				yield { kind: 'done' } as AgentEvent
+			},
+		}),
+	}
+})
+
+const { App } = await import('../App.js')
+
+const ctx: TuiContext = { cwd: process.cwd(), version: '0.0.0-test' }
+const tick = (ms = 40) => new Promise((r) => setTimeout(r, ms))
+const mounted: { unmount: () => void }[] = []
+
+beforeEach(() => {
+	appended.length = 0
+	gates.length = 0
+	signals.length = 0
+	abortSeenAtRelease = false
+	loadShouldFail = false
+	throwAtEnd = false
+	askPermission = false
+	permissionAsked = false
+	decisions.length = 0
+})
+
+afterEach(() => {
+	// Released whatever the test did, so a failing assertion cannot leave a
+	// generator parked forever and take the next file down with it.
+	for (const g of gates) g.release()
+	for (const h of mounted) h.unmount()
+	mounted.length = 0
+	vi.restoreAllMocks()
+})
+
+/** Wait for a frame to say something, rather than sleeping a fixed interval. */
+async function untilFrame(
+	harness: { lastFrame: () => string | undefined },
+	needle: string,
+	why: string,
+): Promise<void> {
+	const started = performance.now()
+	while (!(harness.lastFrame() ?? '').includes(needle) && performance.now() - started < 3_000) {
+		await tick(20)
+	}
+	expect(harness.lastFrame(), why).toContain(needle)
+}
+
+/**
+ * Render, run a turn until it parks on the gate, and open the `/resume` picker.
+ *
+ * Polled rather than slept through, for the reason `app-permission-keys`
+ * documents: a fixed wait passes this file alone and fails under the full
+ * parallel run, and the failure is reported as whatever the test was about.
+ */
+async function pickerOpenMidTurn() {
+	const harness = render(<App ctx={ctx} />)
+	mounted.push(harness)
+	await tick(60)
+	await submit(harness, 'go')
+	harness.stdin.write('/resume')
+	await tick(30)
+	harness.stdin.write('\r')
+	await untilFrame(harness, 'Resume a conversation', 'the resume picker never opened')
+	return harness
+}
+
+/**
+ * Type and send.
+ *
+ * The keys go in separately because Ink delivers one `stdin.write` as ONE
+ * keypress: `'go\r'` arrives with `key.return` false and is taken as pasted
+ * text, so nothing is ever submitted and the test asserts against a turn that
+ * never ran.
+ */
+async function submit(harness: { stdin: { write: (s: string) => void } }, text: string) {
+	harness.stdin.write(text)
+	await tick(20)
+	harness.stdin.write('\r')
+	await tick(60)
+}
+
+/** Wait until `n` turns have persisted themselves. */
+async function appendsReach(n: number, timeoutMs = 3_000): Promise<void> {
+	const started = performance.now()
+	while (appended.length < n && performance.now() - started < timeoutMs) await tick(20)
+}
+
+describe('/resume while a turn is running', () => {
+	it('aborts it, keeps its output out of the resumed transcript, and saves it where it belongs', async () => {
+		const harness = await pickerOpenMidTurn()
+
+		harness.stdin.write('\r')
+		// The resumed conversation has to be on screen before the old turn is let
+		// go, or the test proves nothing about ordering.
+		await untilFrame(harness, 'RESTOREDANSWER', 'the conversation never loaded')
+
+		gates[0]?.release()
+		await appendsReach(1)
+		await tick(120)
+
+		// 1 — it was actually stopped. Without this the two assertions below still
+		// pass, because the transcript guard and the captured destination each
+		// hold on their own; a `/resume` that quietly let the turn keep running
+		// would go unreported.
+		expect(abortSeenAtRelease, 'the running turn was never aborted').toBe(true)
+
+		// 2 — nothing from it reached the screen after the switch. Read across
+		// every frame, not the last one: finalized rows print once through
+		// `<Static>` and a later frame need not carry them, so `lastFrame` alone
+		// would be satisfied by output that did land.
+		const everything = harness.frames.join('\n')
+		expect(everything, "the abandoned turn's tool row landed in the resumed transcript").not.toContain(
+			'LEAKEDTOOL0',
+		)
+		expect(everything, "the abandoned turn's reply landed in the resumed transcript").not.toContain(
+			'LEAKEDREPLY0',
+		)
+
+		// 3 — the durable half. It must be written to the conversation it was
+		// started in, and to no other.
+		expect(appended.map((a) => a.sessionId)).toEqual([STARTED_IN])
+		// And whole: the events after the switch are consumed even though they are
+		// not rendered, so the saved reply is not truncated at the moment the
+		// operator happened to leave.
+		expect(appended[0]?.contents.join(' '), 'the saved reply stops where the operator left').toContain(
+			'LEAKEDREPLY0',
+		)
+
+		// 4 — and the operator is told, because those rows are correctly missing
+		// from the transcript they are now looking at.
+		expect(everything, 'the abandoned turn was dropped in silence').toContain(
+			'saved to the conversation it started in',
+		)
+	})
+
+	it('keeps the abandoned turn from reporting its own failure into the resumed transcript', async () => {
+		// The other end of the same event loop. An abandoned turn that ENDS BADLY
+		// would print `Error: …` into a conversation that had nothing to do with
+		// it — the more confusing half, because an interrupted turn failing reads
+		// to the operator as the resumed conversation failing.
+		throwAtEnd = true
+		const harness = await pickerOpenMidTurn()
+
+		harness.stdin.write('\r')
+		await untilFrame(harness, 'RESTOREDANSWER', 'the conversation never loaded')
+
+		gates[0]?.release()
+		await appendsReach(1)
+		await tick(120)
+
+		expect(
+			harness.frames.join('\n'),
+			"the abandoned turn's failure was reported into the resumed conversation",
+		).not.toContain('TURNBLEWUP')
+		// It still saved what it had, into its own conversation. A turn that fails
+		// is not a turn that produced nothing.
+		expect(appended.map((a) => a.sessionId)).toEqual([STARTED_IN])
+	})
+
+	it('leaves the screen to the turn that has started since', async () => {
+		// The reason the abandoned turn's cleanup is guarded rather than
+		// unconditional. It unwinds long after the switch — by then a turn in the
+		// resumed conversation can already be running, and a `finally` that
+		// cleared the abort handle would leave that turn unstoppable: `Esc` would
+		// do nothing, with no way to tell from the screen.
+		const harness = await pickerOpenMidTurn()
+		harness.stdin.write('\r')
+		await untilFrame(harness, 'RESTOREDANSWER', 'the conversation never loaded')
+
+		await submit(harness, 'ask again')
+		// Both turns are now live: the abandoned one still unwinding, the new one
+		// parked on its own gate.
+		expect(gates.length, 'the second turn never started').toBe(2)
+		await untilFrame(harness, 'RUNNING1', 'the second turn is not showing as running')
+
+		gates[0]?.release()
+		await appendsReach(1)
+		await tick(150)
+
+		// The live region is the visible half: the abandoned turn's cleanup would
+		// clear the active-tool list, so the turn still working would stop looking
+		// like it was — and the queue effect, which only runs while the screen says
+		// idle, would start firing follow-ups into the middle of it.
+		expect(harness.lastFrame(), "the abandoned turn cleared the live turn's state").toContain(
+			'RUNNING1',
+		)
+		// And the invisible half: the abort handle. `Esc` would do nothing, with
+		// nothing on the screen to say why.
+		harness.stdin.write('\x1B')
+		await tick(120)
+		expect(signals[1]?.aborted, 'Esc no longer stops the turn on screen').toBe(true)
+	})
+
+	it('does not send a queued follow-up into the conversation it lands in', async () => {
+		// The composer stays live while the agent works — that is what message
+		// queuing is built on — so a follow-up meant for THIS conversation is
+		// sitting in the queue at the moment the operator leaves it. The queue
+		// drains the instant the screen goes idle, which the interrupt is what
+		// makes happen, so the follow-up would be asked of a conversation nobody
+		// addressed it to. Interrupting means stop, not "run the next one
+		// somewhere else" — the same reason Esc and Ctrl+C drop it.
+		const harness = render(<App ctx={ctx} />)
+		mounted.push(harness)
+		await tick(60)
+		await submit(harness, 'go')
+		await submit(harness, 'FOLLOWUP')
+		await untilFrame(harness, 'queued', 'the follow-up was not queued')
+
+		harness.stdin.write('/resume')
+		await tick(30)
+		harness.stdin.write('\r')
+		await untilFrame(harness, 'Resume a conversation', 'the resume picker never opened')
+		harness.stdin.write('\r')
+		await untilFrame(harness, 'RESTOREDANSWER', 'the conversation never loaded')
+		await tick(200)
+
+		expect(gates.length, 'the queued follow-up ran in the resumed conversation').toBe(1)
+	})
+
+	it('settles a permission prompt the abandoned turn was parked on', async () => {
+		// The picker opens on an `await`, so a tool batch can reach the prompt
+		// while it is up — and the resume picker owns the keyboard ahead of the
+		// prompt, so the operator resumes without ever answering it.
+		//
+		// A turn parked on that promise never reaches its own `finally`, which is
+		// where its reply is saved. An abort alone leaves it there forever: the
+		// work is not stopped, it is suspended, and the partial reply the operator
+		// watched arrive is never written anywhere. So the interrupt answers it,
+		// with the decision Ctrl+C sends at that same prompt.
+		askPermission = true
+		const harness = await pickerOpenMidTurn()
+
+		gates[0]?.release()
+		const started = performance.now()
+		while (!permissionAsked && performance.now() - started < 3_000) await tick(20)
+		expect(permissionAsked, 'the turn never reached the prompt').toBe(true)
+
+		harness.stdin.write('\r')
+		await untilFrame(harness, 'RESTOREDANSWER', 'the conversation never loaded')
+		await appendsReach(1)
+
+		expect(decisions, 'the prompt was left unanswered, so the turn never unwound').toEqual([
+			{ kind: 'reject', feedback: 'User interrupted.' },
+		])
+		expect(appended.map((a) => a.sessionId)).toEqual([STARTED_IN])
+	})
+
+	it('disturbs nothing when the conversation cannot be read', async () => {
+		// The abort, the transcript reset and the scope switch all happen AFTER
+		// the read succeeds, deliberately: a resume that cannot be completed must
+		// leave a running turn running where it belongs, exactly as cancelling the
+		// picker does. Ordering is the whole of it, so it is asserted rather than
+		// left to the order the lines happen to be in.
+		loadShouldFail = true
+		const harness = await pickerOpenMidTurn()
+
+		harness.stdin.write('\r')
+		await untilFrame(harness, 'DISKUNREADABLE', 'the failure was never reported')
+
+		gates[0]?.release()
+		await appendsReach(1)
+		await tick(120)
+
+		expect(abortSeenAtRelease, 'a failed resume aborted the turn anyway').toBe(false)
+		const everything = harness.frames.join('\n')
+		expect(everything, 'the turn stopped rendering into its own transcript').toContain('LEAKEDREPLY0')
+		expect(appended.map((a) => a.sessionId)).toEqual([STARTED_IN])
+	})
+
+	it('leaves the running turn alone when the picker is cancelled', async () => {
+		const harness = await pickerOpenMidTurn()
+
+		harness.stdin.write('\x1B')
+		await tick(80)
+		expect(harness.lastFrame(), 'cancelling the picker resumed something').not.toContain(
+			'RESTOREDANSWER',
+		)
+
+		gates[0]?.release()
+		await appendsReach(1)
+		await tick(120)
+
+		expect(abortSeenAtRelease, 'cancelling the picker aborted the turn').toBe(false)
+		const everything = harness.frames.join('\n')
+		expect(everything, 'the turn stopped rendering into its own transcript').toContain('LEAKEDREPLY0')
+		expect(appended.map((a) => a.sessionId)).toEqual([STARTED_IN])
+	})
+})

--- a/packages/cli/src/tui/__tests__/resume-abandons-its-turn.test.tsx
+++ b/packages/cli/src/tui/__tests__/resume-abandons-its-turn.test.tsx
@@ -222,6 +222,24 @@ afterEach(() => {
 	vi.restoreAllMocks()
 })
 
+/**
+ * Everything that was ever rendered, as one line of words.
+ *
+ * Read across `frames` rather than `lastFrame`, because finalized rows print
+ * once through `<Static>` and a later frame need not carry them — so
+ * `lastFrame` alone would be satisfied by output that DID land.
+ *
+ * Whitespace-collapsed, because Ink wraps at the terminal width and a sentence
+ * long enough to matter is a sentence long enough to wrap. An assertion holding
+ * a phrase that straddles the wrap point passes or fails on where the renderer
+ * broke the line, which is a fact about the column count of whoever ran it: this
+ * file went green locally and red on CI for exactly that, with the sentence
+ * plainly present in the dump. Matching words rather than layout is the fix.
+ */
+function said(harness: { frames: readonly string[] }): string {
+	return harness.frames.join('\n').replace(/\s+/g, ' ')
+}
+
 /** Wait for a frame to say something, rather than sleeping a fixed interval. */
 async function untilFrame(
 	harness: { lastFrame: () => string | undefined },
@@ -294,11 +312,10 @@ describe('/resume while a turn is running', () => {
 		// would go unreported.
 		expect(abortSeenAtRelease, 'the running turn was never aborted').toBe(true)
 
-		// 2 — nothing from it reached the screen after the switch. Read across
-		// every frame, not the last one: finalized rows print once through
-		// `<Static>` and a later frame need not carry them, so `lastFrame` alone
-		// would be satisfied by output that did land.
-		const everything = harness.frames.join('\n')
+		// 2 — nothing from it reached the screen after the switch. `said` reads
+		// across every frame and collapses the wrapping; see its docblock for why
+		// both halves of that matter.
+		const everything = said(harness)
 		expect(everything, "the abandoned turn's tool row landed in the resumed transcript").not.toContain(
 			'LEAKEDTOOL0',
 		)
@@ -342,7 +359,7 @@ describe('/resume while a turn is running', () => {
 		gates[0]?.release()
 		await untilFrame(harness, 'was not saved', 'the failed write was silent')
 
-		const everything = harness.frames.join('\n')
+		const everything = said(harness)
 		// Named, so it does not read as a fault of the conversation on screen.
 		expect(everything, 'did not say which conversation lost the turn').toContain(STARTED_IN)
 		expect(everything, 'named the fault without naming the consequence').toContain('context')
@@ -389,7 +406,7 @@ describe('/resume while a turn is running', () => {
 		await tick(120)
 
 		expect(
-			harness.frames.join('\n'),
+			said(harness),
 			"the abandoned turn's failure was reported into the resumed conversation",
 		).not.toContain('TURNBLEWUP')
 		// It still saved what it had, into its own conversation. A turn that fails
@@ -502,7 +519,7 @@ describe('/resume while a turn is running', () => {
 		await tick(120)
 
 		expect(abortSeenAtRelease, 'a failed resume aborted the turn anyway').toBe(false)
-		const everything = harness.frames.join('\n')
+		const everything = said(harness)
 		expect(everything, 'the turn stopped rendering into its own transcript').toContain('LEAKEDREPLY0')
 		expect(appended.map((a) => a.sessionId)).toEqual([STARTED_IN])
 	})
@@ -521,7 +538,7 @@ describe('/resume while a turn is running', () => {
 		await tick(120)
 
 		expect(abortSeenAtRelease, 'cancelling the picker aborted the turn').toBe(false)
-		const everything = harness.frames.join('\n')
+		const everything = said(harness)
 		expect(everything, 'the turn stopped rendering into its own transcript').toContain('LEAKEDREPLY0')
 		expect(appended.map((a) => a.sessionId)).toEqual([STARTED_IN])
 	})


### PR DESCRIPTION
Closes #307.

`/resume` selected a conversation and reset the transcript without stopping a turn that was still running. The old loop kept going, and three things followed — only the last of which the issue could see from outside:

1. its later events appended into the **resumed** transcript;
2. a follow-up queued for the old conversation was sent to the new one the moment the screen went idle;
3. its `appendMessages` wrote into the **resumed** conversation's durable record, because `scope.sessionId` was mutated in place and the running loop closed over the same object. That one outlives the process.

## What the fix decides

**Aborting is not enough, and the issue said so.** Three mechanisms, because each of the three failures above survives the other two fixes:

- **`interruptTurn`**, shared with `Esc` and `Ctrl+C` and now called by `resumeConversation`. It settles a pending permission prompt *first*: a turn parked on that promise never reaches its own `finally`, which is where its reply is saved — so an abort alone would not stop the work, it would suspend it forever with the partial reply written nowhere. That is the "abandoned silently" case, and it is the one the issue warned about.
- **A turn fixes its destination when it starts.** `abort()` returns long before the `for await` unwinds, so after a mid-turn switch the `finally` *always* runs on the far side of it; reading the shared scope there is what chose the wrong conversation. A captured string cannot be reassigned by anyone.
- **A conversation-generation counter.** Late events are consumed but not rendered — the reply saved to its own conversation stays whole, and no row lands in a transcript it has nothing to do with. Screen cleanup moved to the act that decided to stop, so an abandoned turn cannot reset the state of a turn that has started since.

**What happens to the abandoned turn, said out loud.** It is interrupted; its reply so far is saved to the conversation it started in; and the resumed transcript says so, because those rows are correctly missing from what the operator is now looking at. It also says that a tool call already dispatched was not undone, which is true and which a bare "Interrupted." would have implied the opposite of.

**Ordering.** Nothing is disturbed until the new conversation is in hand. A read that fails now leaves a running turn running where it belongs — the same guarantee cancelling the picker had, which was previously true only by where the code happened to sit and is now asserted.

## Deliberately *not* changed

`scope.sessionId` is still mutated in place. `createAgentSession` closed over that exact object and spreads it into every `query()`, so replacing it would leave the agent attributing every future turn to the conversation the operator has left — and `RunScope` says as much, `sessionId` being its one non-`readonly` field. What changed is on the other side: a turn no longer reads that shared cursor to decide where it lands.

This was found by mutation-checking: restoring the in-place mutation survived the suite, which sent me to look at who else holds the object.

## Tests

`packages/cli/src/tui/__tests__/resume-abandons-its-turn.test.tsx` — seven cases against a rendered `<App>`. The fake session keeps yielding *after* the abort on purpose: that is what a real one does, and a generator that stopped politely on the signal would close the exact window the other two halves live in.

Assertions read across `frames`, not `lastFrame` — finalized rows print once through `<Static>` and a later frame need not carry them, so `lastFrame` alone would be satisfied by output that did land.

| Mutation | Result |
| --- | --- |
| abort removed from `resumeConversation` | killed — *the running turn was never aborted* |
| destination re-read in the `finally` | killed — persisted to `conv-resumed` |
| generation guard removed from the render path | killed — *landed in the resumed transcript* |
| suppressed deltas no longer accumulated | killed — saved reply truncated |
| `catch` reports regardless of generation | killed — failure reported into the resumed conversation |
| `finally` cleanup unguarded | killed — *cleared the live turn's state* |
| queue survives the interrupt | killed — the queued follow-up ran in the resumed conversation |
| permission prompt left hanging | killed — the turn never unwound |
| abort moved ahead of the read | killed — the failed-read case aborted anyway |
| the notice removed | killed — *dropped in silence* |

Two earlier survivors were acted on rather than left in the table: an `=== ac` comparison that could not fail (removed, per `docs/conventions/a-check-that-cannot-fail.md`), and the scope replacement described above.

## Gates

build · typecheck · lint · test (686) · `audit-external-names` · `docs:check` — all green.
