### PR TITLE
docs(conventions): read back the protection you set, and refuse if you cannot

### DIFF
--- a/docs/conventions/index.md
+++ b/docs/conventions/index.md
@@ -84,6 +84,11 @@ probably belong under `docs/sdk/` instead.
   columns away, forty lines above. Unapplied knowledge, not missing knowledge.
 - [Verify the claim, including your own, including a comment's](verify-claims-including-your-own.md)
   — including a report's, including your own from an hour ago.
+- [Read back the protection you set, and refuse if you cannot](read-back-the-protection-you-set.md)
+  — asking for a permission is not holding one, and a wrong value is visible
+  where an unset file mode is not. Includes the platform axis: a readback inside
+  a platform branch cannot fail on any machine but one, so the predicate has to
+  be pure. Deleting a mode check killed no test on the machine it was written on.
 - [Never filter a verification down to something that can read green](never-filter-a-verification.md)
   — the check ran and its answer was invisible. Three incidents in one day.
 

--- a/docs/conventions/meta.json
+++ b/docs/conventions/meta.json
@@ -17,6 +17,7 @@
     "a-check-that-cannot-fail",
     "---Reading The Evidence---",
     "verify-claims-including-your-own",
+    "read-back-the-protection-you-set",
     "never-filter-a-verification"
   ]
 }

--- a/docs/conventions/read-back-the-protection-you-set.md
+++ b/docs/conventions/read-back-the-protection-you-set.md
@@ -1,0 +1,148 @@
+---
+uid: namzu.conventions.read-back-the-protection-you-set
+title: Read back the protection you set, and refuse if you cannot
+description: Asking for a permission is not holding one. A protection must be re-read from the thing it was applied to and refused when the read cannot be made — and because the readback is usually platform-conditional, the predicate has to be pure or it is a check most contributors never see fail.
+type: Convention
+diataxis: explanation
+owner: cogitave/namzu
+status: active
+timestamp: 2026-08-09T00:00:00Z
+lastReviewed: 2026-08-09
+tags: [convention, verification, security, cross-platform]
+---
+
+# Read back the protection you set, and refuse if you cannot
+
+Ratified 2026-08-09, from the subscription sign-in work.
+
+When you apply a **protection** — a file mode, an access-control entry, an
+ownership — do three things, in this order:
+
+1. **Set it.**
+2. **Read it back off the thing you set it on**, not off the value you passed.
+3. **Refuse if the readback cannot be made**, and destroy what you were
+   protecting rather than leaving it.
+
+Asking for a permission is not holding one. `open(path, 'wx', 0o600)` is a
+request; a umask, an inherited access-control list, a filesystem that does not
+implement modes, or an operating system where the call means something else
+entirely can all satisfy the call and not the intent. None of them returns an
+error.
+
+## Why this is not just "verify your own claim"
+
+It is the same shape as
+[verifying against the store you wrote to](verify-claims-including-your-own.md),
+narrowed to the case where the property is a **protection** rather than a
+**value**. The narrowing earns its own page because the consequence is
+different in kind:
+
+**A wrong value is usually visible. An unset file mode is invisible until it is
+somebody else's problem.**
+
+A record that saved with the wrong field is found by the next read, by a test,
+by a user noticing. A credential file that saved world-readable behaves exactly
+like one that did not — same content, same reads, same everything — until an
+account that should never have seen it does. There is no failing path to
+discover, so nothing discovers it. That is why the readback has to be a step
+rather than a review question.
+
+## Refusing means destroying, not warning
+
+If the protection cannot be established, the artefact must not survive. Not a
+warning, not a degraded mode, not a flag — the file is deleted and the caller
+is told why.
+
+This is [refuse, do not silently degrade](refuse-do-not-degrade.md) applied to a
+secret at rest, and the argument for it is unusually clean: a store that cannot
+show it is private is strictly worse than no store, because it takes something
+that would otherwise have stayed in memory for one session and commits it to
+disk under a guarantee nobody checked. Writing anyway and warning is the worst
+of the three — the operator gets the exposure *and* a line of text they will
+scroll past.
+
+## The sharp half: a platform-conditional check cannot fail on almost every machine
+
+Here is the part that is easy to get wrong while doing everything above
+correctly.
+
+A protection is almost always platform-specific. A POSIX mode means nothing on
+Windows; an access-control list means nothing anywhere else. So the readback
+gets written inside a platform branch — and **a check inside a platform branch
+is a check that cannot fail on every machine but one.**
+
+That is [a check that cannot fail](a-check-that-cannot-fail.md) pointed at a
+*platform* axis rather than a logical one, and it is harder to see, because
+nothing about the code looks unreachable. The branch is correct. The check
+inside it is correct. It simply never executes where you are.
+
+The consequence is about mutation, and it is what makes this worth a rule
+rather than a note:
+
+> **A predicate that runs everywhere can be mutated everywhere. A predicate
+> guarded by a platform branch cannot.**
+
+So the assertion has to come **out** of the branch. The branch decides which
+protection applies and gathers the evidence; a **pure function** decides whether
+the evidence is acceptable. The pure function is then tested — and mutated — by
+whoever is running the suite, on whatever they are running it on.
+
+```
+platform branch  →  gathers the evidence   (spawns, stats, reads an ACL)
+pure predicate   →  judges the evidence     (tested on every platform)
+```
+
+## The incident
+
+The credential store applies a POSIX mode off Windows and an access-control
+list on it, and both are read back.
+
+A mutation run of twenty-two mutations was made against the sign-in work. Two
+survived, and one of them was this:
+
+**Deleting the POSIX mode readback killed nothing.** The run was on Windows, so
+the branch containing the assertion never executed. The suite was green with
+the check deleted. It would have gone red in CI, on a Linux runner — which is
+exactly the reassurance that makes this dangerous, because it means the gap is
+invisible to the person writing the code and visible only to a machine they are
+not watching.
+
+The fix was not to add a Windows test for a POSIX property. It was to extract
+`assertOwnerOnlyMode(mode, path)` as a pure function and test it directly:
+owner-only accepted, a group bit refused, an other bit refused, an execute bit
+refused. Five cases, no platform branch, killed on every machine.
+
+The mirror image is the evidence that the shape is right rather than a
+rationalisation. The Windows half was written this way from the start —
+`assertSoleOwnerSddl(sddl, sid, path)` takes a descriptor as a string, so the
+mutations against *it* (accepting a second entry naming another account;
+accepting an inherited list) died immediately, on Windows and everywhere else.
+The same rule, applied and not applied, in one file, with the mutation run
+telling the two apart.
+
+## Applying it
+
+- Name the evidence the platform branch produces, and make it a value: a mode
+  integer, a descriptor string, an owner identifier.
+- Put the judgement in a function that takes that value and the path, and
+  throws with the path named. No spawning, no `platform()`, no filesystem.
+- Test the predicate against the accepting case and **every** rejecting case
+  you can enumerate, including the ones your own platform cannot produce.
+- Then mutate it. If a mutation survives, you have found the platform axis, not
+  a missing test.
+
+## Related
+
+- [A check that cannot fail is worse than no check](a-check-that-cannot-fail.md)
+  — the same defect on a logical axis. This page is the platform axis, which is
+  the one a local run cannot report.
+- [Mutate every test](mutation-check-every-test.md) — how the incident above was
+  found at all. A platform-guarded assertion is one of the few things that
+  reports "kills nothing" for a reason other than a weak test.
+- [Refuse, do not silently degrade](refuse-do-not-degrade.md) — why an
+  unprovable protection deletes the artefact instead of warning about it.
+- [Verify the claim, including your own](verify-claims-including-your-own.md) —
+  the general rule this one narrows.
+- [An optional dependency may degrade a feature, never a check](an-optional-dependency-may-not-degrade-a-check.md)
+  — the neighbouring trap: if the tool that reads the protection back is
+  missing, that is "I cannot establish this", never "this is satisfied".


