### PR TITLE
fix(cli)!: run-stream's exit code sorts the cases it is applied to

### DIFF
--- a/.changeset/run-stream-exit-code-sorts-its-cases.md
+++ b/.changeset/run-stream-exit-code-sorts-its-cases.md
@@ -1,0 +1,52 @@
+---
+'@namzu/cli': major
+---
+
+`run-stream`'s exit code now says whether you can do anything about the failure
+
+**What breaks.** Four conditions that exited `0` now exit `1`, and two flags
+that were accepted and ignored are now refused.
+
+| Condition | Was | Is |
+| --- | --- | --- |
+| `--session <id>` and the conversation cannot be opened | `0` | `1` |
+| No LLM provider available | `0` | `1` |
+| The session has no provider for an environment reason (no credential, a driver that would not load, a chain that contradicts itself) | `0` | `1` |
+| A declared tool server is not available | `0` | `1` |
+| A command file that will not parse | `0` | `1` |
+| `--continue` / `--resume` | silently ignored, ran stateless, `0` | refused with an `error` event, `0` |
+
+Everything else is unchanged. An unknown option, a missing prompt, a `--cwd`
+that does not exist, a bad `--permission-mode`, an interactive command named
+headlessly and a provider id that is not a provider all still exit `0`; so does
+a run that started and failed; and an untrusted folder still exits `77`.
+
+**If you have a host that treats non-zero as "the folder is untrusted"**, that
+is the assumption to change: `77` still means only that, but `1` now means "a
+person has to fix something before this can work". If your host retried on `0`,
+it will stop looping on faults retrying could never fix — which is the point.
+
+**Why.** The documented rule was *started and failed → 0; refused to start →
+non-zero*, and applied to the real cases it did not sort them: an unknown
+option, a missing prompt, a bad `--cwd` and an unavailable tool server are all
+refusals to start, and all four exited `0` while an untrusted folder exited
+`77`. The retry argument the source appealed to does not sort them either —
+retrying an unknown option is as pointless as retrying an untrusted folder.
+
+The axis that does: **can the caller reach the run it asked for by changing what
+it sends?** Yes → `0`, and the host fixes its own invocation. No → non-zero,
+because a person has to act. Dropping `--session` is not "the caller fixing it";
+it abandons what was asked for.
+
+`1` rather than a new code because `namzu run` — the same one-shot, differing
+only in how it prints — already exits `1` for these conditions and `77` for
+trust. `77` stays scoped to trust, because being unambiguous is its whole
+justification.
+
+**Two branches had to be split before they could be sorted.** `hasProvider ===
+false` covered both a provider id that is not a provider (yours to fix) and four
+environment failures; a refused command expansion covered both a bad invocation
+and a command file that will not parse. Each now carries the distinction as a
+field — `AgentSession.errorKind` and the `fixable` flag on a `refused`
+expansion — rather than leaving a caller to match on the message text, after
+which the message could never be reworded.

--- a/docs/cli/headless.md
+++ b/docs/cli/headless.md
@@ -181,10 +181,15 @@ error.
 
 **A conversation that cannot be opened stops the run.** If `--session` is given
 and the store cannot be reached — an unwritable `.namzu`, a corrupt map file —
-`run-stream` emits an `error` event and runs nothing. It does not quietly fall
-back to the stateless path, because that path takes prior turns from stdin: a
-caller who named a conversation would get an answer composed against a different
-history, or none, reported as an ordinary success.
+`run-stream` emits an `error` event, runs nothing, and **exits `1`**. It does not
+quietly fall back to the stateless path, because that path takes prior turns
+from stdin: a caller who named a conversation would get an answer composed
+against a different history, or none, reported as an ordinary success.
+
+The exit code is `1` rather than `0` because a key is *created* on first use —
+so this can never be a key you got wrong, only the store itself. Nothing you
+send changes an unwritable `.namzu`, and a host treating `0` as "render the
+error and move on" would loop on a fault it could have raised to a person.
 
 It cannot be a warning-and-continue either, because the command cannot say what
 was lost. A key is created on first use, so a fresh key legitimately has no
@@ -220,21 +225,48 @@ one a human decision about a folder can fix, and a caller that cannot tell them
 apart ends up matching on the message text — after which the message can never
 be reworded.
 
+### `run-stream`
+
 `namzu run-stream` answers a host that is line-scanning stdout, not a shell, so
-it reports the same conditions **in band** and exits 0. Every run ends with a
-terminal event, including a refusal:
+**every** failure is reported in band — including the ones that also carry an
+exit code. Every run ends with a terminal event, refusals included:
 
 ```json
 {"kind":"error","message":"--cwd does not exist: /projects/typo"}
 {"kind":"done"}
 ```
 
