### PR TITLE
feat(cli): sign in with a subscription, from inside namzu

### DIFF
--- a/.changeset/subscription-sign-in.md
+++ b/.changeset/subscription-sign-in.md
@@ -1,0 +1,36 @@
+---
+'@namzu/cli': minor
+---
+
+Sign in with a subscription instead of pasting an API key.
+
+`/login` runs an authorization-code sign-in with PKCE and stores the result in
+`~/.namzu/credentials.json`, on every platform. namzu refreshes it as it
+expires and finds it again on the next launch; `/logout` removes it. If you
+already use an environment variable or a typed key, nothing changes — this adds
+a door, it does not move one.
+
+**On a machine with no browser** the sign-in still works. namzu prints the
+address; open it wherever you have a browser and hand the result back with
+`/login <address-or-code>`. namzu tells you at the time whether the automatic
+hand-back is available on your machine, rather than leaving you waiting for one
+that is not.
+
+**The credential file is private, and namzu proves it rather than assuming it.**
+It is written owner-only and the protection is then read back — the mode on
+Linux and macOS, the access-control list on Windows, where a POSIX mode proves
+nothing. If that check cannot be made the file is deleted and the sign-in fails
+with a reason.
+
+**Whose OAuth client namzu presents is recorded in the source, next to the
+value** (`packages/cli/src/integrations/providers/identity.ts`). It is not
+namzu's own: the authorization server accepts no other client for plan-backed
+inference and the vendor operates no open registration, so the choice was
+between using it and not offering the capability. You sign in on the vendor's
+page against your own account; nothing is proxied through a namzu service.
+
+Nothing is added to a package's runtime dependencies, and no existing export
+changes shape. Two additions a consumer of `@namzu/cli`'s types may notice:
+`DetectionSource` gains a `'stored'` member, so an exhaustive `switch` over it
+needs an arm; and a discovered provider's `oauth` metadata gains an optional
+`origin`, which defaults to the previous behaviour when omitted.