### PR DESCRIPTION
A convention page, extracted from the subscription sign-in work. Prose only.

## The rule

Set the protection, **read it back off the artefact**, and **refuse if the readback cannot be made** — destroying what you were protecting rather than leaving it.

Asking for a permission is not holding one. `open(path, 'wx', 0o600)` is a *request*: a umask, an inherited access-control list, or a filesystem that does not implement modes all satisfy the call and not the intent, and none of them returns an error.

## Why it is not just "verify your own claim"

It is that rule narrowed to the case where the property is a **protection** rather than a **value**, and the narrowing earns a page because the consequence differs in kind:

> A wrong value is usually visible. An unset file mode is invisible until it is somebody else's problem.

A record saved with a wrong field is found by the next read, a test, or a user. A credential file that saved world-readable behaves *exactly* like one that did not — same content, same reads — until an account that should never have seen it does. There is no failing path, so nothing discovers it. That is why the readback is a step and not a review question.

## The sharp half — the platform axis

A protection is platform-specific, so its readback gets written inside a platform branch. **A check inside a platform branch is a check that cannot fail on every machine but one.**

That is [`a-check-that-cannot-fail`](https://github.com/cogitave/namzu/blob/main/docs/conventions/a-check-that-cannot-fail.md) pointed at a *platform* axis rather than a logical one, and it is harder to see because nothing looks unreachable — the branch is right, the check in it is right, it simply never runs where you are.

The consequence is what makes it worth a rule:

> **A predicate that runs everywhere can be mutated everywhere. A predicate guarded by a platform branch cannot.**

So the branch **gathers evidence** (spawns, stats, reads a descriptor) and a **pure function judges it** — and the pure function is tested and mutated by whoever runs the suite, on whatever they run it on.

## The incident

Of twenty-two mutations run against the sign-in work, **deleting the POSIX mode readback killed nothing.** The run was on Windows; the branch never executed; the suite was green with the check gone.

CI would have caught it on a Linux runner — which is the reassurance that makes it dangerous. The gap was invisible to the person writing the code and visible only to a machine they were not watching.

The fix was not a Windows test for a POSIX property. It was extracting `assertOwnerOnlyMode(mode, path)` as a pure function and testing it directly — owner-only accepted, group bit refused, other bit refused, execute bit refused.

**The mirror is in the same file, and it is the evidence the shape is right rather than a rationalisation.** The Windows half was written pure from the start (`assertSoleOwnerSddl(sddl, sid, path)` takes a descriptor as a string), so its mutations — accepting a second entry naming another account, accepting an inherited list — died immediately, everywhere. The same rule applied and not applied, in one file, with the mutation run telling the two apart.

## Housekeeping

- `docs/conventions/index.md` and `meta.json` updated; the page is filed under **Reading the evidence**, next to the general rule it narrows.
- No `resource:` key, per the directory's own standing reason — a convention is a rule about reasoning and no file can make one false.
- `pnpm docs:check`: **0 problems across 15 files** (was 14). External-name audit passes.

## No changeset

Nothing published moves. A release whose entire content is prose is noise in a changelog someone reads to decide whether to upgrade — the same reasoning as #345.