-**One exception, and it is deliberate: an untrusted folder exits `77`.** The
-"errors are in band, exit 0" rule is about a run that *started* and failed,
-which a host should render and may sensibly retry. A folder that has not been
-trusted is a refusal to start, and a host that cannot tell those apart will
-retry the one thing retrying cannot fix. It gets both: the explanation as an
-event, and the exit code as the fact that nothing ran.
+The exit code answers one question, and only that one:
+
+> **Can the caller reach the run it asked for by changing what it sends?**
+
+| Code | When |
+| --- | --- |
+| `0` | **Yes.** An unknown option, no prompt, a `--cwd` that does not exist, a `--permission-mode` that is not a mode, an interactive command named headlessly, a provider id that is not a provider. Read the `error` event, fix the invocation, send it again. |
+| `0` | A run that **started** and failed. That is an outcome to render, and possibly to retry. |
+| `1` | **No.** A named conversation that cannot be opened, no provider available, a credential or driver the session needs, a declared tool server that is not there, a command file that will not parse. A person has to go and do something first. |
+| `77` | The folder has not been trusted. Also "no", and kept its own code because only a human decision about a folder changes it. |
+
+**This rule replaced one that did not sort the cases.** The old wording was
+*started and failed → 0; refused to start → non-zero*, and by it an unknown
+option, a missing prompt, a bad `--cwd` and an unavailable tool server were all
+refusals to start — and all four exited `0` while an untrusted folder exited
+`77`. The retry argument does not sort them either: retrying an unknown option
+is exactly as pointless as retrying an untrusted folder.
+
+`1` rather than a new code because `namzu run` — the same one-shot, differing
+only in how it prints — already exits `1` for these conditions and `77` for
+trust. A host that shells to one for a script and the other for a UI should not
+be handed two tables for one fact.
+
+**Dropping `--session` is not "the caller fixing it."** It abandons what was
+asked for rather than achieving it, which is why a conversation that cannot be
+opened is on the non-zero side.
+
+**`--continue` and `--resume` are refused, not ignored.** They are `namzu run`
+options; `run-stream` binds history with `--session <id>`. They used to parse
+and do nothing, so a host that asked to reopen a conversation was given a fresh
+one and told it had succeeded.
 
 ## The event stream
 
@@ -358,7 +390,12 @@ lists what is there.
 
 **Both are `namzu run` only.** `run-stream` gets its prior turns from `--session`
 or from a JSON `Message[]` on stdin; that is the channel a host UI already has,
-and it is the one to use there.
+and it is the one to use there. Passing either to `run-stream` is refused with
+an `error` event naming `--session`, and exits `0` — the refusal is fixable by
+sending a different flag. The two commands share one option parser, so the flags
+used to parse and then do nothing: a host that asked to reopen a conversation
+got a fresh one, reported as an ordinary success. This paragraph was already
+true of the intent and false of the code.
 
 **Both refuse when the conversation cannot be reopened, and say why. Neither
 ever falls back to starting a new one.**

