### PR TITLE
fix(cli)!: doctor says when it could not look

### DIFF
--- a/.changeset/doctor-says-when-it-could-not-look.md
+++ b/.changeset/doctor-says-when-it-could-not-look.md
@@ -1,0 +1,48 @@
+---
+'@namzu/sdk': major
+'@namzu/cli': major
+---
+
+`namzu doctor` no longer exits 0 when a check could not answer
+
+**What breaks.** `namzu doctor` gains a new exit code, `69`, and a new status
+word, `skipped`.
+
+- **A CI step running `namzu doctor` can now fail where it used to pass.** If a
+  check times out, is aborted, or the thing it reads throws, the command exits
+  `69` instead of `0`. Nothing is claimed to have failed — `1` still means that
+  — but the report is incomplete, and it used to say so only in text nothing
+  reads. If you need the old behaviour while you look into it, treat `69` as
+  success explicitly rather than by accident.
+- **`DoctorStatus` gains `'skipped'`.** An exhaustive `switch` over it, or a
+  `Record<DoctorStatus, …>`, stops compiling. Handle `skipped` as "there was
+  nothing here to check" — an ordinary state of a healthy machine, not a
+  problem.
+- **`DoctorReport['exit']` gains `69`**, and `DoctorReport['summary']` gains a
+  required `skipped: number`. Code that constructs a `DoctorReport` by hand must
+  add the field; code that reads the summary can now rely on the counts summing
+  to `total`, which they did not while `skipped` was hidden inside
+  `inconclusive`.
+
+**Why.** "Healthy" and "did not manage to look" shared an exit code in the one
+command whose entire job is to report state it read. Fixing that needed the
+status vocabulary split first, because `inconclusive` was carrying two facts:
+*there is nothing here to check* — an optional package absent, a registry with
+no auto-discovery, nothing configured yet — and *this check did not answer*.
+Only the second is a gap worth an exit code; making both non-zero would have
+turned `namzu doctor` red on every healthy machine.
+
+So `vault.registered`, `providers.registered`, `providers.chain` with no
+preferences file, and `telemetry.installed` with the package absent now report
+`skipped`, and they still exit `0`.
+
+**Also fixed:** `telemetry.installed` reported `not installed (optional
+package)` for *any* import failure, so a package that was present and threw on
+load was reported as absent. Resolution and loading are now asked separately —
+cannot resolve is `skipped`, resolves but throws is `fail`, with the reason.
+
+**Why 69 and not 2.** `2` already means "no checks registered" here. `namzu
+eval` spells the same idea `2`, which it can because it never spent that number
+on anything else; giving one number two meanings inside one command is worse
+than giving one meaning two numbers across two. `69` is sysexits
+`EX_UNAVAILABLE`.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -42,6 +42,7 @@ rather than treating it as prompt text, so `namzu run --format json "…"` exits
 | --- | --- |
 | [The TUI](./tui.md) | Header, transcript/composer, slash commands + autocomplete, queuing, `/resume`, `/expand`, interrupting |
 | [Headless runs](./headless.md) | `run` and `run-stream`, their shared options, `--cwd`, permission modes, resuming, exit codes, the NDJSON event stream |
