### PR TITLE
docs: the router names packages that exist

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -115,7 +115,7 @@ Cuts new versions of publishable packages via [Changesets](https://github.com/ch
 - `.changeset/config.json` — Changesets configuration.
   - `access: "public"` — all Namzu packages are public scope.
   - `updateInternalDependencies: "patch"` — when an internal dep bumps, dependents patch-bump.
-  - `ignore: ["@namzu/agents", "@namzu/api", "@namzu/cli"]` — gitignored workspace packages never published.
+  - `ignore: []` — nothing is excluded from versioning. This line previously claimed the list held `@namzu/agents`, `@namzu/api` and `@namzu/cli` as "gitignored workspace packages never published". All three parts were false: the array is empty, the first two packages do not exist, and `@namzu/cli` is published on every release. Anyone reading it would have concluded the CLI was unreleasable.
   - `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange: true` — peer dependents only bump when the peer range would otherwise exclude the new version. Avoids unnecessary provider major-bumps on SDK minor releases.
 - `.github/workflows/release.yml` — the single unified release workflow.
 - `.github/scripts/verify-consumer-install.sh` — pre-publish tarball sanity check; also invoked from `ci.yml` on every PR.

--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -80,7 +80,7 @@ There is no `surface` field. Page topic is implied by directory placement (`docs
    <mapping>
      - New exported SDK type → `"@namzu/sdk"`.
      - CLI flag change → `"@namzu/cli"`.
-     - Wire schema field added → `"@namzu/contracts"` (and consumers like `"@namzu/api"`).
+     - Wire schema field added → `"@namzu/sdk"`, where the wire types live. This example used to name two packages that do not exist.
      - Provider-specific config key → `"@namzu/<provider>"` and usually `"@namzu/sdk"` if it surfaces in SDK config too.
    </mapping>
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,19 +6,28 @@ Canonical instructions for AI agents working in this repository. `CLAUDE.md` imp
 
 Namzu is an AI agent platform. The monorepo ships:
 
-- `@namzu/contracts` — leaf types and wire schemas (no workspace imports)
 - `@namzu/sdk` — core runtime (agents, tools, providers, stores, compaction)
-- `@namzu/agents`, `@namzu/api`, `@namzu/cli` — applications
-- `@namzu/computer-use` — optional subprocess capability package
-- `@namzu/<provider>` — OpenAI, Anthropic, Bedrock, OpenRouter, HTTP, Ollama, LM Studio
+- `@namzu/cli` — the operator application
+- `@namzu/computer-use`, `@namzu/files`, `@namzu/sandbox` — optional capability packages
+- `@namzu/telemetry` — optional observability package
+- `@namzu/evals` — the eval suites
+- `@namzu/<provider>` — one driver package per service
 
 <dependency_direction>
 ```
-contracts  ←  sdk  ←  { agents | api | cli | computer-use | providers }
+sdk  ←  { cli | computer-use | files | sandbox | telemetry | evals | providers }
 ```
 
 No circular dependencies. Nothing imports from the same level or above.
 </dependency_direction>
+
+> This list previously named `@namzu/contracts`, `@namzu/agents` and
+> `@namzu/api`. **None of them exist**, and none appears in `packages/`. A
+> routing document is read by every agent before it reads anything else, so a
+> package named here is a place someone will look, import from, or reason
+> about the layering of — and the layering was stated in terms of two of them.
+> Corrected against `packages/` rather than against memory; if this list and
+> that directory ever disagree again, the directory is right.
 
 ## Build & Test
 

--- a/packages/sdk/src/manager/agent/lifecycle.ts
+++ b/packages/sdk/src/manager/agent/lifecycle.ts
@@ -48,8 +48,8 @@ import type { ThreadManager } from '../thread/lifecycle.js'
  *
  * Phase 9 Known Delta #5: fields are now unconditional required. The legacy
  * "run without deps" compat branch was removed; every `AgentManager` consumer
- * (SDK internals, `@namzu/agents`, `@namzu/api`, `@namzu/cli`) MUST wire the
- * full set before instantiating. Convention #0 (no workarounds): the
+ * (SDK internals and `@namzu/cli`; the list here once also named two packages
+ * that do not exist) MUST wire the full set before instantiating. Convention #0 (no workarounds): the
  * partially-wired mode was a migration-window bridge; 0.2.0 closes it.
  *
  * `workspaceRegistry` is required but may be empty — spawns without a


### PR DESCRIPTION
`AGENTS.md` is the first thing every agent reads, and it advertised three packages that are not in this repository — `@namzu/contracts`, `@namzu/agents` and `@namzu/api`. Two of them also carried the stated dependency direction, so the layering was expressed in terms of things that do not exist.

The list is now derived from `packages/` rather than from memory, and the correction is recorded in place so the next reader knows the directory is authoritative.

**The same three names had spread to three more places**, which is why this is not a one-line fix:

- the release skill documented a changeset `ignore` list holding them — **wrong three ways at once**: the array is empty, two of the packages do not exist, and the third (`@namzu/cli`) is published on every release. A reader would have concluded the CLI was unreleasable.
- the update-docs skill used them in a worked example a reader is meant to copy;
- an SDK source comment told consumers in two non-existent packages that they MUST wire a required set.

Found by an agent that went looking for one of them and could not find it.

**No changeset.** The only `packages/` change is a comment; nothing a consumer of the published package can observe changes, and bump intent is a claim about the consumer rather than about effort.