--- a/packages/cli/src/commands/__tests__/run-stream-exit-codes.test.ts
+++ b/packages/cli/src/commands/__tests__/run-stream-exit-codes.test.ts
@@ -1,0 +1,264 @@
+/**
+ * What `run-stream`'s exit code says, case by case.
+ *
+ * The command had a stated rule — *started and failed → 0; refused to start →
+ * non-zero* — that did not sort the cases it was applied to. An unknown option,
+ * a missing prompt, a `--cwd` that is not there and a tool server that will not
+ * connect are all refusals to start, and all four exited `0` while an untrusted
+ * folder exited `77`.
+ *
+ * The axis that does sort them, and which every assertion below is an
+ * instance of: **can the caller reach the run it asked for by changing what it
+ * sends?**
+ *
+ * Every case asserts three things together, because each one alone is
+ * satisfiable by a defect. The code, so a host branching on `$?` is right; the
+ * `error` event, so the reason is on the stream a host actually reads; and the
+ * terminating `done`, because the NDJSON contract is that every run ends with
+ * one and a refusal that forgot it would leave a line-scanner waiting forever.
+ *
+ * These tests read the handler's RETURN VALUE. Every existing test of this
+ * command discards it, which is why moving four cases across the line broke
+ * none of them.
+ */
+
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { openSessions } from '../../integrations/sessions/store.js'
+import { fakeAgentSession } from '../../tui/__fixtures__/agent-session.js'
+import { createAgentSession, probeAgentSession } from '../../tui/agent.js'
+import { runStreamCommand } from '../run-stream.js'
+import type { CommandContext } from '../types.js'
+
+vi.mock('../../integrations/sessions/store.js', () => ({
+	openSessions: vi.fn(async () => ({}) as never),
+	resolveConversation: vi.fn(async () => 'conv-1' as never),
+	loadConversation: vi.fn(async () => []),
+	appendMessages: vi.fn(async () => undefined),
+}))
+
+const trusted = { value: true }
+vi.mock('../../integrations/trust/store.js', () => ({
+	isTrusted: () => trusted.value,
+	trustDir: () => {},
+}))
+
+vi.mock('../../tui/agent.js', () => ({
+	probeAgentSession: vi.fn(async () => ({
+		preferences: { version: 3, providers: [{ id: 'anthropic' }], subagents: { active: [] } },
+		needsRepickReason: null,
+		detected: [],
+	})),
+	createAgentSession: vi.fn(async () => fakeAgentSession()),
+}))
+
+const ctx = { config: {} } as unknown as CommandContext
+
+let stdinWasTTY: boolean | undefined
+
+/** Run the command and keep BOTH halves of what it answered. */
+async function run(rawArgs: string[]): Promise<{ code: number; out: string }> {
+	const lines: string[] = []
+	const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+		lines.push(String(chunk))
+		return true
+	})
+	try {
+		const code = (await runStreamCommand.handler({ rawArgs, ctx } as never)) as number
+		return { code, out: lines.join('') }
+	} finally {
+		spy.mockRestore()
+	}
+}
+
+/** Assert the shared half: it said why, and it ended the stream. */
+function reported({ out }: { out: string }): void {
+	expect(out, 'the failure was not on the stream').toContain('"kind":"error"')
+	expect(out, 'the stream was left unterminated').toContain('"kind":"done"')
+}
+
+beforeEach(() => {
+	// A terminal, so the stateless path reads nothing rather than waiting on a
+	// pipe vitest never closes — the same reason, and the same note, as
+	// `a-named-conversation-is-not-substituted`.
+	stdinWasTTY = process.stdin.isTTY
+	Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+	trusted.value = true
+	vi.mocked(openSessions).mockImplementation(async () => ({}) as never)
+	vi.mocked(probeAgentSession).mockImplementation(async () => ({
+		preferences: { version: 3, providers: [{ id: 'anthropic' }], subagents: { active: [] } },
+		needsRepickReason: null,
+		detected: [],
+	}))
+	vi.mocked(createAgentSession).mockImplementation(async () => fakeAgentSession())
+})
+
+afterEach(() => {
+	Object.defineProperty(process.stdin, 'isTTY', { value: stdinWasTTY, configurable: true })
+	vi.restoreAllMocks()
+})
+
+describe('exit 0 — the caller can reach the run by sending something else', () => {
+	it('an unknown option', async () => {
+		const r = await run(['--format', 'json', 'hello'])
+		expect(r.code).toBe(0)
+		reported(r)
+	})
+
+	it('no prompt at all', async () => {
+		const r = await run([])
+		expect(r.code).toBe(0)
+		reported(r)
+	})
+
+	it('a --cwd that does not exist', async () => {
+		const r = await run(['--cwd', join(tmpdir(), 'namzu-no-such-dir-xyz'), 'hello'])
+		expect(r.code).toBe(0)
+		reported(r)
+	})
+
+	it('a --permission-mode that is not a mode', async () => {
+		const r = await run(['--permission-mode', 'whatever', 'hello'])
+		expect(r.code).toBe(0)
+		reported(r)
+	})
+
+	it('an interactive command named headlessly', async () => {
+		const r = await run(['/help'])
+		expect(r.code).toBe(0)
+		reported(r)
+		expect(r.out).toContain('interactive')
+	})
+
+	it('a provider id that is not a provider', async () => {
+		// `--provider` is a flag, so this is the caller's own text and the caller
+		// fixes it. It arrives through the same `hasProvider === false` branch as
+		// four environment failures, which is why the session has to say WHICH —
+		// see the classification test in `agent-classifies-its-refusal`.
+		vi.mocked(createAgentSession).mockImplementation(async () =>
+			fakeAgentSession({
+				hasProvider: false,
+				errorHint: 'Unknown provider "not-a-provider" — pick another.',
+				errorKind: 'invocation',
+			}),
+		)
+		const r = await run(['--provider', 'not-a-provider', 'hello'])
+		expect(r.code).toBe(0)
+		reported(r)
+	})
+
+	it('a run that started and then failed', async () => {
+		// Unchanged, and the case the whole in-band contract is built for: the
+		// turn ran, the host renders the failure, and retrying may well work.
+		vi.mocked(createAgentSession).mockImplementation(async () =>
+			fakeAgentSession({
+				send: async function* () {
+					yield { kind: 'error', message: 'the provider returned 503' } as never
+					yield { kind: 'done' } as never
+				},
+			}),
+		)
+		const r = await run(['hello'])
+		expect(r.code).toBe(0)
+		expect(r.out).toContain('503')
+	})
+})
+
+describe('exit 1 — nothing the caller sends changes it', () => {
+	it('a named conversation that cannot be opened', async () => {
+		// The case #314 put on the wrong side. `resolveConversation` creates the
+		// key on first use, so this can never be a key the host got wrong — the
+		// only way here is the store itself, an unwritable `.namzu` or a corrupt
+		// map file, and a host treating 0 as "render it and move on" would loop on
+		// it.
+		vi.mocked(openSessions).mockImplementation(async () => {
+			throw new Error('EACCES: permission denied')
+		})
+		const r = await run(['--session', 'nightly', 'hello'])
+		expect(r.code).toBe(1)
+		reported(r)
+	})
+
+	it('no LLM provider available at all', async () => {
+		vi.mocked(probeAgentSession).mockImplementation(async () => ({
+			preferences: null,
+			needsRepickReason: null,
+			detected: [],
+		}))
+		const r = await run(['hello'])
+		expect(r.code).toBe(1)
+		reported(r)
+	})
+
+	it('a session that came up without a provider for an environment reason', async () => {
+		vi.mocked(createAgentSession).mockImplementation(async () =>
+			fakeAgentSession({
+				hasProvider: false,
+				errorHint: 'No credential found for Anthropic.',
+				errorKind: 'environment',
+			}),
+		)
+		const r = await run(['hello'])
+		expect(r.code).toBe(1)
+		reported(r)
+	})
+
+	it('a declared tool server that is not there', async () => {
+		// Declared in `namzu.config.json`, not in the invocation, so no argument
+		// brings it up. `namzu run` already exits 1 here.
+		vi.mocked(createAgentSession).mockImplementation(async () =>
+			fakeAgentSession({ mcpFailed: [{ name: 'tickets', reason: 'ENOENT' }] as never }),
+		)
+		const r = await run(['hello'])
+		expect(r.code).toBe(1)
+		reported(r)
+		expect(r.out).toContain('tickets')
+	})
+
+	it('a command file that will not parse', async () => {
+		// The other half of the expansion refusal. No prompt fixes a file.
+		const dir = mkdtempSync(join(tmpdir(), 'namzu-cmds-'))
+		mkdirSync(join(dir, '.namzu', 'commands'), { recursive: true })
+		// Frontmatter that opens and never closes — the reader's own definition of
+		// a file it cannot use.
+		writeFileSync(join(dir, '.namzu', 'commands', 'broken.md'), '---\ndescription: half a file\n')
+		const r = await run(['--cwd', dir, '/broken', 'go'])
+		expect(r.code).toBe(1)
+		reported(r)
+		expect(r.out, 'the reader did not say what was wrong with the file').toContain('frontmatter')
+	})
+})
+
+describe('exit 77 — only a person can change it', () => {
+	it('an untrusted folder', async () => {
+		// Kept to this one condition. Being unambiguous is 77's entire
+		// justification, and widening it spends the only thing it has.
+		trusted.value = false
+		const r = await run(['hello'])
+		expect(r.code).toBe(77)
+		reported(r)
+	})
+})
+
+describe('flags this command does not implement', () => {
+	it('refuses --continue rather than quietly running stateless', async () => {
+		// The shared parser accepts both; this command reads neither. A host that
+		// asked to reopen a conversation was given a fresh one, reported as an
+		// ordinary success — the worst cell in the table this file is about, and
+		// the one no exit code could have rescued.
+		const r = await run(['--continue', 'hello'])
+		expect(r.code).toBe(0)
+		reported(r)
+		expect(r.out, 'the refusal does not say what to use instead').toContain('--session')
+	})
+
+	it('refuses --resume the same way', async () => {
+		const r = await run(['--resume', 'ses_123', 'hello'])
+		expect(r.code).toBe(0)
+		reported(r)
+		expect(r.out).toContain('--session')
+	})
+})

