### PR TITLE
feat(sdk): publish the store conformance suite at ./testing

### DIFF
--- a/.changeset/store-conformance-suite.md
+++ b/.changeset/store-conformance-suite.md
@@ -1,0 +1,51 @@
+---
+'@namzu/sdk': minor
+---
+
+Publish the checkpoint-store conformance suite at `@namzu/sdk/testing`
+
+`CheckpointStore` is an interface a host is expected to implement, and the
+in-memory store's source calls itself "the reference a host reads when writing a
+backend of its own". That claim was unbacked. Two days before this change the
+two shipped implementations disagreed at the enforcement point — the in-memory
+one accepted a checkpoint from a worker that had been superseded and then
+released around, the disk one refused it — and the class documented as the
+reference was the one carrying the defect. Nothing threw, nothing logged, and a
+completed worker's checkpoint was silently replaced by a dead worker's. A host
+writing its own backend had no way to find that out.
+
+New: a `./testing` subpath exporting `defineCheckpointStoreConformance` and
+`CHECKPOINT_STORE_CONTRACT_VERSION`. Nothing existing changes; the package's one
+existing export is untouched.
+
+```typescript
+import { describe, expect, it } from 'vitest'
+import { defineCheckpointStoreConformance } from '@namzu/sdk/testing'
+
+defineCheckpointStoreConformance({
+  describe, it, expect,
+  label: 'my-backend',
+  contractVersion: 1,
+  capabilities: { claims: true, listing: true, multiTenant: true },
+  makeStore: async (binding) => ({ store: await MyStore.connect(binding) }),
+})
+```
+
+The suite takes `describe`, `it` and `expect` as arguments, so it binds to no
+test runner and installing `@namzu/sdk` pulls in no test dependency. It
+covers the four rules the types cannot state and the two built-in stores
+actually diverged on: claim exclusivity, claim expiry, refusal of a fenced-out
+write, and listing scope isolation across tenants. `capabilities` names what
+your backend can do so the suite asks only what it can answer.
+
+**Take note before you wire it in.** Once you do, every assertion in the suite
+is something your build fails on — so the suite's assertions are public API from
+here, and tightening or adding one is a `major` for this package rather than a
+`minor`, even though it adds no export. `contractVersion` is the seam that makes
+such a bump legible: write the number as a literal (do **not** re-export the
+constant, which makes the check unfailable), and a contract revision then fails
+with `expected 'checkpoint-store contract v1' to be 'checkpoint-store contract
+v2'` instead of a scatter of assertion failures whose common cause is not
+obvious.
+
+Documented at `docs/sdk/runtime/checkpoint-store-conformance.md`.

--- a/docs/sdk/runtime/checkpoint-store-conformance.md
+++ b/docs/sdk/runtime/checkpoint-store-conformance.md
@@ -1,0 +1,132 @@
+---
+uid: namzu.sdk.runtime.checkpoint-store-conformance
+title: Test your own checkpoint store
+description: Run the shipped checkpoint-store contract against a backend you wrote yourself — what the suite guarantees, how to wire it to any test runner, the capability flags, and why the contract carries a version number.
+type: Guide
+diataxis: how-to
+owner: cogitave/namzu
+status: active
+timestamp: 2026-08-09T00:00:00Z
+lastReviewed: 2026-08-09
+resource: packages/sdk/src/store/run/conformance.ts
+tags: [sdk, store, checkpoints, testing, conformance]
+---
+
+# Test your own checkpoint store
+
+`CheckpointStore` is an interface, and a host is expected to implement it —
+against a database, an object store, whatever the deployment already runs. The
+types say what the methods are called. They cannot say that a claim is
+exclusive, that it expires, that a superseded write is refused, or that a
+listing answers for one tenant and no other.
+
+`@namzu/sdk/testing` ships those rules as a suite you run against your own
+backend.
+
+## Why it exists
+
+The two built-in stores once disagreed at the enforcement point. The in-memory
+one accepted a checkpoint from a worker that had been superseded and then
+released around; the disk one refused it. Nothing was thrown, nothing was
+logged, and the completed worker's checkpoint was silently replaced by the dead
+worker's — and the class whose source calls itself *the reference a host reads
+when writing a backend of its own* was the one carrying the defect.
+
+Reading a reference cannot surface that. Running it can.
+
+## Wire it up
+
+Three runner functions go in; the suite imports no test framework of its own,
+so `@namzu/sdk` adds no test dependency to your install.
+
+```typescript
+import { describe, expect, it } from 'vitest'
+import { defineCheckpointStoreConformance } from '@namzu/sdk/testing'
+
+import { PostgresCheckpointStore } from './store.js'
+
+defineCheckpointStoreConformance({
+  describe,
+  it,
+  expect,
+
+  label: 'postgres',
+  contractVersion: 1,
+  capabilities: { claims: true, listing: true, multiTenant: true },
+
+  makeStore: async (binding) => {
+    const store = await PostgresCheckpointStore.connect(binding)
+    return { store, dispose: () => store.close() }
+  },
+})
+```
+
+`makeStore` is called **once per case**, so no case can be affected by
+another's writes. Whatever producing the store required — a schema, a
+container, a temp directory — is released by `dispose`, which runs whether the
+case passed or failed.
+
+Any runner works. The suite uses four matchers (`toBe`, `toEqual`,
+`toBeGreaterThan`, `toMatch`) and nothing else, and `describe`/`it` only need
+to accept a name and a function.
+
+## What it guarantees
+
+| Group | The rule |
+|---|---|
+| Claim exclusivity | One taker gets the run; a second gets `null`, not an error. Renewing by the current holder mints a **higher** fence, so a duplicate of that holder cannot write with the number it captured earlier. A lease with no duration is refused. |
+| Claim expiry | A run whose holder went away can be taken by somebody else, at a higher fence. Releasing returns it to the queue immediately. A worker that stalled past its lease cannot release a run somebody else now holds. |
+| Fenced-out writes | The current holder writes. An **unfenced** write still succeeds on a claimed run, so claims can be rolled out one worker at a time. A superseded fence is refused — including after the new holder released cleanly, and including the fence a holder just gave up itself. |
+| Listing scope isolation | A listing for a tenant the store does not hold returns nothing, and the same for a project. A scope with a hole in it (`sessionId` without `projectId`) is refused rather than guessed at. Rows come back as full run scopes, so a row can be resumed. With `multiTenant`, one tenant's runs stay out of another's listing. |
+
+Those are not an arbitrary selection. They are the points at which the two
+built-in implementations actually diverged.
+
+## Capability flags
+
+Every flag is required — there is no default. A capability that defaulted to
+`false` would let you skip a whole section by forgetting a key, and a suite you
+can opt out of by omission reports a pass it did not establish.
+
+- **`claims`** — the store implements `claimRun` / `releaseRun` and enforces
+  the fence at `writeCheckpoint`. Set it `false` only for a genuinely
+  single-writer backend. It is a deployment shape, not a shortcut: a
+  multi-worker deployment on a store without a lease loses work silently.
+- **`listing`** — the store implements `listDurableRuns`.
+- **`multiTenant`** — one instance can hold more than one tenant's runs. The
+  built-in disk layout has no tenant segment in it, so for that store a second
+  tenant is a second store; it declares `false` and still answers the isolation
+  case that *can* be put to it.
+
+## `contractVersion`, and why you write the number
+
+`CHECKPOINT_STORE_CONTRACT_VERSION` is exported, and the suite's first case
+compares it against the `contractVersion` you passed.
+
+**Write the literal.** Re-exporting the constant into that slot makes the check
+unfailable, which defeats the point: the number is meant to be frozen in your
+source at the moment you wrote the backend. Upgrading `@namzu/sdk` past a
+contract revision then fails with a sentence naming both numbers, instead of a
+scatter of assertion failures whose common cause is not obvious from any one of
+them.
+
+```
+expected 'checkpoint-store contract v1' to be 'checkpoint-store contract v2'
+```
+
+The version rises only with a `major`, and only when an assertion is added or
+tightened. A case added behind a **new** capability flag does not raise it — a
+backend that does not declare the capability never runs the case.
+
+## The suite's assertions are public API
+
+Once you wire this in, every assertion in it is something your build fails on.
+Adding one is therefore a breaking change for you even though it adds no
+export. That is why the version exists and why tightening the suite is a
+`major` for this package rather than a `minor`.
+
+## Related
+
+- [Testing agents](testing.md) — scripting the model rather than the store.
+- [State and persistence](../architecture/state-and-persistence.md) — where the
+  checkpoint store sits in the runtime.