--- a/docs/cli/providers.md
+++ b/docs/cli/providers.md
@@ -8,7 +8,63 @@ related_packages: ["@namzu/cli", "@namzu/anthropic", "@namzu/openai", "@namzu/op
 
 # Providers & credentials
 
-namzu is **credential-first**: it never runs a login flow. On launch it discovers credentials already present on your machine and lets you choose which LLM provider to chat through.
+namzu is **credential-first**: on launch it discovers credentials already present on your machine and lets you choose which LLM provider to chat through. If it finds none, it can also sign you in — see [Signing in with a subscription](#signing-in-with-a-subscription) below.
+
+## Signing in with a subscription
+
+If you pay for a plan rather than for API usage, `/login` gets you a credential
+without an API key and without installing anything else.
+
+```
+/login
+```
+
+namzu prints an address and tries to open it in your browser. Sign in there;
+when the page finishes, namzu picks the result up and reconnects on its own.
+
+**On a machine with no browser** — a container, a remote shell, a server — open
+the printed address wherever you *do* have a browser, then bring the result
+back:
+
+```
+/login http://localhost:53692/callback?code=…&state=…
+```
+
+The whole address works, and so does just the code. namzu says which of the two
+routes is available to you at the time: if it could not open a listener on this
+machine (the port is busy, or the environment forbids listening), it tells you
+so rather than leaving you waiting for a hand-back that is never coming.
+
+### Where the credential goes
+
+`~/.namzu/credentials.json`, on every platform, readable **only by your
+account**. namzu sets that protection when it writes the file and then reads it
+back to check — on Linux and macOS by re-reading the mode, on Windows by
+removing inherited permissions, granting your account alone, and re-reading the
+resulting access-control list. **If that check cannot be made, the file is
+deleted and the sign-in fails.** A credential store that cannot show it is
+private is worse than none.
+
+namzu refreshes the credential as it expires and finds it again on the next
+launch. `/logout` removes it. Removing it here does not revoke anything at the
+provider — do that in your account settings.
+
+Nothing is written until a sign-in has fully succeeded, so an abandoned or
+rejected attempt leaves nothing behind. No token is ever printed, logged, or
+included in an error message.
+
+### Whose identity you sign in as
+
+namzu presents the OAuth client the vendor's own command-line tool is
+registered under, because the authorization server accepts no other client for
+plan-backed inference and that vendor operates no open registration. The
+sign-in happens on the vendor's page, against your account; no namzu service
+sees the credential and nothing is proxied. See
+`packages/cli/src/integrations/providers/identity.ts`, where the choice and its
+consequences are recorded next to the value.
+
+If you would rather not use it, the other doors are unchanged: set an
+environment variable, or type a key at the picker.
 
 ## If nothing is found, you can type one
 
@@ -19,13 +75,13 @@ straight away, without leaving namzu.
 The screen says so before you type and again after. To make it durable, set the
 environment variable the same screen names, and restart.
 
-That is a deliberate limit rather than an unfinished one. The obvious durable
-home would be the OS keychain, and namzu's keychain support is macOS-only and
-reads a *different* product's credential store — writing your key there would
-file it under someone else's name, and on Windows there is no keychain path at
-all. The remaining option was a plaintext file, and a secret at rest should be
-something you chose rather than something that arrived because you typed into a
-text field.
+That is a deliberate limit rather than an unfinished one, and it is still the
+limit now that a credential store exists. A secret at rest should be something
+you chose, not something that arrived because you typed into a text field — and
+`/login` is the choosing. There, you asked for a credential and namzu obtained
+it; here, you pasted one namzu had no part in and cannot refresh, verify the
+provenance of, or remove on your behalf. Writing it to disk without being asked
+would be namzu deciding that for you.
 
 While you type, only a mask is shown — never the key, and never its length. The
 key is checked with the provider at the moment you enter it, by listing models,
@@ -43,14 +99,15 @@ terminal.
 namzu scans these sources, in order, and offers whatever it finds:
 
 1. **Environment variables** — e.g. `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`.
-2. **macOS Keychain** — the Claude Code OAuth credential (`Claude Code-credentials`). This lets namzu reuse an existing Claude Code sign-in with no API key. macOS only.
-3. **Local probes** — a reachable Ollama server (e.g. `localhost:11434`).
+2. **namzu's own credential store** — `~/.namzu/credentials.json`, written by `/login`. Every platform.
+3. **macOS Keychain** — the Claude Code OAuth credential (`Claude Code-credentials`). This lets namzu reuse an existing Claude Code sign-in with no API key. macOS only.
+4. **Local probes** — a reachable Ollama server (e.g. `localhost:11434`).
 
 > **Removed in 0.7.0:** namzu also used to read the `secrets.toml` of an external peer daemon it integrated with, ahead of the Keychain. That integration is gone. A credential kept only in that file is no longer found — export it as one of the environment variables above instead. `namzu doctor` lists the sources actually scanned.
 
 If nothing is found, namzu shows the picker in an empty state explaining exactly which environment variable to set (or to start Ollama), then restart.
 
-**The Keychain path is macOS-only.** On Windows and Linux there are exactly two doors: an environment variable, or a reachable local server. A credential kept only in your OS credential store is not found on those platforms.
+**The Keychain path is macOS-only**, and reads a credential belonging to a co-installed tool, so it can only help someone who has that tool on that operating system. Source 2 is what closed the gap it used to leave: on Windows and Linux, `/login` gets you a credential of your own, and namzu prefers it over a borrowed one when both are present.
 
 **A local server that is not running is not listed.** Appearing in the list means namzu can use that provider *right now* — `namzu doctor` reads presence itself as "reachable" for a provider that needs no key, and the chain builder will build a member from it. An entry for a server that is down would make both of those wrong. The empty-state screen above is where you are told a local server is an option, and it names both ports.
 

--- a/packages/cli/src/doctor/checks/credentials.ts
+++ b/packages/cli/src/doctor/checks/credentials.ts
@@ -50,6 +50,8 @@ export const credentialSourcesCheck: DoctorCheck = {
 					return `${d.entry.id} (env · ${d.source.envName})`
 				case 'keychain':
 					return `${d.entry.id} (keychain · ${d.source.service})`
+				case 'stored':
+					return `${d.entry.id} (signed in · ${d.source.path})`
 				case 'probe':
 					return `${d.entry.id} (local · ${d.source.url.replace(/^https?:\/\//, '')})`
 			}

--- a/packages/cli/src/integrations/providers/credential-store.test.ts
+++ b/packages/cli/src/integrations/providers/credential-store.test.ts
@@ -1,0 +1,176 @@
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	statSync,
+	writeFileSync,
+} from 'node:fs'
+import { platform, tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { removeTempDir } from '../../__fixtures__/temp-dir.js'
+import {
+	assertSoleOwnerSddl,
+	clearStoredSubscriptionCredential,
+	CredentialStoreError,
+	credentialsPath,
+	readStoredSubscriptionCredential,
+	writeStoredSubscriptionCredential,
+} from './credential-store.js'
+
+const SECRET = 'oat-secret-access-value'
+const REFRESH = 'oat-secret-refresh-value'
+
+let home: string
+
+beforeEach(() => {
+	home = mkdtempSync(join(tmpdir(), 'namzu-cred-'))
+})
+afterEach(() => {
+	removeTempDir(home)
+})
+
+describe('round trip', () => {
+	it('reads back exactly what was written', () => {
+		const at = writeStoredSubscriptionCredential(
+			{ accessToken: SECRET, refreshToken: REFRESH, expiresAt: 1234, scopes: ['a', 'b'] },
+			home,
+		)
+		expect(at).toBe(credentialsPath(home))
+		expect(readStoredSubscriptionCredential(home)).toEqual({
+			accessToken: SECRET,
+			refreshToken: REFRESH,
+			expiresAt: 1234,
+			scopes: ['a', 'b'],
+		})
+	})
+
+	it('is absent, not thrown, when nothing was ever stored', () => {
+		expect(readStoredSubscriptionCredential(home)).toBeNull()
+	})
+
+	it('is absent when the file is not JSON', () => {
+		const path = credentialsPath(home)
+		mkdirSync(dirname(path), { recursive: true })
+		writeFileSync(path, 'not json at all')
+		expect(readStoredSubscriptionCredential(home)).toBeNull()
+	})
+
+	it('is absent when the envelope carries no access token', () => {
+		const path = credentialsPath(home)
+		mkdirSync(dirname(path), { recursive: true })
+		writeFileSync(path, JSON.stringify({ version: 1, subscription: { refreshToken: REFRESH } }))
+		expect(readStoredSubscriptionCredential(home)).toBeNull()
+	})
+
+	it('clears, and clearing something absent is still success', () => {
+		writeStoredSubscriptionCredential({ accessToken: SECRET }, home)
+		clearStoredSubscriptionCredential(home)
+		expect(existsSync(credentialsPath(home))).toBe(false)
+		expect(() => clearStoredSubscriptionCredential(home)).not.toThrow()
+	})
+
+	it('overwrites a previous credential rather than accumulating', () => {
+		writeStoredSubscriptionCredential({ accessToken: 'first' }, home)
+		writeStoredSubscriptionCredential({ accessToken: 'second' }, home)
+		expect(readStoredSubscriptionCredential(home)?.accessToken).toBe('second')
+		const raw = readFileSync(credentialsPath(home), 'utf8')
+		expect(raw).not.toContain('first')
+	})
+
+	it('leaves no temporary file behind', () => {
+		writeStoredSubscriptionCredential({ accessToken: SECRET }, home)
+		// A leftover temp file would be a SECOND copy of the credential, and the
+		// one whose protection nothing re-checks after the rename.
+		const entries = readdirSync(dirname(credentialsPath(home)))
+		expect(entries.filter((e) => e.includes('.tmp.'))).toEqual([])
+	})
+})
+
+describe('the file is private, and the store proves it', () => {
+	it.skipIf(platform() === 'win32')('has no group or other permission bits', () => {
+		writeStoredSubscriptionCredential({ accessToken: SECRET }, home)
+		const mode = statSync(credentialsPath(home)).mode
+		expect(mode & 0o077).toBe(0)
+	})
+
+	it.skipIf(platform() !== 'win32')('grants exactly the current account', () => {
+		// The Windows arm proves itself by not throwing: `restrictToOwner` reads
+		// the access-control list back and refuses when it is not sole-owner.
+		expect(() => writeStoredSubscriptionCredential({ accessToken: SECRET }, home)).not.toThrow()
+		expect(readStoredSubscriptionCredential(home)?.accessToken).toBe(SECRET)
+	})
+})
+
+/**
+ * The Windows assertion, exercised on every platform.
+ *
+ * `restrictToOwner` can only run where its tooling exists, and a security
+ * check that is only ever executed on one operating system is a check most
+ * contributors never see fail. The comparison itself is pure, so it is tested
+ * everywhere — including the case that motivated writing it as a loop.
+ */
+describe('assertSoleOwnerSddl', () => {
+	const US = 'S-1-5-21-1-2-3-1001'
+	const THEM = 'S-1-1-0'
+
+	it('accepts a protected list granting only us', () => {
+		expect(() => assertSoleOwnerSddl(`D:PAI(A;;FA;;;${US})`, US, 'p')).not.toThrow()
+	})
+
+	it('accepts a differently-cased identifier', () => {
+		expect(() =>
+			assertSoleOwnerSddl(`D:PAI(A;;FA;;;${US.toLowerCase()})`, US, 'p'),
+		).not.toThrow()
+	})
+
+	it('refuses a second allow entry naming somebody else', () => {
+		// The case a check that stopped at the first match would call private.
+		expect(() => assertSoleOwnerSddl(`D:PAI(A;;FA;;;${US})(A;;FA;;;${THEM})`, US, 'p')).toThrow(
+			CredentialStoreError,
+		)
+	})
+
+	it('refuses an allow entry naming somebody else FIRST', () => {
+		expect(() => assertSoleOwnerSddl(`D:PAI(A;;FA;;;${THEM})(A;;FA;;;${US})`, US, 'p')).toThrow(
+			CredentialStoreError,
+		)
+	})
+
+	it('refuses a list that still inherits from its parent', () => {
+		expect(() => assertSoleOwnerSddl(`D:AI(A;;FA;;;${US})`, US, 'p')).toThrow(CredentialStoreError)
+	})
+
+	it('refuses a list with no entries at all', () => {
+		expect(() => assertSoleOwnerSddl('D:P', US, 'p')).toThrow(CredentialStoreError)
+	})
+
+	it('refuses a descriptor with no discretionary list', () => {
+		expect(() => assertSoleOwnerSddl('O:BAG:BA', US, 'p')).toThrow(CredentialStoreError)
+	})
+
+	it('refuses a list that only denies, granting nobody', () => {
+		expect(() => assertSoleOwnerSddl(`D:PAI(D;;FA;;;${THEM})`, US, 'p')).toThrow(
+			CredentialStoreError,
+		)
+	})
+
+	it('tolerates a deny entry naming somebody else beside our grant', () => {
+		expect(() =>
+			assertSoleOwnerSddl(`D:PAI(D;;FA;;;${THEM})(A;;FA;;;${US})`, US, 'p'),
+		).not.toThrow()
+	})
+
+	it('never puts the path-holder secret in its message', () => {
+		try {
+			assertSoleOwnerSddl(`D:PAI(A;;FA;;;${THEM})`, US, '/home/x/.namzu/credentials.json')
+			throw new Error('expected a refusal')
+		} catch (err) {
+			expect((err as Error).message).toContain('/home/x/.namzu/credentials.json')
+			expect((err as Error).message).not.toContain(SECRET)
+		}
+	})
+})

--- a/packages/cli/src/integrations/providers/credential-store.test.ts
+++ b/packages/cli/src/integrations/providers/credential-store.test.ts
@@ -2,8 +2,8 @@ import {
 	existsSync,
 	mkdirSync,
 	mkdtempSync,
-	readdirSync,
 	readFileSync,
+	readdirSync,
 	statSync,
 	writeFileSync,
 } from 'node:fs'
@@ -13,10 +13,13 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { removeTempDir } from '../../__fixtures__/temp-dir.js'
 import {
+	CredentialStoreError,
+	assertOwnerOnlyMode,
 	assertSoleOwnerSddl,
 	clearStoredSubscriptionCredential,
-	CredentialStoreError,
 	credentialsPath,
+	currentUserSid,
+	readAclSddl,
 	readStoredSubscriptionCredential,
 	writeStoredSubscriptionCredential,
 } from './credential-store.js'
@@ -97,11 +100,59 @@ describe('the file is private, and the store proves it', () => {
 		expect(mode & 0o077).toBe(0)
 	})
 
-	it.skipIf(platform() !== 'win32')('grants exactly the current account', () => {
-		// The Windows arm proves itself by not throwing: `restrictToOwner` reads
-		// the access-control list back and refuses when it is not sole-owner.
-		expect(() => writeStoredSubscriptionCredential({ accessToken: SECRET }, home)).not.toThrow()
+	it.skipIf(platform() !== 'win32')('grants exactly the current account, and nobody else', () => {
+		writeStoredSubscriptionCredential({ accessToken: SECRET }, home)
+		// Asserted from OUTSIDE the write, against the real list the filesystem
+		// ended up with. Checking only that the write did not throw would leave
+		// the whole protection step deletable without a single test noticing,
+		// on the platform the step exists for.
+		const sddl = readAclSddl(credentialsPath(home))
+		const sid = currentUserSid()
+		expect(sid).not.toBeNull()
+		expect(sddl).not.toBeNull()
+		expect(() => assertSoleOwnerSddl(sddl as string, sid as string, 'p')).not.toThrow()
 		expect(readStoredSubscriptionCredential(home)?.accessToken).toBe(SECRET)
+	})
+
+	it.skipIf(platform() !== 'win32')('does not leave the directory it inherited from open', () => {
+		writeStoredSubscriptionCredential({ accessToken: SECRET }, home)
+		// `P` — the protected flag. Without it the file still takes whatever the
+		// parent grants, which on a shared machine is the whole point missed.
+		expect(readAclSddl(credentialsPath(home))).toMatch(/D:[A-Z]*P/)
+	})
+})
+
+/**
+ * The POSIX assertion, exercised on every platform.
+ *
+ * The branch that calls this only runs off Windows, so on Windows the check
+ * is unreachable and a mutation deleting it kills nothing there. Testing the
+ * comparison directly is what closes that: the rule is checked by whoever is
+ * running the suite, whatever they are running it on.
+ */
+describe('assertOwnerOnlyMode', () => {
+	it('accepts a file only its owner can read or write', () => {
+		expect(() => assertOwnerOnlyMode(0o100600, 'p')).not.toThrow()
+		expect(() => assertOwnerOnlyMode(0o100400, 'p')).not.toThrow()
+	})
+
+	it('refuses a bit granted to the group', () => {
+		expect(() => assertOwnerOnlyMode(0o100640, 'p')).toThrow(CredentialStoreError)
+	})
+
+	it('refuses a bit granted to everyone else', () => {
+		expect(() => assertOwnerOnlyMode(0o100604, 'p')).toThrow(CredentialStoreError)
+		expect(() => assertOwnerOnlyMode(0o100666, 'p')).toThrow(CredentialStoreError)
+	})
+
+	it('refuses execute as readily as read, since either is access we did not grant', () => {
+		expect(() => assertOwnerOnlyMode(0o100601, 'p')).toThrow(CredentialStoreError)
+	})
+
+	it('names the path and the mode, and nothing else', () => {
+		expect(() => assertOwnerOnlyMode(0o100644, '/h/.namzu/credentials.json')).toThrow(
+			/\/h\/\.namzu\/credentials\.json.*644/,
+		)
 	})
 })
 
@@ -122,9 +173,7 @@ describe('assertSoleOwnerSddl', () => {
 	})
 
 	it('accepts a differently-cased identifier', () => {
-		expect(() =>
-			assertSoleOwnerSddl(`D:PAI(A;;FA;;;${US.toLowerCase()})`, US, 'p'),
-		).not.toThrow()
+		expect(() => assertSoleOwnerSddl(`D:PAI(A;;FA;;;${US.toLowerCase()})`, US, 'p')).not.toThrow()
 	})
 
 	it('refuses a second allow entry naming somebody else', () => {

--- a/packages/cli/src/integrations/providers/credential-store.ts
+++ b/packages/cli/src/integrations/providers/credential-store.ts
@@ -1,0 +1,320 @@
+/**
+ * `~/.namzu/credentials.json` — the subscription credential namzu obtained itself.
+ *
+ * ## Why a file, said as a choice rather than a default
+ *
+ * The durable home a credential deserves is the operating system's own secret
+ * store. namzu does not have one. The helper next door reads the macOS login
+ * Keychain and belongs to a DIFFERENT product's entry — namzu borrows a token
+ * from it — so writing namzu's own secret there would file our secret under
+ * somebody else's name. On the platform this was asked for the store is not
+ * that one at all, and no cross-platform binding exists in this package.
+ *
+ * So the options were: ship no durable credential, bind a native store per
+ * platform, or own a file. This owns a file, and pays for it by making the
+ * file's protection a CHECKED property rather than an assumption:
+ *
+ *  - it is created `0600` from birth (`wx` + mode, never a world-readable
+ *    window), inside a `0700` directory;
+ *  - after writing, the protection is READ BACK and asserted;
+ *  - if the assertion cannot be made, the file is deleted and the write
+ *    throws. A credential store that cannot prove it is private is a worse
+ *    outcome than no credential store, and refusing is the rule this
+ *    repository already holds (`docs/conventions/refuse-do-not-degrade.md`).
+ *
+ * The assertion is per-platform because the underlying protection is:
+ *
+ *  - POSIX: `chmod 0600`, then `stat` and require no group/other bits.
+ *  - Windows: POSIX modes do not exist — `fs.chmod` there only toggles the
+ *    read-only attribute, so a `0600` that "succeeded" would prove nothing.
+ *    The equivalent is a discretionary ACL, so inheritance is removed and a
+ *    single full-control entry is granted to the current user's SID; the ACL
+ *    is then saved back as SDDL and required to contain exactly that one
+ *    allow entry and nothing else.
+ *
+ * ## What is in the file
+ *
+ *   { "version": 1,
+ *     "subscription": { "accessToken", "refreshToken", "expiresAt", "scopes" } }
+ *
+ * `subscription` is the credential a person's plan grants, obtained by the
+ * login flow in `subscription-login.ts` and refreshed in place by `oauth.ts`.
+ * Nothing else writes here.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { randomBytes } from 'node:crypto'
+import {
+	closeSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	statSync,
+	writeSync,
+} from 'node:fs'
+import { homedir, platform, tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import type { AgentOAuthCredential } from './keychain.js'
+
+const FILE_MODE = 0o600
+const DIR_MODE = 0o700
+
+export const CREDENTIALS_FILE_VERSION = 1 as const
+
+/** Thrown when a credential could not be stored *privately*. Never carries a secret. */
+export class CredentialStoreError extends Error {
+	override readonly name = 'CredentialStoreError'
+}
+
+export function credentialsPath(home: string = homedir()): string {
+	return join(home, '.namzu', 'credentials.json')
+}
+
+/**
+ * The stored subscription credential, or `null` when there is none.
+ *
+ * Non-throwing on every shape of absence and corruption — a store that
+ * refuses to parse is "no credential", which is what discovery can act on.
+ * It does NOT swallow a permission error into `null` silently; that is still
+ * absence from the reader's point of view, and the login path is what tells
+ * the operator to try again.
+ */
+export function readStoredSubscriptionCredential(
+	home: string = homedir(),
+): AgentOAuthCredential | null {
+	let raw: string
+	try {
+		raw = readFileSync(credentialsPath(home), 'utf8')
+	} catch {
+		return null
+	}
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(raw)
+	} catch {
+		return null
+	}
+	if (typeof parsed !== 'object' || parsed === null) return null
+	const sub = (parsed as { subscription?: unknown }).subscription
+	if (typeof sub !== 'object' || sub === null) return null
+	const rec = sub as Record<string, unknown>
+	const accessToken = rec.accessToken
+	if (typeof accessToken !== 'string' || accessToken.length === 0) return null
+	return {
+		accessToken,
+		refreshToken: typeof rec.refreshToken === 'string' ? rec.refreshToken : undefined,
+		expiresAt: typeof rec.expiresAt === 'number' ? rec.expiresAt : undefined,
+		scopes: Array.isArray(rec.scopes)
+			? (rec.scopes.filter((s) => typeof s === 'string') as string[])
+			: undefined,
+	}
+}
+
+/**
+ * Write the credential, privately, or throw having written nothing that lasts.
+ *
+ * Ordering matters and is the whole point: the temporary file is created with
+ * the restrictive mode, secured, asserted, and only then renamed into place.
+ * A file that appears at the final path and is tightened afterwards has a
+ * window in which it is readable, and that window is the defect this ordering
+ * removes.
+ */
+export function writeStoredSubscriptionCredential(
+	cred: AgentOAuthCredential,
+	home: string = homedir(),
+): string {
+	const path = credentialsPath(home)
+	mkdirSync(dirname(path), { recursive: true, mode: DIR_MODE })
+	const tmp = `${path}.tmp.${process.pid}.${randomBytes(6).toString('hex')}`
+	const body = `${JSON.stringify(
+		{
+			version: CREDENTIALS_FILE_VERSION,
+			subscription: {
+				accessToken: cred.accessToken,
+				...(cred.refreshToken ? { refreshToken: cred.refreshToken } : {}),
+				...(cred.expiresAt ? { expiresAt: cred.expiresAt } : {}),
+				...(cred.scopes ? { scopes: cred.scopes } : {}),
+			},
+		},
+		null,
+		2,
+	)}\n`
+
+	let fd: number | undefined
+	try {
+		// `wx` — refuse an existing path rather than truncate one, so a name
+		// collision can never hand us a file somebody else already opened.
+		fd = openSync(tmp, 'wx', FILE_MODE)
+		writeSync(fd, body)
+	} catch (err) {
+		if (fd !== undefined) closeSync(fd)
+		rmSync(tmp, { force: true })
+		throw new CredentialStoreError(
+			`could not write ${path}: ${err instanceof Error ? err.message : String(err)}`,
+		)
+	}
+	closeSync(fd)
+
+	try {
+		restrictToOwner(tmp)
+	} catch (err) {
+		rmSync(tmp, { force: true })
+		throw err
+	}
+
+	try {
+		renameSync(tmp, path)
+	} catch (err) {
+		rmSync(tmp, { force: true })
+		throw new CredentialStoreError(
+			`could not place ${path}: ${err instanceof Error ? err.message : String(err)}`,
+		)
+	}
+	return path
+}
+
+/** Remove the stored credential. Absence is success. */
+export function clearStoredSubscriptionCredential(home: string = homedir()): void {
+	rmSync(credentialsPath(home), { force: true })
+}
+
+/**
+ * Make `path` readable and writable by its owner and by nobody else, and
+ * PROVE it. Throws `CredentialStoreError` when the proof cannot be produced.
+ *
+ * Exported because it is the load-bearing half of this module and a security
+ * property nobody can check by reading the caller.
+ */
+export function restrictToOwner(path: string): void {
+	if (platform() === 'win32') {
+		restrictToOwnerWindows(path)
+		return
+	}
+	// POSIX. `openSync` already asked for the mode; a umask cannot loosen it,
+	// but an inherited ACL or an exotic filesystem can, so this reads it back
+	// instead of trusting the request.
+	let mode: number
+	try {
+		mode = statSync(path).mode
+	} catch (err) {
+		throw new CredentialStoreError(
+			`could not read back the permissions of ${path}: ${err instanceof Error ? err.message : String(err)}`,
+		)
+	}
+	if ((mode & 0o077) !== 0) {
+		throw new CredentialStoreError(
+			`${path} is readable beyond its owner (mode ${(mode & 0o777).toString(8)}) and the filesystem would not tighten it — refusing to keep a credential there.`,
+		)
+	}
+}
+
+/**
+ * The Windows half: remove inheritance, grant the current user's SID full
+ * control, then read the resulting ACL back as SDDL and require it to be
+ * exactly that one allow entry.
+ *
+ * Both helpers are invoked by absolute path under `%SystemRoot%\System32`.
+ * Resolving them through `PATH` is how a same-named executable earlier on the
+ * path gets to answer a security question on our behalf, and on a developer
+ * machine `PATH` routinely carries a POSIX toolchain that shadows these names.
+ */
+function restrictToOwnerWindows(path: string): void {
+	const system32 = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32')
+	const run = (exe: string, args: readonly string[]): string => {
+		try {
+			return execFileSync(join(system32, exe), [...args], {
+				encoding: 'utf8',
+				timeout: 10_000,
+				stdio: ['ignore', 'pipe', 'ignore'],
+				windowsHide: true,
+			})
+		} catch (err) {
+			throw new CredentialStoreError(
+				`${exe} could not secure ${path} (${err instanceof Error ? err.message : String(err)}). namzu will not keep a credential in a file it cannot prove is private.`,
+			)
+		}
+	}
+
+	// `whoami /user /fo csv /nh` prints  "DOMAIN\user","S-1-5-21-…"
+	const who = run('whoami.exe', ['/user', '/fo', 'csv', '/nh'])
+	const sid = who.match(/"(S-1-[0-9-]+)"/)?.[1]
+	if (!sid) {
+		throw new CredentialStoreError(
+			`could not determine the current account's security identifier, so the protection of ${path} cannot be established.`,
+		)
+	}
+
+	run('icacls.exe', [path, '/inheritance:r', '/grant:r', `*${sid}:F`])
+
+	// Read the access-control list back as SDDL. `icacls /save` writes a
+	// UTF-16 file whose second line is the descriptor; SDDL names principals
+	// by SID, so this comparison does not depend on the display language.
+	const acl = `${path}.acl.${randomBytes(4).toString('hex')}`
+	const aclPath = join(tmpdir(), acl.split(/[\\/]/).pop() as string)
+	let saved: string
+	try {
+		run('icacls.exe', [path, '/save', aclPath])
+		saved = readFileSync(aclPath, 'utf16le')
+	} catch (err) {
+		rmSync(aclPath, { force: true })
+		if (err instanceof CredentialStoreError) throw err
+		throw new CredentialStoreError(
+			`could not read back the access-control list of ${path}: ${err instanceof Error ? err.message : String(err)}`,
+		)
+	} finally {
+		rmSync(aclPath, { force: true })
+	}
+
+	assertSoleOwnerSddl(saved, sid, path)
+}
+
+/**
+ * Require an SDDL discretionary ACL to grant exactly one principal, and that
+ * principal to be `sid`.
+ *
+ * Split out from the spawning above because it is the actual assertion, and
+ * an assertion that can only run on one operating system is an assertion
+ * nobody checks. Every entry is examined, not just the first: an ACL reading
+ * `(A;;FA;;;US)(A;;FA;;;WD)` grants us AND everyone, and a check that stopped
+ * at a match would call that private.
+ */
+export function assertSoleOwnerSddl(sddl: string, sid: string, path: string): void {
+	const dacl = sddl.match(/D:([A-Z]*)((?:\([^)]*\))*)/)
+	const flags = dacl?.[1] ?? ''
+	const body = dacl?.[2] ?? ''
+	if (!dacl || body.length === 0) {
+		throw new CredentialStoreError(
+			`the access-control list of ${path} could not be read back, so its privacy is unestablished.`,
+		)
+	}
+	if (!flags.includes('P')) {
+		throw new CredentialStoreError(
+			`${path} still inherits permissions from its parent folder, so accounts other than yours may read it.`,
+		)
+	}
+	const aces = [...body.matchAll(/\(([^)]*)\)/g)].map((m) => (m[1] ?? '').split(';'))
+	if (aces.length === 0) {
+		throw new CredentialStoreError(
+			`the access-control list of ${path} could not be read back, so its privacy is unestablished.`,
+		)
+	}
+	for (const ace of aces) {
+		const type = ace[0] ?? ''
+		const trustee = ace[5] ?? ''
+		// Only an ALLOW entry grants anything; a DENY entry narrows and is safe.
+		if (type !== 'A' && type !== 'AI') continue
+		if (trustee.toUpperCase() !== sid.toUpperCase()) {
+			throw new CredentialStoreError(
+				`${path} grants access to an account other than yours (${trustee}) — refusing to keep a credential there.`,
+			)
+		}
+	}
+	if (!aces.some((ace) => (ace[0] ?? '') === 'A' || (ace[0] ?? '') === 'AI')) {
+		throw new CredentialStoreError(
+			`${path} ended with no account able to read it, which is not a credential store — refusing.`,
+		)
+	}
+}

--- a/packages/cli/src/integrations/providers/credential-store.ts
+++ b/packages/cli/src/integrations/providers/credential-store.ts
@@ -204,6 +204,19 @@ export function restrictToOwner(path: string): void {
 			`could not read back the permissions of ${path}: ${err instanceof Error ? err.message : String(err)}`,
 		)
 	}
