### PR TITLE
fix(cli): a missing credential lands where one can be entered

### DIFF
--- a/.changeset/brown-donkeys-report.md
+++ b/.changeset/brown-donkeys-report.md
@@ -1,0 +1,41 @@
+---
+'@namzu/cli': minor
+---
+
+A missing credential no longer strands you: enter one from inside namzu
+
+Launching with a provider saved in `~/.namzu/preferences.json` and no credential
+for it produced a screen you could do nothing on — a disabled composer, a hint
+that read `Ctrl+C ×2 to exit`, and a message advising you to pick another
+provider on the one screen that will not let you pick one.
+
+That launch now lands in the **picker**, with the reason printed on the picker
+itself, and you can:
+
+- press `k` to enter a credential for the saved provider and carry straight on
+  into a session, without leaving the program or setting an environment
+  variable — including when other providers are detected, which previously hid
+  the entry key entirely;
+- or choose a different provider, or leave with `Esc` / `Ctrl+C`, both named on
+  screen.
+
+Entering a credential for the saved provider keeps the rest of your saved chain,
+including a pinned model, rather than resetting you to the registry default.
+
+**The entry screen now accepts a subscription token as well as an API key.** It
+reads which kind you pasted, sends it on the wire accordingly, and says which it
+took. A pasted subscription token has no refresh data with it, so it lapses
+within hours and cannot be renewed — you are told that at the paste rather than
+discovering it as an authentication failure mid-turn. A credential is still held
+in memory for the session only and is never written to disk.
+
+Two smaller corrections ride along: a base64 credential ending in `=` padding is
+no longer rejected as a shell fragment, and a refusal that routes you to the
+picker is now drawn *on* the picker (the transcript is not rendered during that
+phase, so those explanations were previously invisible until after you had
+already chosen).
+
+Headless runs (`namzu -p`, `run-stream`, `drain`) are unchanged: a missing
+credential still refuses, with the same exit code, and never silently moves your
+run onto a different provider. The refusal's advice now names `--provider`,
+which is the thing a scripted caller can actually do.

--- a/docs/cli/providers.md
+++ b/docs/cli/providers.md
@@ -12,8 +12,33 @@ namzu is **credential-first**: it never runs a login flow. On launch it discover
 
 ## If nothing is found, you can type one
 
-When no credential is discovered, the picker offers `k` — paste a key and use it
-straight away, without leaving namzu.
+When no credential is discovered, the picker offers `k` — paste a credential and
+use it straight away, without leaving namzu.
+
+**Both kinds are accepted**: an API key, or a subscription token. namzu reads
+which one you pasted from its own shape, sends it on the wire accordingly, and
+says which kind it took. A pasted subscription token comes with no refresh data,
+so it expires within hours and namzu cannot renew it — the screen tells you that
+as you paste, rather than letting you find out as an authentication failure in
+the middle of a turn. A subscription token discovered from the macOS Keychain
+*is* renewed automatically, because that one arrives with its refresh data.
+
+## A saved provider with no credential
+
+Launching with a provider saved in `~/.namzu/preferences.json` and no credential
+for it on the machine puts you **in the picker**, with the reason printed on it.
+From there you can press `k` to enter a credential for that saved provider, or
+choose a different one; `Esc` or `Ctrl+C` leaves.
+
+This is offered even when other providers *are* detected — the list you land on
+would otherwise name every provider except the one you actually chose.
+
+Entering a credential for the saved provider keeps the rest of your saved chain,
+including a pinned model. Choosing a different provider replaces it and is
+written to your preferences as usual.
+
+Before, this launched into a screen with a disabled composer whose only advice
+was to pick another provider — on the one screen that could not pick one.
 
 **It is kept in memory for that session only and is never written anywhere.**
 The screen says so before you type and again after. To make it durable, set the

