### PR TITLE
feat(evals): a security suite, and a probe for state derived from the verifier

### DIFF
--- a/.changeset/oauth-state-probe.md
+++ b/.changeset/oauth-state-probe.md
@@ -1,0 +1,34 @@
+---
+'@namzu/evals': minor
+---
+
+Adds a `security/` suite category, and its first probe: **does `state` derive
+from the PKCE verifier?**
+
+`npx namzu eval` over this package now runs one more suite. Nothing existing
+changes — the `kernel/` suites, their ids and their scores are untouched — so
+the upgrade is additive unless you gate on the total suite count.
+
+**Why the probe exists.** In authorization code + PKCE only the challenge, the
+hash of the verifier, may travel in the authorization URL. `state` travels
+there too, so a flow that sets `state = verifier` writes the verifier into the
+address bar, the browser history and any referrer, and the protection is gone
+while every part of the ceremony is still present. It is a defect
+implementations ship.
+
+**Why it is not caught by the obvious test.** `state !== challenge` holds for
+the broken flow — necessarily, since the challenge is the SHA-256 of the
+verifier — so the assertion a careful person writes passes while the property
+is broken. Even `state !== verifier` catches only literal reuse.
+
+The probe is importable at `@namzu/evals/security/oauth-state.js` and answers
+with the *name* of the relation it found, so you can point it at your own flow:
+
+```js
+import { auditAuthorizationRequest } from '@namzu/evals/security/oauth-state.js'
+const { sound, findings } = auditAuthorizationRequest({ url, state, verifier })
+```
+
+It reads one captured attempt against a fixed list of derivations. A finding is
+proof of coupling; no finding is not proof of independence, and the list is
+written out in the source so the bound is visible.

--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -1,11 +1,51 @@
 # @namzu/evals
 
-Namzu's own kernel behaviour suites.
+Namzu's own behaviour and security suites.
 
-These run against a **scripted provider**, so nothing here measures a model.
-That is the point: the turns are fixed, so a score that moves means the kernel
-changed its behaviour. A suite that calls a real provider measures two things
-at once and cannot say which one moved.
+Nothing here measures a model. The kernel suites run against a **scripted
+provider** and the security suites touch no provider at all, so a score that
+moves means the code changed its behaviour. A suite that calls a real provider
+measures two things at once and cannot say which one moved.
+
+## The two kinds
+
+- **`kernel/`** — invariants of the agent loop, driven against a scripted
+  provider. Every case pins something this kernel has broken at least once.
+- **`security/`** — deterministic probes for properties that are easy to get
+  wrong and hard to notice. No provider, no kernel, no network.
+
+### `security/oauth-state` — does `state` derive from the PKCE verifier?
+
+In authorization code + PKCE, only the *challenge* — the hash of the verifier —
+may travel in the authorization URL. `state` travels in that URL too, so a flow
+that sets `state = verifier` writes the verifier into the address bar, the
+browser history and any referrer, and the protection PKCE exists to provide is
+gone while every part of the ceremony is still present.
+
+**The assertion a careful person writes does not catch it.** `state !== challenge`
+holds for the broken flow — necessarily, because the challenge is the SHA-256 of
+the verifier — so the check passes while the property is broken. Even
+`state !== verifier` only catches literal reuse; a slice, a re-encoding, a
+reversal or a second hash all still couple the two.
+
+The probe is importable, so you can point it at your own flow:
+
+```js
+import {
+  auditAuthorizationRequest,
+} from '@namzu/evals/security/oauth-state.js'
+
+const { sound, findings } = auditAuthorizationRequest({ url, state, verifier })
+if (!sound) throw new Error(findings.join('; '))
+```
+
+It answers with the **name** of the relation it found — "state is the verifier,
+reversed" sends you to the line; "unsound" sends you to re-read a flow you
+believe is correct. It reads one captured attempt and enumerates a fixed list of
+derivations, so a relation outside that list would pass: presence of a finding
+is proof of coupling, absence is not proof of independence. The list is written
+out in the source rather than described, so you can see how far the answer
+reaches.
 
 ## What it is for
 

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@namzu/evals",
   "version": "0.1.0",
-  "description": "Namzu's own kernel behaviour suites, runnable with `namzu eval` against an installed kernel.",
+  "description": "Namzu's own behaviour and security suites, runnable with `namzu eval` against an installed kernel.",
   "license": "FSL-1.1-MIT",
   "type": "module",
   "homepage": "https://github.com/cogitave/namzu#readme",