+| [`namzu doctor`](./doctor.md) | What it checks, the five status words, and what each exit code tells a script — including the one that says a check could not answer |
 | [Providers & credentials](./providers.md) | How credentials are discovered, the first-run picker, switching providers |
 | [Tools & permission](./tools.md) | Builtin + memory + task tools, deferred tools and `search_tools`, how a call is decided, permission modes, the safety gate, bypass mode |
 | [External tool servers](./tool-servers.md) | Declaring tool servers in `namzu.config.json`, naming, failures, lifetime |

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -1,0 +1,117 @@
+---
+uid: cli.doctor
+title: namzu doctor
+description: What namzu doctor checks, what each status word means, and what its exit code tells a script — including the code that says a check could not answer rather than that everything is well.
+type: reference
+diataxis: reference
+owner: bahadirarda
+status: current
+timestamp: 2026-08-09
+lastReviewed: 2026-08-09
+last_updated: 2026-08-09
+related_packages: ["@namzu/cli", "@namzu/sdk"]
+---
+
+# `namzu doctor`
+
+Health checks for the local namzu environment. It reads the machine and prints
+what it found — the sandbox platform, whether the working directory and temp
+directory are writable, which credential sources were scanned and what each
+yielded, the configured provider chain member by member, and whether the
+optional telemetry package is installed.
+
+```bash
+namzu doctor                          # human-readable report
+namzu doctor --json                   # machine-readable DoctorReport
+namzu doctor --category providers     # only these categories
+```
+
+## The five status words
+
+A check reports one of five things, and the last two are separate on purpose.
+
+| Status | Mark | Means |
+| --- | --- | --- |
+| `pass` | `✓` | The check looked and everything is as it should be. |
+| `fail` | `✗` | The check looked and something is wrong. |
+| `warn` | `!` | Usable, but less than you declared — a fallback with no credential, no credential found at all. |
+| `skipped` | `⊘` | **There was nothing here to check.** An optional package is not installed; a registry has no auto-discovery to read; nothing is configured yet. An ordinary state of a healthy machine. |
+| `inconclusive` | `?` | **The check did not answer.** It timed out, it was aborted, or the thing it reads threw. Nothing is known either way. |
+
+`skipped` and `inconclusive` used to be one word, and collapsing them is what
+made the exit code below wrong: an absent optional package and a check that
+never returned were reported identically, so the report could not distinguish
+"there is nothing to say about this" from "I failed to find out".
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Every check answered, and none of them failed. Skipped and warned checks do not move this off `0`. |
+| `1` | At least one check reported `fail`. |
+| `2` | No checks were registered — namzu is not configured here, or a `--category` filter matched nothing. |
+| `69` | At least one check **could not answer**. Nothing was established to have failed, and nothing can be concluded from the rest of the report either. |
+| `70` | An internal CLI error (sysexits `EX_SOFTWARE`) — worth a bug report. |
+
+`69` outranks `0` and is outranked by `1`. A definite failure is the actionable
+fact and `1` claims no health, so reporting it loses nothing; conversely a run
+where nothing failed but something went unanswered must not be reported as
+healthy, because **a report that could not look tells you nothing about the part
+it did look at.** That is the same argument the eval harness makes for its own
+inconclusive code, and it is why the two are not folded together here.
+
+The number differs from the one `namzu eval` uses for the same idea — `eval`
+says `2` — and that is deliberate rather than an oversight: `doctor` had already
+spent `2` on "no checks registered", and giving one number two meanings inside
+one command is worse than giving one meaning two numbers across two.
+
+`69` is sysexits `EX_UNAVAILABLE`, whose own definition ends "a catchall message
+when something you wanted to do doesn't work, but you don't know why".
+
+### In CI
+
+```bash
+namzu doctor || case $? in
+  1)  echo "something is broken";      exit 1 ;;
+  69) echo "the report is incomplete"; exit 1 ;;
+  2)  echo "namzu is not set up here"; exit 1 ;;
+esac
+```
+
+A pipeline that treats every non-zero code the same still behaves correctly;
+what changes is that it now *notices* the incomplete run it used to pass.
+
+## Options
+
+| Option | Effect |
+| --- | --- |
+| `--json` | Emit the `DoctorReport` as JSON instead of the human report. |
+| `--verbose` | List the failures again at the end, with their messages. |
+| `--category <a,b,c>` | Run only these categories: `sandbox`, `providers`, `vault`, `telemetry`, `runtime`, `plugins`, `custom`. |
+| `--per-check-timeout <ms>` | How long one check may take (default `5000`). A check that exceeds it is `inconclusive`. |
+| `--wall-clock-timeout <ms>` | How long the whole run may take (default `10000`). Unfinished checks are `inconclusive`. |
+
+Both timeouts produce `inconclusive`, and therefore `69` — which is the point of
+having them: a diagnostic that hangs is no better than one that lies, and a
+diagnostic that gives up quietly is worse than both.
+
+## Registering your own checks
+
+`vault.registered` and `providers.registered` are `skipped` on every machine.
+Neither a `CredentialVault` nor a provider registry can be discovered from
+outside the process that built it, so there is nothing for a built-in check to
+enumerate. Register one that knows your wiring:
+
+```ts
+import { registerDoctorCheck } from '@namzu/cli'
+
+registerDoctorCheck({
+  id: 'vault.mine',
+  category: 'vault',
+  run: async () => {
+    // Return `inconclusive` only when you could not find out.
+    // "There was nothing to check" is `skipped`, and it exits 0.
+    return { status: 'pass', message: 'vault reachable' }
+  },
+})
+```

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -107,6 +107,66 @@ describe('runDoctorCommand', () => {
 		expect(captured).toMatch(/exit: \d+/)
 	})
 