--- a/packages/cli/src/commands/run-stream.ts
+++ b/packages/cli/src/commands/run-stream.ts
@@ -16,20 +16,48 @@
  * persisted (stateless one-shot).
  *
  * Status lines never hit stdout (logger silenced) so every stdout line is a
- * valid JSON event. Provider/credential failures are emitted as a final
- * `{"kind":"error",…}` line (exit 0) so the host surfaces them in-band.
+ * valid JSON event, and EVERY failure is reported in band, including the ones
+ * that also carry an exit code.
  *
- * ONE condition breaks that rule and exits non-zero: a working directory the
- * operator has not trusted. Exit 0 is right for a run that STARTED and failed,
- * which a host renders and may sensibly retry; a folder that was never trusted
- * is a refusal to start, and a host that cannot tell the two apart retries the
- * one thing retrying cannot fix. That case gets both — the explanation as an
- * event, and `77` as the fact that nothing ran.
+ * ## What the exit code means
+ *
+ * It used to be explained as "a run that STARTED and failed exits 0; a refusal
+ * to start exits non-zero", and that rule did not sort the cases it was applied
+ * to. An unknown option, a missing prompt, a `--cwd` that is not there and a
+ * tool server that will not connect are all refusals to start, and all four
+ * exited 0 while an untrusted folder exited 77. Neither does the retry argument
+ * the old comment appealed to: retrying an unknown option is exactly as
+ * pointless as retrying an untrusted folder.
+ *
+ * The axis that does sort them:
+ *
+ *   CAN THE CALLER REACH THE RUN IT ASKED FOR BY CHANGING WHAT IT SENDS?
+ *
+ * - **Yes → `0`.** The host reads the `error` event and fixes its own
+ *   invocation. An unknown option, no prompt, a `--cwd` that does not exist, a
+ *   `--permission-mode` that is not a mode, an interactive command named
+ *   headlessly, a provider id that is not a provider.
+ * - **A run that started and failed → `0`.** Unchanged: that is an outcome to
+ *   render, and possibly to retry.
+ * - **No → non-zero, because a person has to go and do something.** `77` when
+ *   the folder is untrusted — kept to that one condition, because being
+ *   unambiguous is its entire justification. `1` for everything else in this
+ *   group: a conversation that cannot be opened, no provider available, a
+ *   credential or driver the session needs, a declared tool server that is not
+ *   there, a command file that will not parse.
+ *
+ * `1` rather than a new code because `namzu run` — the same one-shot, differing
+ * only in how it prints — already exits `1` for these conditions and `77` for
+ * trust. A host that shells to one for a script and the other for a UI must not
+ * be handed two tables for one fact.
+ *
+ * Dropping `--session` is NOT "the caller fixing it": it abandons what was
+ * asked for rather than achieving it.
  */
 
 import { type Message, configureLogger } from '@namzu/sdk'
 
