### PR TITLE
test(cli): the TUI can be asserted against a screen, not a frame string

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,6 +60,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
 		"@types/react": "^19.2.15",
+		"@xterm/headless": "^6.0.0",
 		"ink-testing-library": "^4.0.0",
 		"typescript": "^5.5.0",
 		"vitest": "^3.2.6"

--- a/packages/cli/src/tui/__tests__/status-bar-sits-on-the-bottom-row.test.tsx
+++ b/packages/cli/src/tui/__tests__/status-bar-sits-on-the-bottom-row.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * The status bar occupies the bottom row, and exactly one row.
+ *
+ * `status-bar-keeps-the-hint.test.tsx` establishes that the hint SURVIVES a
+ * realistic path, by asking whether the frame string contains `Ctrl+C`. That
+ * question has an answer whether the bar is one row or two, and whether it
+ * landed at the top of the terminal or the bottom — a frame string has no row
+ * geometry, so "the bottom row" is not a thing it can be asked about at all.
+ * Both files stay: this one does not replace that claim, it adds the one that
+ * needed a screen.
+ *
+ * The bar truncates to fit its width. If truncation ever failed, the line
+ * would wrap onto a second row — and every `toContain` assertion in the other
+ * file would still pass, because the text is all still there. Here it fails,
+ * because the row above the bar is required to be empty.
+ */
+
+import { Box, Text } from "ink";
+import { describe, expect, it } from "vitest";
+
+import { StatusBar } from "../StatusBar.js";
+import { renderToScreen } from "./support/screen.js";
+
+/** The picker's first-run hint: the only place its exits are named. */
+const HINT = "↑↓ navigate · enter accept · esc or Ctrl+C exit";
+
+/** Deep but unremarkable — a service inside a monorepo inside a work folder. */
+const DEEP_CWD =
+	"/home/dev/work/acme-platform/services/payments-api/packages/core";
+
+const COLS = 100;
+const ROWS = 24;
+
+/**
+ * The bar pinned to the foot of a full-height column.
+ *
+ * The spacer is this harness's, not the app's — the app derives its own from
+ * the terminal height. What is under test is not who supplies the height but
+ * what the bar does with the row it is given: occupy it, and only it.
+ */
+function bottomPinned(cwd: string) {
+	return (
+		<Box flexDirection="column" height={ROWS}>
+			<Box flexGrow={1} />
+			<StatusBar
+				cwd={cwd}
+				provider="acme-personal (acme)"
+				model="model-of-the-day"
+				state="idle"
+				hint={HINT}
+			/>
+		</Box>
+	);
+}
+
+describe("the status bar on a real screen", () => {
+	it("draws on the bottom row of the viewport", async () => {
+		const screen = await renderToScreen(bottomPinned(DEEP_CWD), {
+			cols: COLS,
+			rows: ROWS,
+		});
+		try {
+			expect(screen.row(-1)).toContain("Ctrl+C");
+			expect(screen.row(-1)).toContain("idle");
+		} finally {
+			await screen.unmount();
+		}
+	});
+
+	it("occupies one row, so the row above it stays empty", async () => {
+		const screen = await renderToScreen(bottomPinned(DEEP_CWD), {
+			cols: COLS,
+			rows: ROWS,
+		});
+		try {
+			// The claim the other file cannot make. A bar that wrapped would put
+			// its overflow here and leave `Ctrl+C` on the bottom row regardless,
+			// so every substring assertion over there would stay green.
+			expect(screen.row(-2)).toBe("");
+			// And the bar is really as wide as the terminal, not a short line
+			// that happens to fit — otherwise "it truncates" is untested.
+			expect(screen.row(-1).length).toBeGreaterThan(COLS / 2);
+			expect(screen.row(-1).length).toBeLessThanOrEqual(COLS);
+		} finally {
+			await screen.unmount();
+		}
+	});
+
+	it("leaves the transcript in the operator’s scrollback", async () => {
+		const screen = await renderToScreen(bottomPinned("/w"), {
+			cols: COLS,
+			rows: ROWS,
+		});
+		try {
+			// An app that took the alternate screen would draw identically and
+			// leave nothing behind when it exits. Only a screen-level reader can
+			// tell those two apart.
+			expect(screen.bufferType()).toBe("normal");
+		} finally {
+			await screen.unmount();
+		}
+	});
+
+	it("would have said so had it taken the alternate screen", async () => {
+		// The assertion above is worth nothing unless this reader can return
+		// the other answer, and nothing shipped here drives it to. So it is
+		// driven from the harness — the point is the reader, not the app.
+		const screen = await renderToScreen(bottomPinned("/w"), {
+			cols: COLS,
+			rows: ROWS,
+			alternateScreen: true,
+		});
+		try {
+			expect(screen.bufferType()).toBe("alternate");
+		} finally {
+			await screen.unmount();
+		}
+	});
+});
+
+describe("the viewport and the scrollback are not the same read", () => {
+	it("shows the last rows on screen and keeps the earlier ones behind", async () => {
+		// Content taller than the terminal. Without this case `viewport()` and
+		// `scrollback()` return the same rows for every test in the suite, and
+		// the offset that separates them is decoration.
+		const lines = Array.from({ length: ROWS * 2 }, (_, i) => `line-${i}`);
+		const screen = await renderToScreen(
+			<Box flexDirection="column">
+				{lines.map((line) => (
+					<Text key={line}>{line}</Text>
+				))}
+			</Box>,
+			{ cols: COLS, rows: ROWS },
+		);
+		try {
+			const visible = screen.viewport();
+			const everything = screen.scrollback();
+
+			// The screen holds the tail.
+			expect(visible).toContain(`line-${ROWS * 2 - 1}`);
+			expect(visible).not.toContain("line-0");
+			// The scrollback holds the head, which has left the screen.
+			expect(everything).toContain("line-0");
+			expect(everything.length).toBeGreaterThan(visible.length);
+		} finally {
+			await screen.unmount();
+		}
+	});
+});
+
+describe("counting what was written", () => {
+	it("writes nothing more when a rerender changes nothing", async () => {
+		const screen = await renderToScreen(bottomPinned(DEEP_CWD), {
+			cols: COLS,
+			rows: ROWS,
+		});
+		try {
+			const afterFirstPaint = screen.bytesWritten();
+			expect(afterFirstPaint).toBeGreaterThan(0);
+
+			screen.rerender(bottomPinned(DEEP_CWD));
+			await screen.waitForRender();
+
+			// "It repainted in place" is a description until something counts
+			// bytes. An identical frame is not written at all, and this is the
+			// reader that can say so — `viewport()` would look the same either
+			// way, which is precisely the blind spot.
+			expect(screen.bytesWritten()).toBe(afterFirstPaint);
+
+			// The other half, or the assertion above passes against a counter
+			// that is simply stuck.
+			screen.rerender(bottomPinned("/somewhere/else/entirely"));
+			await screen.waitForRender();
+			expect(screen.bytesWritten()).toBeGreaterThan(afterFirstPaint);
+		} finally {
+			await screen.unmount();
+		}
+	});
+
+	it("repaints in place rather than printing the bar again", async () => {
+		const screen = await renderToScreen(bottomPinned("/a"), {
+			cols: COLS,
+			rows: ROWS,
+		});
+		try {
+			screen.rerender(bottomPinned("/b"));
+			await screen.waitForRender();
+
+			// One bar on the screen, not two. A renderer that printed the new
+			// frame BELOW the old one would leave both, and the scrollback is
+			// where that shows up.
+			const drawn = screen
+				.scrollback()
+				.filter((line) => line.includes("Ctrl+C"));
+			expect(drawn.length).toBe(1);
+			expect(screen.row(-1)).toContain("/b");
+		} finally {
+			await screen.unmount();
+		}
+	});
+});