+	it('counts every status in the summary line, and the row sums to the total', async () => {
+		// `skipped` had no column while it was folded into `inconc`, so the line
+		// reported an optional package's absence in the same figure as a check
+		// that timed out — and a reader adding the row up got the right total for
+		// the wrong reason.
+		await runDoctorCommand([])
+		const row = captured.split('\n').find((l) => l.includes('pass:'))
+		expect(row, 'the summary line is missing').toBeDefined()
+		const n = (key: string) =>
+			Number(new RegExp(`${key}: (\\d+)`).exec(row ?? '')?.[1] ?? Number.NaN)
+		const parts = ['pass', 'fail', 'warn', 'inconc', 'skipped'].map(n)
+		expect(parts.some(Number.isNaN), `a column is missing from: ${row}`).toBe(false)
+		expect(parts.reduce((a, b) => a + b, 0)).toBe(n('total'))
+	})
+
+	it('gives a skipped row its own mark, distinct from a check that could not answer', async () => {
+		// `vault.registered` and `providers.registered` are skipped on every
+		// machine — there is no discovery mechanism for either — so the built-in
+		// suite always has one to render.
+		await runDoctorCommand([])
+		const skippedRow = captured.split('\n').find((l) => l.includes('vault.registered'))
+		expect(skippedRow, 'the vault row is missing').toBeDefined()
+		expect(skippedRow ?? '').toContain('⊘')
+		expect(skippedRow ?? '', 'a skipped row is marked as unanswered').not.toContain('?')
+	})
+
+	it('exits non-zero exactly when a check could not answer', async () => {
+		// The whole of #310 as one property, asserted against the REAL built-in
+		// suite rather than a hand-built registry: on an ordinary machine nothing
+		// is inconclusive and the command must exit 0, and the moment something
+		// is, it must not.
+		const code = await runDoctorCommand(['--json'])
+		const json = JSON.parse(captured)
+		const unanswered = json.checks.filter(
+			(c: { status: string }) => c.status === 'inconclusive',
+		).length
+		expect(json.summary.inconclusive).toBe(unanswered)
+		if (json.summary.fail > 0) {
+			expect(code).toBe(1)
+		} else {
+			expect(code).toBe(unanswered > 0 ? 69 : 0)
+		}
+	})
+
+	it('never reports the checks that have nothing to look at as unanswered', async () => {
+		// The regression this change could have introduced. Both of these are
+		// unconditional by design — there is no vault or provider auto-discovery
+		// to fail — so calling them `inconclusive` would have made `namzu doctor`
+		// exit 69 on every healthy machine, which is the way to get a diagnostic
+		// switched off.
+		await runDoctorCommand(['--json'])
+		const json = JSON.parse(captured)
+		const byId = new Map<string, string>(
+			json.checks.map((c: { id: string; status: string }) => [c.id, c.status]),
+		)
+		expect(byId.get('vault.registered')).toBe('skipped')
+		expect(byId.get('providers.registered')).toBe('skipped')
+		expect(['pass', 'skipped', 'fail']).toContain(byId.get('telemetry.installed'))
+	})
+
 	it('built-in checks register with stable ids', async () => {
 		const code = await runDoctorCommand(['--json'])
 		expect([0, 1]).toContain(code)

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -41,10 +41,18 @@ Options:
   -h, --help                   Show this help
 
 Exit codes:
-  0   all checks passed (or no failure produced)
+  0   every check answered, and none of them failed
   1   one or more checks reported \`fail\`
   2   no checks registered (Namzu not configured here)
+  69  a check could not answer — it timed out, was aborted, or what it
+      reads threw. Separate from 0 because a report that did not manage
+      to look tells you nothing about the part it did look at, and
+      separate from 1 because nothing was established to have failed.
   70  internal CLI error (sysexits EX_SOFTWARE)
+
+A \`skipped\` check does not affect the exit code: it means there was
+nothing here to check — an optional package absent, nothing configured
+yet — which is an ordinary state of a healthy machine.
 `
 
 function parseArgs(args: readonly string[]): ParsedArgs {
@@ -151,9 +159,15 @@ function statusGlyph(status: DoctorStatus): string {
 		case 'fail':
 			return '✗'
 		case 'inconclusive':
-			return '⊘'
+			return '?'
 		case 'warn':
 			return '!'
+		// The glyph `inconclusive` used to carry. It reads as "not applicable",
+		// which is what this status means and what that status never did — so
+		// the mark moves to the row it was describing all along, and the check
+		// that could not answer takes the question mark.
+		case 'skipped':
+			return '⊘'
 	}
 }
 
@@ -187,10 +201,20 @@ function formatHumanReport(report: DoctorReport, verbose: boolean): string {
 	}
 	lines.push('')
 	const s = report.summary
+	// Every status is counted, so the row sums to `total`. `skipped` was folded
+	// into `inconc` while they were one word, which meant the line silently
+	// reported an optional package's absence in the same figure as a check that
+	// timed out — and a reader adding the numbers up got the right total for the
+	// wrong reason.
 	lines.push(
-		`  pass: ${s.pass}  fail: ${s.fail}  warn: ${s.warn}  inconc: ${s.inconclusive}  total: ${s.total}`,
+		`  pass: ${s.pass}  fail: ${s.fail}  warn: ${s.warn}  inconc: ${s.inconclusive}  skipped: ${s.skipped}  total: ${s.total}`,
 	)
 	lines.push(`  exit: ${report.exit}`)
+	// Named where the number is, because `69` is the one code here a reader will
+	// not recognise and the report is the only place they are looking.
+	if (report.exit === 69) {
+		lines.push('  (69: at least one check could not answer — see the ? rows above)')
+	}
 	if (verbose) {
 		const failed = report.checks.filter((c: DoctorCheckRecord) => c.status === 'fail')
 		if (failed.length > 0) {

--- a/packages/cli/src/doctor/checks/__tests__/chain.test.ts
+++ b/packages/cli/src/doctor/checks/__tests__/chain.test.ts
@@ -31,9 +31,15 @@ function check(env: Record<string, string> = {}) {
 }
 
 describe('the provider chain check', () => {
-	it('is inconclusive, not failing, when nothing is configured yet', async () => {
+	it('is skipped, not failing and not unanswered, when nothing is configured yet', async () => {
+		// `skipped` rather than `inconclusive`: the check reached an answer, and
+		// the answer is that there is no chain here. It used to say
+		// `inconclusive`, which after the split means "could not answer" and now
+		// carries exit 69 — so a machine with a key in the environment and no
+		// preferences file, which is an ordinary working namzu, would have made
+		// `namzu doctor` non-zero.
 		const r = await check()
-		expect(r.status).toBe('inconclusive')
+		expect(r.status).toBe('skipped')
 		expect(r.message ?? '').toMatch(/no provider chain configured/)
 	})
 

--- a/packages/cli/src/doctor/checks/__tests__/telemetry.test.ts
+++ b/packages/cli/src/doctor/checks/__tests__/telemetry.test.ts
@@ -1,0 +1,68 @@
+/**
+ * That "not installed" is said only about a package that is not installed.
+ *
+ * The check used to report `not installed (optional package)` for ANY import
+ * rejection, so a package that was present and threw on load — a broken build,
+ * a native binding that will not open, a dependency of its own that cannot
+ * resolve — was reported as absent. One word, two facts, and the reader was
+ * handed the reassuring one.
+ *
+ * All three states are reached through the real resolver and the real loader.
+ * A code check on the thrown error would not have separated them: a transitive
+ * dependency that cannot resolve raises `ERR_MODULE_NOT_FOUND` exactly as a
+ * missing package does, so the third case below is the one that matters and it
+ * is the one a code check gets wrong.
+ */
+
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { describeInstalledPackage, telemetryInstalledCheck } from '../telemetry.js'
+
+const ctx = { cwd: process.cwd(), env: {}, projectRoot: null }
+
+/** A module that resolves and then throws the moment it is evaluated. */
+function moduleThatThrows(): string {
+	const dir = mkdtempSync(join(tmpdir(), 'namzu-doctor-'))
+	const file = join(dir, 'broken.mjs')
+	writeFileSync(file, "throw new Error('NATIVE BINDING WOULD NOT OPEN')\n")
+	return file
+}
+
+describe('the optional-package probe', () => {
+	it('says skipped when the package is not installed', async () => {
+		const r = await describeInstalledPackage('@namzu/no-such-package-exists')
+		expect(r.status).toBe('skipped')
+		expect(r.message ?? '').toContain('not installed')
+	})
+
+	it('says pass when the package is installed and loads', async () => {
+		const r = await describeInstalledPackage('@namzu/sdk')
+		expect(r.status).toBe('pass')
+	})
+
+	it('says fail — not "not installed" — when the package is there and will not load', async () => {
+		// The case the old catch-all got backwards, and the reason this file
+		// exists. Asserted on the STATUS and on the absence of the wrong sentence,
+		// because reporting the right status with the old message would still
+		// send someone to install what is already on disk.
+		const r = await describeInstalledPackage(moduleThatThrows())
+		expect(r.status).toBe('fail')
+		expect(r.message ?? '').toContain('failed to load')
+		expect(r.message ?? '', 'a present-but-broken package was called absent').not.toContain(
+			'not installed',
+		)
+		expect(r.message ?? '', 'the reason was swallowed').toContain('NATIVE BINDING WOULD NOT OPEN')
+	})
+
+	it('is what the registered check actually asks', async () => {
+		// The helper being right proves nothing about the check reaching it, and
+		// this check is the only caller. It must never come back inconclusive:
+		// absence is an answer, and the exit code now depends on the difference.
+		const r = await telemetryInstalledCheck.run(ctx)
+		expect(r.message ?? '').toContain('@namzu/telemetry')
+		expect(['pass', 'skipped', 'fail']).toContain(r.status)
+	})
+})

--- a/packages/cli/src/doctor/checks/chain.ts
+++ b/packages/cli/src/doctor/checks/chain.ts
@@ -78,8 +78,18 @@ export async function describeProviderChain(
 	}
 
 	if (read.status === 'missing') {
+		// `skipped`: this check LOOKED and there is no chain here to describe.
+		// Not `inconclusive`, which now means the check could not answer — the
+		// answer was reached, and it is "there is none".
+		//
+		// Not `warn` either, which in this file means namzu is usable but
+		// degraded. A machine with no preferences file and a key in the
+		// environment is an ordinary working namzu: `run` builds a default chain
+		// from what it detects, and whether a credential exists at all is
+		// `providers.credentials`' question, answered there and not restated
+		// here.
 		return {
-			status: 'inconclusive',
+			status: 'skipped',
 			message: `no provider chain configured (${path} does not exist)`,
 			remediation: 'Run `namzu` and pick a provider; the choice is saved to that file.',
 		}

--- a/packages/cli/src/doctor/checks/providers.ts
+++ b/packages/cli/src/doctor/checks/providers.ts
@@ -1,7 +1,12 @@
 import type { DoctorCheck, DoctorCheckResult } from '@namzu/sdk'
 
 /**
- * Built-in provider probe is intentionally inconclusive in v1.
+ * Built-in provider probe is intentionally `skipped` in v1.
+ *
+ * `skipped` rather than `inconclusive` for the reason spelled out on
+ * `vault.registered`: there is no discovery mechanism here to fail, so this is
+ * a permanent absence of a subject rather than a question that went unanswered,
+ * and only the latter is worth an exit code.
  *
  * Provider auto-discovery requires walking `ProviderRegistry`, which is
  * a module-private map populated by side-effecting calls in consumer
@@ -20,7 +25,7 @@ export const providersRegisteredCheck: DoctorCheck = {
 	id: 'providers.registered',
 	category: 'providers',
 	run: async (): Promise<DoctorCheckResult> => ({
-		status: 'inconclusive',
+		status: 'skipped',
 		message:
 			'no provider auto-discovery in v1; register a provider check via registerDoctorCheck for your specific provider configuration (call provider.doctorCheck?() per registered provider)',
 	}),

--- a/packages/cli/src/doctor/checks/telemetry.ts
+++ b/packages/cli/src/doctor/checks/telemetry.ts
@@ -1,4 +1,9 @@
+import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
 import type { DoctorCheck, DoctorCheckResult } from '@namzu/sdk'
+
+const TELEMETRY = '@namzu/telemetry'
 
 /**
  * Telemetry presence probe.
@@ -8,20 +13,70 @@ import type { DoctorCheck, DoctorCheckResult } from '@namzu/sdk'
  * (not a failure). Endpoint reachability + dry-run span export are
  * deferred to a follow-up check that the consumer can register
  * themselves once their telemetry config is known.
+ *
+ * ## Resolving and loading are asked separately, on purpose
+ *
+ * This used to be one `import()` in a `try`, and every rejection was reported
+ * as `not installed (optional package)`. A package that IS installed and throws
+ * on load — a broken build, a native binding that will not open, a dependency
+ * of its own that cannot resolve — was reported as absent. One word, two facts,
+ * and the reader is told the reassuring one.
+ *
+ * Splitting the question is what makes each answer honest, and a code check on
+ * the thrown error is not enough to do it: a transitive dependency that cannot
+ * resolve raises `ERR_MODULE_NOT_FOUND` exactly as a missing `@namzu/telemetry`
+ * does, so matching on the code would report a broken installation as no
+ * installation. `resolve` asks only about THIS specifier, so it separates the
+ * two by construction rather than by reading a message that may be reworded.
+ *
+ *   - cannot resolve  → the package is not here          → `skipped`
+ *   - resolves, import throws → it is here and unusable  → `fail`
  */
+/**
+ * Whether `specifier` is installed, and whether it loads.
+ *
+ * Exported separately from the `DoctorCheck` so all three outcomes can be
+ * driven with a specifier the test controls — there is no way to uninstall or
+ * break the real optional package from inside a test run. The check itself is
+ * still exercised through `telemetryInstalledCheck.run`, because a helper
+ * proven in isolation says nothing about whether the check reaches it. Same
+ * arrangement, and the same reason, as `describeProviderChain`.
+ *
+ * The import goes through the RESOLVED path rather than the specifier, so one
+ * code path serves a package name and a file, which is what lets the
+ * present-but-broken case be reached at all. Resolution has already applied the
+ * package's export map by that point.
+ */
+export async function describeInstalledPackage(specifier: string): Promise<DoctorCheckResult> {
+	const require = createRequire(import.meta.url)
+	let resolved: string
+	try {
+		resolved = require.resolve(specifier)
+	} catch {
+		return {
+			status: 'skipped',
+			message: `${specifier} not installed (optional package)`,
+		}
+	}
+	try {
+		await import(pathToFileURL(resolved).href)
+		return { status: 'pass', message: `${specifier} is installed` }
+	} catch (err) {
+		return {
+			status: 'fail',
+			// The reason is the whole value of separating these: "installed but
+			// will not load" sends the reader somewhere, and "not installed" would
+			// have sent them to install what is already there.
+			message: `${specifier} is installed but failed to load: ${
+				err instanceof Error ? err.message : String(err)
+			}`,
+			remediation: `Reinstall ${specifier}, or remove it if you are not using telemetry — it is optional and namzu runs without it.`,
+		}
+	}
+}
+
 export const telemetryInstalledCheck: DoctorCheck = {
 	id: 'telemetry.installed',
 	category: 'telemetry',
-	run: async (): Promise<DoctorCheckResult> => {
-		const specifier = '@namzu/telemetry'
-		try {
-			await import(specifier)
-			return { status: 'pass', message: '@namzu/telemetry is installed' }
-		} catch {
-			return {
-				status: 'inconclusive',
-				message: '@namzu/telemetry not installed (optional package)',
-			}
-		}
-	},
+	run: (): Promise<DoctorCheckResult> => describeInstalledPackage(TELEMETRY),
 }

--- a/packages/cli/src/doctor/checks/vault.ts
+++ b/packages/cli/src/doctor/checks/vault.ts
@@ -1,7 +1,7 @@
 import type { DoctorCheck, DoctorCheckResult } from '@namzu/sdk'
 
 /**
- * Built-in vault probe is intentionally inconclusive.
+ * Built-in vault probe is intentionally `skipped`.
  *
  * `CredentialVault` is an interface, not a globally-discoverable
  * registry — consumers instantiate their own (`InMemoryCredentialVault`,
@@ -9,12 +9,21 @@ import type { DoctorCheck, DoctorCheckResult } from '@namzu/sdk'
  * vaults it doesn't know about. To get a real vault healthcheck, the
  * consumer registers a custom check via `registerDoctorCheck` that
  * exercises their specific vault wiring.
+ *
+ * `skipped`, not `inconclusive`, and the difference is the whole point of the
+ * split: `inconclusive` means a check tried and could not answer, which is a
+ * gap in the report and now carries a non-zero exit code. This check has no
+ * subject to answer about — there is no discovery mechanism to fail — and that
+ * is true on every machine, permanently, by design. Reporting a permanent
+ * design decision as an unanswered question would make `namzu doctor` non-zero
+ * on every healthy machine, and a diagnostic that always complains is one
+ * nobody reads.
  */
 export const vaultRegisteredCheck: DoctorCheck = {
 	id: 'vault.registered',
 	category: 'vault',
 	run: async (): Promise<DoctorCheckResult> => ({
-		status: 'inconclusive',
+		status: 'skipped',
 		message:
 			'no vault auto-discovery in v1; register a vault check via registerDoctorCheck for your specific vault setup',
 	}),

--- a/packages/cli/src/doctor/registry.test.ts
+++ b/packages/cli/src/doctor/registry.test.ts
@@ -2,6 +2,11 @@
  * Ratified in ses_007-probe-and-doctor §9 (agent working memory, gitignored).
  * D4 = registerDoctorCheck + plugin auto-discovery + standalone-CLI /
  * embedded-runDoctor split. D5 = sysexits exit codes (0/1/2/70).
+ *
+ * D5 is extended, not replaced: `69` (EX_UNAVAILABLE) joins the table for a
+ * report that could not be established. `inconclusive` appeared in no exit
+ * expression at all, so a check that could not answer exited the same `0` as a
+ * machine where everything passed.
  */
 
 import { describe, expect, it } from 'vitest'
@@ -59,23 +64,32 @@ describe('runDoctor — aggregation + summary', () => {
 		reg.register(check('b', { status: 'fail', message: 'broken' }))
 		reg.register(check('c', { status: 'inconclusive' }))
 		reg.register(check('d', { status: 'warn' }))
+		reg.register(check('e', { status: 'skipped' }))
 		const report = await runDoctor({ registry: reg, version: '0.0.1' })
 		expect(report.summary).toEqual({
 			pass: 1,
 			fail: 1,
 			inconclusive: 1,
 			warn: 1,
-			total: 4,
+			skipped: 1,
+			total: 5,
 		})
-		expect(report.checks).toHaveLength(4)
+		// The counts must SUM to the total, which is the property a reader takes
+		// from a summary line and the one a new status silently breaks: while
+		// `skipped` had no column, every skipped check was missing from the row
+		// and the arithmetic came out only because it was hidden inside another
+		// figure.
+		const s = report.summary
+		expect(s.pass + s.fail + s.inconclusive + s.warn + s.skipped).toBe(s.total)
+		expect(report.checks).toHaveLength(5)
 		expect(report.version).toBe('0.0.1')
 	})
 
-	it('exit = 0 when all pass / no fail', async () => {
+	it('exit = 0 when every check answered and none failed', async () => {
 		const reg = createDoctorRegistry()
 		reg.register(check('a', { status: 'pass' }))
-		reg.register(check('b', { status: 'inconclusive' }))
-		reg.register(check('c', { status: 'warn' }))
+		reg.register(check('b', { status: 'warn' }))
+		reg.register(check('c', { status: 'skipped' }))
 		const report = await runDoctor({ registry: reg })
 		expect(report.exit).toBe(0)
 	})
@@ -95,12 +109,69 @@ describe('runDoctor — aggregation + summary', () => {
 		expect(report.summary.total).toBe(0)
 	})
 
-	it('inconclusive + warn do not affect exit code', async () => {
+	it('exit = 69 when a check could not answer, even though nothing failed', async () => {
+		// The defect this file used to pin the wrong way round. `inconclusive`
+		// did not appear in the exit expression at all, so "namzu is healthy" and
+		// "namzu did not manage to look" were both 0, in the command whose entire
+		// job is to report state it read.
 		const reg = createDoctorRegistry()
-		reg.register(check('a', { status: 'inconclusive' }))
+		reg.register(check('a', { status: 'pass' }))
+		reg.register(check('b', { status: 'inconclusive' }))
+		const report = await runDoctor({ registry: reg })
+		expect(report.exit).toBe(69)
+	})
+
+	it('exit = 1 when something failed AND something could not answer', async () => {
+		// `fail` outranks `inconclusive`: a definite failure is the actionable
+		// fact and 1 claims no health, so reporting it loses nothing. The
+		// alternative ranking would hide a real failure behind a timeout.
+		const reg = createDoctorRegistry()
+		reg.register(check('a', { status: 'fail' }))
+		reg.register(check('b', { status: 'inconclusive' }))
+		const report = await runDoctor({ registry: reg })
+		expect(report.exit).toBe(1)
+	})
+
+	it('warn and skipped do not affect the exit code', async () => {
+		// The half that must NOT change. `skipped` is an ordinary state of a
+		// healthy machine — an optional package absent, nothing configured yet —
+		// and a diagnostic that went non-zero on every healthy machine would be
+		// switched off within a week.
+		const reg = createDoctorRegistry()
+		reg.register(check('a', { status: 'skipped' }))
 		reg.register(check('b', { status: 'warn' }))
 		const report = await runDoctor({ registry: reg })
 		expect(report.exit).toBe(0)
+	})
+
+	it('exit = 69 when the per-check timeout is what stopped it', async () => {
+		// Reached through the real timeout path rather than by a check returning
+		// the word: the timeout is the commonest way a report goes unanswered,
+		// and a test that only ever hands the status in cannot tell whether the
+		// path that PRODUCES it reaches the exit expression.
+		const reg = createDoctorRegistry()
+		reg.register({
+			id: 'slow',
+			category: 'custom',
+			run: () => new Promise((resolve) => setTimeout(() => resolve({ status: 'pass' }), 5_000)),
+		})
+		const report = await runDoctor({ registry: reg, perCheckTimeoutMs: 10 })
+		expect(report.checks[0]?.status).toBe('inconclusive')
+		expect(report.exit).toBe(69)
+	})
+
+	it('exit = 69 when the run was aborted before the checks answered', async () => {
+		const reg = createDoctorRegistry()
+		reg.register({
+			id: 'slow',
+			category: 'custom',
+			run: () => new Promise((resolve) => setTimeout(() => resolve({ status: 'pass' }), 5_000)),
+		})
+		const controller = new AbortController()
+		setTimeout(() => controller.abort(), 20)
+		const report = await runDoctor({ registry: reg, signal: controller.signal })
+		expect(report.checks[0]?.status).toBe('inconclusive')
+		expect(report.exit).toBe(69)
 	})
 })
 

--- a/packages/cli/src/doctor/registry.ts
+++ b/packages/cli/src/doctor/registry.ts
@@ -250,9 +250,34 @@ function buildReport(records: readonly DoctorCheckRecord[], version: string): Do
 		fail: records.filter((r) => r.status === 'fail').length,
 		inconclusive: records.filter((r) => r.status === 'inconclusive').length,
 		warn: records.filter((r) => r.status === 'warn').length,
+		skipped: records.filter((r) => r.status === 'skipped').length,
 		total: records.length,
 	}
-	const exit: DoctorReport['exit'] = summary.fail > 0 ? 1 : summary.total === 0 ? 2 : 0
+	/**
+	 * What this command's exit code means, decided here because here is where
+	 * the codes are.
+	 *
+	 * `inconclusive` used not to appear in this expression at all, so a check
+	 * that COULD NOT ANSWER exited `0` — the same number as a machine where
+	 * everything passed. A script could not tell "namzu is healthy" from "namzu
+	 * did not manage to look", in the one command whose entire job is to report
+	 * state it read.
+	 *
+	 * The order is the ranking, and it is deliberate:
+	 *
+	 * - `fail` outranks `inconclusive`. A definite failure is the actionable
+	 *   fact, and `1` does not claim health, so nothing is lost by reporting it
+	 *   even when part of the run is also unknown.
+	 * - `2` stays above `inconclusive` because an empty run has no checks to be
+	 *   inconclusive about; the two cannot both be true.
+	 * - `skipped` never moves this off `0`. A skipped check is an ordinary state
+	 *   of a healthy machine — an optional package absent, a registry with
+	 *   nothing to discover — and a diagnostic that went non-zero on every
+	 *   healthy machine would be turned off within a week, which is the failure
+	 *   mode of a check that fires where nothing is wrong.
+	 */
+	const exit: DoctorReport['exit'] =
+		summary.fail > 0 ? 1 : summary.total === 0 ? 2 : summary.inconclusive > 0 ? 69 : 0
 	return Object.freeze({
 		version,
 		timestamp: new Date().toISOString(),

--- a/packages/cli/src/exit-codes.ts
+++ b/packages/cli/src/exit-codes.ts
@@ -6,6 +6,22 @@
  *   1   EXIT_FAIL           — one or more checks reported `fail`
  *   2   EXIT_NO_CONFIG      — Namzu is not configured in this environment
  *                             (no checks registered, no config file found)
+ *   69  EXIT_UNAVAILABLE    — sysexits EX_UNAVAILABLE; something the command
+ *                             needed was not there, so it could not ESTABLISH
+ *                             what it was asked to report. Distinct from 0 for
+ *                             the reason 2 is distinct from 1: a report that
+ *                             could not look tells you nothing about the part
+ *                             it did look at, and collapsing the two lets
+ *                             "healthy" and "did not check" share a number.
+ *                             Distinct from 70 because a check that timed out
+ *                             on a loaded machine is not a bug in this CLI.
+ *
+ *                             `namzu eval` spells the same idea `2`
+ *                             (`EVAL_EXIT.inconclusive`) and that is not an
+ *                             oversight: `doctor` had already spent 2 on "no
+ *                             checks registered", and giving one number two
+ *                             meanings inside one command is worse than giving
+ *                             one meaning two numbers across two.
  *   64  EXIT_USAGE          — sysexits EX_USAGE; the caller's arguments are
  *                             wrong. Distinct from 70 on purpose: 70 says the
  *                             CLI is broken and is worth a bug report, 64 says
@@ -26,6 +42,7 @@ export const EXIT_OK = 0
 export const EXIT_FAIL = 1
 export const EXIT_NO_CONFIG = 2
 export const EXIT_USAGE = 64
+export const EXIT_UNAVAILABLE = 69
 export const EXIT_INTERNAL_ERROR = 70
 export const EXIT_UNTRUSTED = 77
 
@@ -34,5 +51,6 @@ export type CliExitCode =
 	| typeof EXIT_FAIL
 	| typeof EXIT_NO_CONFIG
 	| typeof EXIT_USAGE
+	| typeof EXIT_UNAVAILABLE
 	| typeof EXIT_INTERNAL_ERROR
 	| typeof EXIT_UNTRUSTED

--- a/packages/sdk/src/types/doctor/check.ts
+++ b/packages/sdk/src/types/doctor/check.ts
@@ -1,4 +1,21 @@
-export type DoctorStatus = 'pass' | 'fail' | 'inconclusive' | 'warn'
+/**
+ * What a check concluded.
+ *
+ * `skipped` and `inconclusive` are the two ways a check produces no verdict,
+ * and they are separate because a caller acts on them differently.
+ *
+ * - `skipped` — the check LOOKED and there was nothing here to check: an
+ *   optional package is not installed, a registry the check reads has no
+ *   auto-discovery to read, nothing is configured yet. A permanent or
+ *   by-design absence, and an ordinary state of a healthy machine.
+ * - `inconclusive` — the check DID NOT ANSWER: it timed out, it was aborted,
+ *   the thing it reads threw. Nothing is known either way, and that is itself
+ *   a gap in the report worth acting on.
+ *
+ * The word used to cover both, so `namzu doctor` could not tell "healthy" from
+ * "did not manage to look", and neither could anything reading its exit code.
+ */
+export type DoctorStatus = 'pass' | 'fail' | 'inconclusive' | 'warn' | 'skipped'
 
 export type DoctorCategory =
 	| 'sandbox'
@@ -47,7 +64,16 @@ export interface DoctorReport {
 		readonly fail: number
 		readonly inconclusive: number
 		readonly warn: number
+		readonly skipped: number
+		/** Every other count sums to this. A reader may rely on that. */
 		readonly total: number
 	}
-	readonly exit: 0 | 1 | 2 | 70
+	/**
+	 * `69` is sysexits `EX_UNAVAILABLE`, whose own definition ends "a catchall
+	 * when something you wanted to do doesn't work, but you don't know why".
+	 * That is `inconclusive`. It is not `2`, which this report already spends on
+	 * "nothing was registered", and not `70`, which says the CLI is broken and
+	 * is worth a bug report.
+	 */
+	readonly exit: 0 | 1 | 2 | 69 | 70
 }


### PR DESCRIPTION
Closes #310.

`namzu doctor` exited `0` when a check **could not answer** — the same code it used when every check passed. `inconclusive` appeared in the exit expression nowhere.

## The word had to be split before the code could follow

`inconclusive` was carrying two facts, and only one of them is a problem:

- **Nothing here to check.** `vault.registered` and `providers.registered` are unconditional by design — there is no auto-discovery for either to fail — and an absent optional package, or no preferences file yet, is an ordinary state of a healthy machine.
- **The check did not answer.** A per-check timeout, the wall clock, an abort, a read that threw.

Exiting non-zero on the first group would have made `namzu doctor` red on every healthy machine, which is how a diagnostic gets switched off within a week. So `skipped` is a new status meaning "the check looked and there was nothing here", and `inconclusive` is left meaning only "it did not answer".

## The decision, written where the codes are

`packages/cli/src/exit-codes.ts` and the `--help` table both carry it now, as does a new `docs/cli/doctor.md`.

```
fail > 0        → 1
total === 0     → 2
inconclusive > 0 → 69
otherwise       → 0
```

- **`69`** is sysexits `EX_UNAVAILABLE`, whose own definition ends "a catchall message when something you wanted to do doesn't work, but you don't know why". That is `inconclusive`.
- **Not `2`.** `doctor` already spends `2` on "no checks registered / namzu is not configured here". Merging that with "a check timed out" is the same defect one level up.
- **Not `70`.** `EX_SOFTWARE` says the CLI is broken and is worth a bug report; a check that timed out on a loaded machine is not.
- **`fail` outranks `inconclusive`.** A definite failure is the actionable fact and `1` claims no health, so nothing is lost by reporting it even when part of the run is also unknown. The other ranking would hide a real failure behind a timeout.
- **`skipped` never moves it off `0`.**

**`namzu eval` spells the same idea `2`.** That divergence is deliberate and now documented beside both: `eval` could use `2` because it never spent that number on anything else, and giving one number two meanings inside one command is worse than giving one meaning two numbers across two.

## The smaller instance of the same shape, also fixed

`telemetry.installed` reported `not installed (optional package)` for **any** import failure, so a package that was present and threw on load was reported as absent — the reassuring one of two facts under one sentence.

A code check on the thrown error does not separate them: a transitive dependency that cannot resolve raises `ERR_MODULE_NOT_FOUND` exactly as a missing package does, so matching on the code would report a broken installation as no installation. Resolving and loading are asked separately instead — `resolve` asks only about this specifier, so the two are separated by construction rather than by reading a message that may later be reworded.

## Reading the neighbour

The argument for a separate inconclusive code was already written one package over, in `docs/sdk/evaluation/README.md`, and transfers without modification. What did not transfer was the *number*, for the reason above.

## Scope note

Two lines in `packages/sdk/src/types/doctor/check.ts` — `DoctorStatus` and `DoctorReport`. Unavoidable: the types live there, and everything else is in `packages/cli`.

## Tests

| Mutation | Result |
| --- | --- |
| `inconclusive` taken back out of the exit expression | killed |
| `skipped` made to affect the exit code | killed |
| `fail` no longer outranking `inconclusive` | killed |
| `skipped` dropped from the summary counts | killed |
| `vault.registered` back to `inconclusive` | killed |
| `providers.registered` back to `inconclusive` | killed |
| `providers.chain` with no preferences back to `inconclusive` | killed |
| telemetry: any import failure reported as "not installed" | killed |
| telemetry: the resolve step removed | killed |
| `skipped` glyph made the same as `inconclusive` | killed |
| the `skipped` column dropped from the printed row | killed |

11 of 11. Notable coverage decisions:

- The two timeout paths and the abort path are driven through the **real** timeout, not by a check returning the word — a test that only ever hands the status in cannot tell whether the path that *produces* it reaches the exit expression.
- The telemetry probe's three states all go through the real resolver and the real loader, including a module written to disk that throws on evaluation. That third case is the one a code check gets wrong, so it is the one that had to be real.
- `exits non-zero exactly when a check could not answer` is asserted against the **real built-in suite**, not a hand-built registry, so the regression this change could have introduced — every healthy machine going `69` — is what fails first if a status is misclassified.
- The summary row is asserted to **sum to `total`**. That property held before only because `skipped` was hidden inside another figure.

## Gates

build · typecheck · lint · test · `audit-external-names` · `docs:check` — all green.

`packages/cli/src/commands/doctor.test.ts` needed a `biome format` pass; unrelated pre-existing warnings in `packages/cli/src/__fixtures__/temp-dir.ts` are untouched.