--- a/packages/cli/src/commands/__tests__/run-stream-exit-codes.test.ts
+++ b/packages/cli/src/commands/__tests__/run-stream-exit-codes.test.ts
@@ -50,6 +50,7 @@ vi.mock('../../tui/agent.js', () => ({
 	probeAgentSession: vi.fn(async () => ({
 		preferences: { version: 3, providers: [{ id: 'anthropic' }], subagents: { active: [] } },
 		needsRepickReason: null,
+		credentialGap: null,
 		detected: [],
 	})),
 	createAgentSession: vi.fn(async () => fakeAgentSession()),
@@ -91,6 +92,7 @@ beforeEach(() => {
 	vi.mocked(probeAgentSession).mockImplementation(async () => ({
 		preferences: { version: 3, providers: [{ id: 'anthropic' }], subagents: { active: [] } },
 		needsRepickReason: null,
+		credentialGap: null,
 		detected: [],
 	}))
 	vi.mocked(createAgentSession).mockImplementation(async () => fakeAgentSession())
@@ -186,6 +188,7 @@ describe('exit 1 — nothing the caller sends changes it', () => {
 		vi.mocked(probeAgentSession).mockImplementation(async () => ({
 			preferences: null,
 			needsRepickReason: null,
+			credentialGap: null,
 			detected: [],
 		}))
 		const r = await run(['hello'])

--- a/packages/cli/src/integrations/providers/index.ts
+++ b/packages/cli/src/integrations/providers/index.ts
@@ -37,6 +37,7 @@ export {
 } from './preferences.js'
 export {
 	ALL_PROVIDER_IDS,
+	missingCredentialMessage,
 	PROVIDER_REGISTRY,
 	type ProviderId,
 	type ProviderRegistryEntry,

--- a/packages/cli/src/integrations/providers/registry.ts
+++ b/packages/cli/src/integrations/providers/registry.ts
@@ -181,3 +181,24 @@ export function unsupportedProviderMessage(id: string): string {
 	)
 	return `${label} ("${id}") is not available in this build of namzu — it has no driver bundled, so no session can use it. Pick one of: ${usable}. Following it is tracked in cogitave/namzu#257.`
 }
+
+/**
+ * The sentence an operator reads when their SAVED provider needs a credential
+ * and this machine has none.
+ *
+ * Deliberately different from the one `createAgentSession` prints for the same
+ * fact, and the difference is the whole point. That one is read by a headless
+ * run, where the answers are an environment variable or `--provider`. This one
+ * is printed directly above the picker, so it names what the picker offers:
+ * enter one now, or choose something else. Advice that matches the screen it is
+ * printed on is the property the unbuildable-primary refusal already has and
+ * this case did not — see `docs/conventions/read-the-neighbour.md`.
+ *
+ * The environment variables are still named. They are how the credential
+ * becomes durable, and the entry screen holds one only for the session.
+ */
+export function missingCredentialMessage(entry: ProviderRegistryEntry): string {
+	const looked =
+		entry.envVars.length > 0 ? ` namzu looked for ${entry.envVars.join(', ')} and found none.` : ''
+	return `No credential found for ${entry.label}, your saved provider.${looked} Enter one below with "k", or choose a different provider.`
+}

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -121,6 +121,26 @@ export function App({ ctx }: AppProps) {
 	const [session, setSession] = useState<AgentSession | null>(null)
 	const [detected, setDetected] = useState<readonly DetectedProvider[]>([])
 	const [currentProvider, setCurrentProvider] = useState<ProviderId | null>(null)
+	/**
+	 * The provider the picker offers to take a credential FOR, set only when this
+	 * picker is open because that provider's credential is missing.
+	 *
+	 * Null for `/model` and for first run, where the picker is a choice rather
+	 * than a repair and offering to key in a credential for a provider nobody has
+	 * chosen yet would be answering a question that was not asked.
+	 */
+	const [keyEntryFor, setKeyEntryFor] = useState<ProviderId | null>(null)
+	/** The chain read from disk, held while the picker repairs its credential. */
+	const savedPrefsRef = useRef<Preferences | null>(null)
+	/**
+	 * Why the picker is open, drawn ON the picker.
+	 *
+	 * Pushed into the transcript as well — it belongs in the scrollback the
+	 * operator keeps — but the transcript is not rendered during this phase, so
+	 * the transcript copy alone was an explanation nobody could read at the
+	 * moment it mattered. Both refusals that route here use it.
+	 */
+	const [pickerNotice, setPickerNotice] = useState<string | null>(null)
 	const [permission, setPermission] = useState<PermissionRequest | null>(null)
 	const [activeSkills, setActiveSkills] = useState<ReadonlyArray<{ name: string; body: string }>>(
 		[],
@@ -378,6 +398,24 @@ export function App({ ctx }: AppProps) {
 			setDetected(probe.detected)
 			if (probe.needsRepickReason) {
 				pushMessage('system', probe.needsRepickReason)
+				setPickerNotice(probe.needsRepickReason)
+				setPhase('picker')
+				return
+			}
+			// The saved provider is fine and this machine has no credential for it.
+			// Routed to the picker, exactly like the unbuildable-primary case, and
+			// for the same reason: hydrating would produce a session with no
+			// provider, which sets `unhealthy` — a disabled composer where nothing
+			// the message suggested can be done. The picker is where a credential
+			// can be entered, so the picker is where the refusal belongs.
+			if (probe.credentialGap) {
+				// Kept, not discarded. The file is valid; only the secret is absent,
+				// so the chain it declares — model pins and fallbacks included — is
+				// still the operator's answer once one is supplied.
+				savedPrefsRef.current = probe.preferences
+				setKeyEntryFor(probe.credentialGap.providerId)
+				pushMessage('system', probe.credentialGap.reason)
+				setPickerNotice(probe.credentialGap.reason)
 				setPhase('picker')
 				return
 			}
@@ -913,6 +951,11 @@ export function App({ ctx }: AppProps) {
 						exit()
 						return
 					case 'repick':
+						// Opened as a choice, not as a repair. A launch-time refusal
+						// left on screen here would explain a problem that has since
+						// been solved — the session behind this picker is running.
+						setPickerNotice(null)
+						setKeyEntryFor(null)
 						setPhase('picker')
 						return
 					case 'remember':
@@ -1132,16 +1175,26 @@ export function App({ ctx }: AppProps) {
 		(credential: DetectedProvider, disposition: string) => {
 			const next = [credential, ...detected.filter((d) => d.entry.id !== credential.entry.id)]
 			setDetected(next)
+			setKeyEntryFor(null)
+			setPickerNotice(null)
 			// The disposition, not the key. `credential` never reaches a message.
 			pushMessage('system', disposition)
-			void hydrateSession(
-				{
-					version: 3,
-					providers: [{ id: credential.entry.id as ProviderId }],
-					subagents: { active: [] },
-				},
-				next,
-			)
+			// The SAVED chain when the credential is for the provider that was
+			// already chosen, and a fresh one-member chain otherwise. Rebuilding
+			// from the id alone would have been a quiet demotion in the one case
+			// this routing creates: an operator whose file pins a model, and whose
+			// only problem was a missing secret, would have been moved onto the
+			// registry default for supplying it.
+			const saved = savedPrefsRef.current
+			const prefs: Preferences =
+				saved && primaryProvider(saved).id === credential.entry.id
+					? saved
+					: {
+							version: 3,
+							providers: [{ id: credential.entry.id as ProviderId }],
+							subagents: { active: [] },
+						}
+			void hydrateSession(prefs, next)
 		},
 		[detected, hydrateSession, pushMessage],
 	)
@@ -1160,6 +1213,8 @@ export function App({ ctx }: AppProps) {
 				],
 				subagents: { active: [] },
 			}
+			setKeyEntryFor(null)
+			setPickerNotice(null)
 			try {
 				writePreferences(prefs)
 			} catch (err) {
@@ -1372,6 +1427,8 @@ export function App({ ctx }: AppProps) {
 						onSubmit={handlePickerSubmit}
 						onCancel={handlePickerCancel}
 						onCredential={handleTypedCredential}
+						keyEntryFor={keyEntryFor}
+						notice={pickerNotice}
 					/>
 				) : (
 					<>

--- a/packages/cli/src/tui/Picker.tsx
+++ b/packages/cli/src/tui/Picker.tsx
@@ -19,7 +19,13 @@ import {
 	unsupportedProviderMessage,
 } from '../integrations/providers/index.js'
 import { type ModelListing, describeProviderModels, verifyCredential } from './agent.js'
-import { describeDisposition, keyLooksUsable, maskKey, sessionCredential } from './credential-entry.js'
+import {
+	classifyCredential,
+	describeDisposition,
+	keyLooksUsable,
+	maskKey,
+	sessionCredential,
+} from './credential-entry.js'
 import { type ModelStep, modelStep } from './model-choices.js'
 import { theme } from './theme.js'
 
@@ -55,11 +61,53 @@ export interface PickerProps {
 	 * live credential into it.
 	 */
 	readonly verify?: typeof verifyCredential
+	/**
+	 * The provider a credential is MISSING for, when that is why this picker is
+	 * open.
+	 *
+	 * Two things follow from it, and both were the difference between routing an
+	 * operator here and helping them. Key entry becomes reachable on the
+	 * populated screen — with a local server running, an operator with no key for
+	 * their saved provider used to land on a list that offered no way to enter
+	 * one — and the entry targets THIS provider rather than the first
+	 * key-capable one in the registry, so the credential goes to the provider
+	 * that needed it instead of to whichever happens to be listed first.
+	 */
+	readonly keyEntryFor?: ProviderId | null
+	/**
+	 * Why this picker is open, printed on it.
+	 *
+	 * A prop and not a transcript line, because the transcript is NOT RENDERED
+	 * during this phase — the picker replaces it. Every refusal that routed here
+	 * pushed its sentence into the transcript and then drew a screen that does
+	 * not contain one, so the operator saw a provider list with no statement of
+	 * what was wrong, and the explanation appeared only once they had already
+	 * chosen and the transcript came back.
+	 *
+	 * That is the same shape as the defect this file's routing fixes, one layer
+	 * down: an explanation delivered somewhere it cannot be read.
+	 */
+	readonly notice?: string | null
 }
 
-/** Providers that take a typed API key. Local servers do not. */
+/** Providers that take a typed credential. Local servers do not. */
 function keyCapableProviders(): ProviderRegistryEntry[] {
 	return ALL_PROVIDER_IDS.map((id) => PROVIDER_REGISTRY[id]).filter((e) => e.requiresApiKey)
+}
+
+/**
+ * The provider `k` opens entry for.
+ *
+ * The saved one when this picker is open because its credential is missing;
+ * otherwise the first key-capable provider, which is what the empty screen has
+ * always done. Returns null when nothing here takes a typed credential.
+ */
+function keyEntryTarget(keyEntryFor: ProviderId | null | undefined): ProviderRegistryEntry | null {
+	if (keyEntryFor) {
+		const entry = PROVIDER_REGISTRY[keyEntryFor]
+		if (entry?.requiresApiKey) return entry
+	}
+	return keyCapableProviders()[0] ?? null
 }
 
 export function Picker({
@@ -71,6 +119,8 @@ export function Picker({
 	describeModels = describeProviderModels,
 	onCredential,
 	verify = verifyCredential,
+	keyEntryFor,
+	notice,
 }: PickerProps) {
 	const initialIndex =
 		(currentProvider !== null && currentProvider !== undefined
@@ -86,8 +136,13 @@ export function Picker({
 	} | null>(null)
 	// Key entry. `value` is the secret and never leaves this component except as
 	// a mask or as the credential handed to `onCredential`.
+	//
+	// The provider is held as the ENTRY, not as an index into a filtered registry
+	// list. The index form could only ever address the first key-capable
+	// provider, because nothing on this screen changed it — so a credential typed
+	// for a saved provider would have been built for a different one.
 	const [keyEntry, setKeyEntry] = useState<{
-		readonly providerIndex: number
+		readonly entry: ProviderRegistryEntry
 		readonly value: string
 		readonly status: 'typing' | 'checking'
 		readonly problem?: string
@@ -96,8 +151,7 @@ export function Picker({
 	const acceptKey = async (): Promise<void> => {
 		const state = keyEntry
 		if (!state) return
-		const entry = keyCapableProviders()[state.providerIndex]
-		if (!entry) return
+		const { entry } = state
 
 		const shape = keyLooksUsable(state.value)
 		if (!shape.ok) {
@@ -107,6 +161,10 @@ export function Picker({
 
 		setKeyEntry({ ...state, status: 'checking' })
 		const cred = sessionCredential(entry, state.value)
+		// Classified from the value the operator pasted, and read from the SAME
+		// function the session layer picks the wire header with, so the sentence
+		// on screen cannot disagree with the request that follows it.
+		const kind = classifyCredential(entry, state.value)
 		const verification = await verify(entry.id, cred)
 
 		if (verification.kind === 'rejected') {
@@ -115,11 +173,11 @@ export function Picker({
 			setKeyEntry({
 				...state,
 				status: 'typing',
-				problem: describeDisposition(entry, verification),
+				problem: describeDisposition(entry, verification, kind),
 			})
 			return
 		}
-		onCredential?.(cred, describeDisposition(entry, verification))
+		onCredential?.(cred, describeDisposition(entry, verification, kind))
 	}
 
 	useInput((input, key) => {
@@ -145,14 +203,29 @@ export function Picker({
 			return
 		}
 
-		// `k` from the empty screen. Only there: on a populated picker the letter
-		// would collide with navigation, and someone with a working credential is
-		// not the person this is for.
-		if (detected.length === 0 && onCredential && (input === 'k' || input === 'K')) {
-			if (keyCapableProviders().length > 0) {
-				setKeyEntry({ providerIndex: 0, value: '', status: 'typing' })
+		// `k` opens credential entry. Two screens offer it, for two reasons.
+		//
+		// The empty one always has: with nothing detected, entering a credential
+		// is the only thing that can happen here.
+		//
+		// The POPULATED one offers it when `keyEntryFor` is set, which was the
+		// gap. The old rule was "empty screen only", reasoned as "someone with a
+		// working credential is not the person this is for" — true then, and false
+		// for the person this change routes here, who has a saved provider with no
+		// credential and a local server that happens to be running. They arrived
+		// at a list that named every provider except a way to fix the one they
+		// chose. The letter does not collide with anything: navigation is arrows
+		// and digits.
+		if (
+			(detected.length === 0 || keyEntryFor) &&
+			onCredential &&
+			(input === 'k' || input === 'K')
+		) {
+			const target = keyEntryTarget(keyEntryFor)
+			if (target) {
+				setKeyEntry({ entry: target, value: '', status: 'typing' })
 			} else {
-				setErrorHint('No provider here takes a typed key.')
+				setErrorHint('No provider here takes a typed credential.')
 			}
 			return
 		}
@@ -235,16 +308,33 @@ export function Picker({
 		}
 	})
 
+	// Above every screen this picker draws, so the reason is on the same frame as
+	// the choice it is asking for.
+	const noticeBox = notice ? (
+		<Box paddingBottom={1}>
+			<Text color={theme.status.warn}>{notice}</Text>
+		</Box>
+	) : null
+
 	if (keyEntry) {
-		const entry = keyCapableProviders()[keyEntry.providerIndex]
+		const { entry } = keyEntry
+		// What the operator has typed SO FAR, classified live. It settles as they
+		// finish pasting, and it is the same question `acceptKey` asks — so the
+		// line below is a preview of the sentence they will get, not a second
+		// opinion about it.
+		const kind = classifyCredential(entry, keyEntry.value)
 		return (
 			<Box flexDirection="column" borderStyle="round" borderColor={theme.border.focus} paddingX={1}>
+				{noticeBox}
 				<Box flexDirection="column" paddingBottom={1}>
 					<Text color={theme.accent.system} bold>
-						Paste a key for {entry?.label ?? 'this provider'}
+						Paste a credential for {entry.label}
 					</Text>
+					{/* Both kinds are named because both are accepted, and someone
+					    holding a subscription token has no way to guess that a field
+					    labelled "key" wants it. */}
 					<Text color={theme.text.muted}>
-						↑↓ is not needed — type or paste, then enter. esc cancels.
+						An API key or a subscription token. Type or paste, then enter. esc cancels.
 					</Text>
 				</Box>
 				{/* The mask, never the value. */}
@@ -253,12 +343,18 @@ export function Picker({
 				</Text>
 				<Box paddingTop={1} flexDirection="column">
 					{keyEntry.status === 'checking' ? (
-						<Text color={theme.text.muted}>Checking it with {entry?.label}…</Text>
+						<Text color={theme.text.muted}>Checking it with {entry.label}…</Text>
 					) : (
 						<Text color={theme.text.secondary}>
 							Used for this session only — it is not written anywhere.
 						</Text>
 					)}
+					{keyEntry.value.length > 0 && kind === 'subscription-token' ? (
+						<Text color={theme.status.warn}>
+							Reads as a subscription token — it expires in a few hours and namzu has no
+							refresh data for a pasted one.
+						</Text>
+					) : null}
 					{keyEntry.problem ? <Text color={theme.status.warn}>{keyEntry.problem}</Text> : null}
 				</Box>
 			</Box>
@@ -276,6 +372,11 @@ export function Picker({
 		)
 	}
 
+	// Non-null exactly when `k` is live on the populated list — the same
+	// condition the key handler uses, read from one place so the hint and the
+	// keyboard cannot drift apart.
+	const entryTarget = keyEntryFor && onCredential ? keyEntryTarget(keyEntryFor) : null
+
 	if (detected.length === 0) {
 		return (
 			<Box
@@ -284,6 +385,7 @@ export function Picker({
 				borderColor={theme.status.warn}
 				paddingX={1}
 			>
+				{noticeBox}
 				<Text color={theme.status.warn} bold>
 					No providers detected
 				</Text>
@@ -315,12 +417,12 @@ export function Picker({
 				</Box>
 				<Box paddingTop={1}>
 					<Text color={theme.text.primary}>
-						Or press <Text color={theme.accent.system}>k</Text> to paste a key now and use it for
-						this session.
+						Or press <Text color={theme.accent.system}>k</Text> to paste a credential now and use
+						it for this session.
 					</Text>
 				</Box>
 				<Box paddingTop={1}>
-					<Text color={theme.text.muted}>k: enter a key · esc: exit picker</Text>
+					<Text color={theme.text.muted}>k: enter a credential · esc: exit picker</Text>
 				</Box>
 			</Box>
 		)
@@ -328,6 +430,7 @@ export function Picker({
 
 	return (
 		<Box flexDirection="column" borderStyle="round" borderColor={theme.border.focus} paddingX={1}>
+			{noticeBox}
 			<Box flexDirection="column" paddingBottom={1}>
 				<Text color={theme.accent.system} bold>
 					Choose a provider
@@ -348,7 +451,13 @@ export function Picker({
 				))}
 			</Box>
 			<Box flexDirection="column" paddingTop={1}>
-				<Text color={theme.text.muted}>↑↓ or 1-9 navigate · enter accept · esc cancel</Text>
+				{/* Named only when the key actually does something. A hint that
+				    advertises a key this screen ignores is the same defect as a
+				    message whose advice cannot be followed, one size down. */}
+				<Text color={theme.text.muted}>
+					↑↓ or 1-9 navigate · enter accept
+					{entryTarget ? ` · k enter a credential for ${entryTarget.label}` : ''} · esc cancel
+				</Text>
 				{errorHint ? <Text color={theme.status.warn}>{errorHint}</Text> : null}
 			</Box>
 		</Box>

--- a/packages/cli/src/tui/__tests__/a-credential-gap-is-not-a-missing-preference.test.ts
+++ b/packages/cli/src/tui/__tests__/a-credential-gap-is-not-a-missing-preference.test.ts
@@ -1,0 +1,125 @@
+/**
+ * A missing credential is reported WITHOUT disturbing the preferences it read.
+ *
+ * The obvious way to route the TUI into the picker is to null `preferences` and
+ * reuse `needsRepickReason`, and it would have been a silent regression for
+ * every scripted run. `run`, `run-stream` and `drain` all do
+ * `probe.preferences ?? defaultPrefs(probe.detected)` — so a null there does not
+ * refuse, it FALLS BACK, and a run pinned to a provider whose key had lapsed
+ * would quietly have moved onto whatever else the machine happened to have.
+ *
+ * That is the failure the headless refusal exists to prevent, so the gap is a
+ * field of its own and the preferences come back untouched. This file is the
+ * only place that claim is checked; the TUI tests cannot see it, because the
+ * TUI is the caller that is supposed to act on it.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+	DetectedProvider,
+	Preferences,
+	ProviderId,
+} from '../../integrations/providers/index.js'
+import { PROVIDER_REGISTRY } from '../../integrations/providers/registry.js'
+
+/** Ids are wire values and stay in literals; entries are looked up by them. */
+const SAVED: ProviderId = 'anthropic'
+const LOCAL: ProviderId = 'ollama'
+const SAVED_ENTRY = PROVIDER_REGISTRY[SAVED]
+
+const savedChain = (): Preferences => ({
+	version: 3,
+	providers: [{ id: SAVED }],
+	subagents: { active: [] },
+})
+
+const world: { prefs: Preferences; detected: readonly DetectedProvider[] } = {
+	prefs: savedChain(),
+	detected: [],
+}
+
+vi.mock('../../integrations/providers/index.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../integrations/providers/index.js')>()
+	return {
+		...actual,
+		readPreferences: () => ({ status: 'ok' as const, prefs: world.prefs }),
+		discoverProviders: async () => world.detected,
+	}
+})
+
+const { probeAgentSession } = await import('../agent.js')
+
+/** A credential for the saved provider, as discovery would report one. */
+const WITH_KEY: readonly DetectedProvider[] = [
+	{
+		entry: SAVED_ENTRY,
+		source: { kind: 'env', envName: SAVED_ENTRY.envVars[0] ?? 'A_KEY' },
+		apiKey: 'not-a-real-key',
+		alternatives: [],
+	},
+]
+
+/** A local server: detected, needs no key, and not the saved provider. */
+const LOCAL_ONLY: readonly DetectedProvider[] = [
+	{
+		entry: PROVIDER_REGISTRY[LOCAL],
+		source: { kind: 'probe', url: 'http://localhost:11434' },
+		alternatives: [],
+	},
+]
+
+beforeEach(() => {
+	world.prefs = savedChain()
+	world.detected = []
+})
+
+describe('probing with a saved provider that has no credential', () => {
+	it('reports the gap and still hands back the chain it read', async () => {
+		const probe = await probeAgentSession()
+
+		expect(probe.credentialGap?.providerId).toBe(SAVED)
+		// The half a headless caller depends on. Nulling this would turn a refusal
+		// into a silent provider switch.
+		expect(probe.preferences, 'the saved chain was thrown away').toEqual(world.prefs)
+		expect(probe.needsRepickReason, 'a valid file was reported as unreadable').toBeNull()
+	})
+
+	it('names the provider and what was looked for', async () => {
+		const probe = await probeAgentSession()
+		const reason = probe.credentialGap?.reason ?? ''
+
+		expect(reason).toContain(SAVED_ENTRY.label)
+		for (const envVar of SAVED_ENTRY.envVars) {
+			expect(reason, envVar).toContain(envVar)
+		}
+	})
+
+	it('still reports the gap when something else is running', async () => {
+		// A detected provider is not a credential for the saved one, and the
+		// membership test has to be per-provider rather than "did discovery find
+		// anything at all".
+		world.detected = LOCAL_ONLY
+		expect((await probeAgentSession()).credentialGap?.providerId).toBe(SAVED)
+	})
+})
+
+describe('probing when nothing is missing', () => {
+	it('reports no gap when the credential is there', async () => {
+		world.detected = WITH_KEY
+		const probe = await probeAgentSession()
+
+		expect(probe.credentialGap).toBeNull()
+		expect(probe.preferences).toEqual(world.prefs)
+	})
+
+	it('reports no gap for a provider that takes no credential', async () => {
+		// A local server needs no key, so "no key found" is not a fact about it.
+		// Reporting one would route the operator into the picker to fix something
+		// that was never wrong.
+		world.prefs = { version: 3, providers: [{ id: LOCAL }], subagents: { active: [] } }
+		world.detected = LOCAL_ONLY
+
+		expect((await probeAgentSession()).credentialGap).toBeNull()
+	})
+})

--- a/packages/cli/src/tui/__tests__/credential-prompt-draws.test.tsx
+++ b/packages/cli/src/tui/__tests__/credential-prompt-draws.test.tsx
@@ -53,7 +53,10 @@ describe('the no-credential screen', () => {
 		expect(lastFrame()).toContain('No providers detected')
 		// The cliff this closes: the screen used to end at "restart namzu".
 		expect(lastFrame()).toContain('restart namzu')
-		expect(lastFrame()).toMatch(/press .*k.* to paste a key|k: enter a key/s)
+		// "credential" and not "key": the screen accepts a subscription token as
+		// well, and a field labelled for one of the two kinds is a field the
+		// holder of the other kind will not use.
+		expect(lastFrame()).toMatch(/press .*k.* to paste a credential|k: enter a credential/s)
 		unmount()
 	})
 })
@@ -63,7 +66,7 @@ describe('the credential prompt', () => {
 		const { lastFrame, stdin, unmount } = open()
 		stdin.write('k')
 		await flush()
-		expect(lastFrame()).toContain('Paste a key')
+		expect(lastFrame()).toContain('Paste a credential')
 		unmount()
 	})
 
@@ -127,7 +130,7 @@ describe('the credential prompt', () => {
 		expect(frame).toContain('HTTP 401')
 		expect(frame).toContain('Nothing was stored')
 		// Still on the screen, so a one-character slip is fixable...
-		expect(frame).toContain('Paste a key')
+		expect(frame).toContain('Paste a credential')
 		// ...and the key is still not on it.
 		expect(frame).not.toContain(KEY)
 		expect(onCredential).not.toHaveBeenCalled()

--- a/packages/cli/src/tui/__tests__/no-credential-reaches-a-screen-that-helps.test.tsx
+++ b/packages/cli/src/tui/__tests__/no-credential-reaches-a-screen-that-helps.test.tsx
@@ -1,0 +1,306 @@
+/**
+ * A saved provider with no credential must land somewhere an operator can act.
+ *
+ * The defect this pins: a saved primary that requires a key, launched on a
+ * machine with none, produced an empty session — `hasProvider: false` — which
+ * sets the `unhealthy` phase. That phase is a disabled composer whose only hint
+ * is "Ctrl+C x2 to exit", and the refusal printed on it ended with "or pick
+ * another provider". The advice named the one screen that cannot follow it.
+ *
+ * ## Why this drives `<App>` on a screen and not a helper
+ *
+ * Every piece of this existed already and none of it was reachable. The picker
+ * could take a credential; the probe could see there was none; the phase
+ * machine could route. Only a mounted app decides which of those runs, so a
+ * unit test on any one of them stays green with the operator still stranded —
+ * see `docs/conventions/mutation-check-every-test.md` on a helper test not
+ * proving its caller.
+ *
+ * Asserting on the MESSAGE would prove nothing at all: the message was always
+ * there. What was missing is a screen that can act on it, so what is asserted
+ * is what the operator can reach — the credential field, the disclosure it
+ * makes, and a running session on the other side of it.
+ *
+ * The real `probeAgentSession` runs here. Only its two inputs are replaced (the
+ * preferences file, and what discovery found), because those are the machine
+ * this operator was sitting at.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+	DetectedProvider,
+	Preferences,
+	ProviderId,
+} from '../../integrations/providers/index.js'
+import { PROVIDER_REGISTRY } from '../../integrations/providers/registry.js'
+import type { AgentEvent, AgentSession } from '../agent.js'
+import type { TuiContext } from '../types.js'
+import { renderToScreen, type Screen } from './support/screen.js'
+
+/**
+ * The three providers this exercises, named as ids and looked up.
+ *
+ * Ids are wire values and live in string literals; labels are read from the
+ * registry rather than spelled out. A test that hardcodes a label both plants a
+ * third-party name in tracked prose and goes stale the day the registry is
+ * reworded.
+ */
+const SAVED: ProviderId = 'anthropic'
+const OTHER_KEY_PROVIDER: ProviderId = 'openai'
+const LOCAL: ProviderId = 'ollama'
+
+const SAVED_LABEL = PROVIDER_REGISTRY[SAVED].label
+const OTHER_KEY_LABEL = PROVIDER_REGISTRY[OTHER_KEY_PROVIDER].label
+
+/** The operator's file: a provider chosen, and a model pinned on it. */
+const SAVED_PREFS: Preferences = {
+	version: 3,
+	providers: [{ id: SAVED, model: 'a-pinned-model' }],
+	subagents: { active: [] },
+}
+
+/** A local server, which needs no key — so the picker draws a populated list. */
+const LOCAL_ONLY: readonly DetectedProvider[] = [
+	{
+		entry: PROVIDER_REGISTRY[LOCAL],
+		source: { kind: 'probe', url: 'http://localhost:11434' },
+		alternatives: [],
+	},
+]
+
+const world: {
+	prefs: Preferences
+	detected: readonly DetectedProvider[]
+	built: Preferences | null
+	credentials: DetectedProvider[]
+} = { prefs: SAVED_PREFS, detected: [], built: null, credentials: [] }
+
+vi.mock('../../integrations/trust/store.js', () => ({ isTrusted: () => true, trustDir: () => {} }))
+vi.mock('../../integrations/updates.js', () => ({ checkUpdates: async () => [] }))
+vi.mock('../../integrations/sessions/store.js', () => ({
+	openSessions: async () => ({ tenantId: 't' }),
+	startConversation: async () => 'conv',
+	appendMessages: async () => {},
+	listRecent: async () => [],
+	loadConversation: async () => [],
+}))
+vi.mock('../../user-commands/store.js', () => ({ discoverUserCommands: () => [] }))
+
+// The machine, not the logic. `readPreferences` and `discoverProviders` are the
+// two leaves the real probe reads; everything between them stays real.
+vi.mock('../../integrations/providers/index.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../integrations/providers/index.js')>()
+	return {
+		...actual,
+		readPreferences: () => ({ status: 'ok' as const, prefs: world.prefs }),
+		discoverProviders: async () => world.detected,
+		writePreferences: () => {},
+	}
+})
+
+vi.mock('../agent.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../agent.js')>()
+	return {
+		...actual,
+		describeProviderModels: async () => ({ kind: 'ok' as const, models: [] }),
+		// The provider's answer, stubbed. Verification honesty is pinned by
+		// `credential-prompt-draws.test.tsx`; what matters here is that a good
+		// credential carries on into a session.
+		verifyCredential: async () => ({ kind: 'verified' as const }),
+		createAgentSession: async (prefs: Preferences, det: readonly DetectedProvider[]) => {
+			world.built = prefs
+			world.credentials = det.filter((d) => d.source.kind === 'session')
+			return {
+				hasProvider: true,
+				providerSummary: 'a-provider',
+				modelSummary: prefs.providers[0]?.model ?? 'a-model',
+				toolNames: () => [],
+				errorHint: null,
+				errorKind: null,
+				instructionFiles: [],
+				skippedInstructionFiles: [],
+				mcpConnected: [],
+				mcpFailed: [],
+				agentIds: [],
+				configNotices: [],
+				resumeDurable: async () => {
+					throw new Error('not used by the TUI')
+				},
+				close: async () => {},
+				approvalLatched: () => false,
+				promptExemptTools: () => [],
+				send: async function* (): AsyncIterable<AgentEvent> {
+					yield { kind: 'done', stopReason: 'end_turn' } as AgentEvent
+				},
+			} satisfies AgentSession
+		},
+	}
+})
+
+const { App } = await import('../App.js')
+
+const ctx: TuiContext = { cwd: '/w', version: '0.0.0-test' }
+
+/** Everything the emulator holds, so a line that scrolled off still counts. */
+function text(screen: Screen): string {
+	return screen.scrollback().join('\n')
+}
+
+/**
+ * Poll until the screen says `needle`, or give up.
+ *
+ * A poll on a condition, not a fixed wait: the app's launch path is two awaited
+ * promises deep and a duration here would be the scaffolding flake this suite
+ * has already had three of.
+ */
+async function until(screen: Screen, needle: string, attempts = 400): Promise<void> {
+	for (let i = 0; i < attempts; i += 1) {
+		if (text(screen).includes(needle)) return
+		await new Promise((r) => setTimeout(r, 0))
+		await screen.waitForRender()
+	}
+}
+
+async function launch(): Promise<Screen> {
+	const screen = await renderToScreen(<App ctx={ctx} />, { cols: 100, rows: 40 })
+	await until(screen, 'No credential found')
+	return screen
+}
+
+beforeEach(() => {
+	world.prefs = SAVED_PREFS
+	world.detected = []
+	world.built = null
+	world.credentials = []
+})
+
+describe('launching with a saved provider and no credential', () => {
+	it('reaches a screen that takes a credential, not a disabled composer', async () => {
+		const screen = await launch()
+		try {
+			// The refusal, and then the thing that makes it a refusal rather than a
+			// dead end: the picker, which `unhealthy` is not.
+			expect(text(screen)).toContain('No credential found')
+			expect(text(screen), 'landed on the phase with no way out').not.toContain(
+				'Ctrl+C ×2 to exit',
+			)
+
+			screen.press('k')
+			await until(screen, 'Paste a credential')
+
+			expect(text(screen)).toContain('Paste a credential')
+			// For the provider that was actually missing one.
+			expect(text(screen)).toContain(SAVED_LABEL)
+		} finally {
+			await screen.unmount()
+		}
+	})
+
+	it('starts the session from what was typed, without leaving the program', async () => {
+		const screen = await launch()
+		try {
+			screen.press('k')
+			await until(screen, 'Paste a credential')
+			screen.press('sk-ant-api03-not-a-real-key')
+			await until(screen, '••••')
+			screen.press('\r')
+			await until(screen, 'Type a message')
+
+			// The whole point of the change: a running session, reached from inside
+			// namzu by an operator who launched it with nothing.
+			expect(text(screen), 'never reached a usable composer').toContain('Type a message')
+			expect(world.built, 'no session was built').not.toBeNull()
+			expect(world.credentials, 'the typed credential never reached the session').toHaveLength(1)
+		} finally {
+			await screen.unmount()
+		}
+	})
+
+	it('keeps the model the file pinned, having only been missing a secret', async () => {
+		const screen = await launch()
+		try {
+			screen.press('k')
+			await until(screen, 'Paste a credential')
+			screen.press('sk-ant-api03-not-a-real-key')
+			await until(screen, '••••')
+			screen.press('\r')
+			await until(screen, 'Type a message')
+
+			// Rebuilding the chain from the provider id alone would silently move
+			// this operator onto the registry default for the crime of supplying a
+			// key.
+			expect(world.built?.providers[0]?.model).toBe('a-pinned-model')
+		} finally {
+			await screen.unmount()
+		}
+	})
+
+	it('says it took a subscription token, and that it will lapse', async () => {
+		const screen = await launch()
+		try {
+			screen.press('k')
+			await until(screen, 'Paste a credential')
+			screen.press('sk-ant-oat01-not-a-real-token')
+			await until(screen, 'Reads as a subscription token')
+
+			// Told at the paste, on the value they actually typed. Discovering it as
+			// a 401 mid-turn is the difference between a feature and a trap.
+			expect(text(screen)).toContain('Reads as a subscription token')
+			expect(text(screen)).toContain('expires')
+
+			screen.press('\r')
+			await until(screen, 'Type a message')
+			expect(text(screen), 'the disclosure did not survive into the session').toContain(
+				'no refresh data',
+			)
+		} finally {
+			await screen.unmount()
+		}
+	})
+})
+
+describe('when something else is running on the machine', () => {
+	it('still offers to take a credential for the saved provider', async () => {
+		// The case the old "empty screen only" gate got wrong. A local server is
+		// detected, so the picker draws a list — and the operator's actual problem,
+		// a missing key for the provider they chose, is not on it.
+		world.detected = LOCAL_ONLY
+		const screen = await launch()
+		try {
+			expect(text(screen), 'the populated list never drew').toContain('Choose a provider')
+			// Advertised before it is pressed: a key nothing on screen names is a
+			// key nobody presses.
+			expect(text(screen)).toContain('k enter a credential')
+
+			screen.press('k')
+			await until(screen, 'Paste a credential')
+
+			expect(text(screen)).toContain('Paste a credential')
+			expect(text(screen)).toContain(SAVED_LABEL)
+		} finally {
+			await screen.unmount()
+		}
+	})
+})
+
+describe('the credential is for the provider that needed one', () => {
+	it('targets the saved provider, not the first one in the registry', async () => {
+		// Entry used to address a fixed index into the key-capable list, which is
+		// the FIRST such provider whatever was saved. With that provider saved the
+		// bug is invisible, so this saves a different one.
+		world.prefs = { version: 3, providers: [{ id: OTHER_KEY_PROVIDER }], subagents: { active: [] } }
+		const screen = await launch()
+		try {
+			screen.press('k')
+			await until(screen, 'Paste a credential')
+
+			expect(text(screen)).toContain(OTHER_KEY_LABEL)
+			expect(text(screen), 'the credential was offered to the wrong provider').not.toContain(
+				SAVED_LABEL,
+			)
+		} finally {
+			await screen.unmount()
+		}
+	})
+})

--- a/packages/cli/src/tui/__tests__/no-credential-reaches-a-screen-that-helps.test.tsx
+++ b/packages/cli/src/tui/__tests__/no-credential-reaches-a-screen-that-helps.test.tsx
@@ -260,6 +260,48 @@ describe('launching with a saved provider and no credential', () => {
 	})
 })
 
+describe('after the credential has been supplied', () => {
+	it('does not keep explaining a problem that is solved', async () => {
+		// The failure path of the routing rather than its happy path: a launch
+		// refusal left on the picker would greet an operator who opens `/model`
+		// from a working session with the reason their PREVIOUS launch failed, and
+		// offer to fix a credential they already entered.
+		const screen = await launch()
+		try {
+			screen.press('k')
+			await until(screen, 'Paste a credential')
+			screen.press('sk-ant-api03-not-a-real-key')
+			await until(screen, '••••')
+			screen.press('\r')
+			await until(screen, 'Type a message')
+
+			screen.press('/model')
+			await until(screen, '/model')
+			screen.press('\r')
+			await until(screen, 'Choose a provider')
+
+			// The LIVE picker box, not the whole viewport. The launch refusal is
+			// also sitting further up the terminal as transcript history, which is
+			// where it belongs and must not be asserted away — the claim here is
+			// about what the picker itself is drawing right now.
+			const rows = screen.viewport()
+			const lastBorder = rows.reduce((at, row, i) => (row.includes('╭') ? i : at), 0)
+			const box = rows.slice(lastBorder)
+			const drawn = box.join('\n')
+
+			expect(drawn, 'the picker never reopened').toContain('Choose a provider')
+			expect(drawn, 'a stale launch refusal is drawn on the picker').not.toContain(
+				'No credential found',
+			)
+			expect(drawn, 'still offering to repair a credential that is present').not.toContain(
+				'k enter a credential',
+			)
+		} finally {
+			await screen.unmount()
+		}
+	})
+})
+
 describe('when something else is running on the machine', () => {
 	it('still offers to take a credential for the saved provider', async () => {
 		// The case the old "empty screen only" gate got wrong. A local server is

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -81,6 +81,7 @@ import {
 	findDetected,
 	isAnthropicOAuthToken,
 	isRegistered,
+	missingCredentialMessage,
 	primaryProvider,
 	readAgentKeychainCredential,
 	readPreferences,
@@ -387,6 +388,27 @@ export interface AgentSessionContext {
 	readonly preferences: Preferences | null
 	readonly needsRepickReason: string | null
 	readonly detected: readonly DetectedProvider[]
+	/**
+	 * The saved chain is fine and the MACHINE has no credential for its primary.
+	 *
+	 * A separate field rather than a second flavour of `needsRepickReason`, and
+	 * separate from nulling `preferences`, because the three readers of this
+	 * object want different things from it:
+	 *
+	 *  - the TUI routes into the picker, where the operator can enter a
+	 *    credential or choose something else;
+	 *  - `run`, `run-stream` and `drain` do `probe.preferences ?? defaultPrefs(...)`,
+	 *    so nulling preferences here would silently move a scripted run onto
+	 *    whatever else happened to be detected — the opposite of a refusal;
+	 *  - `createAgentSession` refuses again on its own, which is what keeps those
+	 *    headless exit codes and their `errorKind` classification unchanged.
+	 *
+	 * Carries the provider id as well as the sentence: a surface that offers to
+	 * take a credential has to know which provider it is for, and re-deriving
+	 * that from `preferences` at the call site is the same lookup in a second
+	 * place.
+	 */
+	readonly credentialGap: { readonly providerId: ProviderId; readonly reason: string } | null
 }
 
 /**
@@ -398,12 +420,55 @@ export async function probeAgentSession(): Promise<AgentSessionContext> {
 	const detected = await discoverProviders()
 	switch (read.status) {
 		case 'ok':
-			return { preferences: read.prefs, needsRepickReason: null, detected }
+			return {
+				preferences: read.prefs,
+				needsRepickReason: null,
+				detected,
+				credentialGap: credentialGap(read.prefs, detected),
+			}
 		case 'missing':
-			return { preferences: null, needsRepickReason: null, detected }
+			return { preferences: null, needsRepickReason: null, detected, credentialGap: null }
 		case 'needs-repick':
-			return { preferences: null, needsRepickReason: read.reason, detected }
+			return {
+				preferences: null,
+				needsRepickReason: read.reason,
+				detected,
+				credentialGap: null,
+			}
 	}
+}
+
+/**
+ * Whether the saved primary needs a key that discovery did not find.
+ *
+ * Asked HERE rather than at construction, which is where it used to be asked
+ * and is the whole defect. `createAgentSession` can only answer by returning an
+ * empty session, and an empty session sets the `unhealthy` phase — a disabled
+ * composer from which `/model` cannot be typed. So the refusal ended with "or
+ * pick another provider" printed on the one screen that will not let you. The
+ * neighbouring branch, an unbuildable primary, was moved to read time for
+ * exactly this reason; see `describeInvalidChain` in `preferences.ts`.
+ *
+ * Only the PRIMARY, matching that neighbour's asymmetry. A fallback with no
+ * credential is dropped from the chain at launch with a notice (`planFallbacks`)
+ * and the session still runs on the primary the operator has; taking that
+ * session away over a spare would be the trade the notice already refuses.
+ */
+function credentialGap(
+	prefs: Preferences,
+	detected: readonly DetectedProvider[],
+): { providerId: ProviderId; reason: string } | null {
+	const primary = primaryProvider(prefs)
+	const entry = PROVIDER_REGISTRY[primary.id]
+	// An id that is not a provider, or one with no driver in this build, is
+	// already `needs-repick` from `readPreferences` and never reaches here. If
+	// one ever did, it is not a credential problem and must not be reported as
+	// one — a wrong diagnosis sends the operator to paste a key that would not
+	// have helped.
+	if (!entry || !entry.constructible || !entry.requiresApiKey) return null
+	const det = findDetected(detected, primary.id)
+	if (det?.apiKey) return null
+	return { providerId: primary.id, reason: missingCredentialMessage(entry) }
 }
 
 // Builtins we don't expose: `verify_outputs` — a host-side check rather
@@ -536,8 +601,16 @@ export async function createAgentSession(
 	}
 	const det = findDetected(detected, primary.id)
 	if (entry.requiresApiKey && (!det || !det.apiKey)) {
+		// The BACKSTOP, not the operator-facing answer. The TUI never reaches this
+		// line any more: `probeAgentSession` reports the same gap as a
+		// `credentialGap` and the App routes into the picker, where a credential
+		// can actually be entered. What still arrives here is a headless caller —
+		// `run`, `run-stream`, `drain` — which has no picker and for which both
+		// pieces of advice below are real: an environment variable, or
+		// `--provider`. Keeping the refusal is what makes those runs fail rather
+		// than quietly start on something else.
 		return emptySession(
-			`No credential found for ${entry.label}. Set one of: ${entry.envVars.join(', ')} — or pick another provider.`,
+			`No credential found for ${entry.label}. Set one of: ${entry.envVars.join(', ')} — or pass --provider with one that is configured.`,
 		)
 	}
 	try {

--- a/packages/cli/src/tui/credential-entry.test.ts
+++ b/packages/cli/src/tui/credential-entry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+	classifyCredential,
 	describeDisposition,
 	keyLooksUsable,
 	maskKey,
@@ -80,6 +81,37 @@ describe('keyLooksUsable', () => {
 		// format is worse than one that lets the provider answer.
 		expect(keyLooksUsable('completely-unfamiliar-but-plausible-000').ok).toBe(true)
 	})
+
+	it('accepts a base64 token carrying padding', () => {
+		// The check used to reject any `=` anywhere. That is harmless for an API
+		// key and wrong for a subscription token: a JWT-shaped one is base64 and
+		// may end in padding, so the screen refused a valid credential and told
+		// the operator their paste was a shell fragment. Nothing about it is.
+		expect(keyLooksUsable('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.c2ln==').ok).toBe(true)
+	})
+})
+
+describe('classifyCredential', () => {
+	it('reads a subscription token from its own shape', () => {
+		expect(classifyCredential(entry, 'sk-ant-oat01-abc')).toBe('subscription-token')
+		expect(classifyCredential(entry, 'eyJhbGciOiJIUzI1NiJ9.abc')).toBe('subscription-token')
+	})
+
+	it('reads a console key as a key', () => {
+		expect(classifyCredential(entry, KEY)).toBe('api-key')
+	})
+
+	it('trims first, so a pasted trailing newline does not change the answer', () => {
+		expect(classifyCredential(entry, '  sk-ant-oat01-abc\n')).toBe('subscription-token')
+	})
+
+	it('does not invent the distinction for providers that lack it', () => {
+		const other = { ...(entry as object), id: 'openai' } as never
+		// Every other driver takes an API key and nothing else. Answering
+		// "subscription token" for one would put a wording on screen that the
+		// wire cannot honour.
+		expect(classifyCredential(other, 'eyJhbGciOiJIUzI1NiJ9.abc')).toBe('api-key')
+	})
 })
 
 describe('describeDisposition', () => {
@@ -101,12 +133,17 @@ describe('describeDisposition', () => {
 		// covers two things: a driver that declares no credential probe, and one
 		// whose probe could not be reached. The old phrase asserted the first and
 		// would be false for a probe that timed out.
+		//
+		// Adjusted when the sentence started naming the KIND of credential it
+		// took ("accepted the API key"), which is a claim this file did not
+		// previously make and the operator now depends on. The assertion tracks
+		// the claim, not the old wording.
 		const unverifiable = describeDisposition(entry, { kind: 'unverifiable' })
 		expect(unverifiable).toContain('NOT checked')
-		expect(unverifiable).not.toContain('accepted the key')
+		expect(unverifiable).not.toContain('accepted the')
 
 		const verified = describeDisposition(entry, { kind: 'verified' })
-		expect(verified).toContain('accepted the key')
+		expect(verified).toContain('accepted the API key')
 	})
 
 	it('reports a rejection without implying anything was kept', () => {
@@ -117,8 +154,37 @@ describe('describeDisposition', () => {
 
 	it('never contains a key, because it is never given one', () => {
 		// The signature is the guarantee: a function with no access to the secret
-		// cannot put it in a message that reaches a transcript.
+		// cannot put it in a message that reaches a transcript. `kind` is a
+		// classification of the secret, not the secret — and it is defaulted, so
+		// it does not count toward the arity this assertion reads.
 		expect(describeDisposition.length).toBe(2)
+	})
+
+	it('discloses that a pasted subscription token cannot be renewed', () => {
+		// The whole reason the kind is tracked. A discovered subscription token
+		// arrives with refresh data and is renewed between turns; a pasted one has
+		// none, so it lapses in hours. Said at the paste, or discovered as a 401
+		// mid-turn.
+		const text = describeDisposition(entry, { kind: 'verified' }, 'subscription-token')
+		expect(text).toContain('subscription token')
+		expect(text).toContain('expires')
+		expect(text).toContain('no refresh data')
+	})
+
+	it('does not warn about expiry for a key that does not expire', () => {
+		const text = describeDisposition(entry, { kind: 'verified' }, 'api-key')
+		expect(text).not.toContain('expires')
+		expect(text).toContain('API key')
+	})
+
+	it('names the kind in a rejection too', () => {
+		const text = describeDisposition(
+			entry,
+			{ kind: 'rejected', reason: '401' },
+			'subscription-token',
+		)
+		expect(text).toContain('subscription token')
+		expect(text).toContain('Nothing was stored')
 	})
 })
 
@@ -132,5 +198,13 @@ describe('sessionCredential', () => {
 
 	it('is marked as typed, so a surface can say it disappears', () => {
 		expect(sessionCredential(entry, KEY).source).toEqual({ kind: 'session' })
+	})
+
+	it('claims no refresh path, for a subscription token as much as a key', () => {
+		// `oauth` means "renewable from a refresh token", and the session layer
+		// gates its refresh on the field being present. A paste supplies no
+		// refresh token, so filling it in would turn a disclosed expiry into a
+		// silent 401 at the moment the token lapsed.
+		expect(sessionCredential(entry, 'sk-ant-oat01-abc').oauth).toBeUndefined()
 	})
 })

--- a/packages/cli/src/tui/credential-entry.ts
+++ b/packages/cli/src/tui/credential-entry.ts
@@ -26,7 +26,37 @@
  * unverifiable.
  */
 
-import type { DetectedProvider, ProviderRegistryEntry } from '../integrations/providers/index.js'
+import {
+	type DetectedProvider,
+	type ProviderRegistryEntry,
+	isAnthropicOAuthToken,
+} from '../integrations/providers/index.js'
+
+/**
+ * Which kind of secret was pasted.
+ *
+ * The distinction is not cosmetic: the two travel differently on the wire —
+ * `constructProvider` sends one as `authToken` and the other as `apiKey` — and
+ * they expire differently. A subscription token is short-lived and is renewed
+ * from refresh metadata that only the discovered credential carries; a hand
+ * pasted one has none, so it lapses in hours with nothing to renew it. An
+ * operator who is not told that at the moment they paste discovers it as a 401
+ * mid-turn, which is the difference between a feature and a trap.
+ */
+export type CredentialKind = 'api-key' | 'subscription-token'
+
+/**
+ * Classify a pasted secret by its own shape.
+ *
+ * Reuses the classifier the session layer already decides the wire header with
+ * (`isAnthropicOAuthToken`), so the screen cannot say one thing while the
+ * request says another. Every other provider takes an API key and nothing else,
+ * so asking the question of them would invent a distinction they do not have.
+ */
+export function classifyCredential(entry: ProviderRegistryEntry, key: string): CredentialKind {
+	if (entry.id !== 'anthropic') return 'api-key'
+	return isAnthropicOAuthToken(key.trim()) ? 'subscription-token' : 'api-key'
+}
 
 /**
  * What a key looks like on screen. Never the key.
@@ -58,11 +88,15 @@ export function keyLooksUsable(key: string): { ok: true } | { ok: false; reason:
 	if (/\s/.test(trimmed)) {
 		return { ok: false, reason: 'That contains a space — check for a truncated or wrapped paste.' }
 	}
-	if (trimmed.startsWith('$') || trimmed.includes('=')) {
+	// Assignment-SHAPED, not "contains an equals sign". The old test rejected any
+	// `=` anywhere, which is fine for an API key and wrong for a subscription
+	// token: a JWT-shaped one is base64 and may carry `=` padding, so the screen
+	// refused a valid credential and blamed the operator's paste for it. This
+	// still catches the case the check exists for — `ANTHROPIC_API_KEY=sk-…`
+	// copied out of a shell profile — because that has a variable name in front.
+	if (trimmed.startsWith('$') || /^[A-Za-z_][A-Za-z0-9_]*=/.test(trimmed)) {
 		return {
 			ok: false,
-			// The classic: pasting `ANTHROPIC_API_KEY=sk-…` or `$MY_KEY` from a
-			// shell profile rather than the value.
 			reason: 'That looks like a shell assignment or variable. Paste the key itself.',
 		}
 	}
@@ -79,27 +113,33 @@ export type Verification =
 /**
  * What namzu tells the operator it did with what they typed.
  *
- * Every branch says three things: that it worked or did not, that the key is
- * held for this session only, and the environment variable that persists it.
- * The middle one is the part a person is most likely to assume otherwise —
- * typing a credential into an application usually means it was saved.
+ * Every branch says four things: that it worked or did not, WHICH KIND of
+ * credential it took, that it is held for this session only, and the
+ * environment variable that persists it. The third is the part a person is most
+ * likely to assume otherwise — typing a credential into an application usually
+ * means it was saved.
+ *
+ * The kind is said out loud because the two behave differently after this
+ * screen, and only one of them can be renewed. See {@link CredentialKind}.
  */
 export function describeDisposition(
 	entry: ProviderRegistryEntry,
 	verification: Verification,
+	kind: CredentialKind = 'api-key',
 ): string {
+	const noun = kind === 'subscription-token' ? 'subscription token' : 'API key'
 	const persist = entry.envVars[0]
 	const durable = persist
 		? `To keep it, set ${persist} in your shell and restart.`
 		: 'To keep it, configure the credential in your environment and restart.'
 
 	if (verification.kind === 'rejected') {
-		return `${entry.label} rejected that key: ${verification.reason}\nNothing was stored.`
+		return `${entry.label} rejected that ${noun}: ${verification.reason}\nNothing was stored.`
 	}
 
 	const checked =
 		verification.kind === 'verified'
-			? `${entry.label} accepted the key.`
+			? `${entry.label} accepted the ${noun}.`
 			: // Said plainly rather than implied. Claiming a key is good would be
 				// inventing a verification that did not happen — and this now covers
 				// two ways of not happening: a driver that declares no credential
@@ -107,9 +147,20 @@ export function describeDisposition(
 				// wording asserted the first ("offers no way to check it"), which
 				// would be false for a probe that timed out. Neither is a bad key,
 				// and neither is a checked one.
-				`Key accepted, but NOT checked — ${entry.label} could not confirm it just now, so the first message will be the test.`
+				`${noun.replace(/^./, (c) => c.toUpperCase())} accepted, but NOT checked — ${entry.label} could not confirm it just now, so the first message will be the test.`
 
-	return `${checked}\nHeld in memory for this session only — it is not written anywhere. ${durable}`
+	// Disclosed HERE, at the paste, and not left to be discovered as a 401 in the
+	// middle of a turn. A discovered subscription token arrives with a refresh
+	// token and an expiry, and the session layer renews it between turns; a
+	// pasted one carries neither, so there is nothing to renew it with. Saying
+	// "it lasts hours" is the honest form of a limitation we cannot remove
+	// without an authorization flow namzu does not have.
+	const expiry =
+		kind === 'subscription-token'
+			? '\nA pasted subscription token has no refresh data with it, so it expires in a few hours and namzu cannot renew it — expect to enter it again.'
+			: ''
+
+	return `${checked}\nHeld in memory for this session only — it is not written anywhere. ${durable}${expiry}`
 }
 
 /**
@@ -118,6 +169,13 @@ export function describeDisposition(
  * Shaped exactly like a discovered one so every downstream path — session
  * construction, the model picker, `/provider` — treats it identically. The only
  * difference is `source`, so a surface can say where it came from.
+ *
+ * `oauth` is deliberately NOT set, for a subscription token as much as for an
+ * API key. That field means "this credential can be renewed from a refresh
+ * token", the session layer gates its refresh on it, and a hand-pasted token
+ * supplies no refresh token — so filling it in would claim a renewal path that
+ * does not exist and turn a disclosed expiry into a silent 401. The disclosure
+ * in `describeDisposition` is the substitute.
  */
 export function sessionCredential(entry: ProviderRegistryEntry, key: string): DetectedProvider {
 	return {


### PR DESCRIPTION
## The defect

Launching `namzu` with a provider saved in `~/.namzu/preferences.json` and no
credential for it on the machine returned an empty session, which sets the
`unhealthy` phase — a disabled composer where `/model` cannot be typed, whose
only hint is `Ctrl+C ×2 to exit`. The refusal printed there ended with *"or pick
another provider"*, addressed to the one screen that will not let you pick one.

The repository already knew this sentence. `preferences.ts` reasons it out for
the **unbuildable-primary** case — refused at read time and routed to the picker,
"a refusal whose advice cannot be followed is not a refusal; it is a dead end
wearing one". The missing-credential case sat one branch away and never got it.
`docs/conventions/read-the-neighbour.md` in production.

## What this does

**Routes at probe time.** `probeAgentSession` is the only function holding both
halves of the question — the file and the machine — so it reports a
`credentialGap` and the App puts the operator in the picker with the reason on
screen.

It is a **field of its own**, not a null `preferences`, and that is load-bearing:
`run`, `run-stream` and `drain` all do `probe.preferences ?? defaultPrefs(...)`,
so nulling it would turn a headless refusal into a silent provider switch on the
worst day. `createAgentSession` still refuses, which leaves every headless exit
code and its `errorKind` classification untouched. Pinned by
`a-credential-gap-is-not-a-missing-preference.test.ts`.

**Makes the destination able to help.** Routing alone was not enough. Credential
entry was gated to the *empty* picker and always addressed the first key-capable
provider in the registry — so with a local server running, the operator landed on
a list naming every provider except a way to fix the one they had chosen. Entry
is now reachable when there is a saved provider to repair, targets that provider,
and keeps the saved chain (a pinned model included) when the credential is for
the provider already chosen.

**Takes a subscription token, and says so.** Classified with the same function
the session layer picks its wire header with, so the screen cannot disagree with
the request that follows it. A pasted subscription token is deliberately **not**
given `oauth` metadata — that field means *renewable from a refresh token*, the
session layer gates its refresh on it, and inventing one would convert a
disclosed expiry into a silent 401. The expiry is disclosed at the paste instead,
live on the entry screen and again in the acceptance message.

Storage stays **session-only**, and the existing argument for that still holds
(the keychain helper is one platform and writes another product's store; a
plaintext file is the operator's call, not a bug fix's). What changed is the
cost of it: re-entry is now two keystrokes on every launch instead of a dead end.

## Two defects found while testing

1. **The picker phase does not render the transcript.** Every refusal that routed
   there pushed its explanation into a component that is not on screen, so the
   operator saw a provider list with no statement of the problem and the reason
   appeared only after they had already chosen. That includes the pre-existing
   re-pick route, whose own comment claims the sentence is "printed above it".
   The reason is now a prop drawn on the picker.
2. **`keyLooksUsable` rejected any `=`**, which refuses a base64 credential
   carrying padding and blames the operator's paste for it. Narrowed to an
   assignment shape.

## Explicitly not here

No browser-based authorization flow, and no widening of the existing refresh
path's use of its hardcoded client id. This change makes the question sharper —
a pasted subscription token is the one credential namzu accepts and cannot renew
— and stops there.

## Gates

| gate | result |
|---|---|
| `pnpm build` | pass |
| `pnpm typecheck` | pass |
| `pnpm lint` | pass (2 pre-existing warnings in cli, 22 in sdk) |
| `pnpm test` | pass — cli 83 files / 772 passed / 3 skipped; sdk 352 / 3178 |
| `pnpm docs:check` | pass — 0 problems |
| `node scripts/audit-external-names.mjs` | pass (exit 0) |
| `node .github/scripts/verify-public-surface.mjs` | pass — runtime 555/555, declared 1276/1276 |

Mutation table in a follow-up comment.