--- a/packages/cli/src/tui/__tests__/support/screen.ts
+++ b/packages/cli/src/tui/__tests__/support/screen.ts
@@ -1,0 +1,318 @@
+/**
+ * Render the TUI into an emulated terminal and read the SCREEN back.
+ *
+ * ## What the frame-string surface cannot say
+ *
+ * Every TUI test here renders through a test renderer and asserts on frame
+ * strings. A frame string has no row geometry, no scrollback and no byte
+ * count, so it cannot distinguish "printed again below" from "rewritten in
+ * place" — and that distinction is not academic. A defect this repository
+ * already found turned on exactly it: pressing the expand key produced one
+ * further frame whose transcript region was byte-identical to the previous
+ * one, and only a screen-level observation could say so.
+ *
+ * A frame string also cannot express "the bottom row". It is a blob of text
+ * with no notion of where the viewport ends, so `toContain('Ctrl+C')` passes
+ * whether the status bar is one row or two, on the last row or the first.
+ *
+ * ## What this gives instead
+ *
+ * The renderer's stdout is a **headless terminal emulator** — the same VT
+ * parser a terminal uses, with no display attached. It interprets the cursor
+ * moves and erase sequences the renderer emits, so what comes back is the
+ * screen an operator would be looking at, not the bytes on the way to it:
+ *
+ *  - {@link Screen.viewport} / {@link Screen.row} — the visible rows, indexable
+ *    from the bottom.
+ *  - {@link Screen.scrollback} — everything, including what has scrolled off.
+ *  - {@link Screen.cursor} and {@link Screen.bufferType} — where the cursor
+ *    landed, and whether the app took the alternate screen (it must not: the
+ *    transcript has to survive in the operator's scrollback).
+ *  - {@link Screen.bytesWritten} — "it repainted in place" is a description
+ *    until something counts bytes.
+ *
+ * ## Production-shaped on purpose
+ *
+ * The shipped test renderer runs the renderer in debug mode, which emits every
+ * update as a fresh full frame with no erase sequences at all. That is a
+ * different renderer from the one that ships, and a fixture unlike production
+ * tests a system that does not ship — see
+ * `docs/conventions/fixture-must-match-production.md`. So this drives the real
+ * `render` with `interactive: true` and the production frame-rate cap, which
+ * is what puts the in-place repaint on the wire in the first place.
+ *
+ * That cap is also why {@link Screen.waitForRender} exists. Fixed waits have
+ * caused three separate flakes in this suite, every one of them in scaffolding
+ * rather than in a test — so there is no duration in this file, and no test
+ * written against it should introduce one. The renderer can be asked to SETTLE
+ * its throttle, which fires the pending frame immediately; sleeping past the
+ * throttle window would reach the same frame by the one mechanism already
+ * known to go red under load.
+ */
+
+import { EventEmitter } from 'node:events'
+
+import { Terminal } from '@xterm/headless'
+import { type Instance, render } from 'ink'
+import type { ReactElement } from 'react'
+
+/** Geometry and timing the emulated terminal is built with. */
+export interface ScreenOptions {
+	/** Terminal width. */
+	readonly cols?: number
+	/** Terminal height — the number of rows a viewport read returns. */
+	readonly rows?: number
+	/**
+	 * Frame-rate cap handed to the renderer. Defaults to what ships, so a test
+	 * exercises the throttled renderer rather than an unthrottled one that
+	 * behaves differently. {@link Screen.waitForRender} settles the throttle
+	 * rather than waiting it out, so raising this does not make tests faster
+	 * and lowering it does not make them slower.
+	 */
+	readonly maxFps?: number
+	/** How many rows of scrollback the emulator keeps. */
+	readonly scrollback?: number
+	/**
+	 * Mount on the terminal's alternate screen.
+	 *
+	 * Nothing this repository ships does, and nothing should — the transcript
+	 * has to survive in the operator's scrollback. It is settable so that
+	 * {@link Screen.bufferType} can be shown to distinguish the two: an
+	 * assertion that the app stayed on the normal screen proves nothing if the
+	 * reader has no way to ever say otherwise.
+	 */
+	readonly alternateScreen?: boolean
+}
+
+/** Where the cursor is, in viewport coordinates. */
+export interface CursorPosition {
+	readonly col: number
+	readonly row: number
+}
+
+/** A mounted app plus readers for the screen it is drawing on. */
+export interface Screen {
+	/** The visible rows, top to bottom, with trailing blanks trimmed per row. */
+	viewport(): string[]
+	/**
+	 * One visible row. Negative indexes count from the bottom, so `row(-1)` is
+	 * the bottom row — the assertion a frame string cannot express.
+	 */
+	row(index: number): string
+	/** Every row the emulator holds, scrollback first. */
+	scrollback(): string[]
+	cursor(): CursorPosition
+	/**
+	 * `'alternate'` once the app has taken the alternate screen. A TUI that
+	 * does is one whose transcript never reaches the operator's scrollback.
+	 */
+	bufferType(): 'normal' | 'alternate'
+	/** Total bytes the renderer has written to stdout since mount. */
+	bytesWritten(): number
+	/** Every write, in order. The raw bytes, before the emulator interpreted them. */
+	writes(): readonly string[]
+	/** Send input, as one keypress. */
+	press(input: string): void
+	/** Swap the mounted element. Follow with `await waitForRender()`. */
+	rerender(node: ReactElement): void
+	/**
+	 * Settle: let the reconciler commit, settle the renderer's throttle so its
+	 * pending frame is written now, and drain the emulator's parser. No
+	 * duration anywhere in it.
+	 */
+	waitForRender(): Promise<void>
+	unmount(): Promise<void>
+}
+
+/** The renderer's own default frame-rate cap. */
+const DEFAULT_MAX_FPS = 30
+
+/**
+ * stdin the renderer will accept.
+ *
+ * One `write` is delivered as ONE keypress, which is why `press` is named for
+ * a press: sending `'/expand\r'` in a single call arrives with the return key
+ * unset and is taken as pasted text.
+ */
+class ScreenStdin extends EventEmitter {
+	isTTY = true
+	private data: string | null = null
+
+	press(input: string): void {
+		this.data = input
+		this.emit('readable')
+		this.emit('data', input)
+	}
+
+	read(): string | null {
+		const { data } = this
+		this.data = null
+		return data
+	}
+
+	setEncoding(): void {}
+	setRawMode(): void {}
+	resume(): void {}
+	pause(): void {}
+	ref(): void {}
+	unref(): void {}
+}
+
+/** stdout that forwards to the emulator and keeps the tally. */
+class ScreenStdout extends EventEmitter {
+	isTTY = true
+	readonly columns: number
+	readonly rows: number
+
+	readonly chunks: string[] = []
+	bytes = 0
+
+	/** Writes the emulator's parser has not finished with. */
+	private outstanding = 0
+	private readonly waiters: (() => void)[] = []
+
+	constructor(
+		private readonly term: Terminal,
+		cols: number,
+		rows: number,
+	) {
+		super()
+		this.columns = cols
+		this.rows = rows
+	}
+
+	/**
+	 * `callback` is not optional decoration: the renderer's flush writes an
+	 * EMPTY string and waits on the callback to know the stream drained. A
+	 * stdout that ignored it would hang that flush, which is the one call
+	 * {@link Screen.waitForRender} is built on.
+	 *
+	 * The empty write is not recorded — it carries no output, and putting it in
+	 * the log would make `writes()` count flushes as frames.
+	 */
+	write = (chunk: string, callback?: () => void): boolean => {
+		if (chunk.length > 0) {
+			this.chunks.push(chunk)
+			this.bytes += Buffer.byteLength(chunk, 'utf8')
+		}
+		this.outstanding += 1
+		this.term.write(chunk, () => {
+			this.outstanding -= 1
+			if (this.outstanding === 0) for (const done of this.waiters.splice(0)) done()
+			callback?.()
+		})
+		return true
+	}
+
+	/** Resolves once the parser has consumed everything written so far. */
+	drain(): Promise<void> {
+		if (this.outstanding === 0) return Promise.resolve()
+		return new Promise((resolve) => this.waiters.push(resolve))
+	}
+}
+
+const immediate = () => new Promise<void>((resolve) => setImmediate(resolve))
+
+/**
+ * Mount `node` on an emulated terminal of the given size.
+ *
+ * Resolves once the first frame is on the screen, so a caller reads without
+ * an initial wait of its own.
+ */
+export async function renderToScreen(
+	node: ReactElement,
+	options: ScreenOptions = {},
+): Promise<Screen> {
+	const cols = options.cols ?? 80
+	const rows = options.rows ?? 24
+	const maxFps = options.maxFps ?? DEFAULT_MAX_FPS
+
+	const term = new Terminal({
+		cols,
+		rows,
+		scrollback: options.scrollback ?? 1_000,
+		// A line feed alone moves DOWN, not down-and-left. On a real terminal
+		// the line-discipline layer between the process and the emulator turns
+		// it into a carriage return plus a line feed; there is no such layer
+		// here, so the emulator does it. Without this every multi-row render
+		// comes back as a staircase — which looks like a layout bug in the
+		// component and is an artefact of the harness.
+		convertEol: true,
+		allowProposedApi: true,
+	})
+	const stdout = new ScreenStdout(term, cols, rows)
+	const stdin = new ScreenStdin()
+
+	const instance: Instance = render(node, {
+		stdout: stdout as unknown as NodeJS.WriteStream,
+		stdin: stdin as unknown as NodeJS.ReadStream,
+		stderr: stdout as unknown as NodeJS.WriteStream,
+		// The two that make this the shipped renderer rather than the test one:
+		// real erase sequences and the real frame-rate cap.
+		debug: false,
+		interactive: true,
+		alternateScreen: options.alternateScreen ?? false,
+		maxFps,
+		exitOnCtrlC: false,
+		patchConsole: false,
+	})
+
+	/**
+	 * Settle, without a duration anywhere in it.
+	 *
+	 * The obvious implementation waits `1000 / maxFps` milliseconds for the
+	 * throttle's trailing edge. It is also the wrong one, and measurably so:
+	 * that is a fixed wait in scaffolding, which is what three separate flakes
+	 * in this suite have been. The renderer instead exposes a way to SETTLE the
+	 * throttle — force the pending trailing call to fire now — so the frame
+	 * lands because it was flushed, not because enough time passed.
+	 *
+	 * Mutation-checked: removing the flush leaves both byte-counting cases red.
+	 */
+	const waitForRender = async (): Promise<void> => {
+		// Let the reconciler commit and its passive effects run first, or the
+		// flush below settles a throttle that has nothing queued yet.
+		await immediate()
+		await instance.waitUntilRenderFlush()
+		await immediate()
+		await stdout.drain()
+	}
+
+	const lineAt = (index: number): string =>
+		term.buffer.active.getLine(index)?.translateToString(true) ?? ''
+
+	const screen: Screen = {
+		viewport: () => {
+			// `baseY` is where the viewport starts inside the whole buffer; rows
+			// below it are the visible ones and rows above are scrollback.
+			const top = term.buffer.active.baseY
+			return Array.from({ length: rows }, (_, i) => lineAt(top + i))
+		},
+		row: (index) => {
+			const top = term.buffer.active.baseY
+			const offset = index < 0 ? rows + index : index
+			return lineAt(top + offset)
+		},
+		scrollback: () => Array.from({ length: term.buffer.active.length }, (_, i) => lineAt(i)),
+		cursor: () => ({
+			col: term.buffer.active.cursorX,
+			row: term.buffer.active.cursorY,
+		}),
+		bufferType: () => term.buffer.active.type,
+		bytesWritten: () => stdout.bytes,
+		writes: () => stdout.chunks,
+		press: (input) => stdin.press(input),
+		rerender: (next) => instance.rerender(next),
+		waitForRender,
+		unmount: async () => {
+			instance.unmount()
+			await instance.waitUntilExit().catch(() => {})
+			instance.cleanup()
+			await stdout.drain()
+			term.dispose()
+		},
+	}
+
+	await waitForRender()
+	return screen
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
+      '@xterm/headless':
+        specifier: ^6.0.0
+        version: 6.0.0
       ink-testing-library:
         specifier: ^4.0.0
         version: 4.0.0(@types/react@19.2.15)
@@ -1595,6 +1598,9 @@ packages:
 
   '@vitest/utils@3.2.7':
     resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
+
+  '@xterm/headless@6.0.0':
+    resolution: {integrity: sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -3778,6 +3784,8 @@ snapshots:
       '@vitest/pretty-format': 3.2.7
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  '@xterm/headless@6.0.0': {}
 
   agent-base@7.1.4: {}
 


### PR DESCRIPTION
A headless terminal emulator as the TUI test surface. Test-only; one new helper, one new test file, one dev dependency.

Independent of #330 — branched off `main`, touches no file that PR touches.

## Why

TUI tests here render through a test renderer and assert on frame strings. A frame string has **no row geometry, no scrollback and no byte count**, so it cannot distinguish "printed again below" from "rewritten in place" — the distinction a defect this repository already found turned on, where pressing the expand key produced one further frame whose transcript region was byte-identical to the previous one. It also cannot express "the bottom row" at all.

## What is in it

`packages/cli/src/tui/__tests__/support/screen.ts` — `renderToScreen(node, { cols, rows })` hands a headless terminal emulator's write function to the renderer as its stdout and returns readers for the **visible viewport** (indexable from the bottom via `row(-1)`), the **full scrollback**, the **cursor**, the **active buffer type**, and a tally of **every byte written**.

Three decisions worth calling out.

**It drives the shipped renderer, not the test one.** The existing test renderer forces debug mode, which emits every update as a fresh full frame with no erase sequences — a different renderer from the one that ships, and `docs/conventions/fixture-must-match-production.md` is about exactly that. This uses `interactive: true` and the production frame-rate cap, which is what puts the in-place repaint on the wire in the first place.

**`waitForRender()` contains no duration — and this is a deviation from the brief, deliberately.** The brief asked it to "wait past the render throttle". The renderer exposes a way to *settle* the throttle: force the pending trailing frame to fire now. That reaches the same state without a timer, which is closer to the brief's stated reason (fixed waits caused three flakes here, all in scaffolding) than to its literal wording. Mutation-checked below: with no timer to fall back on, removing the flush leaves both byte-counting cases red.

**The emulator is given the tty driver's line-feed translation.** A line feed alone moves down, not down-and-left; on a real terminal the line-discipline layer converts it. Without that, every multi-row render came back as a staircase — a harness artefact that reads as a layout bug in the component. This cost the first draft of the scrollback test.

## The proof, and what it fails against

`status-bar-sits-on-the-bottom-row.test.tsx` re-expresses one existing behaviour claim: the hint occupies the **bottom row** of a 100x24 emulated viewport, and the row above it stays **empty**. `status-bar-keeps-the-hint.test.tsx` is untouched and stays — this adds the claim that needed a screen, it does not replace the one that did not.

The decisive measurement. A compound regression — the bar budgets against twice the terminal width *and* stops truncating, so the status line still contains **every character** but now spreads over two rows:

- all six assertions in `status-bar-keeps-the-hint.test.tsx`: **green**. Every substring is still there.
- `occupies one row, so the row above it stays empty`: **red**.

That is the gap, measured rather than asserted.

## Mutation table

Baseline 7 tests, 0 failing.

| # | Mutation | Killed by |
|---|---|---|
| N1 | `row(-1)` is not read from the bottom | 3 |
| N2 | the viewport starts at the top of the whole buffer, ignoring the scroll offset | 1 |
| N3 | `scrollback()` returns only the visible rows | 1 |
| N4 | the byte tally never moves after the first write | 1 |
| N5 | `bufferType()` is hard-coded to `'normal'` | 1 |
| N7 | `waitForRender()` never flushes the renderer | 2 |
| N8 | the renderer runs in debug mode (full frames, no erase sequences) | 2 |
| N9 | status bar: the line is all present but no longer fits one row | 1 (**0** from the frame-string file) |
| N10 | the bar is no longer pinned to the foot of the column | 3 |

Two findings worth reporting rather than hiding.

**N6 — "`waitForRender` does not wait past the throttle" — survived, and that is why the timer is gone.** Removing the fixed wait killed nothing, because the flush alone settles the frame; removing the flush killed nothing, because the wait alone did. Removing *both together* killed 2. Two mechanisms where one suffices is one mechanism plus a flake surface, so the timer was deleted and N7 now kills 2 on its own.

**Two readers were unfailable when first written, and both were fixed rather than kept.** `bufferType()` could never return `'alternate'` because nothing here drives it there — so `alternateScreen` is now a harness option and a case proves the reader distinguishes. `viewport()` and `scrollback()` returned identical rows in every test, making the scroll offset decoration — so a case renders content taller than the viewport and asserts the head is behind and the tail is on screen.

## Dependency

One dev dependency on `packages/cli`, providing a VT parser with no display attached. `npm pack --dry-run` on the branch: **zero** test files in the tarball (`files` already excludes `__tests__`), and a devDependency does not enter the published graph.

## Changeset: none, deliberately

The published artifact is unchanged. A `patch` would ship a byte-identical tarball under a new version number — telling every consumer there is something to take when there is not.

## Gates

build ✅ · typecheck ✅ · lint ✅ · `pnpm -r test` — **683 passed** in cli, all packages green ✅ · `audit-external-names` ✅ · `docs:check` ✅

Note on the audit: no product name appears in any comment. The package name is in `package.json` and the import specifier only, which the audit's own docblock exempts as identity rather than a borrowed idea.