+	assertOwnerOnlyMode(mode, path)
+}
+
+/**
+ * Require a POSIX mode to grant nothing to group or other.
+ *
+ * Split out for the same reason `assertSoleOwnerSddl` is: it is the actual
+ * assertion, and one that only ever executes on some platforms is one most
+ * contributors never see fail. As a pure function it is checked everywhere,
+ * including by whoever is on the operating system where the branch that calls
+ * it is unreachable.
+ */
+export function assertOwnerOnlyMode(mode: number, path: string): void {
 	if ((mode & 0o077) !== 0) {
 		throw new CredentialStoreError(
 			`${path} is readable beyond its owner (mode ${(mode & 0o777).toString(8)}) and the filesystem would not tighten it — refusing to keep a credential there.`,
@@ -239,8 +252,7 @@ function restrictToOwnerWindows(path: string): void {
 	}
 
 	// `whoami /user /fo csv /nh` prints  "DOMAIN\user","S-1-5-21-…"
-	const who = run('whoami.exe', ['/user', '/fo', 'csv', '/nh'])
-	const sid = who.match(/"(S-1-[0-9-]+)"/)?.[1]
+	const sid = currentUserSid()
 	if (!sid) {
 		throw new CredentialStoreError(
 			`could not determine the current account's security identifier, so the protection of ${path} cannot be established.`,
@@ -249,26 +261,62 @@ function restrictToOwnerWindows(path: string): void {
 
 	run('icacls.exe', [path, '/inheritance:r', '/grant:r', `*${sid}:F`])
 
-	// Read the access-control list back as SDDL. `icacls /save` writes a
-	// UTF-16 file whose second line is the descriptor; SDDL names principals
-	// by SID, so this comparison does not depend on the display language.
-	const acl = `${path}.acl.${randomBytes(4).toString('hex')}`
-	const aclPath = join(tmpdir(), acl.split(/[\\/]/).pop() as string)
-	let saved: string
-	try {
-		run('icacls.exe', [path, '/save', aclPath])
-		saved = readFileSync(aclPath, 'utf16le')
-	} catch (err) {
-		rmSync(aclPath, { force: true })
-		if (err instanceof CredentialStoreError) throw err
+	const saved = readAclSddl(path)
+	if (saved === null) {
 		throw new CredentialStoreError(
-			`could not read back the access-control list of ${path}: ${err instanceof Error ? err.message : String(err)}`,
+			`could not read back the access-control list of ${path}, so its privacy is unestablished.`,
 		)
+	}
+	assertSoleOwnerSddl(saved, sid, path)
+}
+
+/**
+ * The file's discretionary access-control list, as SDDL, or `null`.
+ *
+ * `null` off Windows and on any failure to read. Exported so a test can make
+ * the Windows arm a real assertion instead of "the write did not throw" —
+ * without it, deleting the entire protection step would kill no test on the
+ * platform the protection is FOR, and the only coverage would be the POSIX
+ * branch running somewhere else.
+ *
+ * `icacls /save` writes a UTF-16 file whose second line is the descriptor.
+ * SDDL names principals by security identifier, so nothing here depends on
+ * the machine's display language.
+ */
+export function readAclSddl(path: string): string | null {
+	if (platform() !== 'win32') return null
+	const system32 = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32')
+	const aclPath = join(tmpdir(), `namzu-acl-${randomBytes(6).toString('hex')}`)
+	try {
+		execFileSync(join(system32, 'icacls.exe'), [path, '/save', aclPath], {
+			encoding: 'utf8',
+			timeout: 10_000,
+			stdio: ['ignore', 'pipe', 'ignore'],
+			windowsHide: true,
+		})
+		return readFileSync(aclPath, 'utf16le')
+	} catch {
+		return null
 	} finally {
 		rmSync(aclPath, { force: true })
 	}
+}
 
-	assertSoleOwnerSddl(saved, sid, path)
+/** The current account's security identifier, or `null` off Windows / on failure. */
+export function currentUserSid(): string | null {
+	if (platform() !== 'win32') return null
+	const system32 = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32')
+	try {
+		const out = execFileSync(join(system32, 'whoami.exe'), ['/user', '/fo', 'csv', '/nh'], {
+			encoding: 'utf8',
+			timeout: 10_000,
+			stdio: ['ignore', 'pipe', 'ignore'],
+			windowsHide: true,
+		})
+		return out.match(/"(S-1-[0-9-]+)"/)?.[1] ?? null
+	} catch {
+		return null
+	}
 }
 
 /**

--- a/packages/cli/src/integrations/providers/discover.ts
+++ b/packages/cli/src/integrations/providers/discover.ts
@@ -1,11 +1,13 @@
 /**
  * Credential discoverer for LLM provider clients.
  *
- * For each entry in `PROVIDER_REGISTRY`, ask three questions in order:
+ * For each entry in `PROVIDER_REGISTRY`, ask four questions in order:
  *   1. Is one of its env vars set in `process.env`?
- *   2. Is there an OAuth credential in the login Keychain? (macOS only, and
+ *   2. Is there a subscription credential in namzu's own store — the one the
+ *      login flow writes? (every platform, and only `anthropic` consumes it.)
+ *   3. Is there an OAuth credential in the login Keychain? (macOS only, and
  *      only `anthropic` consumes it.)
- *   3. Is the probe URL (if any) reachable right now?
+ *   4. Is the probe URL (if any) reachable right now?
  *
  * The header used to say "three" and list two, and the one it omitted was the
  * Keychain — the question that reads a secret off the machine, so the one a
@@ -13,11 +15,18 @@
  * tell that the list stopped being maintained; in a file about credentials that
  * is worth more than a typo.
  *
- * **The Keychain path is macOS-only and that is a gap, not a nuance.**
- * `readAgentKeychainCredential` returns `null` on any other platform before it
- * looks at anything, so on Windows and Linux exactly two doors exist: an
- * environment variable, and a reachable local server. An operator whose
- * credential lives in their OS credential store gets no help from namzu there.
+ * **The Keychain path is macOS-only, and question 2 is why that is no longer a
+ * hole.** `readAgentKeychainCredential` returns `null` on any other platform
+ * before it looks at anything; it reads a credential belonging to a
+ * co-installed tool, so it can only ever help someone who has that tool, on
+ * that operating system. namzu's own store is asked first among the credential
+ * sources and works everywhere, which is what makes signing in from inside
+ * namzu useful on a machine that has neither.
+ *
+ * Order between the two matters when both answer. namzu's own store wins,
+ * because it is the one namzu wrote and refreshes; preferring a borrowed
+ * credential over the operator's own sign-in would make the login look
+ * ineffective on precisely the machine where they bothered to run it.
  *
  * The first positive answer per provider wins; subsequent sources are
  * recorded as "also available from" so the picker can show alternatives
@@ -52,13 +61,21 @@
  * picker can render immediately and refine if discovery completes later.
  */
 
+import { credentialsPath, readStoredSubscriptionCredential } from './credential-store.js'
 import { KEYCHAIN_SERVICE, readAgentKeychainCredential } from './keychain.js'
+import type { CredentialOrigin } from './oauth.js'
 import { PROVIDER_REGISTRY, type ProviderId, type ProviderRegistryEntry } from './registry.js'
 
 export type DetectionSource =
 	| { readonly kind: 'env'; readonly envName: string }
 	| { readonly kind: 'probe'; readonly url: string }
 	| { readonly kind: 'keychain'; readonly service: string }
+	/**
+	 * namzu's own credential store — a subscription the operator signed in to
+	 * from inside namzu. Carries the path because "where did this come from"
+	 * is the first question asked of a credential nobody typed.
+	 */
+	| { readonly kind: 'stored'; readonly path: string }
 	/**
 	 * Typed into a running namzu and held in memory for this session.
 	 *
@@ -79,10 +96,19 @@ export interface DetectedProvider {
 	readonly baseUrl?: string
 	/**
 	 * OAuth refresh metadata, present only when `apiKey` is an OAuth access
-	 * token carrying a refresh token + expiry (the Keychain source). Lets
-	 * the session layer renew a lapsed token instead of failing with a 401.
+	 * token carrying a refresh token + expiry (namzu's own store, or the
+	 * Keychain). Lets the session layer renew a lapsed token instead of
+	 * failing with a 401.
+	 *
+	 * `origin` travels with it because the refresh has to be written BACK, and
+	 * the two sources are not interchangeable: one is namzu's file and the
+	 * other is a co-installed tool's Keychain entry.
 	 */
-	readonly oauth?: { readonly refreshToken?: string; readonly expiresAt?: number }
+	readonly oauth?: {
+		readonly refreshToken?: string
+		readonly expiresAt?: number
+		readonly origin?: CredentialOrigin
+	}
 	/** Other sources that also satisfy this provider — informational. */
 	readonly alternatives: readonly DetectionSource[]
 }
@@ -100,6 +126,8 @@ export interface DiscoverOptions {
 	readonly skipProbes?: boolean
 	/** Skip the macOS Keychain read (tests, non-darwin runs). */
 	readonly skipKeychain?: boolean
+	/** Skip namzu's own credential store (tests, and `--no-stored-credential`). */
+	readonly skipStored?: boolean
 }
 
 const DEFAULT_PROBE_TIMEOUT_MS = 500
@@ -110,9 +138,13 @@ export async function discoverProviders(
 	const env = opts.env ?? process.env
 	const detected: DetectedProvider[] = []
 
-	// macOS-only: read the third-party OAuth credential stored in the login
-	// Keychain once. Only anthropic consumes it, but we scan up front so
-	// the loop body stays uniform.
+	// Read both credential sources once, up front, so the loop body stays
+	// uniform. Only anthropic consumes either.
+	const storedCredential = opts.skipStored
+		? null
+		: readStoredSubscriptionCredential(...(opts.home === undefined ? [] : [opts.home]))
+	// macOS-only: the OAuth credential a co-installed tool keeps in the login
+	// Keychain.
 	const keychainCredential = opts.skipKeychain ? null : readAgentKeychainCredential()
 
 	for (const id of Object.keys(PROVIDER_REGISTRY) as readonly ProviderId[]) {
@@ -127,15 +159,30 @@ export async function discoverProviders(
 				sources.push({ kind: 'env', envName })
 			}
 		}
+		if (id === 'anthropic' && storedCredential) {
+			if (apiKey === undefined) apiKey = storedCredential.accessToken
+			sources.push({
+				kind: 'stored',
+				path: credentialsPath(...(opts.home === undefined ? [] : [opts.home])),
+			})
+			// Only carry refresh metadata when this token is the one we'll
+			// actually use (an env/secrets token has no refresh path).
+			if (apiKey === storedCredential.accessToken) {
+				oauth = {
+					refreshToken: storedCredential.refreshToken,
+					expiresAt: storedCredential.expiresAt,
+					origin: 'stored',
+				}
+			}
+		}
 		if (id === 'anthropic' && keychainCredential) {
 			if (apiKey === undefined) apiKey = keychainCredential.accessToken
 			sources.push({ kind: 'keychain', service: KEYCHAIN_SERVICE })
-			// Only carry refresh metadata when the Keychain token is the one we'll
-			// actually use (an env/secrets token has no refresh path).
 			if (apiKey === keychainCredential.accessToken) {
 				oauth = {
 					refreshToken: keychainCredential.refreshToken,
 					expiresAt: keychainCredential.expiresAt,
+					origin: 'keychain',
 				}
 			}
 		}

--- a/packages/cli/src/integrations/providers/identity.ts
+++ b/packages/cli/src/integrations/providers/identity.ts
@@ -1,0 +1,78 @@
+/**
+ * The OAuth client namzu presents when it signs an operator in, and the
+ * addresses that identity is valid against.
+ *
+ * ## Whose identity this is — the decision, written where the value is
+ *
+ * `OAUTH_CLIENT_ID` was **not registered by namzu**. It is the public client
+ * identifier that the vendor's own command-line tool is registered under, and
+ * it is the only one the subscription authorization server will issue
+ * plan-scoped inference tokens to. This project has no client of its own
+ * there because that vendor operates no open client registration for this
+ * grant: there is no form to fill in, no application to make. The choice was
+ * therefore between presenting this identity, and not offering the capability
+ * at all.
+ *
+ * The owner decided the capability should exist, so this is the identity used,
+ * and the consequences are stated rather than discovered later:
+ *
+ *  - **The authorization server cannot tell namzu apart from that tool.** A
+ *    credential obtained here is, at the server, a credential obtained there.
+ *  - **The operator's own plan governs it.** namzu mediates a sign-in the
+ *    person completes themselves, on the vendor's own page, against the
+ *    vendor's own account. No namzu service sees the credential, and nothing
+ *    is proxied — the token goes from the vendor to this machine.
+ *  - **This identity can be revoked by its owner at any time,** and if it is,
+ *    every sign-in below stops working at once. That is a dependency namzu
+ *    accepted knowingly; it is not a bug to be worked around when it happens.
+ *  - **It is not a secret and is not treated as one.** A public OAuth client
+ *    identifier is public by definition — that is why PKCE exists. Nearby
+ *    implementations obscure this value behind a base64 decode at runtime,
+ *    which hides nothing from anyone reading the request and hides the one
+ *    fact a reviewer of THIS file most needs. It stays legible.
+ *
+ * Anyone uncomfortable with the above has the other door: set the credential
+ * in the environment and namzu never runs this flow at all.
+ *
+ * ## The addresses
+ *
+ * Verified 2026-08-09 rather than assumed. Two hosts serve this token
+ * endpoint — the one below and `platform.claude.com` on the same path — and
+ * both answer an `authorization_code` grant identically (`400 invalid_grant`
+ * for a bogus code, from the same handler). namzu keeps the address its
+ * existing refresh path has always used, because there was no behaviour to
+ * gain by moving and a live refresh to lose by guessing.
+ *
+ * The redirect port is fixed and NOT free to change: it is part of what the
+ * client identity above is registered with, so a different port is simply not
+ * an accepted redirect. That is why a busy port degrades to the paste flow
+ * rather than picking another one.
+ */
+
+export const OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e'
+export const OAUTH_TOKEN_URL = 'https://console.anthropic.com/v1/oauth/token'
+export const AUTHORIZE_URL = 'https://claude.ai/oauth/authorize'
+
+/** Registered with the client identity above; not ours to choose. */
+export const SUBSCRIPTION_REDIRECT_PORT = 53692
+export const REDIRECT_URI = `http://localhost:${SUBSCRIPTION_REDIRECT_PORT}/callback`
+
+/**
+ * Asked for at sign-in.
+ *
+ * This is WIDER than namzu needs, and that is a knowing compromise rather
+ * than an oversight. Least privilege would ask for an identity and the right
+ * to run inference, and stop; this set also admits key creation and file
+ * upload. It is the set the client identity above is exercised with by the
+ * implementations that are known to work, and a narrower request cannot be
+ * tested from here — nobody on this side of the flow holds a plan-backed
+ * account to try it against. Guessing narrow fails in the worst place: the
+ * sign-in succeeds, and inference is refused afterwards with an error about
+ * scope that the operator cannot act on.
+ *
+ * So it is recorded as debt with the measurement that would settle it: sign
+ * in with `user:profile user:inference` alone and send one message. If that
+ * works, this shrinks to those two.
+ */
+export const OAUTH_SCOPES =
+	'org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload'

--- a/packages/cli/src/integrations/providers/index.ts
+++ b/packages/cli/src/integrations/providers/index.ts
@@ -11,10 +11,29 @@ export {
 	readAgentKeychainCredential,
 } from './keychain.js'
 export {
+	clearStoredSubscriptionCredential,
+	CREDENTIALS_FILE_VERSION,
+	CredentialStoreError,
+	credentialsPath,
+	readStoredSubscriptionCredential,
+	writeStoredSubscriptionCredential,
+} from './credential-store.js'
+export { OAUTH_SCOPES, REDIRECT_URI } from './identity.js'
+export {
+	type CredentialOrigin,
 	ensureFreshAnthropicToken,
 	type OAuthMetadata,
+	readSubscriptionCredential,
 	refreshAgentOAuthToken,
 } from './oauth.js'
+export {
+	beginSubscriptionLogin,
+	type LoginOutcome,
+	parsePastedInput,
+	type SubscriptionLogin,
+	type SubscriptionLoginOptions,
+	subscriptionDetectedProvider,
+} from './subscription-login.js'
 export {
 	type CapabilityDisagreement,
 	chainCapabilityDisagreements,

--- a/packages/cli/src/integrations/providers/oauth.test.ts
+++ b/packages/cli/src/integrations/providers/oauth.test.ts
@@ -7,7 +7,23 @@ vi.mock('./keychain.js', async (importOriginal) => {
 	return { ...actual, writeAgentKeychainCredential: vi.fn(() => false) }
 })
 
-import { ensureFreshAnthropicToken, refreshAgentOAuthToken } from './oauth.js'
+const writeStored = vi.hoisted(() => vi.fn())
+const readStored = vi.hoisted(() => vi.fn(() => null))
+vi.mock('./credential-store.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('./credential-store.js')>()
+	return {
+		...actual,
+		writeStoredSubscriptionCredential: writeStored,
+		readStoredSubscriptionCredential: readStored,
+	}
+})
+
+import { writeAgentKeychainCredential } from './keychain.js'
+import {
+	ensureFreshAnthropicToken,
+	readSubscriptionCredential,
+	refreshAgentOAuthToken,
+} from './oauth.js'
 
 function mockFetch(impl: typeof fetch): void {
 	vi.stubGlobal('fetch', impl)
@@ -15,6 +31,83 @@ function mockFetch(impl: typeof fetch): void {
 
 afterEach(() => {
 	vi.unstubAllGlobals()
+	vi.clearAllMocks()
+})
+
+function respondWithFreshToken(): void {
+	mockFetch(
+		(async () =>
+			new Response(JSON.stringify({ access_token: 'cc-fresh', expires_in: 3600 }), {
+				status: 200,
+			})) as typeof fetch,
+	)
+}
+
+/**
+ * A refreshed token goes back to the store it came from, and to no other.
+ *
+ * Reading one store and writing the other is the failure this exists to
+ * prevent: nothing errors, the session works, and the credential is refreshed
+ * again from scratch on every single launch because the new token never
+ * landed anywhere the next launch reads.
+ */
+describe('a refreshed credential is written back to its own store', () => {
+	it("to namzu's own store when that is where it came from", async () => {
+		respondWithFreshToken()
+		await ensureFreshAnthropicToken('cc-stale', {
+			refreshToken: 'rt',
+			expiresAt: Date.now() - 1000,
+			origin: 'stored',
+		})
+		expect(writeStored).toHaveBeenCalledWith(expect.objectContaining({ accessToken: 'cc-fresh' }))
+		expect(writeAgentKeychainCredential).not.toHaveBeenCalled()
+	})
+
+	it('to the borrowed Keychain entry when that is where it came from', async () => {
+		respondWithFreshToken()
+		await ensureFreshAnthropicToken('cc-stale', {
+			refreshToken: 'rt',
+			expiresAt: Date.now() - 1000,
+			origin: 'keychain',
+		})
+		expect(writeAgentKeychainCredential).toHaveBeenCalled()
+		expect(writeStored).not.toHaveBeenCalled()
+	})
+
+	it('to the Keychain when no origin is stated, which is what callers predating the store meant', async () => {
+		respondWithFreshToken()
+		await ensureFreshAnthropicToken('cc-stale', {
+			refreshToken: 'rt',
+			expiresAt: Date.now() - 1000,
+		})
+		expect(writeAgentKeychainCredential).toHaveBeenCalled()
+		expect(writeStored).not.toHaveBeenCalled()
+	})
+
+	it('survives a store that refuses the write, keeping the token it already has', async () => {
+		respondWithFreshToken()
+		writeStored.mockImplementationOnce(() => {
+			throw new Error('could not prove the file private')
+		})
+		const token = await ensureFreshAnthropicToken('cc-stale', {
+			refreshToken: 'rt',
+			expiresAt: Date.now() - 1000,
+			origin: 'stored',
+		})
+		expect(token).toBe('cc-fresh')
+	})
+})
+
+describe('readSubscriptionCredential', () => {
+	it("reads namzu's own store for a stored credential", () => {
+		readStored.mockReturnValueOnce({ accessToken: 'from-store' } as never)
+		expect(readSubscriptionCredential('stored')).toEqual({ accessToken: 'from-store' })
+	})
+
+	it("does not read namzu's store for a keychain credential", () => {
+		readSubscriptionCredential('keychain')
+		expect(readStored).not.toHaveBeenCalled()
+	})
 })
 
 describe('refreshAgentOAuthToken', () => {

--- a/packages/cli/src/integrations/providers/oauth.ts
+++ b/packages/cli/src/integrations/providers/oauth.ts
@@ -1,38 +1,74 @@
 /**
- * OAuth token refresh for a discovered subscription credential.
+ * OAuth token refresh for a subscription credential.
  *
- * The access token discovered from the macOS Keychain
- * is short-lived (~8h). When it lapses the provider answers 401 and the
- * agent stream dies. Refreshing proactively against the public OAuth token
- * endpoint, using the long-lived refresh token, renews a stale token before
- * the session starts instead of surfacing it as an authentication error.
+ * A subscription access token is short-lived (~8h). When it lapses the
+ * provider answers 401 and the agent stream dies. Refreshing proactively
+ * against the token endpoint, using the long-lived refresh token, renews a
+ * stale token before the session starts instead of surfacing it as an
+ * authentication error.
  *
  * Non-throwing: any failure (no refresh token, network down, endpoint error)
  * returns the existing token unchanged — at worst the caller hits the same
  * 401 it would have hit anyway, never a crash.
+ *
+ * ## Where a refreshed token is written back
+ *
+ * There are two places a subscription credential can live and they are not
+ * interchangeable, so `origin` says which one this credential came from and
+ * the refreshed value goes back to the same place:
+ *
+ *  - `'stored'` — namzu's own store, written by the login flow, present on
+ *    every platform.
+ *  - `'keychain'` — a co-installed tool's macOS entry, which namzu reads but
+ *    does not own.
+ *
+ * `origin` is optional and defaults to `'keychain'` because that is the only
+ * source that existed when this file was written, and a caller compiled
+ * against the old shape must keep behaving as it did. Every namzu-owned
+ * caller passes it explicitly; a credential that came from the login flow and
+ * was written back to the Keychain would be a no-op off macOS, leaving the
+ * real store holding a token that is refreshed again on every launch.
  */
 
-import { type AgentOAuthCredential, writeAgentKeychainCredential } from './keychain.js'
-
-/**
- * The public OAuth client id and token endpoint this credential was issued
- * against. Addresses, verbatim — the refresh only succeeds against these.
- */
-const CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e'
-const TOKEN_URL = 'https://console.anthropic.com/v1/oauth/token'
+import {
+	readStoredSubscriptionCredential,
+	writeStoredSubscriptionCredential,
+} from './credential-store.js'
+import { OAUTH_CLIENT_ID, OAUTH_TOKEN_URL } from './identity.js'
+import {
+	type AgentOAuthCredential,
+	readAgentKeychainCredential,
+	writeAgentKeychainCredential,
+} from './keychain.js'
 
 /** Refresh a few seconds early so an about-to-expire token isn't used. */
 const EXPIRY_SKEW_MS = 60_000
 
+/**
+ * Re-read the current credential from the store it lives in.
+ *
+ * The session layer calls this between turns because another process may
+ * have rotated the token since launch. Pairing it with `origin` is what stops
+ * a long-running session reading one store and writing the other.
+ */
+export function readSubscriptionCredential(origin: CredentialOrigin): AgentOAuthCredential | null {
+	return origin === 'stored' ? readStoredSubscriptionCredential() : readAgentKeychainCredential()
+}
+
+/** Which store a subscription credential came from, and goes back to. */
+export type CredentialOrigin = 'stored' | 'keychain'
+
 export interface OAuthMetadata {
 	readonly refreshToken?: string
 	readonly expiresAt?: number
+	/** Defaults to `'keychain'` — see the note at the top of this file. */
+	readonly origin?: CredentialOrigin
 }
 
 /**
  * Return a non-expired access token, refreshing first if the current one is
  * lapsed/about-to-lapse and a refresh token is available. On a successful
- * refresh the new credential is persisted back to the Keychain (best-effort).
+ * refresh the new credential is persisted back to its own store (best-effort).
  */
 export async function ensureFreshAnthropicToken(
 	accessToken: string,
@@ -44,8 +80,29 @@ export async function ensureFreshAnthropicToken(
 
 	const refreshed = await refreshAgentOAuthToken(oauth.refreshToken)
 	if (!refreshed) return accessToken
-	writeAgentKeychainCredential(refreshed)
+	persistRefreshed(refreshed, oauth.origin ?? 'keychain')
 	return refreshed.accessToken
+}
+
+/**
+ * Write a refreshed credential back to the store it came from.
+ *
+ * Best-effort in both arms, and for the same reason the refresh itself is:
+ * the token is already in hand and usable for this session, so a store that
+ * will not take it costs a re-refresh next launch, not the session.
+ */
+function persistRefreshed(cred: AgentOAuthCredential, origin: CredentialOrigin): void {
+	if (origin === 'keychain') {
+		writeAgentKeychainCredential(cred)
+		return
+	}
+	try {
+		writeStoredSubscriptionCredential(cred)
+	} catch {
+		// The store refused to prove the file private and therefore wrote
+		// nothing. Deliberately silent: the message would be about a file, on
+		// a path the operator did not ask about, in the middle of a turn.
+	}
 }
 
 /** Exchange a refresh token for a new credential, or `null` on any failure. */
@@ -53,13 +110,13 @@ export async function refreshAgentOAuthToken(
 	refreshToken: string,
 ): Promise<AgentOAuthCredential | null> {
 	try {
-		const res = await fetch(TOKEN_URL, {
+		const res = await fetch(OAUTH_TOKEN_URL, {
 			method: 'POST',
 			headers: { 'content-type': 'application/json' },
 			body: JSON.stringify({
 				grant_type: 'refresh_token',
 				refresh_token: refreshToken,
-				client_id: CLIENT_ID,
+				client_id: OAUTH_CLIENT_ID,
 			}),
 		})
 		if (!res.ok) return null

--- a/packages/cli/src/integrations/providers/subscription-login.test.ts
+++ b/packages/cli/src/integrations/providers/subscription-login.test.ts
@@ -1,0 +1,360 @@
+import { existsSync, mkdtempSync, readdirSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { removeTempDir } from '../../__fixtures__/temp-dir.js'
+import { credentialsPath, readStoredSubscriptionCredential } from './credential-store.js'
+import { discoverProviders } from './discover.js'
+import { OAUTH_CLIENT_ID, OAUTH_TOKEN_URL, REDIRECT_URI } from './identity.js'
+import {
+	beginSubscriptionLogin,
+	parsePastedInput,
+	subscriptionDetectedProvider,
+} from './subscription-login.js'
+
+/**
+ * The values a leak test hunts for.
+ *
+ * Distinctive on purpose: a substring search for `token` would match prose,
+ * and a search that matches prose cannot tell a leak from a sentence about
+ * one.
+ */
+const ACCESS = 'zzz-access-4a7f2b9c-must-never-be-printed'
+const REFRESH = 'zzz-refresh-91d0e3aa-must-never-be-printed'
+const CODE = 'auth-code-abc123'
+
+let home: string
+
+beforeEach(() => {
+	home = mkdtempSync(join(tmpdir(), 'namzu-login-'))
+})
+afterEach(() => {
+	removeTempDir(home)
+	vi.restoreAllMocks()
+})
+
+/** A token endpoint that answers `body` with `status`. Records what it saw. */
+function stubEndpoint(status: number, body: unknown) {
+	const seen: { url?: string; init?: RequestInit } = {}
+	const fetchFn = (async (url: string | URL | Request, init?: RequestInit) => {
+		seen.url = String(url)
+		seen.init = init
+		return new Response(typeof body === 'string' ? body : JSON.stringify(body), {
+			status,
+			headers: { 'content-type': 'application/json' },
+		})
+	}) as unknown as typeof fetch
+	return { fetchFn, seen }
+}
+
+const GOOD = { access_token: ACCESS, refresh_token: REFRESH, expires_in: 28_800 }
+
+describe('the authorization request', () => {
+	it('asks for a code with a S256 challenge, and never carries the verifier', async () => {
+		const login = await beginSubscriptionLogin({ home, loopback: false })
+		const url = new URL(login.url)
+		expect(url.searchParams.get('response_type')).toBe('code')
+		expect(url.searchParams.get('client_id')).toBe(OAUTH_CLIENT_ID)
+		expect(url.searchParams.get('code_challenge_method')).toBe('S256')
+		expect(url.searchParams.get('redirect_uri')).toBe(REDIRECT_URI)
+		const challenge = url.searchParams.get('code_challenge') ?? ''
+		expect(challenge.length).toBeGreaterThan(20)
+		// The verifier is what PKCE keeps OUT of this URL. Reusing it as `state`
+		// — which nearby implementations do — would put it here.
+		expect(url.searchParams.get('state')).not.toBe(challenge)
+		login.cancel()
+	})
+
+	it('mints a different state and challenge on every attempt', async () => {
+		const a = await beginSubscriptionLogin({ home, loopback: false })
+		const b = await beginSubscriptionLogin({ home, loopback: false })
+		const sa = new URL(a.url).searchParams
+		const sb = new URL(b.url).searchParams
+		expect(sa.get('state')).not.toBe(sb.get('state'))
+		expect(sa.get('code_challenge')).not.toBe(sb.get('code_challenge'))
+		a.cancel()
+		b.cancel()
+	})
+})
+
+describe('a completed sign-in', () => {
+	it('stores a credential a session can make a request with', async () => {
+		const { fetchFn, seen } = stubEndpoint(200, GOOD)
+		const login = await beginSubscriptionLogin({ home, loopback: false, fetch: fetchFn })
+		const state = new URL(login.url).searchParams.get('state') as string
+
+		const outcome = await login.completeWithPastedCode(
+			`http://localhost:53692/callback?code=${CODE}&state=${state}`,
+		)
+		expect(outcome.ok).toBe(true)
+		if (!outcome.ok) return
+
+		// The exchange went where it was supposed to, with the verifier this time.
+		expect(seen.url).toBe(OAUTH_TOKEN_URL)
+		const body = JSON.parse(String(seen.init?.body)) as Record<string, string>
+		expect(body.grant_type).toBe('authorization_code')
+		expect(body.code).toBe(CODE)
+		expect(body.redirect_uri).toBe(REDIRECT_URI)
+		expect(body.code_verifier?.length).toBeGreaterThan(20)
+
+		// The credential landed where discovery looks — the property that makes
+		// the next launch work without signing in again.
+		expect(readStoredSubscriptionCredential(home)).toMatchObject({
+			accessToken: ACCESS,
+			refreshToken: REFRESH,
+		})
+
+		// And it is usable NOW, as a provider a session can be built from,
+		// without waiting for a relaunch.
+		const detected = subscriptionDetectedProvider(outcome.credential, outcome.storedAt)
+		expect(detected.entry.id).toBe('anthropic')
+		expect(detected.apiKey).toBe(ACCESS)
+		expect(detected.oauth?.origin).toBe('stored')
+
+		// The same credential, found by discovery on a cold start.
+		const found = await discoverProviders({ home, env: {}, skipProbes: true, skipKeychain: true })
+		const anthropic = found.find((d) => d.entry.id === 'anthropic')
+		expect(anthropic?.apiKey).toBe(ACCESS)
+		expect(anthropic?.source).toEqual({ kind: 'stored', path: credentialsPath(home) })
+		expect(anthropic?.oauth).toMatchObject({ refreshToken: REFRESH, origin: 'stored' })
+	})
+
+	it('records an expiry so the refresh path knows when to run', async () => {
+		const { fetchFn } = stubEndpoint(200, GOOD)
+		const login = await beginSubscriptionLogin({ home, loopback: false, fetch: fetchFn })
+		const state = new URL(login.url).searchParams.get('state') as string
+		const before = Date.now()
+		await login.completeWithPastedCode(`${CODE}#${state}`)
+		const expiresAt = readStoredSubscriptionCredential(home)?.expiresAt ?? 0
+		expect(expiresAt).toBeGreaterThanOrEqual(before + 28_800_000)
+	})
+
+	it('cannot be replayed — a second completion is refused', async () => {
+		const { fetchFn } = stubEndpoint(200, GOOD)
+		const login = await beginSubscriptionLogin({ home, loopback: false, fetch: fetchFn })
+		const state = new URL(login.url).searchParams.get('state') as string
+		expect((await login.completeWithPastedCode(`${CODE}#${state}`)).ok).toBe(true)
+		const second = await login.completeWithPastedCode(`${CODE}#${state}`)
+		expect(second.ok).toBe(false)
+	})
+})
+
+describe('a failed sign-in leaves nothing behind', () => {
+	const noCredentialOnDisk = () => {
+		expect(existsSync(credentialsPath(home))).toBe(false)
+		// Not even a temp file, which would be the partial credential this
+		// claim is really about.
+		const dir = dirname(credentialsPath(home))
+		if (existsSync(dir)) {
+			expect(readdirSync(dir).filter((e) => e.includes('credentials'))).toEqual([])
+		}
+	}
+
+	it('when the endpoint refuses the exchange', async () => {
+		const { fetchFn } = stubEndpoint(400, { error: 'invalid_grant' })
+		const login = await beginSubscriptionLogin({ home, loopback: false, fetch: fetchFn })
+		const state = new URL(login.url).searchParams.get('state') as string
+		const outcome = await login.completeWithPastedCode(`${CODE}#${state}`)
+		expect(outcome.ok).toBe(false)
+		noCredentialOnDisk()
+	})
+
+	it('when the state does not match — and it never reaches the endpoint', async () => {
+		const { fetchFn, seen } = stubEndpoint(200, GOOD)
+		const login = await beginSubscriptionLogin({ home, loopback: false, fetch: fetchFn })
+		const outcome = await login.completeWithPastedCode(`${CODE}#not-the-state-we-sent`)
+		expect(outcome.ok).toBe(false)
+		expect(seen.url).toBeUndefined()
+		noCredentialOnDisk()
+	})
+
+	it('when the endpoint answers 200 with no token in it', async () => {
+		const { fetchFn } = stubEndpoint(200, { refresh_token: REFRESH })
+		const login = await beginSubscriptionLogin({ home, loopback: false, fetch: fetchFn })
+		const state = new URL(login.url).searchParams.get('state') as string
+		const outcome = await login.completeWithPastedCode(`${CODE}#${state}`)
+		expect(outcome.ok).toBe(false)
+		noCredentialOnDisk()
+	})
+
+	it('when the endpoint answers with something that is not JSON', async () => {
+		const { fetchFn } = stubEndpoint(200, '<html>gateway</html>')
+		const login = await beginSubscriptionLogin({ home, loopback: false, fetch: fetchFn })
+		const state = new URL(login.url).searchParams.get('state') as string
+		const outcome = await login.completeWithPastedCode(`${CODE}#${state}`)
+		expect(outcome.ok).toBe(false)
+		noCredentialOnDisk()
+	})
+
+	it('when the endpoint is unreachable', async () => {
+		const fetchFn = (async () => {
+			throw new Error('getaddrinfo ENOTFOUND')
+		}) as unknown as typeof fetch
+		const login = await beginSubscriptionLogin({ home, loopback: false, fetch: fetchFn })
+		const state = new URL(login.url).searchParams.get('state') as string
+		const outcome = await login.completeWithPastedCode(`${CODE}#${state}`)
+		expect(outcome.ok).toBe(false)
+		noCredentialOnDisk()
+	})
+
+	it('when nothing usable was pasted', async () => {
+		const { fetchFn, seen } = stubEndpoint(200, GOOD)
+		const login = await beginSubscriptionLogin({ home, loopback: false, fetch: fetchFn })
+		for (const junk of ['', '   ', 'I signed in already', 'https://not a url']) {
+			expect((await login.completeWithPastedCode(junk)).ok).toBe(false)
+		}
+		expect(seen.url).toBeUndefined()
+		noCredentialOnDisk()
+	})
+})
+
+/**
+ * The non-negotiable: a secret reaches its store and nowhere else.
+ *
+ * Driven through the real failure paths with console captured, because the
+ * tempting way to write a refusal is to quote what the server said — and what
+ * a token endpoint says on a failure is the document the token is in.
+ */
+describe('no token is ever printed, logged, or put in a message', () => {
+	it('not on a refused exchange whose body contains one', async () => {
+		const logged: string[] = []
+		for (const method of ['log', 'warn', 'error', 'info', 'debug'] as const) {
+			vi.spyOn(console, method).mockImplementation((...args: unknown[]) => {
+				logged.push(args.map(String).join(' '))
+			})
+		}
+		const stdout: string[] = []
+		vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+			stdout.push(String(chunk))
+			return true
+		}) as typeof process.stdout.write)
+		vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: unknown) => {
+			stdout.push(String(chunk))
+			return true
+		}) as typeof process.stderr.write)
+
+		// A 400 whose body carries a token — the shape that makes "include the
+		// response body in the error" a leak rather than a courtesy.
+		const { fetchFn } = stubEndpoint(400, {
+			error: 'invalid_grant',
+			error_description: `token ${ACCESS} was already used`,
+			refresh_token: REFRESH,
+		})
+		const login = await beginSubscriptionLogin({ home, loopback: false, fetch: fetchFn })
+		const state = new URL(login.url).searchParams.get('state') as string
+		const outcome = await login.completeWithPastedCode(`${CODE}#${state}`)
+
+		expect(outcome.ok).toBe(false)
+		const captured = [...logged, ...stdout, outcome.ok ? '' : outcome.reason].join('\n')
+		expect(captured).not.toContain(ACCESS)
+		expect(captured).not.toContain(REFRESH)
+		// The refusal still has to be actionable, or the leak was removed by
+		// removing the message.
+		expect(outcome.ok ? '' : outcome.reason).toContain('400')
+	})
+
+	it('not in the outcome of a SUCCESSFUL login, whose message names only the path', async () => {
+		const { fetchFn } = stubEndpoint(200, GOOD)
+		const login = await beginSubscriptionLogin({ home, loopback: false, fetch: fetchFn })
+		const state = new URL(login.url).searchParams.get('state') as string
+		const outcome = await login.completeWithPastedCode(`${CODE}#${state}`)
+		expect(outcome.ok).toBe(true)
+		if (!outcome.ok) return
+		expect(outcome.storedAt).not.toContain(ACCESS)
+		expect(outcome.storedAt).toBe(credentialsPath(home))
+	})
+
+	it('and the authorization URL carries no secret either', async () => {
+		const login = await beginSubscriptionLogin({ home, loopback: false })
+		expect(login.url).not.toContain(ACCESS)
+		expect(login.url).not.toContain(REFRESH)
+		login.cancel()
+	})
+
+	it('the store file is the only place the secret exists', async () => {
+		const { fetchFn } = stubEndpoint(200, GOOD)
+		const login = await beginSubscriptionLogin({ home, loopback: false, fetch: fetchFn })
+		const state = new URL(login.url).searchParams.get('state') as string
+		await login.completeWithPastedCode(`${CODE}#${state}`)
+		const dir = dirname(credentialsPath(home))
+		const holders = readdirSync(dir).filter((name) =>
+			readFileSync(join(dir, name), 'utf8').includes(ACCESS),
+		)
+		expect(holders).toEqual(['credentials.json'])
+	})
+})
+
+describe('waitForCallback', () => {
+	it('is null when no loopback listener was arranged, so nothing awaits forever', async () => {
+		const login = await beginSubscriptionLogin({ home, loopback: false })
+		expect(login.loopback).toBe(false)
+		expect(login.waitForCallback()).toBeNull()
+		login.cancel()
+	})
+
+	it('resolves to a refusal when the attempt is cancelled', async () => {
+		const login = await beginSubscriptionLogin({ home })
+		if (!login.loopback) {
+			// The port was busy on this machine; the claim under test needs the
+			// listener, and the paste path is covered above.
+			expect(login.waitForCallback()).toBeNull()
+			return
+		}
+		const pending = login.waitForCallback() as Promise<{ ok: boolean }>
+		login.cancel()
+		expect((await pending).ok).toBe(false)
+	})
+
+	it('does not bind twice — a second attempt degrades to paste-only', async () => {
+		const first = await beginSubscriptionLogin({ home })
+		if (!first.loopback) return
+		const second = await beginSubscriptionLogin({ home })
+		expect(second.loopback).toBe(false)
+		expect(second.waitForCallback()).toBeNull()
+		first.cancel()
+		second.cancel()
+	})
+})
+
+describe('parsePastedInput', () => {
+	it('reads a full redirect address', () => {
+		expect(parsePastedInput('http://localhost:53692/callback?code=abc&state=xyz')).toEqual({
+			code: 'abc',
+			state: 'xyz',
+		})
+	})
+
+	it('reads a query string on its own, with or without the leading question mark', () => {
+		expect(parsePastedInput('code=abc&state=xyz')).toEqual({ code: 'abc', state: 'xyz' })
+		expect(parsePastedInput('?code=abc&state=xyz')).toEqual({ code: 'abc', state: 'xyz' })
+	})
+
+	it('reads the hash-joined pair a consent screen offers for copying', () => {
+		expect(parsePastedInput('abc#xyz')).toEqual({ code: 'abc', state: 'xyz' })
+	})
+
+	it('reads a bare code', () => {
+		expect(parsePastedInput('abc')).toEqual({ code: 'abc' })
+	})
+
+	it('trims what a terminal paste adds', () => {
+		expect(parsePastedInput('  abc#xyz \n')).toEqual({ code: 'abc', state: 'xyz' })
+	})
+
+	it('finds no code in a sentence, rather than posting the sentence', () => {
+		expect(parsePastedInput('I have signed in').code).toBeUndefined()
+		expect(parsePastedInput('').code).toBeUndefined()
+		expect(parsePastedInput('   ').code).toBeUndefined()
+	})
+
+	it('finds no code in an address that has none', () => {
+		expect(parsePastedInput('http://localhost:53692/callback?error=access_denied').code).toBe(
+			undefined,
+		)
+	})
+
+	it('finds no code in an unparseable address', () => {
+		expect(parsePastedInput('http://[not-an-address').code).toBeUndefined()
+	})
+})

--- a/packages/cli/src/integrations/providers/subscription-login.test.ts
+++ b/packages/cli/src/integrations/providers/subscription-login.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readdirSync, readFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, readdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -60,10 +60,27 @@ describe('the authorization request', () => {
 		expect(url.searchParams.get('redirect_uri')).toBe(REDIRECT_URI)
 		const challenge = url.searchParams.get('code_challenge') ?? ''
 		expect(challenge.length).toBeGreaterThan(20)
-		// The verifier is what PKCE keeps OUT of this URL. Reusing it as `state`
-		// — which nearby implementations do — would put it here.
-		expect(url.searchParams.get('state')).not.toBe(challenge)
 		login.cancel()
+	})
+
+	it('never puts the PKCE verifier in the authorization URL', async () => {
+		// The claim that matters, and it can only be checked against the
+		// verifier itself — which is not exposed, but IS sent on the exchange.
+		// Comparing `state` to the CHALLENGE instead looks like this test and
+		// proves nothing: reusing the verifier as state leaves state and
+		// challenge different, because one is the hash of the other.
+		const { fetchFn, seen } = stubEndpoint(200, GOOD)
+		const login = await beginSubscriptionLogin({ home, loopback: false, fetch: fetchFn })
+		const params = new URL(login.url).searchParams
+		const state = params.get('state') as string
+		await login.completeWithPastedCode(`${CODE}#${state}`)
+		const verifier = (JSON.parse(String(seen.init?.body)) as { code_verifier: string })
+			.code_verifier
+		expect(verifier.length).toBeGreaterThan(20)
+		// The address bar, the browser history and any referrer see this URL.
+		// The verifier is the one value PKCE exists to keep out of it.
+		expect(login.url).not.toContain(verifier)
+		expect(state).not.toBe(verifier)
 	})
 
 	it('mints a different state and challenge on every attempt', async () => {

--- a/packages/cli/src/integrations/providers/subscription-login.ts
+++ b/packages/cli/src/integrations/providers/subscription-login.ts
@@ -1,0 +1,436 @@
+/**
+ * Obtaining a subscription credential from inside namzu.
+ *
+ * namzu could already USE and REFRESH a plan-backed credential; it could not
+ * get one. The only way in was to install another product, sign in there, and
+ * let discovery borrow what that product had stored — which works on exactly
+ * one operating system and requires the other product. This is the missing
+ * half: an authorization-code exchange, run by namzu, that ends with a
+ * credential in namzu's own store (`credential-store.ts`).
+ *
+ * ## The flow
+ *
+ * Authorization code with PKCE (RFC 7636, S256), redirected to a loopback
+ * address (RFC 8252 §7.3). Two ways to finish, and BOTH are always offered:
+ *
+ *  1. **Loopback.** A one-request server on `127.0.0.1` at the port the
+ *     redirect is registered under. The browser lands on it and the code
+ *     never touches a screen.
+ *  2. **Paste.** The operator copies the code — or the whole redirect URL —
+ *     out of a browser and hands it back.
+ *
+ * The second is not a consolation prize. A container, a remote shell over
+ * SSH, a machine with no graphical session: none of them can be redirected
+ * to, and on all of them the loopback server is either unreachable from
+ * wherever the browser actually is or cannot bind at all. `start()` says
+ * which of the two it managed to arrange (`loopback`), and the paste path
+ * works whether or not it did.
+ *
+ * ## What never happens here
+ *
+ * No token is logged, printed, or put in an error. Failures name the status,
+ * the endpoint and the stage; they never carry the response body, because a
+ * token endpoint's body is where the token is. Nothing is written to the
+ * store until an exchange has fully succeeded, so an abandoned or rejected
+ * login leaves no partial credential behind.
+ */
+
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
+import { type Server, createServer } from 'node:http'
+
+import { writeStoredSubscriptionCredential } from './credential-store.js'
+import type { DetectedProvider } from './discover.js'
+import {
+	AUTHORIZE_URL,
+	OAUTH_CLIENT_ID,
+	OAUTH_SCOPES,
+	OAUTH_TOKEN_URL,
+	REDIRECT_URI,
+	SUBSCRIPTION_REDIRECT_PORT,
+} from './identity.js'
+import type { AgentOAuthCredential } from './keychain.js'
+import { PROVIDER_REGISTRY } from './registry.js'
+
+/** What a completed attempt produced. Never carries a secret in `reason`. */
+export type LoginOutcome =
+	| {
+			readonly ok: true
+			/** The stored credential, so the caller can open a session without re-reading. */
+			readonly credential: AgentOAuthCredential
+			/** Where it landed, so a surface can say so without guessing the path. */
+			readonly storedAt: string
+	  }
+	| { readonly ok: false; readonly reason: string }
+
+export interface SubscriptionLogin {
+	/** The page to open. Safe to print — it carries a challenge, never a secret. */
+	readonly url: string
+	readonly redirectUri: string
+	/**
+	 * Whether the loopback listener came up.
+	 *
+	 * `false` is not a failure: the port was busy, or the environment forbids
+	 * listening. The paste path is unaffected, and a surface should say so
+	 * rather than imply the login is broken.
+	 */
+	readonly loopback: boolean
+	/**
+	 * Resolve when the browser reaches the loopback listener, or never.
+	 *
+	 * `null` when `loopback` is false, so a caller cannot await a promise that
+	 * has no way to settle. Racing this against `completeWithPastedCode` is the
+	 * intended use; whichever finishes first wins and `cancel()` releases the
+	 * other.
+	 */
+	waitForCallback(): Promise<LoginOutcome> | null
+	/** Finish from a pasted redirect URL, `code#state`, or a bare code. */
+	completeWithPastedCode(input: string): Promise<LoginOutcome>
+	/** Release the listener. Safe to call twice, and safe to call after success. */
+	cancel(): void
+}
+
+export interface SubscriptionLoginOptions {
+	/** Override `homedir()` — tests, and an operator with a relocated home. */
+	readonly home?: string
+	/** Override the token-exchange transport (tests inject a stub). */
+	readonly fetch?: typeof fetch
+	/**
+	 * Try to listen on the loopback redirect. Default true.
+	 *
+	 * A caller that knows there is no browser here — `--no-browser`, a
+	 * container — passes false and skips a bind that would only ever time out.
+	 */
+	readonly loopback?: boolean
+}
+
+/**
+ * Begin a login. Returns the page to open plus the two ways to finish it.
+ *
+ * Deliberately does NOT open a browser. Which of `open`, `xdg-open` or a
+ * Windows protocol handler to spawn — and whether spawning anything is even
+ * appropriate — is a property of the surface the operator is sitting in front
+ * of, not of the protocol. A module that reached for a browser would be
+ * unusable from the one place that most needs it: a machine that has none.
+ */
+export async function beginSubscriptionLogin(
+	options: SubscriptionLoginOptions = {},
+): Promise<SubscriptionLogin> {
+	const verifier = base64Url(randomBytes(32))
+	const challenge = base64Url(createHash('sha256').update(verifier).digest())
+	// An independent value, not the verifier reused.
+	//
+	// Reusing the verifier as `state` is a thing implementations do, and it
+	// undoes PKCE: `state` travels in the authorization URL, so the verifier
+	// would sit in the address bar, the browser history and any referrer along
+	// the way — and the secret PKCE exists to keep out of that URL is exactly
+	// the verifier.
+	const state = base64Url(randomBytes(16))
+
+	const listener = options.loopback === false ? null : await openLoopback(state)
+
+	let settled = false
+	const exchangeOnce = async (code: string, seenState: string): Promise<LoginOutcome> => {
+		if (settled) return { ok: false, reason: 'This login was already completed.' }
+		if (!constantTimeEquals(seenState, state)) {
+			return {
+				ok: false,
+				reason:
+					'The sign-in did not come back with the value namzu sent, so it cannot be matched to this attempt. Nothing was stored. Start the login again.',
+			}
+		}
+		settled = true
+		return exchange(code, state, verifier, options)
+	}
+
+	return {
+		url: authorizeUrl(challenge, state),
+		redirectUri: REDIRECT_URI,
+		loopback: listener !== null,
+		waitForCallback: () =>
+			listener === null
+				? null
+				: listener.received.then((got) =>
+						got === null
+							? ({
+									ok: false,
+									reason: 'The sign-in was cancelled before the browser came back.',
+								} as LoginOutcome)
+							: got.error
+								? ({
+										ok: false,
+										reason: `The sign-in did not complete (${got.error}). Nothing was stored.`,
+									} as LoginOutcome)
+								: exchangeOnce(got.code, got.state),
+					),
+		completeWithPastedCode: async (input) => {
+			const parsed = parsePastedInput(input)
+			if (!parsed.code) {
+				return {
+					ok: false,
+					reason:
+						'That does not contain an authorization code. Paste the whole address the browser finished on, or the code it showed you.',
+				}
+			}
+			return exchangeOnce(parsed.code, parsed.state ?? state)
+		},
+		cancel: () => listener?.close(),
+	}
+}
+
+/**
+ * The detected-provider record a completed sign-in produces.
+ *
+ * Shaped exactly like a discovered one — the same shape `discoverProviders`
+ * would return on the NEXT launch, having read the file this login just
+ * wrote — so every downstream path treats it identically and nothing has to
+ * learn that a session began with a login. It carries `origin: 'stored'`, so
+ * the between-turn refresh writes back to the file rather than to a Keychain
+ * this machine may not have.
+ */
+export function subscriptionDetectedProvider(
+	credential: AgentOAuthCredential,
+	storedAt: string,
+): DetectedProvider {
+	return {
+		entry: PROVIDER_REGISTRY.anthropic,
+		source: { kind: 'stored', path: storedAt },
+		apiKey: credential.accessToken,
+		oauth: {
+			refreshToken: credential.refreshToken,
+			expiresAt: credential.expiresAt,
+			origin: 'stored',
+		},
+		alternatives: [],
+	}
+}
+
+function authorizeUrl(challenge: string, state: string): string {
+	const params = new URLSearchParams({
+		code: 'true',
+		client_id: OAUTH_CLIENT_ID,
+		response_type: 'code',
+		redirect_uri: REDIRECT_URI,
+		scope: OAUTH_SCOPES,
+		code_challenge: challenge,
+		code_challenge_method: 'S256',
+		state,
+	})
+	return `${AUTHORIZE_URL}?${params.toString()}`
+}
+
+/**
+ * Exchange the code, and store the result only once it is whole.
+ *
+ * The store write is the LAST thing. A response missing an access token, a
+ * non-2xx, a transport failure and a malformed body all return before it, so
+ * there is no path on which a failed login leaves a file behind.
+ */
+async function exchange(
+	code: string,
+	state: string,
+	verifier: string,
+	options: SubscriptionLoginOptions,
+): Promise<LoginOutcome> {
+	const fetchFn = options.fetch ?? globalThis.fetch
+	let res: Response
+	try {
+		res = await fetchFn(OAUTH_TOKEN_URL, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json', accept: 'application/json' },
+			body: JSON.stringify({
+				grant_type: 'authorization_code',
+				client_id: OAUTH_CLIENT_ID,
+				code,
+				state,
+				redirect_uri: REDIRECT_URI,
+				code_verifier: verifier,
+			}),
+			signal: AbortSignal.timeout(30_000),
+		})
+	} catch (err) {
+		// The MESSAGE of a transport error is safe (a hostname, a timeout); the
+		// body of a response is not, and there is none here.
+		return {
+			ok: false,
+			reason: `Could not reach the sign-in service (${err instanceof Error ? err.message : String(err)}). Nothing was stored.`,
+		}
+	}
+	if (!res.ok) {
+		// The status, never the body. A token endpoint answers failures with a
+		// document that can contain the very thing this module must not leak.
+		return {
+			ok: false,
+			reason: `The sign-in service refused the exchange (HTTP ${res.status}). The code may have already been used, or expired. Nothing was stored.`,
+		}
+	}
+	let data: { access_token?: unknown; refresh_token?: unknown; expires_in?: unknown }
+	try {
+		data = (await res.json()) as typeof data
+	} catch {
+		return {
+			ok: false,
+			reason:
+				'The sign-in service answered with something that is not a token. Nothing was stored.',
+		}
+	}
+	if (typeof data.access_token !== 'string' || data.access_token.length === 0) {
+		return {
+			ok: false,
+			reason: 'The sign-in service answered without a token. Nothing was stored.',
+		}
+	}
+	const credential: AgentOAuthCredential = {
+		accessToken: data.access_token,
+		...(typeof data.refresh_token === 'string' && data.refresh_token.length > 0
+			? { refreshToken: data.refresh_token }
+			: {}),
+		...(typeof data.expires_in === 'number'
+			? { expiresAt: Date.now() + data.expires_in * 1_000 }
+			: {}),
+	}
+	let storedAt: string
+	try {
+		storedAt = writeStoredSubscriptionCredential(credential, options.home)
+	} catch (err) {
+		// The store refused to prove the file private, so there is no file. Say
+		// what happened; the credential is dropped with the process.
+		return {
+			ok: false,
+			reason: `Signed in, but the credential could not be stored privately: ${err instanceof Error ? err.message : String(err)}`,
+		}
+	}
+	return { ok: true, credential, storedAt }
+}
+
+interface Loopback {
+	readonly received: Promise<{ code: string; state: string; error?: string } | null>
+	close(): void
+}
+
+/**
+ * A single-purpose listener on the loopback redirect, or `null`.
+ *
+ * `null` on every failure to bind — the port is in use (a second namzu, or
+ * another product's login mid-flight), the sandbox forbids listening, there
+ * is no loopback interface. None of those is fatal, because the paste path
+ * does not need this.
+ */
+async function openLoopback(expectedState: string): Promise<Loopback | null> {
+	let settle: (v: { code: string; state: string; error?: string } | null) => void = () => {}
+	const received = new Promise<{ code: string; state: string; error?: string } | null>((r) => {
+		let done = false
+		settle = (v) => {
+			if (done) return
+			done = true
+			r(v)
+		}
+	})
+
+	const server: Server = createServer((req, res) => {
+		const url = new URL(req.url ?? '/', `http://127.0.0.1:${SUBSCRIPTION_REDIRECT_PORT}`)
+		const error = url.searchParams.get('error')
+		const code = url.searchParams.get('code')
+		const state = url.searchParams.get('state')
+		const finish = (status: number, text: string) => {
+			res.writeHead(status, { 'content-type': 'text/plain; charset=utf-8' })
+			res.end(text)
+		}
+		if (error) {
+			finish(400, 'Sign-in did not complete. Return to namzu.')
+			settle({ code: '', state: '', error })
+			return
+		}
+		if (!code || !state) {
+			// Not our redirect — a browser probing the port, a favicon request.
+			// Answering and NOT settling keeps the listener alive for the real one.
+			finish(404, 'Not the sign-in callback.')
+			return
+		}
+		if (!constantTimeEquals(state, expectedState)) {
+			// Refused here as well as at the exchange. This is the request a
+			// cross-site attempt would make, and answering it with "done" would
+			// tell whoever made it that the port is a live login.
+			finish(400, 'Sign-in did not complete. Return to namzu.')
+			return
+		}
+		finish(200, 'Signed in. You can close this tab and return to namzu.')
+		settle({ code, state })
+	})
+
+	const bound = await new Promise<boolean>((resolve) => {
+		server.once('error', () => resolve(false))
+		server.listen(SUBSCRIPTION_REDIRECT_PORT, '127.0.0.1', () => resolve(true))
+	})
+	if (!bound) {
+		server.close()
+		return null
+	}
+	return {
+		received,
+		close: () => {
+			settle(null)
+			server.close()
+		},
+	}
+}
+
+/**
+ * Pull a code (and a state, when there is one) out of whatever got pasted.
+ *
+ * Four spellings reach this in practice: the full redirect address, its query
+ * string alone, the `code#state` pair a consent screen offers for copying,
+ * and a bare code. Anything else yields no code and is refused by the caller
+ * — guessing at a fifth shape would send an arbitrary string to a token
+ * endpoint as if it were an authorization code.
+ */
+export function parsePastedInput(input: string): { code?: string; state?: string } {
+	const value = input.trim()
+	if (value.length === 0) return {}
+
+	if (/^https?:\/\//i.test(value)) {
+		try {
+			const url = new URL(value)
+			return {
+				code: url.searchParams.get('code') ?? undefined,
+				state: url.searchParams.get('state') ?? undefined,
+			}
+		} catch {
+			return {}
+		}
+	}
+	if (value.includes('code=')) {
+		const params = new URLSearchParams(value.replace(/^\?/, ''))
+		return {
+			code: params.get('code') ?? undefined,
+			state: params.get('state') ?? undefined,
+		}
+	}
+	if (value.includes('#')) {
+		const [code, state] = value.split('#', 2)
+		return { code: code || undefined, state: state || undefined }
+	}
+	// A bare code. Whitespace already ruled out by the trim + the checks above
+	// only when it contained a separator, so reject an obviously-wrong paste
+	// (a sentence, a wrapped line) rather than posting it.
+	if (/\s/.test(value)) return {}
+	return { code: value }
+}
+
+/**
+ * Compare two opaque values without leaking their relationship through timing.
+ *
+ * `state` is compared, not a secret, so this is belt-and-braces — but the
+ * cheap version of this comparison is `===`, and `===` on strings of equal
+ * length is the shape that teaches the next person to write it for the
+ * verifier too.
+ */
+function constantTimeEquals(a: string, b: string): boolean {
+	const left = Buffer.from(a, 'utf8')
+	const right = Buffer.from(b, 'utf8')
+	if (left.length !== right.length) return false
+	return timingSafeEqual(left, right)
+}
+
+function base64Url(bytes: Buffer): string {
+	return bytes.toString('base64url')
+}

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -17,12 +17,19 @@ import { relative } from 'node:path'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import {
+	beginSubscriptionLogin,
+	clearStoredSubscriptionCredential,
+	credentialsPath,
 	type DetectedProvider,
 	type Preferences,
 	type ProviderId,
 	primaryProvider,
+	readStoredSubscriptionCredential,
+	type SubscriptionLogin,
 	writePreferences,
 } from '../integrations/providers/index.js'
+import { describeLoginOutcome, describeLoginStart, describeLogout } from './login-prompt.js'
+import { openInBrowser } from './open-browser.js'
 import { isTrusted, trustDir } from '../integrations/trust/store.js'
 import { appendMemory, composeMemoryPrompt, readMemory } from '../memory/store.js'
 import { composeSkillsPrompt, discoverSkills, loadSkillBody } from '../skills/store.js'
@@ -146,6 +153,15 @@ export function App({ ctx }: AppProps) {
 	const [selectedResume, setSelectedResume] = useState<number>(0)
 	const exitArmedRef = useRef<boolean>(false)
 	const abortRef = useRef<AbortController | null>(null)
+	/**
+	 * The sign-in attempt awaiting its authorization code, if any.
+	 *
+	 * A ref and not state: nothing renders from it, and a re-render between
+	 * `/login` and `/login <address>` must not lose the verifier — without
+	 * which the code that comes back cannot be exchanged for anything.
+	 */
+	const loginRef = useRef<SubscriptionLogin | null>(null)
+	const runProbeRef = useRef<(() => Promise<void>) | null>(null)
 	/**
 	 * The session currently holding resources, so a re-hydration can release the
 	 * one it replaces. A `/model` switch builds a new session, and a tool
@@ -372,6 +388,85 @@ export function App({ ctx }: AppProps) {
 		[ctx.cwd, ctx.rules, pushMessage],
 	)
 
+	/**
+	 * Sign in to a subscription without leaving namzu.
+	 *
+	 * Two calls, one command. Bare `/login` starts an attempt and parks it in
+	 * `loginRef`; `/login <address>` finishes that one. Nothing here parses the
+	 * argument — `slashCommands` already decided which of the two this is.
+	 *
+	 * ## Why it re-probes instead of installing the credential directly
+	 *
+	 * The login writes to the same file `discoverProviders` reads, so re-running
+	 * the probe is not a lazy substitute for wiring the credential in: it is the
+	 * only version that cannot disagree with a cold start. Building a session
+	 * from the returned credential here, in parallel, would be a SECOND way to
+	 * arrive at a provider — and the day the two differ, the operator's session
+	 * works until they restart, which is the worst possible moment to find out.
+	 *
+	 * It also gets the no-preferences case right for free: a first-run operator
+	 * who signs in lands in the picker, which is exactly where someone with a
+	 * working credential and no chosen provider should be.
+	 */
+	const startOrFinishLogin = useCallback(
+		async (pasted?: string) => {
+			if (pasted !== undefined) {
+				const pending = loginRef.current
+				if (!pending) {
+					pushMessage(
+						'system',
+						'There is no sign-in waiting to be finished. Run /login on its own to start one.',
+					)
+					return
+				}
+				const outcome = await pending.completeWithPastedCode(pasted)
+				pending.cancel()
+				loginRef.current = null
+				pushMessage('system', describeLoginOutcome(outcome))
+				if (outcome.ok) await runProbeRef.current?.()
+				return
+			}
+
+			loginRef.current?.cancel()
+			loginRef.current = null
+			let start: SubscriptionLogin
+			try {
+				start = await beginSubscriptionLogin()
+			} catch (err) {
+				pushMessage(
+					'system',
+					`Could not start a sign-in: ${err instanceof Error ? err.message : String(err)}`,
+				)
+				return
+			}
+			loginRef.current = start
+			pushMessage(
+				'system',
+				describeLoginStart({
+					url: start.url,
+					loopback: start.loopback,
+					browserOpened: openInBrowser(start.url),
+				}),
+			)
+			// The automatic half, when there is one. Not awaited by the caller:
+			// the composer stays live throughout, so the operator can paste
+			// instead — or type anything else — while this waits.
+			const waiting = start.waitForCallback()
+			if (!waiting) return
+			const outcome = await waiting
+			if (loginRef.current !== start) return // superseded, or finished by paste
+			loginRef.current = null
+			start.cancel()
+			// A cancelled listener resolves to a refusal, and saying "sign-in
+			// failed" when the operator finished it another way would be a lie
+			// about their own successful login.
+			if (!outcome.ok && outcome.reason.includes('cancelled')) return
+			pushMessage('system', describeLoginOutcome(outcome))
+			if (outcome.ok) await runProbeRef.current?.()
+		},
+		[pushMessage],
+	)
+
 	const runProbe = useCallback(async () => {
 		try {
 			const probe = await probeAgentSession()
@@ -394,6 +489,11 @@ export function App({ ctx }: AppProps) {
 			)
 		}
 	}, [hydrateSession, pushMessage])
+
+	// `startOrFinishLogin` is declared above `runProbe` and calls it, so it
+	// reads the current one through a ref rather than closing over a stale
+	// binding or forcing the two into a declaration order that reads backwards.
+	runProbeRef.current = runProbe
 
 	// Trust gate runs first: don't touch the folder until the user trusts it.
 	useEffect(() => {
@@ -915,6 +1015,24 @@ export function App({ ctx }: AppProps) {
 					case 'repick':
 						setPhase('picker')
 						return
+					case 'login':
+						void startOrFinishLogin(slash.pasted)
+						return
+					case 'logout': {
+						const path = credentialsPath()
+						const had = readStoredSubscriptionCredential() !== null
+						try {
+							clearStoredSubscriptionCredential()
+						} catch (err) {
+							pushMessage(
+								'system',
+								`Could not remove ${path}: ${err instanceof Error ? err.message : String(err)}`,
+							)
+							return
+						}
+						pushMessage('system', describeLogout(path, had))
+						return
+					}
 					case 'remember':
 						try {
 							appendMemory(slash.text)

--- a/packages/cli/src/tui/Picker.tsx
+++ b/packages/cli/src/tui/Picker.tsx
@@ -462,6 +462,10 @@ function describeSource(d: DetectedProvider): string {
 			return `local · ${d.source.url.replace(/^https?:\/\//, '')}`
 		case 'keychain':
 			return `keychain · ${d.source.service}`
+		case 'stored':
+			// Named for what the operator DID, not for where the bytes live. They
+			// signed in; the path is in `/doctor` for when it matters.
+			return 'signed in · this machine'
 		case 'session':
 			// Named as temporary wherever it is listed. Someone scanning this
 			// column should be able to see which credential disappears when they

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -82,8 +82,8 @@ import {
 	isAnthropicOAuthToken,
 	isRegistered,
 	primaryProvider,
-	readAgentKeychainCredential,
 	readPreferences,
+	readSubscriptionCredential,
 	resolveChainCapabilities,
 	unresolvedMembers,
 	unsupportedProviderMessage,
@@ -581,18 +581,26 @@ export async function createAgentSession(
 	// OAuth access tokens on this path are short-lived (~8h). They rarely lapse
 	// *during* a turn, but they do between turns — an idle session that sends
 	// again hours later would otherwise 401. So before each turn (see `send`)
-	// we re-read the keychain (another process may have rotated it) and refresh a
-	// stale token, rebuilding the client only when the token actually changed.
-	// Gated on `det.oauth` so env / secrets credentials are never touched.
-	const keychainRefresh = primary.id === 'anthropic' && Boolean(det?.oauth)
+	// we re-read the credential store (another process may have rotated it) and
+	// refresh a stale token, rebuilding the client only when the token actually
+	// changed. Gated on `det.oauth` so env / secrets credentials are never
+	// touched.
+	//
+	// `origin` decides WHICH store, and travels with the credential from
+	// discovery rather than being assumed here: namzu's own store and the
+	// borrowed Keychain entry both produce a refreshable credential, and reading
+	// one while writing the other would refresh forever without ever landing.
+	const subscriptionRefresh = primary.id === 'anthropic' && Boolean(det?.oauth)
+	const credentialOrigin = det?.oauth?.origin ?? 'keychain'
 	let currentToken = det?.apiKey
 	const refreshTokenIfNeeded = async (): Promise<void> => {
-		if (!keychainRefresh) return
-		const cred = readAgentKeychainCredential()
+		if (!subscriptionRefresh) return
+		const cred = readSubscriptionCredential(credentialOrigin)
 		if (!cred) return
 		const fresh = await ensureFreshAnthropicToken(cred.accessToken, {
 			refreshToken: cred.refreshToken,
 			expiresAt: cred.expiresAt,
+			origin: credentialOrigin,
 		})
 		if (fresh === currentToken) return
 		currentToken = fresh

--- a/packages/cli/src/tui/credential-entry.ts
+++ b/packages/cli/src/tui/credential-entry.ts
@@ -7,19 +7,23 @@
  *
  * ## Why session-only, stated as a decision rather than a limitation
  *
- * The obvious durable home is the OS keychain, and here it does not exist. The
- * keychain helper in this package is macOS-only, and it reads and writes a
- * DIFFERENT product's credential store — namzu borrows an OAuth token from it.
- * Writing a namzu key into that envelope would put our secret under their name.
- * On Windows, which is where this was asked for, there is no keychain path at
- * all.
+ * A durable store now exists next door (`credential-store.ts`), and this path
+ * still does not use it — which is the interesting part, because the original
+ * reason for session-only was that no such store had been written.
  *
- * So the durable options were a plaintext file or a per-platform credential
- * store nobody has written. Keeping the key in memory for the session is the
- * honest third answer: nothing lands on disk, it works everywhere, and the
- * screen names the environment variable that makes it durable. A secret at rest
- * should be something the operator chose, not something that arrived because
- * they typed into a text field.
+ * That reason is gone; the decision is not, and it rests on the one thing the
+ * two paths do not share. `/login` OBTAINS a credential: the operator asked for
+ * one, namzu got it, and namzu can refresh it, name where it came from, and
+ * remove it again. A key typed here arrived from somewhere namzu had no part
+ * in — there is nothing to refresh it with, no origin to report, and no
+ * meaningful way to revoke it on the operator's behalf. Writing that to disk
+ * uninvited would be namzu deciding, for someone else, that their secret should
+ * persist.
+ *
+ * So the key stays in memory: nothing lands on disk, it works everywhere, and
+ * the screen names the environment variable that makes it durable. A secret at
+ * rest should be something the operator chose, not something that arrived
+ * because they typed into a text field — and now there are two ways to choose.
  *
  * Everything decidable lives here rather than in the component, because this
  * package has no component tests and a secret is the worst thing to leave

--- a/packages/cli/src/tui/login-prompt.test.ts
+++ b/packages/cli/src/tui/login-prompt.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+
+import type { LoginOutcome } from '../integrations/providers/index.js'
+import {
+	describeLoginOutcome,
+	describeLoginStart,
+	describeLogout,
+	isCompletionArgument,
+} from './login-prompt.js'
+
+const URL_ = 'https://example.invalid/oauth/authorize?client_id=x&code_challenge=y&state=z'
+
+describe('describeLoginStart', () => {
+	it('prints the address whether or not a browser was launched', () => {
+		for (const browserOpened of [true, false]) {
+			expect(describeLoginStart({ url: URL_, loopback: true, browserOpened })).toContain(URL_)
+		}
+	})
+
+	it('does not claim a browser opened when none was launched', () => {
+		const text = describeLoginStart({ url: URL_, loopback: true, browserOpened: false })
+		expect(text).not.toContain('Opening your browser')
+	})
+
+	it('says the automatic hand-back is missing when there is no listener', () => {
+		const without = describeLoginStart({ url: URL_, loopback: false, browserOpened: true })
+		// The case an operator must be told about: they would otherwise wait for
+		// something that is never going to happen.
+		expect(without).toContain('not available')
+		expect(without).toContain('/login <the address, or just the code>')
+	})
+
+	it('offers the paste route even when the listener came up', () => {
+		// The remote-browser case: the listener exists and is unreachable from
+		// wherever the person is actually looking at a browser.
+		const withListener = describeLoginStart({ url: URL_, loopback: true, browserOpened: true })
+		expect(withListener).toContain('/login <the address, or just the code>')
+		expect(withListener).toContain('automatically')
+	})
+})
+
+describe('describeLoginOutcome', () => {
+	it('names where the credential landed, and how to remove it', () => {
+		const outcome: LoginOutcome = {
+			ok: true,
+			credential: { accessToken: 'zzz-secret-token-value' },
+			storedAt: '/home/x/.namzu/credentials.json',
+		}
+		const text = describeLoginOutcome(outcome)
+		expect(text).toContain('/home/x/.namzu/credentials.json')
+		expect(text).toContain('/logout')
+		// The credential is IN the value handed to this function, so this is the
+		// place a careless rewrite would print it.
+		expect(text).not.toContain('zzz-secret-token-value')
+	})
+
+	it('repeats the refusal it was given and says how to retry', () => {
+		const text = describeLoginOutcome({ ok: false, reason: 'HTTP 400 something.' })
+		expect(text).toContain('HTTP 400 something.')
+		expect(text).toContain('/login')
+	})
+})
+
+describe('describeLogout', () => {
+	it('distinguishes removing something from removing nothing', () => {
+		const removed = describeLogout('/p/credentials.json', true)
+		const absent = describeLogout('/p/credentials.json', false)
+		expect(removed).toContain('/p/credentials.json')
+		expect(removed).not.toBe(absent)
+	})
+
+	it('does not claim to have revoked anything at the provider', () => {
+		// Deleting a local file is not revocation, and an operator who believes
+		// otherwise leaves a live credential behind.
+		expect(describeLogout('/p', true)).toContain('does not revoke')
+	})
+
+	it('says whose credential it is when there is nothing of ours to remove', () => {
+		expect(describeLogout('/p', false)).toContain('environment')
+	})
+})
+
+describe('isCompletionArgument', () => {
+	it('treats a bare command as a start', () => {
+		expect(isCompletionArgument([])).toBe(false)
+		expect(isCompletionArgument([''])).toBe(false)
+		expect(isCompletionArgument(['  '])).toBe(false)
+	})
+
+	it('treats anything typed after it as a completion', () => {
+		expect(isCompletionArgument(['abc'])).toBe(true)
+		expect(isCompletionArgument(['http://localhost:53692/callback?code=a&state=b'])).toBe(true)
+	})
+})

--- a/packages/cli/src/tui/login-prompt.ts
+++ b/packages/cli/src/tui/login-prompt.ts
@@ -1,0 +1,80 @@
+/**
+ * What namzu says while an operator signs in to their subscription.
+ *
+ * Every decidable thing lives here rather than in the component, for the
+ * reason `credential-entry.ts` gives next door: this package has no component
+ * tests, and wording that handles a credential is the worst thing to leave
+ * unverifiable. What the component does with these strings is print them.
+ *
+ * The one rule these functions exist to keep: **an outcome is described by
+ * what happened, never by quoting what came back.** A refusal from a token
+ * endpoint arrives in a document that can contain a token, so no function
+ * here ever receives one — `LoginOutcome.reason` is already sanitised at the
+ * protocol layer, and the success arm is handed a path, not a credential.
+ */
+
+import type { LoginOutcome } from '../integrations/providers/index.js'
+
+/**
+ * The screen the operator reads when a sign-in starts.
+ *
+ * The URL is printed WHATEVER happened with the browser. A launcher that
+ * started is not a browser that appeared — no platform reports that — and a
+ * message that says "your browser is opening" and nothing else leaves someone
+ * on a machine with no browser staring at a line that is simply false.
+ */
+export function describeLoginStart(start: {
+	readonly url: string
+	readonly loopback: boolean
+	readonly browserOpened: boolean
+}): string {
+	const lines = [
+		start.browserOpened
+			? 'Opening your browser to sign in. If nothing opened, or the browser is on another machine, use this address:'
+			: 'Open this address to sign in — on this machine, or on any machine you can reach it from:',
+		'',
+		start.url,
+		'',
+	]
+	lines.push(
+		start.loopback
+			? 'When the page finishes, namzu will pick it up automatically. If your browser is somewhere this machine cannot be reached from — a container, a remote shell — copy the address it lands on and run:'
+			: // Said plainly. The listener is what makes the automatic path work,
+				// and an operator who is not told it is missing will sit waiting for
+				// something that is never going to happen.
+				'The automatic hand-back is not available in this session (the port is in use, or this environment does not allow listening), so finish it by hand. Copy the address the browser lands on and run:',
+	)
+	lines.push('', '  /login <the address, or just the code>')
+	return lines.join('\n')
+}
+
+/** What the operator reads when the attempt ends, either way. */
+export function describeLoginOutcome(outcome: LoginOutcome): string {
+	if (!outcome.ok) {
+		return `${outcome.reason}\n\nRun /login to try again.`
+	}
+	return [
+		'Signed in. The credential is stored on this machine, readable only by your account:',
+		`  ${outcome.storedAt}`,
+		'',
+		'namzu will refresh it as it expires, and will find it again next time it starts. Run /logout to remove it.',
+	].join('\n')
+}
+
+/** What the operator reads after asking namzu to forget the credential. */
+export function describeLogout(path: string, removed: boolean): string {
+	return removed
+		? `Removed the stored credential at ${path}. This session keeps working until it ends; the next one will ask you to sign in again.\n\nSigning out here does not revoke anything at the provider — do that in your account settings if you need to.`
+		: "There was no stored credential to remove. If namzu is using one, it came from your environment or from another tool on this machine, and neither is namzu's to delete."
+}
+
+/**
+ * Whether a `/login` argument is an attempt to finish, rather than to start.
+ *
+ * Bare `/login` starts an attempt; `/login <something>` finishes one. Drawn
+ * here rather than in the command so the rule is testable and so the command
+ * cannot quietly grow a third meaning.
+ */
+export function isCompletionArgument(args: readonly string[]): boolean {
+	return args.join(' ').trim().length > 0
+}

--- a/packages/cli/src/tui/open-browser.test.ts
+++ b/packages/cli/src/tui/open-browser.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const spawn = vi.hoisted(() => vi.fn())
+vi.mock('node:child_process', () => ({ spawn }))
+
+import { openInBrowser } from './open-browser.js'
+
+function child() {
+	return { on: vi.fn(), unref: vi.fn() }
+}
+
+describe('openInBrowser', () => {
+	it('refuses anything that is not a web address', () => {
+		spawn.mockReturnValue(child())
+		for (const bad of [
+			'file:///etc/passwd',
+			'javascript:alert(1)',
+			'ftp://example.invalid',
+			'/usr/bin/thing',
+			'',
+		]) {
+			expect(openInBrowser(bad)).toBe(false)
+		}
+		expect(spawn).not.toHaveBeenCalled()
+	})
+
+	it('never routes the address through a shell', () => {
+		spawn.mockReturnValue(child())
+		// The metacharacters that make `cmd /c start <url>` a command line.
+		openInBrowser('https://example.invalid/?a=1&b=2^c|d')
+		expect(spawn).toHaveBeenCalledTimes(1)
+		const [command, args, options] = spawn.mock.calls[0] as [string, string[], object]
+		expect(options).not.toHaveProperty('shell', true)
+		expect(command).not.toMatch(/cmd(\.exe)?$/i)
+		expect(command).not.toMatch(/(^|[\\/])sh$|bash|powershell/i)
+		// The address is one argument, unsplit and unquoted.
+		expect(args).toContain('https://example.invalid/?a=1&b=2^c|d')
+	})
+
+	it('reports failure rather than throwing when no launcher can start', () => {
+		spawn.mockImplementation(() => {
+			throw new Error('ENOENT')
+		})
+		expect(openInBrowser('https://example.invalid/')).toBe(false)
+	})
+
+	it('survives a launcher that fails asynchronously, which is the headless case', () => {
+		const c = child()
+		spawn.mockReturnValue(c)
+		expect(openInBrowser('https://example.invalid/')).toBe(true)
+		// An `error` handler must be attached, or a missing `xdg-open` in a
+		// container becomes an unhandled event and takes the process down.
+		expect(c.on).toHaveBeenCalledWith('error', expect.any(Function))
+		const handler = c.on.mock.calls.find((call) => call[0] === 'error')?.[1] as () => void
+		expect(() => handler()).not.toThrow()
+		// And it must be detached, or namzu waits on a browser to exit.
+		expect(c.unref).toHaveBeenCalled()
+	})
+})

--- a/packages/cli/src/tui/open-browser.ts
+++ b/packages/cli/src/tui/open-browser.ts
@@ -1,0 +1,59 @@
+/**
+ * Hand a URL to whatever the machine opens URLs with, or say it could not.
+ *
+ * ## No shell, ever
+ *
+ * The URL this receives carries operator-visible parameters and is built from
+ * a template, so the tempting Windows spelling — `cmd /c start <url>` — is the
+ * one to avoid on principle rather than after an incident: `cmd.exe` re-parses
+ * `&`, `|`, `^` and friends BEFORE `start` sees them, which makes any URL a
+ * command line. `rundll32 url.dll,FileProtocolHandler` takes the address as an
+ * argument and nothing re-reads it, and the launcher is invoked by absolute
+ * path under the system directory so a same-named executable earlier on `PATH`
+ * cannot answer instead.
+ *
+ * ## Best effort, reported honestly
+ *
+ * Returns whether a launcher was even STARTED, not whether a browser appeared
+ * — nothing on any platform tells us that. A caller must therefore print the
+ * URL regardless: `true` means "a browser is probably opening", never "you can
+ * stop reading". On a machine with no graphical session there is nothing to
+ * start and this says so, which is the case the paste path exists for.
+ */
+
+import { spawn } from 'node:child_process'
+import { platform } from 'node:os'
+import { join } from 'node:path'
+
+export function openInBrowser(url: string): boolean {
+	// Refuse anything that is not a web address. This is handed to the
+	// machine's protocol handler, and `file:` or a custom scheme reaching it
+	// would be this function opening something nobody named.
+	if (!/^https?:\/\//i.test(url)) return false
+
+	const [command, args] =
+		platform() === 'darwin'
+			? ['open', [url]]
+			: platform() === 'win32'
+				? [
+						join(process.env.SystemRoot ?? 'C:\\Windows', 'System32', 'rundll32.exe'),
+						['url.dll,FileProtocolHandler', url],
+					]
+				: ['xdg-open', [url]]
+
+	try {
+		const child = spawn(command as string, args as string[], {
+			stdio: 'ignore',
+			detached: true,
+		})
+		// A missing launcher — no `xdg-open` in a container — arrives as an
+		// async error event, long after this function returned. Swallowing it
+		// keeps a headless machine from taking the process down over a browser
+		// nobody was going to see; the caller already printed the URL.
+		child.on('error', () => {})
+		child.unref()
+		return true
+	} catch {
+		return false
+	}
+}

--- a/packages/cli/src/tui/slashCommands.test.ts
+++ b/packages/cli/src/tui/slashCommands.test.ts
@@ -509,3 +509,49 @@ describe('/expand argument parsing', () => {
 		expect(runSlash('  /expand 3  ', ctx)).toEqual({ kind: 'expand', which: 3 })
 	})
 })
+
+describe('/login and /logout', () => {
+	it('starts an attempt when typed on its own', () => {
+		expect(runSlash('/login', ctx)).toEqual({ kind: 'login' })
+	})
+
+	it('finishes the attempt in flight when given an address or a code', () => {
+		expect(runSlash('/login abc#xyz', ctx)).toEqual({ kind: 'login', pasted: 'abc#xyz' })
+		expect(runSlash('/login http://localhost:53692/callback?code=a&state=b', ctx)).toEqual({
+			kind: 'login',
+			pasted: 'http://localhost:53692/callback?code=a&state=b',
+		})
+	})
+
+	it('treats a trailing space as a start, not an empty paste', () => {
+		// An empty `pasted` would be sent onward as if it were an authorization
+		// code, and refused by a token endpoint rather than by us.
+		expect(runSlash('/login   ', ctx)).toEqual({ kind: 'login' })
+	})
+
+	it('keeps the whole argument rather than only the first word', () => {
+		// A pasted address can arrive broken by a terminal wrap; dropping
+		// everything after the first space would silently truncate the code.
+		expect(runSlash('/login a b', ctx)).toEqual({ kind: 'login', pasted: 'a b' })
+	})
+
+	it('offers logout with no argument to misread', () => {
+		expect(runSlash('/logout', ctx)).toEqual({ kind: 'logout' })
+		expect(runSlash('/logout everything', ctx)).toEqual({ kind: 'logout' })
+	})
+
+	it('both appear in /help, or nobody finds them', () => {
+		const help = runSlash('/help', ctx)
+		expect(help?.kind).toBe('message')
+		if (help?.kind === 'message') {
+			expect(help.content).toContain('/login')
+			expect(help.content).toContain('/logout')
+		}
+	})
+
+	it('both are offered by autocomplete', () => {
+		expect(matchSlashCommands('/log').map((c) => c.name)).toEqual(
+			expect.arrayContaining(['login', 'logout']),
+		)
+	})
+})

--- a/packages/cli/src/tui/slashCommands.ts
+++ b/packages/cli/src/tui/slashCommands.ts
@@ -26,6 +26,7 @@
 import type { VerificationRule } from '@namzu/sdk'
 
 import { type UserCommand, expandCommand } from '../user-commands/store.js'
+import { isCompletionArgument } from './login-prompt.js'
 
 export type SlashAction =
 	| { kind: 'message'; role: 'system'; content: string }
@@ -55,6 +56,18 @@ export type SlashAction =
 	 * the model uses.
 	 */
 	| { kind: 'prompt'; text: string }
+	/**
+	 * Sign in to a subscription without leaving namzu.
+	 *
+	 * Bare `/login` STARTS an attempt; `/login <address-or-code>` FINISHES the
+	 * one in flight. Two verbs on one command because they are one act from
+	 * where the operator sits, and because the second is the whole point on a
+	 * machine whose browser is somewhere else — a container, a remote shell.
+	 * The distinction is `pasted`, and this module decides it (see
+	 * `isCompletionArgument`) so App never has to parse an argument.
+	 */
+	| { kind: 'login'; pasted?: string }
+	| { kind: 'logout' }
 	| { kind: 'none' }
 
 export interface SlashContext {
@@ -318,6 +331,19 @@ export const SLASH_COMMANDS: readonly SlashCommand[] = [
 		name: 'model',
 		description: 'Re-open the provider picker to switch the primary provider.',
 		action: () => ({ kind: 'repick' }),
+	},
+	{
+		name: 'login',
+		description: 'Sign in with a subscription: /login, then /login <address> if asked.',
+		action: (_ctx, args) =>
+			isCompletionArgument(args)
+				? { kind: 'login', pasted: args.join(' ').trim() }
+				: { kind: 'login' },
+	},
+	{
+		name: 'logout',
+		description: 'Remove the subscription credential namzu stored on this machine.',
+		action: () => ({ kind: 'logout' }),
 	},
 	{
 		name: 'cost',


### PR DESCRIPTION
namzu could already **use** and **refresh** a plan-backed credential. It could not **obtain** one, and it could only **find** one on macOS. This adds both halves, plus the surface to reach them.

## What I read first, and what it changed

Two working implementations were read before anything was written. Both are the same lineage — the first imports the second's published package for its credential storage — so they agree on every answer below.

| Question | `packages/ai/src/utils/oauth/anthropic.ts` (A) · `packages/ai/src/auth/oauth/anthropic.ts` (B) |
|---|---|
| **Whose client identity?** | **Neither registered its own.** Both hardcode the *same* public client identifier the vendor's own command-line tool is registered under — A:28, B:29 — and both hide it behind a runtime `atob()`. It is byte-identical to the one namzu's `oauth.ts` already carried in plaintext for its refresh path. |
| **What flow?** | Authorization code + PKCE (S256). Authorize at `claude.ai/oauth/authorize` with `code=true`, `client_id`, `response_type=code`, `redirect_uri`, `scope`, `code_challenge`, `code_challenge_method=S256`, `state`. Exchange as JSON at `/v1/oauth/token`. Loopback redirect on a **fixed** port (`127.0.0.1:53692/callback`), racing a manual paste prompt. |
| **Where does the token go?** | A plain JSON file, `auth.json`, under the tool's home directory — `packages/coding-agent/src/core/auth-storage.ts` in both. Mode `0600`, directory `0700`, `chmodSync` after every write, `proper-lockfile` around it. **The refresh token sits in plaintext beside the access token. Neither repo contains a keyring, keychain, or credential-manager call of any kind** — I grepped for all of them. |
| **How does it refresh?** | Lazily, in `getApiKeyWithSourceToken`: if `Date.now() >= expires`, refresh under a file lock. On failure it re-reads the file (another process may have won), and if that fails too it returns *no key*, so model discovery skips the provider and the operator is told to `/login`. Credentials are preserved for the retry. |
| **No browser, no keyring?** | The paste path. Both start the loopback listener *and* immediately prompt for a pasted code/URL, whichever settles first. B also carries a full RFC 8628 device-code implementation (`auth/oauth/device-code.ts`) — but **not for this provider**; it is used by others. `PI_OAUTH_CALLBACK_HOST` lets the bind address be overridden. |

**Both systems do initiate a login** — the finding the brief asked me to flag is not present here.

### Three things I did *not* copy, and why

1. **The obfuscation.** Both wrap the client id in `atob()`. A public OAuth client identifier is public by definition — that is what PKCE exists for — so this hides nothing from anyone reading the request while hiding the one fact a reviewer of that file needs. namzu keeps it legible.
2. **`state` = the PKCE verifier.** Both pass the verifier as `state` (A:252, B:255). `state` travels in the authorization URL, so this puts the verifier in the address bar, the browser history, and any referrer — the exact place PKCE exists to keep it out of. namzu mints `state` independently.
3. **Response bodies in error messages.** Both interpolate the raw body into thrown errors (`body=${responseBody}`, A:183/216, B:184/222). A token endpoint's failure document is where the token is. namzu's refusals name the status and the stage and never the body — there is a test that drives exactly that case.

## The client-identity decision

**namzu presents the vendor's own command-line client identifier.** Written down at the constant, in `packages/cli/src/integrations/providers/identity.ts`, with the consequences rather than only the fact: the authorization server cannot tell namzu apart from that tool; the operator's own plan governs the credential; the sign-in happens on the vendor's page against the operator's account with nothing proxied; and the identity can be revoked by its owner at any time, at which point every sign-in stops working.

The alternative was not "register our own" — the vendor operates no open client registration for this grant. It was "do not offer the capability", which the owner has ruled out. Anyone uncomfortable with it has the unchanged other doors: an environment variable, or a typed key.

**Verified rather than assumed:** two hosts serve this token endpoint (`console.anthropic.com` and `platform.claude.com`, same path). I probed both with a real `authorization_code` grant shape; they answer identically from the same handler. So namzu keeps the address its existing refresh path has always used, and no working code was moved for a change with nothing to gain.

## What was built

**`credential-store.ts` — `~/.namzu/credentials.json`, every platform.** The file-over-native-store choice is stated, not defaulted into, and paid for by making the file's privacy a *checked* property: created `0600` from birth (`wx` + mode, no world-readable window) inside a `0700` directory, then **read back and asserted**. On Windows a POSIX mode proves nothing — `fs.chmod` there only toggles read-only — so inheritance is removed, a single full-control entry is granted to the current account's SID, and the resulting ACL is saved back as SDDL and required to name that SID and nobody else. **If the proof cannot be made, the file is deleted and the write throws.**

**`subscription-login.ts` — authorization code + PKCE.** Loopback *and* paste, always both. The module deliberately does not open a browser: which launcher to spawn, and whether spawning anything is appropriate, is a property of the surface, and a module that reached for one would be unusable from the machine that most needs it. A busy port degrades to paste-only and *says so* — the port is part of the registered redirect and not ours to change.

**Nothing is written until an exchange fully succeeds.** Asserted on five failure paths, including the absence of a leftover temp file.

**Refresh keeps working, and there is no second store.** Discovery asks namzu's store first on every platform, then the borrowed macOS one. `origin` travels with the credential so a refreshed token goes back where it came from — reading one store and writing the other would refresh forever without ever landing.

## What I exposed for the no-credential screen

Another agent owns the routing at `tui/agent.ts` and App's `unhealthy` phase. I stayed out of both. Callable from `packages/cli/src/integrations/providers/index.js`:

- `beginSubscriptionLogin(options?) => Promise<SubscriptionLogin>` — `{ url, redirectUri, loopback, waitForCallback(), completeWithPastedCode(input), cancel() }`. `waitForCallback()` returns `null` when no listener came up, so nothing can await a promise that cannot settle.
- `subscriptionDetectedProvider(credential, storedAt) => DetectedProvider` — the record a completed sign-in produces, shaped exactly like a discovered one.
- `readStoredSubscriptionCredential` / `writeStoredSubscriptionCredential` / `clearStoredSubscriptionCredential` / `credentialsPath` / `CredentialStoreError`.
- `readSubscriptionCredential(origin)`, `CredentialOrigin`.

And from `tui/login-prompt.js`: `describeLoginStart`, `describeLoginOutcome`, `describeLogout` — the wording, decided outside the component because this package has no component tests.

The operator-facing surface is `/login`, `/login <address-or-code>`, and `/logout`. App re-probes after success rather than installing the credential it was handed: the login wrote to the file discovery reads, so re-probing is the only version that cannot disagree with a cold start.

## Mutation table — 22 applied, 22 killed

| # | Claim under test | Verdict |
|---|---|---|
| M1 | a mismatched `state` is refused before anything is exchanged | killed |
| M2 | a 200 with no access token is not stored | killed |
| M3 | a refusal never carries the response body | killed |
| M4 | the PKCE verifier is not reused as `state` | **survived first pass** → killed |
| M5 | a login cannot be completed twice | killed |
| M6 | the file is made private before it is put in place | killed |
| M7 | the POSIX mode is read back rather than assumed | **survived first pass** → killed |
| M8 | *every* ACL entry is checked, not just the first | killed |
| M9 | an inherited ACL is refused | killed |
| M10 | discovery marks a stored credential with its origin | killed |
| M11 | discovery finds the credential namzu stored | killed |
| M12 | a refreshed token goes back to the store it came from | killed |
| M13 | an unstated origin still means the borrowed store | killed |
| M14 | the browser launcher never goes through a shell | killed |
| M15 | only a web address reaches the protocol handler | killed |
| M16 | a launcher failure does not take the process down | killed |
| M17 | the success message names the path, not the credential | killed |
| M18 | a missing loopback listener is said out loud | killed |
| M19 | the address is printed even when a browser was launched | killed |
| M20 | a whitespace-only argument starts a login, not finishes one | killed |
| M21 | logout says it revoked nothing at the provider | killed |
| M22 | a pasted sentence is not sent onward as an authorization code | killed |

**Both survivors were real defects in the tests, and both are fixed:**

- **M4.** The test compared `state` to the *challenge*. Reusing the verifier as `state` leaves those two different — one is the SHA-256 of the other — so the assertion held while the property it named was broken. It now compares against the verifier as actually sent on the exchange, and asserts the verifier does not appear in the authorization URL at all.
- **M7.** The POSIX mode check is unreachable on Windows, where I ran, so deleting it killed nothing locally. Extracted `assertOwnerOnlyMode` as a pure function and tested it on every platform — the same treatment `assertSoleOwnerSddl` already had for the mirror-image reason.

## Gates — all seven

| Gate | Result |
|---|---|
| `pnpm build` | pass |
| `pnpm typecheck` | pass |
| `pnpm lint` | pass (0 errors) |
| `pnpm test` | pass — 831 cli tests, 85 files |
| `pnpm docs:check` | pass — 0 problems / 14 checked |
| `node scripts/audit-external-names.mjs` | pass |
| `node .github/scripts/verify-public-surface.mjs` | pass — runtime 555/555, declared 1276/1276 |

## Open questions for the owner

1. **Scope breadth.** namzu asks for the same scope set the working implementations use, which is wider than it needs — it also admits key creation and file upload. Narrowing is untested from here because nobody on this side holds a plan-backed account, and guessing narrow fails in the worst place: the sign-in succeeds and inference is refused afterwards. Recorded as debt in `identity.ts` with the one measurement that settles it.
2. **No standalone `namzu login` command.** The TUI path covers the container case (open the address elsewhere, `/login <code>`), so a second entry point would be a second thing to document. Say the word if a headless-only invocation is wanted.
3. **Not exercised against a live account.** Every protocol detail is asserted against stubs and against a live probe of the token endpoint. The end-to-end path needs someone with a subscription to run `/login` once.