@@ -14,10 +14,12 @@
     "url": "https://github.com/cogitave/namzu/issues"
   },
   "exports": {
-    "./kernel/*": "./kernel/*"
+    "./kernel/*": "./kernel/*",
+    "./security/*": "./security/*"
   },
   "files": [
     "kernel",
+    "security",
     "LICENSE.md",
     "README.md",
     "CHANGELOG.md"

--- a/packages/evals/security/oauth-state.eval.js
+++ b/packages/evals/security/oauth-state.eval.js
@@ -1,0 +1,250 @@
+/**
+ * The `state`-derives-from-verifier probe, scored against attempts whose
+ * answer is known.
+ *
+ * ## What this suite is about, said plainly
+ *
+ * The deliverable here is the **probe** in `./oauth-state.js`, and this suite
+ * scores the probe — not namzu's own sign-in, which is guarded by unit tests
+ * beside the flow it belongs to. Saying so matters: a suite named for a
+ * security property, sitting in a security folder, reads as "this proves the
+ * product is safe", and this one does not. It proves the instrument reads
+ * correctly in both directions, which is what makes an answer from it worth
+ * anything anywhere else.
+ *
+ * A probe scored only against BROKEN samples would pass while always
+ * returning "broken". A probe scored only against SOUND ones would pass while
+ * always returning "fine" — and that is the direction that matters, because a
+ * security check stuck on "fine" is indistinguishable from a working one until
+ * the day it is needed. So every case pins both halves: the verdict, and the
+ * NAME of the relation found.
+ *
+ * ## Why these particular broken shapes
+ *
+ * They are not invented. `state = verifier` is what real authorization-code
+ * implementations ship, and it survives the assertion a careful person writes
+ * (`state !== challenge`) because the challenge is the hash of the verifier —
+ * so the two differ by the width of a hash while the property is broken. The
+ * rest are the shapes an equality check waves through: a slice, a
+ * re-encoding, a reversal, and a leak through a parameter that is not `state`
+ * at all.
+ *
+ * Deterministic: no provider, no kernel, no network. The `run` step returns a
+ * fabricated `EvalRun` carrying the attempt, and the scorers read it.
+ */
+
+import { createHash, randomBytes } from 'node:crypto'
+import { customScorer, runExperiment } from '@namzu/sdk'
+
+import { auditAuthorizationRequest, stateDerivesFromVerifier } from './oauth-state.js'
+
+const AUTHORIZE = 'https://authorization.example/oauth/authorize'
+
+/** A verifier of the shape RFC 7636 asks for: 43+ base64url characters. */
+function verifier() {
+	return randomBytes(32).toString('base64url')
+}
+
+/** @param {string} v */
+function challengeFor(v) {
+	return createHash('sha256').update(v).digest('base64url')
+}
+
+/**
+ * Build the authorization request a flow would actually send.
+ *
+ * @param {{ state: string, verifier: string, extra?: Record<string, string> }} input
+ */
+function authorizationUrl(input) {
+	const params = new URLSearchParams({
+		response_type: 'code',
+		client_id: 'probe-client',
+		redirect_uri: 'http://localhost:1/callback',
+		code_challenge: challengeFor(input.verifier),
+		code_challenge_method: 'S256',
+		state: input.state,
+		...(input.extra ?? {}),
+	})
+	return `${AUTHORIZE}?${params.toString()}`
+}
+
+/**
+ * An `EvalRun` that drove nothing.
+ *
+ * `error` is deliberately absent: setting it makes the scorers short-circuit
+ * to zero with a "run failed" reason, which would report a broken harness as
+ * a failed property.
+ *
+ * @param {{ url: string, state: string, verifier: string }} attempt
+ */
+function runFor(attempt) {
+	return {
+		output: null,
+		steps: [],
+		toolCalls: [],
+		totalTokens: 0,
+		totalCostUsd: 0,
+		durationMs: 0,
+		attempt,
+	}
+}
+
+/**
+ * Did the probe reach the expected verdict, and name the expected relation?
+ *
+ * The name is scored, not just the verdict, because a probe that flags
+ * everything for the wrong reason sends the next person to the wrong line —
+ * and would otherwise score full marks on every broken case here.
+ */
+const verdictScorer = customScorer('state-independence', (run, evalCase) => {
+	const attempt = run.attempt
+	if (!attempt) {
+		return { score: 0, reason: 'the case carried no captured attempt' }
+	}
+	const audit = auditAuthorizationRequest(attempt)
+	const expected = evalCase.input.expect
+
+	if (expected === 'sound') {
+		return audit.sound
+			? { score: 1, reason: 'independent state, no recoverable verifier in the request' }
+			: {
+					score: 0,
+					reason: `a sound attempt was flagged: ${audit.findings.join('; ')}`,
+					details: { findings: audit.findings },
+				}
+	}
+	if (audit.sound) {
+		return {
+			score: 0,
+			reason: `a broken attempt was passed as sound — expected ${expected}`,
+			details: { expected },
+		}
+	}
+	const named = audit.findings.some((f) => f.includes(expected))
+	return named
+		? { score: 1, reason: audit.findings.join('; ') }
+		: {
+				score: 0,
+				reason: `flagged, but for the wrong reason — expected ${expected}, got: ${audit.findings.join('; ')}`,
+				details: { expected, findings: audit.findings },
+			}
+})
+
+/**
+ * The specific false negative this whole probe exists for.
+ *
+ * Scored on its own rather than folded into the case list, because it is not
+ * a claim about one sample: it is the claim that the assertion a careful
+ * person writes CANNOT see this defect, which is the reason the probe is
+ * needed at all. If this ever scores zero — if `state === verifier` started
+ * making `state` equal the challenge — the argument for the probe has changed
+ * and the reasoning in `oauth-state.js` needs rereading, not patching.
+ */
+const insufficiencyScorer = customScorer('difference-check-is-insufficient', () => {
+	const v = verifier()
+	const challenge = challengeFor(v)
+	const broken = v // the shipped defect: state = verifier
+
+	if (broken === challenge) {
+		return { score: 0, reason: 'the verifier equalled its own challenge, which cannot happen' }
+	}
+	const caught = stateDerivesFromVerifier(broken, v)
+	return caught
+		? {
+				score: 1,
+				reason: `state !== challenge holds for the broken flow, and the probe still names it: ${caught}`,
+			}
+		: { score: 0, reason: 'the probe missed state = verifier' }
+})
+
+export default async function oauthState() {
+	return runExperiment({
+		name: 'security/oauth-state',
+		scorers: [verdictScorer, insufficiencyScorer],
+		run: async (input) => runFor(input.attempt()),
+		cases: [
+			{
+				name: 'independent state passes',
+				input: {
+					expect: 'sound',
+					attempt: () => {
+						const v = verifier()
+						const state = randomBytes(16).toString('base64url')
+						return { url: authorizationUrl({ state, verifier: v }), state, verifier: v }
+					},
+				},
+			},
+			{
+				name: 'state = the verifier, the shape that ships',
+				input: {
+					expect: 'the verifier itself',
+					attempt: () => {
+						const v = verifier()
+						return { url: authorizationUrl({ state: v, verifier: v }), state: v, verifier: v }
+					},
+				},
+			},
+			{
+				name: 'state = a slice of the verifier',
+				input: {
+					expect: 'a slice of the verifier',
+					attempt: () => {
+						const v = verifier()
+						const state = v.slice(0, 20)
+						return { url: authorizationUrl({ state, verifier: v }), state, verifier: v }
+					},
+				},
+			},
+			{
+				name: 'state = the verifier reversed',
+				input: {
+					expect: 'reversed',
+					attempt: () => {
+						const v = verifier()
+						const state = [...v].reverse().join('')
+						return { url: authorizationUrl({ state, verifier: v }), state, verifier: v }
+					},
+				},
+			},
+			{
+				name: 'state = the verifier re-encoded',
+				input: {
+					expect: 're-encoded as hex',
+					attempt: () => {
+						const v = verifier()
+						const state = Buffer.from(v, 'utf8').toString('hex')
+						return { url: authorizationUrl({ state, verifier: v }), state, verifier: v }
+					},
+				},
+			},
+			{
+				name: 'state = the challenge, which is public',
+				input: {
+					expect: 'this is the PKCE challenge',
+					attempt: () => {
+						const v = verifier()
+						const state = challengeFor(v)
+						return { url: authorizationUrl({ state, verifier: v }), state, verifier: v }
+					},
+				},
+			},
+			{
+				name: 'the verifier leaks through a parameter that is not state',
+				input: {
+					expect: 'the verifier itself',
+					attempt: () => {
+						const v = verifier()
+						const state = randomBytes(16).toString('base64url')
+						return {
+							url: authorizationUrl({ state, verifier: v, extra: { debug_verifier: v } }),
+							state,
+							verifier: v,
+						}
+					},
+				},
+			},
+		],
+	})
+}
+
+export const tags = ['security', 'ci']

--- a/packages/evals/security/oauth-state.js
+++ b/packages/evals/security/oauth-state.js
@@ -1,0 +1,217 @@
+/**
+ * Does `state` derive from the PKCE verifier?
+ *
+ * A red-team probe for an authorization-code flow, published because the
+ * defect it looks for is one a careful person writes on purpose, ships, and
+ * is never told about.
+ *
+ * ## The defect
+ *
+ * In authorization code + PKCE, two secrets are minted per attempt:
+ *
+ *  - the **verifier**, which must never leave the client until the token
+ *    exchange. Only its `S256` hash — the **challenge** — travels in the
+ *    authorization URL. That is the entire mechanism: an attacker who
+ *    intercepts the authorization code cannot redeem it, because redeeming it
+ *    needs the verifier and the verifier was never sent.
+ *  - the **state**, an unguessable value echoed back by the authorization
+ *    server so the client can match the response to its own request.
+ *
+ * `state` travels in the authorization URL. So a flow that sets
+ * `state = verifier` writes the verifier into the address bar, the browser
+ * history, and any referrer along the way — and the one secret PKCE exists to
+ * keep out of that URL is exactly the verifier. The ceremony is entirely
+ * present: a real challenge, `S256`, a real `code_verifier` on the exchange.
+ * The protection is gone.
+ *
+ * ## Why the obvious assertion does not catch it
+ *
+ * The check a careful person naturally writes is:
+ *
+ *     expect(state).not.toBe(challenge)
+ *
+ * **That passes while the property is broken.** The challenge is the SHA-256
+ * of the verifier, so `state === verifier` leaves `state` and `challenge`
+ * different — necessarily, and by the width of a hash. The assertion is not
+ * wrong; it is about the wrong pair.
+ *
+ * Even `state !== verifier` is not enough on its own. It catches literal
+ * reuse and nothing else: a truncation, a re-encoding, a reversal or a
+ * second hash all still couple the two values, and a `state` computed from
+ * the verifier carries no independent entropy — which makes it useless as the
+ * anti-forgery value it exists to be, whatever else it leaks.
+ *
+ * So the question has to be asked as **"does `state` derive from the
+ * verifier"**, against every derivation cheap enough to enumerate, in both
+ * directions.
+ *
+ * ## What this cannot tell you
+ *
+ * It reads one captured attempt. A flow that derived `state` from the
+ * verifier by a route not listed below would pass — the list is the honest
+ * bound, and it is written out rather than described so a reader can see
+ * exactly how far the answer reaches. Absence of a listed relation is not
+ * proof of independence; presence of one is proof of coupling.
+ */
+
+import { createHash } from 'node:crypto'
+
+/**
+ * Shortest overlap treated as containment.
+ *
+ * Below this, a shared run is coincidence rather than derivation — two
+ * independent base64url values of ordinary length share short substrings all
+ * the time, and a probe that called that a leak would cry wolf until someone
+ * switched it off.
+ */
+const MIN_CONTAINMENT = 8
+
+/**
+ * Relations that let a reader RECOVER the verifier from the value.
+ *
+ * Kept apart from the one-way relations below because the two answer
+ * different questions. A hash of the verifier appearing in the authorization
+ * URL is not a leak — that is what the challenge IS. The verifier reversed,
+ * re-encoded, or truncated in that URL is a leak.
+ *
+ * @param {string} verifier
+ * @returns {ReadonlyArray<readonly [string, string]>}
+ */
+function reversibleForms(verifier) {
+	const bytes = Buffer.from(verifier, 'utf8')
+	return [
+		['the verifier itself', verifier],
+		['the verifier, reversed', [...verifier].reverse().join('')],
+		['the verifier, re-encoded as base64url', bytes.toString('base64url')],
+		['the verifier, re-encoded as base64', bytes.toString('base64')],
+		['the verifier, re-encoded as hex', bytes.toString('hex')],
+	]
+}
+
+/**
+ * Relations that couple the two values without exposing the verifier.
+ *
+ * Still disqualifying for `state`. `sha256`/base64url is the PKCE challenge
+ * itself, which is public by design — a `state` equal to it is a public
+ * value, and an anti-forgery token an attacker can read out of the request it
+ * is meant to protect is not one.
+ *
+ * @param {string} verifier
+ * @returns {ReadonlyArray<readonly [string, string]>}
+ */
+function oneWayForms(verifier) {
+	/** @type {Array<readonly [string, string]>} */
+	const forms = []
+	for (const algorithm of /** @type {const} */ (['sha256', 'sha1', 'md5'])) {
+		const digest = createHash(algorithm).update(verifier).digest()
+		const label =
+			algorithm === 'sha256'
+				? `${algorithm} of the verifier, base64url — this is the PKCE challenge`
+				: `${algorithm} of the verifier, base64url`
+		forms.push([label, digest.toString('base64url')])
+		forms.push([`${algorithm} of the verifier, hex`, digest.toString('hex')])
+		forms.push([`${algorithm} of the verifier, base64`, digest.toString('base64')])
+	}
+	return forms
+}
+
+/**
+ * @param {string} a
+ * @param {string} b
+ */
+function containsMeaningfully(a, b) {
+	const [shorter, longer] = a.length <= b.length ? [a, b] : [b, a]
+	return shorter.length >= MIN_CONTAINMENT && longer.includes(shorter)
+}
+
+/**
+ * Name the relation tying `state` to `verifier`, or `null` when there is none
+ * this probe can find.
+ *
+ * A NAME rather than a boolean: "state derives from the verifier" sends
+ * someone to re-read a flow they believe is correct, and "state is the
+ * verifier, reversed" sends them to the line.
+ *
+ * @param {string} state
+ * @param {string} verifier
+ * @returns {string | null}
+ */
+export function stateDerivesFromVerifier(state, verifier) {
+	if (typeof state !== 'string' || typeof verifier !== 'string') return null
+	if (state.length === 0 || verifier.length === 0) return null
+
+	for (const [name, form] of [...reversibleForms(verifier), ...oneWayForms(verifier)]) {
+		if (state === form) return name
+		if (state.toLowerCase() === form.toLowerCase()) return `${name}, differing only in case`
+	}
+	// The inverse direction: `state` is an encoding that DECODES to the
+	// verifier. A flow that base64url-encodes its verifier into `state` is
+	// caught above; one that stores the verifier already-encoded and uses the
+	// raw bytes as state is caught here.
+	for (const encoding of /** @type {const} */ (['base64url', 'base64', 'hex'])) {
+		let decoded = ''
+		try {
+			decoded = Buffer.from(state, encoding).toString('utf8')
+		} catch {
+			continue
+		}
+		if (decoded === verifier) return `a ${encoding} encoding of the verifier`
+	}
+	// Truncation, prefixing, wrapping — the shapes that survive an equality
+	// check. Asked last so an exact relation is reported by its own name.
+	if (containsMeaningfully(state, verifier)) {
+		return state.length < verifier.length
+			? 'a slice of the verifier'
+			: 'a value containing the verifier'
+	}
+	return null
+}
+
+/**
+ * Name a recoverable form of the verifier present in an authorization
+ * request, or `null`.
+ *
+ * Separate from the question above because a request can leak the verifier
+ * through a parameter that is not `state` at all — a debug field, a login
+ * hint, a redirect carrying it round. Only reversible forms are reported: the
+ * challenge is a hash of the verifier and is *supposed* to be here, so
+ * flagging one-way forms would make this fire on every correct flow, which is
+ * the fastest way to get a security check disabled.
+ *
+ * @param {string} url
+ * @param {string} verifier
+ * @returns {string | null}
+ */
+export function authorizationRequestLeaksVerifier(url, verifier) {
+	if (typeof url !== 'string' || typeof verifier !== 'string') return null
+	if (url.length === 0 || verifier.length === 0) return null
+
+	const haystacks = [url]
+	try {
+		for (const [, value] of new URL(url).searchParams) haystacks.push(value)
+	} catch {
+		// Not a parseable URL; the raw-string check above still applies.
+	}
+	for (const [name, form] of reversibleForms(verifier)) {
+		if (form.length < MIN_CONTAINMENT) continue
+		for (const haystack of haystacks) {
+			if (haystack.includes(form)) return name
+		}
+	}
+	return null
+}
+
+/**
+ * Both questions about one captured attempt.
+ *
+ * @param {{ url: string, state: string, verifier: string }} attempt
+ * @returns {{ sound: boolean, findings: readonly string[] }}
+ */
+export function auditAuthorizationRequest(attempt) {
+	const findings = []
+	const derived = stateDerivesFromVerifier(attempt.state, attempt.verifier)
+	if (derived) findings.push(`state is ${derived}`)
+	const leaked = authorizationRequestLeaksVerifier(attempt.url, attempt.verifier)
+	if (leaked) findings.push(`the authorization request carries ${leaked}`)
+	return { sound: findings.length === 0, findings }
+}


### PR DESCRIPTION
The red-team assertion offered in #342's follow-up. Adds a `security/` suite category to `@namzu/evals` and its first probe.

**Where I put it, and why there:** `packages/evals/security/oauth-state.js` (the probe, importable) and `packages/evals/security/oauth-state.eval.js` (the suite that scores it). CI already runs `namzu eval --dir packages/evals` with no `--tag`, so this is gated from the first merge without touching the workflow.

## The defect

In authorization code + PKCE only the **challenge** — the hash of the verifier — may travel in the authorization request. `state` travels there too, so a flow that sets `state = verifier` writes the verifier into the address bar, the browser history and any referrer. The one secret PKCE exists to keep out of that URL is exactly the verifier. Every part of the ceremony is still present: a real challenge, `S256`, a real `code_verifier` on the exchange. The protection is gone.

## Why it is worth a probe rather than a review note

**The assertion a careful person writes passes while the property is broken.**

```js
expect(state).not.toBe(challenge)   // holds for the broken flow
```

It holds *necessarily* — the challenge is the SHA-256 of the verifier, so `state === verifier` leaves state and challenge different by the width of a hash. The assertion is not wrong; it is about the wrong pair. That is not a slip anyone notices, and not one a reviewer catches by reading.

Even `state !== verifier` is insufficient on its own: it catches literal reuse and nothing else. A slice, a re-encoding, a reversal or a second hash all still couple the two values — and a `state` computed from the verifier carries no independent entropy, which makes it useless as the anti-forgery value it exists to be, whatever else it leaks.

So the question is asked as **"does `state` derive from the verifier"**, against an enumerated list, in both directions.

## Design notes worth a reviewer's attention

**It answers with a name, not a boolean.** "unsound" sends someone to re-read a flow they believe is correct; "state is the verifier, reversed" sends them to the line.

**The leak check is deliberately narrower than the state check.** It reports only forms the verifier can be *recovered* from, because the challenge is a hash of the verifier and is *supposed* to be in that request. A security check that fires on every correct flow is switched off within a week.

**The bound is written out rather than described.** A finding is proof of coupling; no finding is **not** proof of independence. The derivation list is in the source so a reader can see exactly how far the answer reaches.

**The suite scores the probe, not namzu's own sign-in — and the header says so.** A file named for a security property, in a folder called `security/`, reads as "this proves the product is safe". This one does not; namzu's flow is guarded by the unit tests beside it. Both directions are scored, because a probe stuck on "fine" is indistinguishable from a working one until the day it matters, and a probe stuck on "broken" would pass a suite built only from broken samples.

## What I decided against

**Importing `@namzu/cli` so the suite guards namzu's real flow.** The CLI's public entry (`packages/cli/src/index.ts`) does not export the providers barrel, so this would mean widening a published API — with the changeset and public-surface baseline that implies — to reach a test probe. Worth doing deliberately if wanted; not worth doing as a side effect of this.

## Mutation table — 10 applied, 10 killed

| # | Claim | Verdict |
|---|---|---|
| E1 | a blinded probe cannot pass | killed — 0/7 |
| E2 | a probe that cries wolf cannot pass | killed — 4/7 |
| E3 | containment is checked (truncated verifier) | killed — 6/7 |
| E4 | the reversed form is enumerated | killed — 6/7 |
| E5 | a hex re-encoding is enumerated | killed — 6/7 |
| E6 | one-way forms disqualify `state` (the public challenge) | killed — 6/7 |
| E7 | the whole request is searched, not just `state` | killed — 6/7 |
| E8 | the leak check does **not** fire on the challenge | killed — 6/7 |
| E9 | the scorer checks *why* it flagged, not just that it did | killed — 5/7 |
| E10 | the sound case is a real case | killed — 6/7 |

E1 and E2 are the pair that matter: blinding the probe fails every broken case, and making it cry wolf fails the sound one.

## Gates

`pnpm build` · `pnpm typecheck` · `pnpm lint` (0 errors) · `pnpm docs:check` (0 problems) · external-name audit · `verify-public-surface` (intact) — all pass. `namzu eval --dir packages/evals`: **`security/oauth-state: 7/7 passed`**, kernel suites unchanged at 5/5 and 4/4, exit 0.

## Changeset

`@namzu/evals` **minor** — this one *does* touch `packages/` behaviour: a consumer running `npx namzu eval` gets one more suite, and `./security/*` is a new export path. Additive; existing suite ids and scores are untouched.