-import { EXIT_UNTRUSTED } from '../exit-codes.js'
+import { EXIT_FAIL, EXIT_OK, EXIT_UNTRUSTED } from '../exit-codes.js'
 import type { DetectedProvider, Preferences } from '../integrations/providers/index.js'
 import {
 	appendMessages,
@@ -103,26 +131,61 @@ export const runStreamCommand: CommandDef = {
 		'Takes the same options as `namzu run`, including --permission-mode and',
 		'the [permissions] table from the config file.',
 		'',
+		'History is bound with --session <id>. --continue and --resume are `run`',
+		'options and are refused here rather than ignored.',
+		'',
 		'The folder has to be trusted: run `namzu` here once and accept the',
 		'prompt, or pass --trust for one run. An untrusted folder emits an error',
-		'event and exits 77 without running anything — the one case where this',
-		'command exits non-zero, because nothing started and a retry cannot help.',
+		'event and exits 77 without running anything.',
 		'',
 		'Needs a provider. Set a credential in the environment, or run namzu',
 		'once to pick one interactively.',
+		'',
+		'Every failure is an event on stdout. The exit code says whether YOU can',
+		'do anything about it: 0 when changing what you send would reach the run',
+		'(a wrong option, no prompt, a bad --cwd) and when a run started and',
+		'failed; 1 when it would not (no provider, a tool server that is not',
+		'there, a conversation that cannot be opened); 77 when the folder has not',
+		'been trusted, which only a person can change.',
 	].join('\n'),
 	handler: async ({ ctx, rawArgs }) => {
 		const write = (o: unknown): void => {
 			process.stdout.write(`${JSON.stringify(o)}\n`)
 		}
+		/**
+		 * Report and stop.
+		 *
+		 * Always in band, always terminated with `done`, and the code says only
+		 * whether the caller can reach the run by sending something else. The
+		 * argument for each case is in this file's header; the two spellings exist
+		 * so that every call site below has to state which side it is on rather
+		 * than inheriting a default nobody re-reads.
+		 */
 		const fail = (message: string): number => {
 			write({ kind: 'error', message })
 			write({ kind: 'done' })
-			return 0
+			return EXIT_OK
+		}
+		const refuse = (message: string): number => {
+			write({ kind: 'error', message })
+			write({ kind: 'done' })
+			return EXIT_FAIL
 		}
 
 		const flags = parseRunFlags(rawArgs)
 		if (flags.unknown.length > 0) return fail(unknownOptionMessage(flags.unknown))
+		// `--continue` and `--resume` parse here because the two commands share one
+		// parser, and this command reads neither. Accepting a flag and doing
+		// nothing with it is the failure mode the shared parser was introduced to
+		// end: a host that asked to reopen a conversation was given a stateless
+		// run, reported as an ordinary success, and the next turn had no history
+		// with nothing anywhere connecting the two. Refused instead, and named,
+		// because a host CAN fix this — `--session` is the flag it wanted.
+		if (flags.continueLast || flags.resume !== null) {
+			return fail(
+				'run-stream does not take --continue or --resume; they are `namzu run` options. Bind history with --session <id>, which keys a persisted conversation in this folder.',
+			)
+		}
 		const sessionKey = flags.session
 		const prompt = flags.rest.join(' ').trim()
 		if (!prompt) return fail('no prompt — pass it as an argument')
@@ -137,7 +200,13 @@ export const runStreamCommand: CommandDef = {
 			cwd,
 			builtins: SLASH_COMMANDS.map((c) => c.name),
 		})
-		if (expansion.kind === 'refused') return fail(expansion.reason)
+		// Two different refusals wear this one word. An interactive builtin named
+		// headlessly, or arguments handed to a template that takes none, are fixed
+		// by sending a different prompt. A command FILE that will not parse is not
+		// — and no prompt fixes a file.
+		if (expansion.kind === 'refused') {
+			return expansion.fixable ? fail(expansion.reason) : refuse(expansion.reason)
+		}
 		const finalPrompt = expansion.kind === 'expanded' ? expansion.prompt : prompt
 
 		// Before the session store is opened, before anything is read or run in
@@ -188,7 +257,15 @@ export const runStreamCommand: CommandDef = {
 				// In band, like every other failure here, because that is what the
 				// host reads. No session has been built at this point in the flow,
 				// so there is nothing to close on the way out.
-				return fail(
+				//
+				// Non-zero, which is the correction #321 is about. `resolveConversation`
+				// CREATES the key on first use, so this cannot be a key the host got
+				// wrong — the only way here is the store itself: an unwritable
+				// `.namzu`, a corrupt map file. Nothing the host sends changes that,
+				// so a host treating 0 as "render the error and move on" would loop
+				// on an environment fault it could have raised to a person. Dropping
+				// `--session` is not a fix; it abandons what was asked for.
+				return refuse(
 					`could not open conversation "${sessionKey}": ${err instanceof Error ? err.message : String(err)}. Nothing ran, because continuing the wrong history is worse than not continuing. Drop --session to run this turn stateless.`,
 				)
 			}
@@ -202,7 +279,9 @@ export const runStreamCommand: CommandDef = {
 		const probe = await probeAgentSession()
 		let prefs = probe.preferences ?? defaultPrefs(probe.detected)
 		if (!prefs) {
-			return fail(
+			// Nothing detected and nothing configured. `--provider` cannot conjure a
+			// credential, so no argument the host changes gets past this line.
+			return refuse(
 				'no LLM provider available — set a credential (e.g. ANTHROPIC_API_KEY) or run `namzu` to pick one',
 			)
 		}
@@ -242,7 +321,18 @@ export const runStreamCommand: CommandDef = {
 		})
 		if (!session.hasProvider) {
 			await session.close()
-			return fail(session.errorHint ?? 'agent is not ready')
+			// The one branch here that is genuinely BOTH. `createAgentSession`
+			// refuses an id that is not a provider — which `--provider` put there,
+			// so the host fixes it — and, with the same result object, a missing
+			// credential, a driver package that would not load, a chain that
+			// contradicts itself, a client that would not construct. None of those
+			// four move for any argument.
+			//
+			// The session says which, in a field. Deciding it here by reading its
+			// `errorHint` would be the message-matching that `exit-codes.ts` exists
+			// to prevent, and would make that sentence unrewordable.
+			const message = session.errorHint ?? 'agent is not ready'
+			return session.errorKind === 'invocation' ? fail(message) : refuse(message)
 		}
 		// A configured tool server that is not here means the turn cannot do what
 		// the operator set it up to do, and this command answers a host, not a
@@ -253,7 +343,10 @@ export const runStreamCommand: CommandDef = {
 				.map((f) => `tool server "${f.name}" is not available: ${f.reason}`)
 				.join('; ')
 			await session.close()
-			return fail(said)
+			// The servers come from `namzu.config.json`, not from the invocation, so
+			// there is no argument the host can change to bring one up. `run`
+			// already exits 1 here.
+			return refuse(said)
 		}
 
 		// "Printed on every launch" has to reach a host UI too, or the one caller

--- a/packages/cli/src/tui/__fixtures__/agent-session.ts
+++ b/packages/cli/src/tui/__fixtures__/agent-session.ts
@@ -41,6 +41,10 @@ export function fakeAgentSession(overrides: Partial<AgentSession> = {}): AgentSe
 		modelSummary: 'mock-model',
 		toolNames: () => [],
 		errorHint: null,
+		// No failure, so nothing to classify. A test about the refusal codes sets
+		// this and `hasProvider` together — they are one fact in two fields, and a
+		// session with a kind and a provider describes nothing real.
+		errorKind: null,
 		instructionFiles: [],
 		skippedInstructionFiles: [],
 		mcpConnected: [],

--- a/packages/cli/src/tui/__tests__/a-session-classifies-its-refusal.test.ts
+++ b/packages/cli/src/tui/__tests__/a-session-classifies-its-refusal.test.ts
@@ -1,0 +1,54 @@
+/**
+ * That a session which came up without a provider says WHICH KIND of failure it
+ * was.
+ *
+ * `hasProvider === false` is one flag over five different refusals, and they do
+ * not want the same response. A provider id that is not a provider came from
+ * `--provider`, so whoever typed it fixes it by typing something else; a
+ * missing credential, a driver package that would not load, a chain that
+ * contradicts itself and a client that would not construct are all about the
+ * machine, and no argument moves any of them.
+ *
+ * `run-stream` branches on that difference to choose its exit code. The
+ * exit-code suite stubs the session, so it can only prove that the COMMAND
+ * reacts to the field — this file is the other half, and without it a session
+ * that labelled everything `environment` would pass every test in the repo.
+ *
+ * The two cases below both return before any network call: the registry lookup
+ * fails on the first, and the credential check on the second.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import type { Preferences, ProviderId } from '../../integrations/providers/index.js'
+import { createAgentSession } from '../agent.js'
+
+function prefs(id: string): Preferences {
+	return { version: 3, providers: [{ id: id as ProviderId }], subagents: { active: [] } }
+}
+
+describe('a session that could not be built', () => {
+	it('calls an unknown provider id an invocation failure', async () => {
+		const session = await createAgentSession(prefs('not-a-provider'), [])
+		expect(session.hasProvider).toBe(false)
+		expect(session.errorKind).toBe('invocation')
+		// And still says it in words, because a person reads the event too.
+		expect(session.errorHint ?? '').toContain('not-a-provider')
+	})
+
+	it('calls a missing credential an environment failure', async () => {
+		// A real provider, asked for with nothing detected. Nothing the caller
+		// sends conjures a credential.
+		const session = await createAgentSession(prefs('anthropic'), [])
+		expect(session.hasProvider).toBe(false)
+		expect(session.errorKind).toBe('environment')
+	})
+
+	it('leaves the kind null when there is nothing to classify', async () => {
+		// The field is about a refusal. A session with a provider AND a kind would
+		// describe nothing real, and a reader checking the kind first would be
+		// answered about a session that works.
+		const session = await createAgentSession(prefs('not-a-provider'), [])
+		expect(session.errorKind !== null).toBe(!session.hasProvider)
+	})
+})

--- a/packages/cli/src/tui/__tests__/app-draft-survives.test.tsx
+++ b/packages/cli/src/tui/__tests__/app-draft-survives.test.tsx
@@ -58,6 +58,7 @@ vi.mock('../agent.js', async (importOriginal) => {
 			modelSummary: 'a-model',
 			toolNames: () => ['bash'],
 			errorHint: null,
+			errorKind: null,
 			instructionFiles: [],
 			skippedInstructionFiles: [],
 			mcpConnected: [],

--- a/packages/cli/src/tui/__tests__/app-permission-keys.test.tsx
+++ b/packages/cli/src/tui/__tests__/app-permission-keys.test.tsx
@@ -92,6 +92,7 @@ vi.mock('../agent.js', async (importOriginal) => {
 				modelSummary: 'a-model',
 				toolNames: () => ['bash'],
 				errorHint: null,
+				errorKind: null,
 				instructionFiles: [],
 				skippedInstructionFiles: [],
 				mcpConnected: [],

--- a/packages/cli/src/tui/__tests__/app-picker-exits.test.tsx
+++ b/packages/cli/src/tui/__tests__/app-picker-exits.test.tsx
@@ -75,6 +75,7 @@ vi.mock('../agent.js', async (importOriginal) => {
 			modelSummary: 'a-model',
 			toolNames: () => [],
 			errorHint: null,
+			errorKind: null,
 			instructionFiles: [],
 			skippedInstructionFiles: [],
 			mcpConnected: [],

--- a/packages/cli/src/tui/__tests__/ctrl-v-says-what-happened.test.tsx
+++ b/packages/cli/src/tui/__tests__/ctrl-v-says-what-happened.test.tsx
@@ -54,6 +54,7 @@ vi.mock('../agent.js', async (importOriginal) => {
 			modelSummary: 'a-model',
 			toolNames: () => [],
 			errorHint: null,
+			errorKind: null,
 			instructionFiles: [],
 			skippedInstructionFiles: [],
 			mcpConnected: [],

--- a/packages/cli/src/tui/__tests__/expand-emits-a-row.test.tsx
+++ b/packages/cli/src/tui/__tests__/expand-emits-a-row.test.tsx
@@ -80,6 +80,7 @@ vi.mock('../agent.js', async (importOriginal) => {
 			modelSummary: 'a-model',
 			toolNames: () => ['bash'],
 			errorHint: null,
+			errorKind: null,
 			instructionFiles: [],
 			skippedInstructionFiles: [],
 			mcpConnected: [],

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -232,6 +232,25 @@ export interface AgentSession {
 	readonly toolNames: () => readonly string[]
 	readonly errorHint: string | null
 	/**
+	 * WHY there is no provider, for a caller that has to act differently on the
+	 * two answers. `null` when there is one.
+	 *
+	 * - `invocation` — the caller asked for something that does not exist. A
+	 *   provider id that is not in the registry is the case: whoever typed it
+	 *   fixes it by typing something else.
+	 * - `environment` — the ask was fine and the machine cannot serve it. No
+	 *   credential, a driver package that would not load, a chain that
+	 *   contradicts itself, a client that would not construct. Nothing the
+	 *   caller sends changes any of that; a person has to go and do something.
+	 *
+	 * Reported as a field rather than left to be read out of `errorHint`,
+	 * because a caller that has to distinguish two conditions and is given only
+	 * prose ends up matching on the message text — after which the message can
+	 * never be reworded. `exit-codes.ts` makes exactly that argument about
+	 * `77`, and this is the same argument one level in.
+	 */
+	readonly errorKind: 'invocation' | 'environment' | null
+	/**
 	 * Absolute paths of the `AGENTS.md` files whose text is in this session's
 	 * system prompt — outermost first, exactly the set that was injected.
 	 *
@@ -434,7 +453,10 @@ export async function createAgentSession(
 	const primary = primaryProvider(prefs)
 	const entry = PROVIDER_REGISTRY[primary.id]
 	if (!entry) {
-		return emptySession(`Unknown provider "${primary.id}" — pick another.`)
+		// The one failure on this path that whoever asked can fix by asking for
+		// something else: `--provider` is a flag, and this id is not a provider.
+		// Every other refusal below is about the machine.
+		return emptySession(`Unknown provider "${primary.id}" — pick another.`, 'invocation')
 	}
 	const det = findDetected(detected, primary.id)
 	if (entry.requiresApiKey && (!det || !det.apiKey)) {
@@ -635,6 +657,7 @@ export async function createAgentSession(
 		],
 		close: () => mcp.close(),
 		errorHint: null,
+		errorKind: null,
 		// Reads the same object the handler mutates, at call time.
 		approvalLatched: () => approval.all,
 		promptExemptTools: () => promptExemptToolNames(registry),
@@ -1677,9 +1700,13 @@ function firstLine(result: string): string {
 	return truncate(cleaned.split('\n').find((l) => l.trim().length > 0) ?? '', 120)
 }
 
-function emptySession(errorHint: string): AgentSession {
+function emptySession(
+	errorHint: string,
+	errorKind: 'invocation' | 'environment' = 'environment',
+): AgentSession {
 	return {
 		hasProvider: false,
+		errorKind,
 		providerSummary: null,
 		modelSummary: null,
 		toolNames: () => [],

--- a/packages/cli/src/user-commands/store.ts
+++ b/packages/cli/src/user-commands/store.ts
@@ -147,7 +147,18 @@ export type HeadlessExpansion =
 	/** Not a command. Send it as written. */
 	| { readonly kind: 'unchanged'; readonly prompt: string }
 	| { readonly kind: 'expanded'; readonly prompt: string; readonly name: string }
-	| { readonly kind: 'refused'; readonly reason: string }
+	/**
+	 * `fixable` says whether the caller can get what it asked for by sending
+	 * something else.
+	 *
+	 * `true` — an interactive builtin named headlessly, or arguments given to a
+	 * template that takes none. Change the prompt and it works.
+	 *
+	 * `false` — the command FILE is the problem, and no prompt fixes a file. The
+	 * two used to be one `refused`, which is fine for a person reading the
+	 * reason and not for a host process deciding whether to try again.
+	 */
+	| { readonly kind: 'refused'; readonly reason: string; readonly fixable: boolean }
 
 /**
  * Resolve a headless prompt that may name one of the operator's own commands.
@@ -192,6 +203,7 @@ export function expandHeadlessCommand(
 		return {
 			kind: 'refused',
 			reason: `/${name} is an interactive command and does nothing in \`namzu run\`. Run \`namzu\` for the terminal agent, or pass a prompt instead.`,
+			fixable: true,
 		}
 	}
 
@@ -206,7 +218,11 @@ export function expandHeadlessCommand(
 	const expanded = expandCommand(found, rest.join(' '))
 	return expanded.ok
 		? { kind: 'expanded', prompt: expanded.prompt, name }
-		: { kind: 'refused', reason: expanded.reason }
+		: // A command whose FILE is the problem is not fixable by sending a
+			// different prompt. Taken from `found.problem` rather than from the
+			// refusal reason, because that is where the fact lives — reading it back
+			// out of the sentence would make the sentence unrewordable.
+			{ kind: 'refused', reason: expanded.reason, fixable: found.problem === undefined }
 }
 
 export type ExpandResult =


### PR DESCRIPTION
Closes #321.

The stated rule was *started and failed → 0; refused to start → non-zero*, and applied to the real cases it did not sort them. An unknown option, a missing prompt, a `--cwd` that is not there and a tool server that will not connect are all refusals to start; all four exited `0` while an untrusted folder exited `77`.

Neither does the retry argument the source comment actually appealed to: **retrying an unknown option is exactly as pointless as retrying an untrusted folder.** Both rules had to go.

## The axis, decided

> **Can the caller reach the run it asked for by changing what it sends?**

| Case | Fixable by the caller | Exit | Change |
| --- | --- | --- | --- |
| unknown option | yes | `0` | — |
| no prompt | yes | `0` | — |
| `--cwd` does not exist | yes | `0` | — |
| `--permission-mode` is not a mode | yes | `0` | — |
| interactive command named headlessly | yes | `0` | — |
| provider id that is not a provider | yes | `0` | — |
| **a run that started and failed** | — it started | `0` | — |
| untrusted folder | no | `77` | — |
| conversation cannot be opened (#314) | no | `1` | **was 0** |
| no provider available | no | `1` | **was 0** |
| session refused for an environment reason | no | `1` | **was 0** |
| declared tool server not available | no | `1` | **was 0** |
| command file that will not parse | no | `1` | **was 0** |
| `--continue` / `--resume` | yes | `0` | **was silently ignored** |

**Dropping `--session` is not "the caller fixing it"** — it abandons what was asked for rather than achieving it.

## Why `1`, and not a new code or `77`

`namzu run` — described in its own header as the same one-shot differing only in how it prints — **already exits `1` for three of these four conditions and `77` for trust**. A host that shells to one for a script and the other for a UI must not be handed two tables for one fact.

- **Not `77`.** Being unambiguous is that code's entire justification, and widening it spends the only thing it has.
- **Not a new code.** It would be more taxonomically precise and less useful: the point is that the two commands agree.
- **The "third state" objection from the issue is real but is about the docs, not the codes.** `run-stream` already had two non-zero-capable outcomes; what was wrong was a documented axis that never sorted them. `docs/cli/headless.md` is rewritten.

**Correction to my own reasoning, from the adversarial review.** I first claimed four-way parity with `run`. That is false for the conversation case: `run --resume <id>` exits `64`, because it names a conversation that must already exist and a wrong id is the caller's to fix. `run-stream --session <key>` *creates* the key on first use, so its only failure mode is the store itself — an unwritable `.namzu`, a corrupt map file. Different conditions, correctly different codes. Parity is claimed for three; the fourth is argued on its own.

## Two branches had to be split before they could be sorted

Both mixed a caller fault with an environment fault under one result, and in both cases the distinction is now carried as a **field** — because a caller that must distinguish two conditions and is given only prose ends up matching on the message text, after which the message can never be reworded. `exit-codes.ts` makes exactly that argument about `77`.

- **`AgentSession.errorKind`** — `hasProvider === false` covered a provider id that is not a provider (`--provider` put it there) *and* a missing credential, a driver that would not load, a chain that contradicts itself, a client that would not construct.
- **`HeadlessExpansion.fixable`** — a refused expansion covered an interactive builtin or surplus arguments (fix the prompt) *and* a command file that will not parse (no prompt fixes a file).

## `--continue` / `--resume`: refused, not ignored

The shared parser accepts both; this command reads neither. A host that asked to reopen a conversation was given a stateless run and told it had succeeded — the worst cell in the whole table, and one no exit code could have rescued.

`docs/cli/headless.md` **already said** both flags were `namzu run` only. It was true of the intent and false of the code, and the code now matches what was published.

## Tests

New: `packages/cli/src/commands/__tests__/run-stream-exit-codes.test.ts` (15 cases) and `packages/cli/src/tui/__tests__/a-session-classifies-its-refusal.test.ts` (3).

Every exit-code case asserts three things together, because each alone is satisfiable by a defect: the **code**, so `$?` is right; the **`error` event**, so the reason is on the stream a host reads; and the **terminating `done`**, because a refusal that forgot it leaves a line-scanner waiting forever.

These read the handler's **return value**. Every pre-existing test of this command discards it — which is why moving four cases across the line broke none of them, and is exactly the "what would this pass against?" question.

The session-classification file is the reachability half: the exit-code suite stubs the session, so on its own it proves only that the *command* reacts to the field. Without the second file, a session that labelled everything `environment` would pass every test in the repo.

| Mutation | Result |
| --- | --- |
| `refuse()` collapsed back to `0` | killed (5) |
| `fail()` promoted to `1` | killed (8) |
| conversation refusal back to `0` | killed |
| tool-server refusal back to `0` | killed |
| no-provider refusal back to `0` | killed |
| session kind ignored — everything non-zero | killed |
| session kind ignored — everything zero | killed |
| expansion fixability ignored | killed |
| `--continue`/`--resume` silently ignored again | killed (2) |
| untrusted folder folded into `1` | killed |
| unknown provider classified as `environment` | killed |
| every refusal classified as `invocation` | killed |
| a broken command file called fixable | killed |

13 of 13.

## Gates

build · typecheck · lint · test · `audit-external-names` · `docs:check` — all green.

**One pre-existing flake, measured rather than assumed.** `packages/cli/src/tui/__tests__/app-draft-survives.test.tsx` intermittently fails under the full parallel run and passes in isolation. Reproduced on **clean `origin/main` with this branch stashed**, so it is not a regression from this change. It uses fixed sleeps; `app-permission-keys.test.tsx` documents the polling cure for exactly this load cliff. Filed separately rather than folded in here.