--- a/docs/sdk/runtime/meta.json
+++ b/docs/sdk/runtime/meta.json
@@ -6,6 +6,7 @@
     "loop-control",
     "duplex",
     "testing",
+    "checkpoint-store-conformance",
     "identities",
     "low-level",
     "replay"

--- a/packages/sdk/knip.json
+++ b/packages/sdk/knip.json
@@ -2,7 +2,8 @@
 	"$schema": "https://unpkg.com/knip@6/schema.json",
 	"entry": [
 		"src/index.ts",
-		"src/provider/mock-register.ts"
+		"src/provider/mock-register.ts",
+		"src/store/run/conformance.ts"
 	],
 	"project": [
 		"src/**/*.ts"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -20,6 +20,11 @@
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
 			"default": "./dist/index.js"
+		},
+		"./testing": {
+			"types": "./dist/store/run/conformance.d.ts",
+			"import": "./dist/store/run/conformance.js",
+			"default": "./dist/store/run/conformance.js"
 		}
 	},
 	"files": [

--- a/packages/sdk/src/store/run/__tests__/conformance-fails-a-wrong-store.test.ts
+++ b/packages/sdk/src/store/run/__tests__/conformance-fails-a-wrong-store.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest'
+
+import type { IterationCheckpoint } from '../../../types/hitl/index.js'
+import type {
+	CheckpointRunScope,
+	ClaimRunOptions,
+	RunClaim,
+} from '../../../types/run/checkpoint-store.js'
+import { InMemoryCheckpointStore } from '../checkpoint-memory.js'
+import {
+	CHECKPOINT_STORE_CONTRACT_VERSION,
+	type CheckpointStoreCapabilities,
+	type ConformanceDescribe,
+	type ConformanceIt,
+	type MakeCheckpointStore,
+	defineCheckpointStoreConformance,
+} from '../conformance.js'
+
+/**
+ * A conformance suite that no wrong implementation fails is decoration.
+ *
+ * `run-claim.test.ts` runs the suite against the two backends that SHIP, and
+ * both pass — which establishes that the suite is satisfiable and nothing
+ * else. The question it cannot answer is the only one that matters to a host
+ * writing a backend of its own: would this have caught me?
+ *
+ * So this file breaks a store on purpose and requires the suite to say so, by
+ * name. Both breakages below are real: the first is the mistake a first
+ * implementation makes (hand the run to whoever asks), the second is the one
+ * this repository actually shipped (mint fences correctly and then not check
+ * them at the write), and the second is the one a reader would never find by
+ * reading, because everything about the claim path looks right.
+ *
+ * The mechanism is the reason the suite takes its runner as an argument. A
+ * recording `describe`/`it` turns the whole contract into ordinary async
+ * functions this file can call and catch, so a case FAILING is an observation
+ * here rather than a red run.
+ */
+
+/** One registered case and what it did when run. */
+type Outcome = { readonly name: string; readonly failure?: string }
+
+const ALL: CheckpointStoreCapabilities = { claims: true, listing: true, multiTenant: true }
+
+/**
+ * Run the whole contract against `makeStore` and report per case.
+ *
+ * `expect` is vitest's real one — an assertion still throws, and the throw is
+ * what this catches. Only `describe` and `it` are replaced.
+ */
+async function runConformance(
+	makeStore: MakeCheckpointStore,
+	contractVersion = CHECKPOINT_STORE_CONTRACT_VERSION,
+): Promise<Outcome[]> {
+	const cases: { name: string; body: () => Promise<void> }[] = []
+	const path: string[] = []
+	const record: ConformanceDescribe = (name, body) => {
+		path.push(name)
+		body()
+		path.pop()
+	}
+	const collect: ConformanceIt = (name, body) => {
+		cases.push({ name: [...path.slice(1), name].join(' > '), body })
+	}
+
+	defineCheckpointStoreConformance({
+		describe: record,
+		it: collect,
+		expect,
+		contractVersion,
+		capabilities: ALL,
+		makeStore,
+	})
+
+	const outcomes: Outcome[] = []
+	for (const one of cases) {
+		try {
+			await one.body()
+			outcomes.push({ name: one.name })
+		} catch (error) {
+			outcomes.push({
+				name: one.name,
+				failure: error instanceof Error ? error.message : String(error),
+			})
+		}
+	}
+	return outcomes
+}
+
+function failed(outcomes: readonly Outcome[]): string[] {
+	return outcomes.filter((o) => o.failure !== undefined).map((o) => o.name)
+}
+
+const honest: MakeCheckpointStore = () => ({ store: new InMemoryCheckpointStore() })
+
+/** Hands the run to every taker. The mistake a first implementation makes. */
+class GrantsEveryClaim extends InMemoryCheckpointStore {
+	override async claimRun(_scope: CheckpointRunScope, options: ClaimRunOptions): Promise<RunClaim> {
+		return { holder: options.holder, fence: 1, expiresAt: (options.now ?? 0) + options.ttlMs }
+	}
+}
+
+/**
+ * Mints fences correctly and then ignores the one presented at the write.
+ *
+ * The defect this repository shipped, in the class documented as the
+ * reference. Nothing about the claim path looks wrong — the numbers are right,
+ * they advance, they survive a release — and a stalled holder's write is
+ * accepted anyway, so a completed worker's checkpoint is silently overwritten
+ * by a dead one's.
+ */
+class AcceptsEveryWrite extends InMemoryCheckpointStore {
+	override async writeCheckpoint(
+		scope: CheckpointRunScope,
+		checkpoint: IterationCheckpoint,
+	): Promise<void> {
+		return super.writeCheckpoint(scope, checkpoint)
+	}
+}
+
+describe('the store conformance suite', () => {
+	it('passes the reference implementation', async () => {
+		// The control, and not a formality. Every assertion below reads a
+		// FAILURE as evidence, and a harness that mis-registers cases or
+		// mis-wires the store would produce failures for both the broken stores
+		// and the sound one — proving the suite detects nothing while looking
+		// like it detects everything.
+		const outcomes = await runConformance(honest)
+		expect(failed(outcomes)).toEqual([])
+		// And it registered a contract, not an empty shell: a `defineX` that
+		// silently registered nothing would also report zero failures.
+		expect(outcomes.length).toBeGreaterThan(10)
+	})
+
+	it('fails a store that hands the run to every taker', async () => {
+		const outcomes = await runConformance(() => ({ store: new GrantsEveryClaim() }))
+		const names = failed(outcomes)
+
+		expect(names).toContain(
+			'claim exclusivity > gives the run to the first taker and refuses the second',
+		)
+		// Named individually rather than counted. A count passes on any three
+		// failures, including three that have nothing to do with exclusivity.
+		expect(names).toContain(
+			'claim exclusivity > advances the fence on renewal, so a stalled twin cannot write',
+		)
+		expect(names).toContain('claim expiry > releases only on the fence that currently holds it')
+	})
+
+	it('fails a store that mints fences and then does not check them', async () => {
+		const outcomes = await runConformance(() => ({ store: new AcceptsEveryWrite() }))
+		const names = failed(outcomes)
+
+		expect(names).toContain(
+			'fenced-out writes > fences the stalled holder out at the moment it writes',
+		)
+		expect(names).toContain(
+			'fenced-out writes > still refuses a superseded fence after the new holder releases',
+		)
+		expect(names).toContain('fenced-out writes > refuses the fence its own holder just released')
+		// Its claim path is untouched and must stay green, or the suite is
+		// reporting the wrong subject and a host would go looking in the wrong
+		// file.
+		expect(names).not.toContain(
+			'claim exclusivity > gives the run to the first taker and refuses the second',
+		)
+	})
+
+	it('fails a backend that declares an older contract revision', async () => {
+		const outcomes = await runConformance(honest, CHECKPOINT_STORE_CONTRACT_VERSION - 1)
+		const version = outcomes[0]
+
+		expect(version?.name).toBe('declares the contract revision this suite implements')
+		// The message has to name BOTH numbers, and survive the truncation a
+		// runner applies when it builds a failure message — the first draft put
+		// the explanation in the actual value and lost both numbers at 37
+		// characters, which is a check that fires and says nothing.
+		expect(version?.failure ?? '').toMatch(
+			new RegExp(`contract v${CHECKPOINT_STORE_CONTRACT_VERSION - 1}\\b`),
+		)
+		expect(version?.failure ?? '').toMatch(
+			new RegExp(`contract v${CHECKPOINT_STORE_CONTRACT_VERSION}\\b`),
+		)
+	})
+})

--- a/packages/sdk/src/store/run/__tests__/run-claim.test.ts
+++ b/packages/sdk/src/store/run/__tests__/run-claim.test.ts
@@ -7,18 +7,15 @@ import { promisify } from 'node:util'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { removeTempDirAsync } from '../../../__fixtures__/temp-dir.js'
 
-import type { IterationCheckpoint } from '../../../types/hitl/index.js'
-import type {
-	CheckpointId,
-	ProjectId,
-	RunId,
-	SessionId,
-	TenantId,
-} from '../../../types/ids/index.js'
+import type { ProjectId, RunId, SessionId, TenantId } from '../../../types/ids/index.js'
 import type { CheckpointRunScope, CheckpointStore } from '../../../types/run/checkpoint-store.js'
 import { DiskCheckpointStore } from '../checkpoint-disk.js'
 import { InMemoryCheckpointStore } from '../checkpoint-memory.js'
-import { claimRun, listDurableRuns, releaseRun } from '../listing.js'
+import {
+	CHECKPOINT_STORE_CONTRACT_VERSION,
+	defineCheckpointStoreConformance,
+} from '../conformance.js'
+import { claimRun, releaseRun } from '../listing.js'
 
 /**
  * Two workers draining a queue are two PROCESSES. A single-process test of a
@@ -27,229 +24,124 @@ import { claimRun, listDurableRuns, releaseRun } from '../listing.js'
  * and the race never happens. So the contention test below spawns real
  * children that share nothing but a directory.
  *
- * Everything else here is about the two facts a lease has to get right and a
- * mutex does not: it expires, and a holder that stalls past its expiry does
- * not know it.
+ * Everything a single process CAN establish about the lease — exclusivity,
+ * expiry, that a superseded write is refused, that a listing answers for one
+ * tenant only — now lives in `../conformance.ts` and ships, because the
+ * in-memory store calls itself the reference a host reads when writing a
+ * backend of its own and that claim was worth exactly nothing while the suite
+ * backing it was unpublishable. Both shipped backends answer it below.
+ *
+ * What stays here is what is not a property of the CONTRACT: the real-process
+ * race, which no host can run against its own store without this repository's
+ * worker script, and the refusals the `listing.ts` helpers raise for a store
+ * that implements neither.
  */
 
-const T1 = 'tnt_claim' as TenantId
-const P1 = 'prj_claim' as ProjectId
-const S1 = 'ses_claim' as SessionId
-
-function scope(runId = 'run_a'): CheckpointRunScope {
-	return { tenantId: T1, projectId: P1, sessionId: S1, runId: runId as RunId }
-}
-
-let seq = 0
-function checkpoint(runId = 'run_a'): IterationCheckpoint {
-	seq += 1
-	return {
-		id: `cp_${seq}` as CheckpointId,
-		runId: runId as RunId,
-		iteration: 1,
-		messages: [],
-		tokenUsage: {
-			promptTokens: 1,
-			completionTokens: 1,
-			totalTokens: 2,
-			cachedTokens: 0,
-			cacheWriteTokens: 0,
-		},
-		costInfo: { totalCost: 0 } as IterationCheckpoint['costInfo'],
-		guardState: { iterationCount: 1, elapsedMs: 1 },
-		createdAt: Date.now(),
-	}
-}
-
-const NOW = 5_000_000
+const scope = (runId: string): CheckpointRunScope => ({
+	tenantId: 'tnt_claim' as TenantId,
+	projectId: 'prj_claim' as ProjectId,
+	sessionId: 'ses_claim' as SessionId,
+	runId: runId as RunId,
+})
 
 /**
  * Both shipped stores answer the same suite. A claim implemented one way in
  * memory and another on disk is two claims, and a host tests against one and
  * ships the other.
  */
-const BACKENDS: readonly ['in-memory' | 'disk', (dir: string) => CheckpointStore][] = [
-	['in-memory', () => new InMemoryCheckpointStore()],
+defineCheckpointStoreConformance({
+	describe,
+	it,
+	expect,
+	label: 'in-memory',
+	// The literal, not the imported constant — see the constant's own note.
+	// Re-exporting it into this slot would make the check unfailable.
+	contractVersion: 1,
+	// The only implementation that can hold more than one tenant at once: the
+	// disk layout has no tenant segment in it.
+	capabilities: { claims: true, listing: true, multiTenant: true },
+	makeStore: () => ({ store: new InMemoryCheckpointStore() }),
+})
+
+defineCheckpointStoreConformance({
+	describe,
+	it,
+	expect,
+	label: 'disk',
+	contractVersion: 1,
+	capabilities: { claims: true, listing: true, multiTenant: false },
 	// The disk store is the one a host actually gets, and the only one whose
 	// arbitration has to survive leaving the process.
-	[
-		'disk',
-		(dir) =>
-			new DiskCheckpointStore({ baseDir: dir }, { tenantId: T1, projectId: P1, sessionId: S1 }),
-	],
-]
+	makeStore: async (binding) => {
+		const dir = await mkdtemp(join(tmpdir(), 'namzu-claim-'))
+		return {
+			store: new DiskCheckpointStore({ baseDir: dir }, binding),
+			dispose: () => removeTempDirAsync(dir),
+		}
+	},
+})
 
-describe.each(BACKENDS)('a run claim (%s)', (_kind, make) => {
-	let dir: string
-	let store: CheckpointStore
+describe('the two shipped stores, side by side', () => {
+	/**
+	 * Not in the conformance suite, and deliberately.
+	 *
+	 * The published contract promises fences are monotonic and unique. It does
+	 * NOT promise particular numbers, and it must not: a host backing this with
+	 * a database sequence gets gaps for free, and a suite that failed such a
+	 * backend would be enforcing an implementation detail of two filesystems.
+	 *
+	 * Inside this repository the exact numbering IS a claim, though — the
+	 * in-memory store's source says a released run's next claim is `fence + 2`
+	 * "in both stores, because the tombstone consumed one. That is parity, not
+	 * an off-by-one." A mutation that moved the disk tombstone to `fence + 2`
+	 * (making the next claim `fence + 3`) killed no test at all, so that
+	 * sentence was undriven. This is the one that drives it.
+	 */
+	it('numbers a released run’s next claim identically', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'namzu-parity-'))
+		try {
+			const stores: CheckpointStore[] = [
+				new InMemoryCheckpointStore(),
+				new DiskCheckpointStore(
+					{ baseDir: dir },
+					{
+						tenantId: 'tnt_claim' as TenantId,
+						projectId: 'prj_claim' as ProjectId,
+						sessionId: 'ses_claim' as SessionId,
+					},
+				),
+			]
 
-	beforeEach(async () => {
-		dir = await mkdtemp(join(tmpdir(), 'namzu-claim-'))
-		store = make(dir)
+			const nextFences: number[] = []
+			for (const store of stores) {
+				const first = await claimRun(store, scope('run_parity'), {
+					holder: 'w1',
+					ttlMs: 60_000,
+					now: 1,
+				})
+				await releaseRun(store, scope('run_parity'), first?.fence as number)
+				const second = await claimRun(store, scope('run_parity'), {
+					holder: 'w2',
+					ttlMs: 60_000,
+					now: 2,
+				})
+				expect(first?.fence).toBe(1)
+				nextFences.push(second?.fence as number)
+			}
+
+			// The tombstone consumed exactly one number, in both.
+			expect(nextFences).toEqual([3, 3])
+		} finally {
+			await removeTempDirAsync(dir)
+		}
 	})
 
-	afterEach(async () => {
-		await removeTempDirAsync(dir)
-	})
-
-	it('gives the run to the first taker and refuses the second', async () => {
-		const first = await claimRun(store, scope(), { holder: 'w1', ttlMs: 60_000, now: NOW })
-		const second = await claimRun(store, scope(), { holder: 'w2', ttlMs: 60_000, now: NOW })
-
-		expect(first?.holder).toBe('w1')
-		// `null`, not a throw: two readers on one queue is the ordinary case,
-		// and an exception would make the normal outcome look like a fault.
-		expect(second).toBeNull()
-	})
-
-	it('lets a later worker take a run whose holder went away', async () => {
-		const first = await claimRun(store, scope(), { holder: 'w1', ttlMs: 1_000, now: NOW })
-		const second = await claimRun(store, scope(), {
-			holder: 'w2',
-			ttlMs: 60_000,
-			now: NOW + 2_000,
-		})
-
-		// A lock held by a dead process is held forever. The expiry is the
-		// whole difference between a lease and a wedged run.
-		expect(second?.holder).toBe('w2')
-		expect(second?.fence).toBeGreaterThan(first?.fence as number)
-	})
-
-	it('fences the stalled holder out at the moment it writes', async () => {
-		const first = await claimRun(store, scope(), { holder: 'w1', ttlMs: 1_000, now: NOW })
-		await claimRun(store, scope(), { holder: 'w2', ttlMs: 60_000, now: NOW + 2_000 })
-
-		// `w1` believes it still holds the run. It cannot know otherwise: a
-		// long pause, a suspended container and a partition all look from the
-		// inside like time not passing. The write is the only place it can be
-		// told, and this is that place.
-		await expect(store.writeCheckpoint(scope(), checkpoint(), first?.fence)).rejects.toThrow(
-			/no longer holds it/,
-		)
-	})
-
-	it('lets the current holder keep writing', async () => {
-		const claim = await claimRun(store, scope(), { holder: 'w1', ttlMs: 60_000, now: NOW })
-		await expect(
-			store.writeCheckpoint(scope(), checkpoint(), claim?.fence),
-		).resolves.toBeUndefined()
-	})
-
-	it('advances the fence on renewal, so a stalled twin cannot write', async () => {
-		const first = await claimRun(store, scope(), { holder: 'w1', ttlMs: 1_000, now: NOW })
-		const renewed = await claimRun(store, scope(), { holder: 'w1', ttlMs: 60_000, now: NOW + 500 })
-
-		// Renewal and reclamation are one operation, and both advance. A
-		// renewal that kept the fence would leave any duplicate of the holder
-		// — a retried job, a double-scheduled pod — able to write with the
-		// number it captured before.
-		expect(renewed?.fence).toBeGreaterThan(first?.fence as number)
-		await expect(store.writeCheckpoint(scope(), checkpoint(), first?.fence)).rejects.toThrow(
-			/no longer holds it/,
-		)
-	})
-
-	it('still accepts an unfenced write on a claimed run', async () => {
-		await claimRun(store, scope(), { holder: 'w1', ttlMs: 60_000, now: NOW })
-		// A host that adopts claims on one worker must not break the workers
-		// that have not adopted them yet. Refusing here would make the
-		// capability impossible to roll out incrementally.
-		await expect(store.writeCheckpoint(scope(), checkpoint())).resolves.toBeUndefined()
-	})
-
-	it('releases only on the fence that currently holds it', async () => {
-		const first = await claimRun(store, scope(), { holder: 'w1', ttlMs: 1_000, now: NOW })
-		await claimRun(store, scope(), { holder: 'w2', ttlMs: 60_000, now: NOW + 2_000 })
-
-		// A worker that stalled past its lease must not be able to hand away
-		// a run somebody else is now holding.
-		await releaseRun(store, scope(), first?.fence as number)
-
-		const third = await claimRun(store, scope(), { holder: 'w3', ttlMs: 60_000, now: NOW + 3_000 })
-		expect(third).toBeNull()
-	})
-
-	it('still refuses a superseded fence after the new holder releases', async () => {
-		// The silent one. Not a duplicate write — a LOST one.
-		//
-		// w1 stalls at its fence. w2 reclaims, does the work, and releases
-		// cleanly, which is the documented `finally { releaseRun() }`. w1 then
-		// wakes believing it still holds the run and writes. If that write is
-		// accepted, its checkpoint carries a fresh `createdAt`, sorts newest,
-		// and the next resume restores w1's stale history — so w2's completed
-		// work vanishes with no error anywhere.
-		//
-		// The in-memory store accepted it, because the release deleted the
-		// claim and the check read the claim rather than the high-water mark.
-		// The disk store refused it, because the release appends a tombstone
-		// and the check reads file names. Two shipped stores disagreeing at
-		// the enforcement point is the thing this test exists to prevent: a
-		// host writing its own backend reads the reference.
-		const stale = await claimRun(store, scope(), { holder: 'w1', ttlMs: 1_000, now: NOW })
-		const live = await claimRun(store, scope(), { holder: 'w2', ttlMs: 60_000, now: NOW + 2_000 })
-		await releaseRun(store, scope(), live?.fence as number)
-
-		await expect(store.writeCheckpoint(scope(), checkpoint(), stale?.fence)).rejects.toThrow(
-			/no longer holds it/,
-		)
-	})
-
-	it('refuses the fence its own holder just released', async () => {
-		// The same hole one step shorter, and the one that pins the release
-		// itself rather than a reclaim before it. A holder that gives a run
-		// back has given up the right to write to it; nothing else took the
-		// run in between, so only the release can be what refuses this.
-		const claim = await claimRun(store, scope(), { holder: 'w1', ttlMs: 60_000, now: NOW })
-		await releaseRun(store, scope(), claim?.fence as number)
-
-		await expect(store.writeCheckpoint(scope(), checkpoint(), claim?.fence)).rejects.toThrow(
-			/no longer holds it/,
-		)
-	})
-
-	it('returns the run to the queue when its holder releases', async () => {
-		const claim = await claimRun(store, scope(), { holder: 'w1', ttlMs: 60_000, now: NOW })
-		await releaseRun(store, scope(), claim?.fence as number)
-
-		const next = await claimRun(store, scope(), { holder: 'w2', ttlMs: 60_000, now: NOW + 1 })
-		expect(next?.holder).toBe('w2')
-	})
-
-	it('shows the queue reader which runs nobody holds', async () => {
-		await store.writeCheckpoint(scope('run_a'), checkpoint('run_a'))
-		await store.writeCheckpoint(scope('run_b'), checkpoint('run_b'))
-		await store.writeCheckpoint(scope('run_c'), checkpoint('run_c'))
-
-		await claimRun(store, scope('run_a'), { holder: 'w1', ttlMs: 60_000, now: NOW })
-		await claimRun(store, scope('run_b'), { holder: 'w1', ttlMs: 1_000, now: NOW })
-
-		const free = await listDurableRuns(
-			store,
-			{ tenantId: T1 },
-			{ claimed: false, now: NOW + 2_000 },
-		)
-		// `run_b`'s holder is gone. An expired claim counts as unheld, or a
-		// dead worker's runs stay invisible forever — the failure the lease
-		// exists to prevent, reintroduced by the filter that reads it.
-		expect(free.entries.map((e) => e.runId)).toEqual(['run_b', 'run_c'])
-
-		const taken = await listDurableRuns(
-			store,
-			{ tenantId: T1 },
-			{ claimed: true, now: NOW + 2_000 },
-		)
-		expect(taken.entries.map((e) => e.runId)).toEqual(['run_a'])
-		expect(taken.entries[0]?.claim?.holder).toBe('w1')
-		expect(taken.entries[0]?.claim?.expired).toBe(false)
-	})
-
-	it('refuses a lease with no duration', async () => {
-		// A lease that expires immediately is a lease every worker can take at
-		// once, which is the condition this call exists to prevent.
-		await expect(claimRun(store, scope(), { holder: 'w1', ttlMs: 0, now: NOW })).rejects.toThrow(
-			/positive number of milliseconds/,
-		)
+	it('is the revision this build ships', () => {
+		// The two calls above hard-code `1`, which is the point of the check
+		// they feed. Nothing else in the repository would notice the constant
+		// moving without them — and a bumped constant with unbumped callers is
+		// a `major` that shipped as a `minor`.
+		expect(CHECKPOINT_STORE_CONTRACT_VERSION).toBe(1)
 	})
 })
 
@@ -265,13 +157,15 @@ describe('a store that cannot arbitrate', () => {
 		// Skipping an absent optional method is the natural thing to do and
 		// the fatal one: every worker would proceed believing it holds a run
 		// nobody arbitrated.
-		await expect(claimRun(cannot, scope(), { holder: 'w1', ttlMs: 1_000 })).rejects.toThrow(
+		await expect(claimRun(cannot, scope('run_a'), { holder: 'w1', ttlMs: 1_000 })).rejects.toThrow(
 			/does not implement `claimRun`/,
 		)
 	})
 
 	it('refuses to release rather than pretending it did', async () => {
-		await expect(releaseRun(cannot, scope(), 1)).rejects.toThrow(/does not implement `releaseRun`/)
+		await expect(releaseRun(cannot, scope('run_a'), 1)).rejects.toThrow(
+			/does not implement `releaseRun`/,
+		)
 	})
 })
 

--- a/packages/sdk/src/store/run/conformance.ts
+++ b/packages/sdk/src/store/run/conformance.ts
@@ -1,0 +1,705 @@
+/**
+ * The checkpoint-store contract, as a suite a host can run against its own
+ * backend.
+ *
+ * ## Why this ships rather than staying a test
+ *
+ * {@link import('./checkpoint-memory.js').InMemoryCheckpointStore} says in its
+ * own doc comment that it is "the reference a host reads when writing a
+ * backend of its own". That claim was unbacked, and the cost of it was not
+ * hypothetical: the two shipped stores disagreed at the enforcement point —
+ * the in-memory one accepted a write from a holder that had been superseded
+ * and then released around, the disk one refused it — and the class documented
+ * as the reference was the one carrying the defect. Reading a reference cannot
+ * tell you that. Running it can.
+ *
+ * The rules below are the ones a claim depends on and no type can state:
+ * exclusivity, expiry, that a superseded write is refused, and that a listing
+ * answers for the tenant it was asked about and no other. Those are exactly
+ * the points at which the two built-in implementations already diverged.
+ *
+ * ## Why it takes its runner as an argument
+ *
+ * `describe`, `it` and `expect` come in through
+ * {@link CheckpointStoreConformanceOptions}. The suite therefore imports no
+ * test framework, `@namzu/sdk` gains no test dependency from publishing it,
+ * and a host on a different runner can still run it by handing over three
+ * functions of the shapes below.
+ *
+ * It also buys the one property that separates this file from decoration: a
+ * caller can pass a *recording* `describe`/`it` and run the whole contract as
+ * ordinary code, which is how `conformance-fails-a-wrong-store.test.ts`
+ * establishes that a deliberately broken store fails it.
+ *
+ * ## Consuming it
+ *
+ * See `docs/sdk/runtime/checkpoint-store-conformance.md`. In short:
+ *
+ * ```typescript
+ * import { describe, expect, it } from 'your-runner'
+ * import { defineCheckpointStoreConformance } from '@namzu/sdk/testing'
+ *
+ * defineCheckpointStoreConformance({
+ *   describe, it, expect,
+ *   label: 'my-backend',
+ *   contractVersion: 1,
+ *   capabilities: { claims: true, listing: true, multiTenant: true },
+ *   makeStore: (binding) => ({ store: new MyStore(binding) }),
+ * })
+ * ```
+ *
+ * ## The assertions are public API
+ *
+ * Once a host wires this in, every assertion below is something their build
+ * fails on. Adding one is therefore a breaking change for them even though it
+ * adds no export — so a new rule arrives behind a raised
+ * {@link CHECKPOINT_STORE_CONTRACT_VERSION} and a `major`, and the version
+ * check is what turns "your backend silently satisfies an older, smaller
+ * contract" into a named failure.
+ */
+
+import type { CostInfo } from '../../types/common/index.js'
+import type { IterationCheckpoint } from '../../types/hitl/index.js'
+import type { CheckpointId, ProjectId, RunId, SessionId, TenantId } from '../../types/ids/index.js'
+import type { CheckpointStore } from '../../types/run/checkpoint-store.js'
+import { claimRun, listDurableRuns, releaseRun } from './listing.js'
+
+/**
+ * Which revision of the contract the assertions in this file express.
+ *
+ * A host DECLARES the version it wrote its backend against, as a literal in
+ * its own test file, and the suite's first case compares the two. Re-exporting
+ * this constant into that slot defeats the check — the point is that the
+ * number is frozen in the host's source at the moment they wrote the backend,
+ * so upgrading `@namzu/sdk` past a contract revision fails with a sentence
+ * naming both numbers instead of a scatter of assertion failures whose common
+ * cause is not obvious.
+ *
+ * Raised only together with a `major`, and only when an assertion is ADDED or
+ * TIGHTENED. Adding a case behind a new optional capability flag does not
+ * raise it: a host that does not declare the capability never runs the case.
+ */
+export const CHECKPOINT_STORE_CONTRACT_VERSION = 1
+
+/**
+ * What a backend can do, so the suite runs the cases it is answerable for and
+ * no others.
+ *
+ * Every field is required rather than defaulted. A capability that defaults to
+ * `false` lets a host skip a whole section by forgetting a key, and a suite you
+ * can opt out of by omission is a suite that reports a pass it did not
+ * establish.
+ */
+export interface CheckpointStoreCapabilities {
+	/**
+	 * The store implements `claimRun` / `releaseRun` and enforces the fence at
+	 * `writeCheckpoint`. `false` skips every claim case — appropriate only for
+	 * a single-writer backend, which is a deployment shape, not a shortcut.
+	 */
+	readonly claims: boolean
+	/** The store implements `listDurableRuns`. */
+	readonly listing: boolean
+	/**
+	 * One instance can hold more than one tenant's runs.
+	 *
+	 * `false` for a store whose addressing fixes the tenant — the built-in disk
+	 * layout has no tenant segment in it, so a second tenant is a second store.
+	 * Such a backend still answers the isolation case that CAN be put to it: a
+	 * listing for a tenant it does not hold returns nothing.
+	 */
+	readonly multiTenant: boolean
+}
+
+/** The attribution the suite addresses its runs under. */
+export interface CheckpointStoreBinding {
+	readonly tenantId: TenantId
+	readonly projectId: ProjectId
+	readonly sessionId: SessionId
+}
+
+/** A store to test, plus whatever teardown producing it required. */
+export interface CheckpointStoreHandle {
+	readonly store: CheckpointStore
+	/** Called after each case, pass or fail. */
+	dispose?(): void | Promise<void>
+}
+
+/**
+ * Build a store bound to `binding`. Called once per case, so no case can be
+ * affected by another's writes — the suite never assumes a shared instance and
+ * never cleans one.
+ */
+export type MakeCheckpointStore = (
+	binding: CheckpointStoreBinding,
+) => CheckpointStoreHandle | Promise<CheckpointStoreHandle>
+
+/** The assertions the suite uses, and nothing more. */
+export interface ConformanceAssertion {
+	toBe(expected: unknown): void
+	toEqual(expected: unknown): void
+	toBeGreaterThan(expected: number): void
+	toMatch(expected: RegExp): void
+}
+
+/** Shape of the `expect` a runner supplies. */
+export type ConformanceExpect = (actual: unknown) => ConformanceAssertion
+/** Shape of the `it` a runner supplies. */
+export type ConformanceIt = (name: string, body: () => Promise<void>) => unknown
+/** Shape of the `describe` a runner supplies. */
+export type ConformanceDescribe = (name: string, body: () => void) => unknown
+
+/** Everything {@link defineCheckpointStoreConformance} needs. */
+export interface CheckpointStoreConformanceOptions {
+	readonly describe: ConformanceDescribe
+	readonly it: ConformanceIt
+	readonly expect: ConformanceExpect
+	/**
+	 * The contract revision this backend was written against, written as a
+	 * literal. See {@link CHECKPOINT_STORE_CONTRACT_VERSION}.
+	 */
+	readonly contractVersion: number
+	readonly capabilities: CheckpointStoreCapabilities
+	readonly makeStore: MakeCheckpointStore
+	/** Names the backend in test output. Defaults to `checkpoint store`. */
+	readonly label?: string
+}
+
+/** The tenant/project/session every case addresses unless it needs a second. */
+const BINDING: CheckpointStoreBinding = {
+	tenantId: 'tnt_conformance' as TenantId,
+	projectId: 'prj_conformance' as ProjectId,
+	sessionId: 'ses_conformance' as SessionId,
+}
+
+/** A tenant no backend under test holds runs for. */
+const FOREIGN_TENANT = 'tnt_conformance_other' as TenantId
+
+/** Fixed instant, so every expiry in a case is judged against one clock. */
+const NOW = 5_000_000
+
+const NO_COST: CostInfo = {
+	inputCostPer1M: 0,
+	outputCostPer1M: 0,
+	totalCost: 0,
+	cacheDiscount: 0,
+}
+
+let checkpointSeq = 0
+
+function checkpoint(runId: string): IterationCheckpoint {
+	checkpointSeq += 1
+	return {
+		id: `cp_conformance_${checkpointSeq}` as CheckpointId,
+		runId: runId as RunId,
+		iteration: 1,
+		messages: [],
+		tokenUsage: {
+			promptTokens: 1,
+			completionTokens: 1,
+			totalTokens: 2,
+			cachedTokens: 0,
+			cacheWriteTokens: 0,
+		},
+		costInfo: NO_COST,
+		guardState: { iterationCount: 1, elapsedMs: 1 },
+		createdAt: NOW,
+	}
+}
+
+function runScope(binding: CheckpointStoreBinding, runId = 'run_conformance_a') {
+	return { ...binding, runId: runId as RunId }
+}
+
+/**
+ * Assert that `call` rejected with a message matching `pattern`.
+ *
+ * Written against `toMatch` rather than a runner's `rejects` helper so the
+ * suite needs no matcher beyond the four on {@link ConformanceAssertion}. A
+ * call that RESOLVES yields a sentence saying so, which is the diagnostic that
+ * matters: the failure this whole file exists for is a write that was accepted
+ * when it should have been refused.
+ */
+async function expectRejection(
+	expect: ConformanceExpect,
+	call: () => Promise<unknown>,
+	pattern: RegExp,
+): Promise<void> {
+	let message = '<the call resolved; no rejection was raised>'
+	try {
+		await call()
+	} catch (error) {
+		message = error instanceof Error ? error.message : String(error)
+	}
+	expect(message).toMatch(pattern)
+}
+
+/**
+ * Register the checkpoint-store contract against one backend.
+ *
+ * Call it once per backend. It registers cases through the supplied `describe`
+ * and `it`; it does not run them.
+ */
+export function defineCheckpointStoreConformance(options: CheckpointStoreConformanceOptions): void {
+	const { describe, it, expect, capabilities, makeStore } = options
+	const label = options.label ?? 'checkpoint store'
+
+	/**
+	 * Run `body` against a store built for this case alone.
+	 *
+	 * `finally`, so a failing assertion still disposes — a suite that leaks a
+	 * temp directory per failure makes a red run expensive to iterate on, and
+	 * an expensive red run is one people stop running.
+	 */
+	const withStore = (body: (store: CheckpointStore) => Promise<void>) => async () => {
+		const handle = await makeStore(BINDING)
+		try {
+			await body(handle.store)
+		} finally {
+			await handle.dispose?.()
+		}
+	}
+
+	describe(`${label} conformance`, () => {
+		it('declares the contract revision this suite implements', async () => {
+			// First case on purpose. When it fails, every case below it is
+			// answering a different contract than the backend was written for,
+			// and reading their failures as defects would send a host chasing
+			// bugs that are really a version skew.
+			//
+			// Both numbers ride in the COMPARED VALUES rather than in a
+			// sentence, because a runner truncates a long actual when it builds
+			// the failure message — measured, on the first draft of this, at 37
+			// characters, which cut off the very numbers the case exists to
+			// report. The guidance that would not fit lives on
+			// `CHECKPOINT_STORE_CONTRACT_VERSION`, which is where a reader of
+			// this failure is being sent anyway.
+			expect(`checkpoint-store contract v${options.contractVersion}`).toBe(
+				`checkpoint-store contract v${CHECKPOINT_STORE_CONTRACT_VERSION}`,
+			)
+		})
+
+		if (capabilities.claims) {
+			describe('claim exclusivity', () => {
+				it(
+					'gives the run to the first taker and refuses the second',
+					withStore(async (store) => {
+						const first = await claimRun(store, runScope(BINDING), {
+							holder: 'w1',
+							ttlMs: 60_000,
+							now: NOW,
+						})
+						const second = await claimRun(store, runScope(BINDING), {
+							holder: 'w2',
+							ttlMs: 60_000,
+							now: NOW,
+						})
+
+						expect(first?.holder).toBe('w1')
+						// `null`, not a throw: two readers on one queue is the
+						// ordinary case, and an exception would make the normal
+						// outcome look like a fault.
+						expect(second).toBe(null)
+					}),
+				)
+
+				it(
+					'advances the fence on renewal, so a stalled twin cannot write',
+					withStore(async (store) => {
+						const first = await claimRun(store, runScope(BINDING), {
+							holder: 'w1',
+							ttlMs: 1_000,
+							now: NOW,
+						})
+						const renewed = await claimRun(store, runScope(BINDING), {
+							holder: 'w1',
+							ttlMs: 60_000,
+							now: NOW + 500,
+						})
+
+						// Renewal and reclamation are one operation and both
+						// advance. A renewal that kept the fence would leave any
+						// duplicate of the holder — a retried job, a
+						// double-scheduled pod — able to write with the number it
+						// captured before.
+						expect(renewed?.fence).toBeGreaterThan(first?.fence as number)
+					}),
+				)
+
+				it(
+					'refuses a lease with no duration',
+					withStore(async (store) => {
+						// A lease that expires immediately is a lease every worker
+						// can take at once, which is the condition the call exists
+						// to prevent.
+						await expectRejection(
+							expect,
+							() => claimRun(store, runScope(BINDING), { holder: 'w1', ttlMs: 0, now: NOW }),
+							/positive number of milliseconds/,
+						)
+					}),
+				)
+			})
+
+			describe('claim expiry', () => {
+				it(
+					'lets a later worker take a run whose holder went away',
+					withStore(async (store) => {
+						const first = await claimRun(store, runScope(BINDING), {
+							holder: 'w1',
+							ttlMs: 1_000,
+							now: NOW,
+						})
+						const second = await claimRun(store, runScope(BINDING), {
+							holder: 'w2',
+							ttlMs: 60_000,
+							now: NOW + 2_000,
+						})
+
+						// A lock held by a dead process is held forever. The expiry
+						// is the whole difference between a lease and a wedged run.
+						expect(second?.holder).toBe('w2')
+						expect(second?.fence).toBeGreaterThan(first?.fence as number)
+					}),
+				)
+
+				it(
+					'returns the run to the queue when its holder releases',
+					withStore(async (store) => {
+						const claim = await claimRun(store, runScope(BINDING), {
+							holder: 'w1',
+							ttlMs: 60_000,
+							now: NOW,
+						})
+						await releaseRun(store, runScope(BINDING), claim?.fence as number)
+
+						const next = await claimRun(store, runScope(BINDING), {
+							holder: 'w2',
+							ttlMs: 60_000,
+							now: NOW + 1,
+						})
+						expect(next?.holder).toBe('w2')
+					}),
+				)
+
+				it(
+					'releases only on the fence that currently holds it',
+					withStore(async (store) => {
+						const first = await claimRun(store, runScope(BINDING), {
+							holder: 'w1',
+							ttlMs: 1_000,
+							now: NOW,
+						})
+						await claimRun(store, runScope(BINDING), {
+							holder: 'w2',
+							ttlMs: 60_000,
+							now: NOW + 2_000,
+						})
+
+						// A worker that stalled past its lease must not be able to
+						// hand away a run somebody else is now holding.
+						await releaseRun(store, runScope(BINDING), first?.fence as number)
+
+						const third = await claimRun(store, runScope(BINDING), {
+							holder: 'w3',
+							ttlMs: 60_000,
+							now: NOW + 3_000,
+						})
+						expect(third).toBe(null)
+					}),
+				)
+			})
+
+			describe('fenced-out writes', () => {
+				it(
+					'lets the current holder keep writing',
+					withStore(async (store) => {
+						const claim = await claimRun(store, runScope(BINDING), {
+							holder: 'w1',
+							ttlMs: 60_000,
+							now: NOW,
+						})
+						await store.writeCheckpoint(
+							runScope(BINDING),
+							checkpoint('run_conformance_a'),
+							claim?.fence,
+						)
+						const written = await store.listCheckpoints(runScope(BINDING))
+						expect(written.length).toBe(1)
+					}),
+				)
+
+				it(
+					'still accepts an unfenced write on a claimed run',
+					withStore(async (store) => {
+						await claimRun(store, runScope(BINDING), {
+							holder: 'w1',
+							ttlMs: 60_000,
+							now: NOW,
+						})
+						// A host that adopts claims on one worker must not break the
+						// workers that have not adopted them yet. Refusing here would
+						// make the capability impossible to roll out incrementally.
+						await store.writeCheckpoint(runScope(BINDING), checkpoint('run_conformance_a'))
+						const written = await store.listCheckpoints(runScope(BINDING))
+						expect(written.length).toBe(1)
+					}),
+				)
+
+				it(
+					'fences the stalled holder out at the moment it writes',
+					withStore(async (store) => {
+						const first = await claimRun(store, runScope(BINDING), {
+							holder: 'w1',
+							ttlMs: 1_000,
+							now: NOW,
+						})
+						await claimRun(store, runScope(BINDING), {
+							holder: 'w2',
+							ttlMs: 60_000,
+							now: NOW + 2_000,
+						})
+
+						// `w1` believes it still holds the run. It cannot know
+						// otherwise: a long pause, a suspended container and a
+						// partition all look from the inside like time not passing.
+						// The write is the only place it can be told, and this is
+						// that place.
+						await expectRejection(
+							expect,
+							() =>
+								store.writeCheckpoint(
+									runScope(BINDING),
+									checkpoint('run_conformance_a'),
+									first?.fence,
+								),
+							/no longer holds it/,
+						)
+					}),
+				)
+
+				it(
+					'still refuses a superseded fence after the new holder releases',
+					withStore(async (store) => {
+						// The silent one, and the case on which the two built-in
+						// stores actually disagreed. Not a duplicate write — a LOST
+						// one.
+						//
+						// w1 stalls at its fence. w2 reclaims, does the work, and
+						// releases cleanly, which is the documented
+						// `finally { releaseRun() }`. w1 then wakes believing it
+						// still holds the run and writes. If that write is accepted,
+						// its checkpoint carries a fresh `createdAt`, sorts newest,
+						// and the next resume restores w1's stale history — so w2's
+						// completed work vanishes with no error anywhere.
+						const stale = await claimRun(store, runScope(BINDING), {
+							holder: 'w1',
+							ttlMs: 1_000,
+							now: NOW,
+						})
+						const live = await claimRun(store, runScope(BINDING), {
+							holder: 'w2',
+							ttlMs: 60_000,
+							now: NOW + 2_000,
+						})
+						await releaseRun(store, runScope(BINDING), live?.fence as number)
+
+						await expectRejection(
+							expect,
+							() =>
+								store.writeCheckpoint(
+									runScope(BINDING),
+									checkpoint('run_conformance_a'),
+									stale?.fence,
+								),
+							/no longer holds it/,
+						)
+					}),
+				)
+
+				it(
+					'refuses the fence its own holder just released',
+					withStore(async (store) => {
+						// The same hole one step shorter, and the one that pins the
+						// release itself rather than a reclaim before it. A holder
+						// that gives a run back has given up the right to write to
+						// it; nothing else took the run in between, so only the
+						// release can be what refuses this.
+						const claim = await claimRun(store, runScope(BINDING), {
+							holder: 'w1',
+							ttlMs: 60_000,
+							now: NOW,
+						})
+						await releaseRun(store, runScope(BINDING), claim?.fence as number)
+
+						await expectRejection(
+							expect,
+							() =>
+								store.writeCheckpoint(
+									runScope(BINDING),
+									checkpoint('run_conformance_a'),
+									claim?.fence,
+								),
+							/no longer holds it/,
+						)
+					}),
+				)
+			})
+		}
+
+		if (capabilities.listing) {
+			describe('listing scope isolation', () => {
+				it(
+					'answers nothing for a tenant it does not hold',
+					withStore(async (store) => {
+						await store.writeCheckpoint(
+							runScope(BINDING, 'run_conformance_a'),
+							checkpoint('run_conformance_a'),
+						)
+
+						const foreign = await listDurableRuns(store, { tenantId: FOREIGN_TENANT })
+						// A listing is SCOPED, not addressed: another tenant is a
+						// question this store has no rows for. Leaking one row here
+						// is the whole of a cross-tenant read.
+						expect(foreign.entries.map((e) => e.runId)).toEqual([])
+					}),
+				)
+
+				it(
+					'answers nothing for a project it does not hold',
+					withStore(async (store) => {
+						await store.writeCheckpoint(
+							runScope(BINDING, 'run_conformance_a'),
+							checkpoint('run_conformance_a'),
+						)
+
+						const foreign = await listDurableRuns(store, {
+							tenantId: BINDING.tenantId,
+							projectId: 'prj_conformance_other' as ProjectId,
+						})
+						expect(foreign.entries.map((e) => e.runId)).toEqual([])
+					}),
+				)
+
+				it(
+					'refuses a listing scope with a hole in it',
+					withStore(async (store) => {
+						// `{ tenantId, sessionId }` reads as "that session under
+						// whichever project holds it". A flat backend can answer it
+						// and a hierarchical one cannot, so answering differently per
+						// backend is the one thing this contract exists to prevent.
+						await expectRejection(
+							expect,
+							() =>
+								listDurableRuns(store, {
+									tenantId: BINDING.tenantId,
+									sessionId: BINDING.sessionId,
+								}),
+							/contiguous prefix|without `projectId`/,
+						)
+					}),
+				)
+
+				it(
+					'rebuilds an addressable row for every run it holds',
+					withStore(async (store) => {
+						await store.writeCheckpoint(
+							runScope(BINDING, 'run_conformance_a'),
+							checkpoint('run_conformance_a'),
+						)
+						await store.writeCheckpoint(
+							runScope(BINDING, 'run_conformance_b'),
+							checkpoint('run_conformance_b'),
+						)
+
+						const page = await listDurableRuns(store, { tenantId: BINDING.tenantId })
+						expect(page.entries.map((e) => e.runId)).toEqual([
+							'run_conformance_a',
+							'run_conformance_b',
+						])
+						// A row that cannot be turned back into a scope is a report,
+						// not a work queue.
+						expect(page.entries.map((e) => e.tenantId)).toEqual([
+							BINDING.tenantId,
+							BINDING.tenantId,
+						])
+						expect(page.entries.map((e) => e.sessionId)).toEqual([
+							BINDING.sessionId,
+							BINDING.sessionId,
+						])
+					}),
+				)
+
+				if (capabilities.multiTenant) {
+					it(
+						'keeps one tenant’s runs out of another tenant’s listing',
+						withStore(async (store) => {
+							await store.writeCheckpoint(
+								runScope(BINDING, 'run_conformance_a'),
+								checkpoint('run_conformance_a'),
+							)
+							await store.writeCheckpoint(
+								{
+									tenantId: FOREIGN_TENANT,
+									projectId: BINDING.projectId,
+									sessionId: BINDING.sessionId,
+									runId: 'run_conformance_z' as RunId,
+								},
+								checkpoint('run_conformance_z'),
+							)
+
+							const mine = await listDurableRuns(store, { tenantId: BINDING.tenantId })
+							expect(mine.entries.map((e) => e.runId)).toEqual(['run_conformance_a'])
+
+							const theirs = await listDurableRuns(store, { tenantId: FOREIGN_TENANT })
+							expect(theirs.entries.map((e) => e.runId)).toEqual(['run_conformance_z'])
+						}),
+					)
+				}
+
+				if (capabilities.claims) {
+					it(
+						'shows the queue reader which runs nobody holds',
+						withStore(async (store) => {
+							for (const id of ['run_conformance_a', 'run_conformance_b', 'run_conformance_c'])
+								await store.writeCheckpoint(runScope(BINDING, id), checkpoint(id))
+
+							await claimRun(store, runScope(BINDING, 'run_conformance_a'), {
+								holder: 'w1',
+								ttlMs: 60_000,
+								now: NOW,
+							})
+							await claimRun(store, runScope(BINDING, 'run_conformance_b'), {
+								holder: 'w1',
+								ttlMs: 1_000,
+								now: NOW,
+							})
+
+							const free = await listDurableRuns(
+								store,
+								{ tenantId: BINDING.tenantId },
+								{ claimed: false, now: NOW + 2_000 },
+							)
+							// `run_conformance_b`'s holder is gone. An expired claim
+							// counts as unheld, or a dead worker's runs stay invisible
+							// forever — the failure the lease exists to prevent,
+							// reintroduced by the filter that reads it.
+							expect(free.entries.map((e) => e.runId)).toEqual([
+								'run_conformance_b',
+								'run_conformance_c',
+							])
+
+							const taken = await listDurableRuns(
+								store,
+								{ tenantId: BINDING.tenantId },
+								{ claimed: true, now: NOW + 2_000 },
+							)
+							expect(taken.entries.map((e) => e.runId)).toEqual(['run_conformance_a'])
+							expect(taken.entries[0]?.claim?.holder).toBe('w1')
+							expect(taken.entries[0]?.claim?.expired).toBe(false)
+						}),
+					)
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
`@namzu/sdk` gains a `./testing` subpath exporting the checkpoint-store contract as a suite a host runs against its own backend.

## Why

`InMemoryCheckpointStore`'s source calls itself *"the reference a host reads when writing a backend of its own"*. That claim was unbacked, and the cost was not hypothetical: the two shipped stores disagreed **at the enforcement point** — the in-memory one accepted a checkpoint from a worker that had been superseded and then released around, the disk one refused it — and the class documented as the reference was the one carrying the defect. Nothing threw. A host writing its own backend had no way to find that out.

Two facts blocked publication, both re-verified on this branch before touching anything:

- `packages/sdk/package.json#exports` had exactly one entry, `"."`.
- `files` strips `__tests__` from **both** `dist` and `src`, so a suite left where it was could not ship.

## What is in it

`packages/sdk/src/store/run/conformance.ts` — `defineCheckpointStoreConformance({ describe, it, expect, contractVersion, capabilities, makeStore, label })`.

Taking the runner primitives as arguments buys three things: the suite imports no test framework, the published package gains no test dependency, and a caller can hand it *recording* primitives and run the whole contract as ordinary async code. That last one is what makes the self-test below possible.

It names what it guarantees rather than implying it — **claim exclusivity, claim expiry, fenced-out writes refused, listing scope isolation across tenants**. Those are the four points at which the two implementations already diverged.

`CHECKPOINT_STORE_CONTRACT_VERSION` ships beside it. The suite's first case compares it against a literal the host writes down, so a backend written against an older contract fails with `expected 'checkpoint-store contract v1' to be 'checkpoint-store contract v2'` rather than silently answering a smaller contract. The docs page says explicitly not to re-export the constant into that slot, which would make the check unfailable.

`capabilities` is three required flags — `claims`, `listing`, `multiTenant`. None defaults: a capability defaulting to `false` lets a host skip a section by forgetting a key, and a suite you can opt out of by omission reports a pass it did not establish. The disk store declares `multiTenant: false` (its layout has no tenant segment) and still answers the isolation case that *can* be put to it — a listing for a tenant it does not hold returns nothing.

## The test that separates this from decoration

`__tests__/conformance-fails-a-wrong-store.test.ts` runs the suite against two stores broken on purpose and requires it to name the failures:

- `GrantsEveryClaim` — five lines, `claimRun` returns a claim unconditionally.
- `AcceptsEveryWrite` — mints fences correctly and then drops the one presented at the write. **This is the defect this repository actually shipped**, and the one a reader would never find by reading, because everything about the claim path looks right.

Failures are asserted **by name**, not by count — a count passes on any three failures, including three with nothing to do with the subject. The second store's claim cases are asserted to stay *green*, or the suite would be reporting the wrong subject.

A control case requires the sound in-memory store to produce zero failures and to have registered more than ten cases. Without it, a mis-wired harness would fail everything and look exactly like detection.

## Mutation table

15 mutations; `M*` = mutant, killed-by counts exclude the self-test control where noted in the session log.

| # | Mutation | Killed by |
|---|---|---|
| M1 | memory: drop the write-time fence check | 4 (3 in-memory fenced-out cases + control) |
| M2 | memory: release does not step the high-water mark | 2 |
| M3 | memory: a live claim blocks its own holder | 2 |
| M4 | memory: listing ignores the tenant asked for | 3 |
| M5 | listing: an expired claim counts as held | 3 (both backends) |
| M6 | listing: a scope with a hole is answered, not refused | 3 (both backends) |
| M7 | listing: a zero-duration lease is accepted | 3 (both backends) |
| M8 | conformance: the version check always passes | 1 |
| M9 | conformance: a call that never rejects passes `expectRejection` | 1 |
| M10 | conformance: exclusivity stops asserting the second taker is refused | 1 |
| M11 | self-test: the broken claim store is made honest | 1 |
| M12 | self-test: the unchecked-write store is made honest | 1 |
| M13 | disk: drop the write-time fence check | 4 (3 **disk** fenced-out cases + control) |
| M14 | disk: release tombstones at `fence + 2` | **0 — SURVIVED** |
| M15 | listing: a claim is never reported expired | 3 (both backends) |

M1 and M13 killing disjoint sets of cases is the parity property working: mutating one backend fails only that backend's cases.

**M14 survived**, and it was worth having. Nothing observed the disk tombstone's fence number, so `checkpoint-memory.ts`'s comment — *"a released run's next claim is `fence + 2` in both stores, because the tombstone consumed one. That is parity, not an off-by-one"* — was undriven prose.

It is now driven by a **repo-internal** test, not a suite assertion, and that boundary is deliberate: the published contract promises fences are monotonic and unique, and must not promise particular numbers, or a host backing this with a database sequence would fail the suite for having gaps. Re-running M14 against the new test: `expected [ 3, 4 ] to deeply equal [ 3, 3 ]`.

## Changeset

`minor` — additive export, nothing existing changes. The changeset states the caveat: once a host wires this in, every assertion is something their build fails on, so the suite's assertions are public API and tightening one later is a `major` for this package even though it adds no export.

## Gates

build ✅ · typecheck ✅ · lint ✅ · `pnpm -r test` — sdk **3072 passed** ✅ · `audit-external-names` ✅ · `docs:check` ✅ (0 problems / 14 files)

One CLI test failed in the full run — `app-draft-survives.test.tsx` — and a **different case in the same file** failed on re-run. It is a pre-existing timing flake in the TUI frame-polling harness; this branch touches no CLI code. It is also precisely the class of problem the follow-up screen-surface PR addresses.
