### PR TITLE
docs(cli): say at the read sites why there are two credential lookups

### DIFF
--- a/packages/cli/src/integrations/providers/discover.ts
+++ b/packages/cli/src/integrations/providers/discover.ts
@@ -140,6 +140,30 @@ export async function discoverProviders(
 
 	// Read both credential sources once, up front, so the loop body stays
 	// uniform. Only anthropic consumes either.
+	//
+	// ## Two lookups, one store per credential — do not "fix" this
+	//
+	// These are two SOURCES, not two stores, and the difference is the whole
+	// design. A credential belongs to exactly one of them for its whole life:
+	// the one namzu obtained lives in namzu's file, the one a co-installed tool
+	// obtained lives in that tool's Keychain entry, and `origin` — set below and
+	// carried on the detected provider — is what pairs every later READ with the
+	// matching WRITE (see `oauth.ts`).
+	//
+	// So the two obvious tidy-ups are both defects:
+	//
+	//  - **Merging them into one lookup** would blend fields across sources —
+	//    an access token from one with a refresh token from the other. The
+	//    refresh would then be attempted with a token the endpoint never issued
+	//    against that access token, and the failure surfaces as a 401 in a
+	//    session the operator signed into successfully.
+	//  - **Writing a refresh back to both** would put namzu's secret in another
+	//    product's envelope, under their name, and give one credential two
+	//    homes that drift the moment either side rotates.
+	//
+	// A second lookup is not a gap to be closed; it is the only way to reach a
+	// credential namzu did not write. What must stay single is the store each
+	// credential is read from and written to, and that is `origin`'s job.
 	const storedCredential = opts.skipStored
 		? null
 		: readStoredSubscriptionCredential(...(opts.home === undefined ? [] : [opts.home]))

--- a/packages/cli/src/integrations/providers/oauth.ts
+++ b/packages/cli/src/integrations/providers/oauth.ts
@@ -47,9 +47,20 @@ const EXPIRY_SKEW_MS = 60_000
 /**
  * Re-read the current credential from the store it lives in.
  *
- * The session layer calls this between turns because another process may
- * have rotated the token since launch. Pairing it with `origin` is what stops
- * a long-running session reading one store and writing the other.
+ * The session layer calls this between turns because another process may have
+ * rotated the token since launch. Pairing it with `origin` is what stops a
+ * long-running session reading one store and writing the other.
+ *
+ * **It takes an origin rather than searching, and that is the point.** A
+ * version that tried both and returned the first hit would look more helpful
+ * and would silently break the pairing: a session that started on namzu's own
+ * credential would, on the machine where both exist, quietly begin refreshing
+ * a co-installed tool's credential instead — writing namzu's refreshed token
+ * into somebody else's envelope, and leaving the store the operator actually
+ * signed into holding a token that lapses again on every launch.
+ *
+ * One credential, one store, for its whole life. `discover.ts` decides which
+ * at detection; everything after that is told, not asked.
  */
 export function readSubscriptionCredential(origin: CredentialOrigin): AgentOAuthCredential | null {
 	return origin === 'stored' ? readStoredSubscriptionCredential() : readAgentKeychainCredential()


### PR DESCRIPTION
Follow-up to #342. Comments only — no behaviour changes.

#342 left one thing implicit that a reader is likely to get wrong in the *tidying-up* direction. `discoverProviders` reads two credential sources, and the comment there explained the **order** between them without ever saying what the two *are*. So the next person meets what looks like a divergence and closes it.

Both closings that suggests are defects, and they are now named at the code that invites them:

- **Merging the two lookups into one** blends fields across sources — an access token from one with a refresh token from the other. The refresh is then attempted with a token the endpoint never issued against that access token, and it surfaces as a 401 *inside a session the operator signed into successfully*. The failure points at the sign-in, which worked.
- **Writing a refresh back to both** puts namzu's secret in a co-installed tool's envelope under their name, and gives one credential two homes that drift the moment either side rotates.

The invariant is not "one lookup". It is **one store per credential, for the credential's whole life**, and `origin` is what holds it: discovery decides which store at detection, and everything downstream is *told* rather than asking. A second lookup is not a gap — it is the only way to reach a credential namzu did not write.

`readSubscriptionCredential` now also says why it takes an origin instead of searching. That is the part that most looks like an omission and is not: a version that tried both and returned the first hit would, on the one machine where both exist, quietly move a session off the credential the operator signed into and start refreshing somebody else's.

## No changeset

A release whose entire content is a source comment is noise in a changelog somebody reads to decide whether to upgrade. Nothing published moves.

## Gates

build · typecheck · lint (0 errors) · provider tests (132 passed / 2 skipped) · `docs:check` (0 problems) · external-name audit — all pass.
