### PR TITLE
perf(cli): parse a streaming reply one block at a time

### DIFF
--- a/.changeset/eighty-pears-tap.md
+++ b/.changeset/eighty-pears-tap.md
@@ -1,0 +1,15 @@
+---
+'@namzu/cli': patch
+---
+
+Parse a streaming reply one block at a time instead of re-parsing the whole
+message on every token.
+
+The pending transcript row re-renders per token, and each render re-parsed the
+entire message: a forty-block answer was parsed forty blocks deep on every
+token, so the cost of streaming a reply grew with the square of its length. Long
+replies now stream at a cost that tracks their length rather than its square.
+
+Nothing changes for a caller. `@namzu/cli` exports no markdown API; the new
+`scanBlocks` and `parseBlock` are internal to the terminal UI, and
+`parseMarkdown` is now the composition of the two with identical output.

--- a/packages/cli/src/tui/Markdown.tsx
+++ b/packages/cli/src/tui/Markdown.tsx
@@ -13,8 +13,10 @@
  */
 
 import { Box, Text } from 'ink'
+import { memo, useRef } from 'react'
 
-import { type InlineSpan, type MdBlock, parseInline, parseMarkdown } from './markdownParser.js'
+import { type BlockCache, createBlockCache } from './markdown-block-cache.js'
+import { type InlineSpan, type MdBlock, parseInline } from './markdownParser.js'
 import { theme } from './theme.js'
 
 const CODE_COLOR = theme.status.ok
@@ -24,8 +26,24 @@ export interface MarkdownProps {
 	readonly color?: string
 }
 
+/**
+ * A message's markdown, parsed incrementally.
+ *
+ * The cache is per mounted component, so it lives exactly as long as the row
+ * it serves and is collected with it — a module-level one would hold every
+ * block of every message for the life of the process, which is the shape of
+ * the retention problem the transcript already had to solve once.
+ *
+ * The blocks it returns are reused between renders when their source text has
+ * not changed, and {@link BlockView} is memoised on them, so a streaming reply
+ * re-renders only the block currently being written. See
+ * `markdown-block-cache.ts` for why the key is the block's raw text and why
+ * the tail of the document is never stored.
+ */
 export function Markdown({ text, color = theme.text.primary }: MarkdownProps) {
-	const blocks = parseMarkdown(text)
+	const cache = useRef<BlockCache>(undefined)
+	cache.current ??= createBlockCache()
+	const blocks = cache.current.parse(text)
 	return (
 		<Box flexDirection="column">
 			{blocks.map((block, i) => (
@@ -35,7 +53,16 @@ export function Markdown({ text, color = theme.text.primary }: MarkdownProps) {
 	)
 }
 
-function BlockView({
+/**
+ * One block.
+ *
+ * Memoised on its props, all three of which are stable across a token when the
+ * block is: the cache hands back the same `block` and `prev` objects and
+ * `color` is a constant. Without this the cache would still save the parse and
+ * then throw the saving away — `parseInline` runs here, per span, on every
+ * render, and it is the more expensive half.
+ */
+const BlockView = memo(function BlockView({
 	block,
 	prev,
 	color,
@@ -107,7 +134,7 @@ function BlockView({
 				</Box>
 			)
 	}
-}
+})
 
 const TABLE_MAX_COL = 32
 

--- a/packages/cli/src/tui/__tests__/a-streaming-reply-parses-each-block-once.test.tsx
+++ b/packages/cli/src/tui/__tests__/a-streaming-reply-parses-each-block-once.test.tsx
@@ -1,0 +1,253 @@
+/**
+ * A reply that arrives a token at a time is parsed a block at a time.
+ *
+ * The pending row is the only row that re-renders, and it re-rendered the whole
+ * message: a forty-block answer was parsed forty blocks deep on every token, so
+ * the cost of streaming a reply grew with the square of its length. The fix is a
+ * per-block cache keyed on the block's raw text.
+ *
+ * ## What these tests are written against
+ *
+ * Two things can go wrong, and each has its own test here.
+ *
+ * The first is CORRECTNESS: a cache that hands back a block the document no
+ * longer says. The property that catches it is that a single long-lived cache,
+ * fed every prefix of a document in order, must agree with a fresh
+ * `parseMarkdown` on every one of those prefixes — an unterminated fence, a
+ * table that only becomes a table when its separator arrives, a paragraph
+ * still growing. A test that checked the finished document alone would pass
+ * for a cache that is wrong for the whole length of the stream and right at
+ * the end, which is the entire interval the operator is looking at.
+ *
+ * The second is that the cache is not REACHED. `Markdown` is where the saving
+ * has to happen, so the counting tests drive the rendered component rather than
+ * the cache: a unit test on the helper stays green if the component goes back
+ * to calling `parseMarkdown` directly, which is the defect these exist for.
+ *
+ * The count is scale-checked rather than compared to one number. Parse calls
+ * per token is ~1 with the cache and ~blocks/2 without, so a single fixture can
+ * be passed by accident at a size where the two are close; measuring the same
+ * ratio at two document sizes cannot be.
+ */
+
+import { render } from 'ink-testing-library'
+import { describe, expect, it, vi } from 'vitest'
+
+import { createBlockCache } from '../markdown-block-cache.js'
+import { parseMarkdown } from '../markdownParser.js'
+
+/**
+ * Counts real parse calls, and delegates.
+ *
+ * Mocked at the module the cache imports from, so what is counted is the work
+ * the cache actually performs. `parseMarkdown` is left genuine — it calls its
+ * own local `parseBlock` and so is both an honest oracle and uncounted.
+ */
+let parseCalls = 0
+let inlineCalls = 0
+vi.mock('../markdownParser.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../markdownParser.js')>()
+	return {
+		...actual,
+		parseBlock: (raw: string) => {
+			parseCalls++
+			return actual.parseBlock(raw)
+		},
+		// The other half of the cost, and the one the memo on `BlockView` is
+		// there for: a cached block still costs a full inline re-parse if the
+		// view that renders it re-runs.
+		parseInline: (text: string) => {
+			inlineCalls++
+			return actual.parseInline(text)
+		},
+	}
+})
+
+const { Markdown } = await import('../Markdown.js')
+
+/** A document with every construct the parser knows, `blocks` blocks long. */
+function document(blocks: number): string {
+	const out: string[] = []
+	for (let i = 0; i < blocks; i++) {
+		switch (i % 5) {
+			case 0:
+				out.push(`## Section ${i}`)
+				break
+			case 1:
+				out.push(`Some **prose** about section ${i} with \`code\` in it.`)
+				break
+			case 2:
+				out.push(`- a bullet in section ${i}`)
+				break
+			case 3:
+				out.push(`\`\`\`ts\nconst section${i} = ${i}\n\`\`\``)
+				break
+			default:
+				out.push(`| A${i} | B${i} |\n|---|---|\n| 1 | 2 |`)
+				break
+		}
+	}
+	return out.join('\n\n')
+}
+
+/** Every prefix of `src`, in order, growing by `step` characters. */
+function prefixes(src: string, step: number): string[] {
+	const out: string[] = []
+	for (let n = step; n < src.length; n += step) out.push(src.slice(0, n))
+	out.push(src)
+	return out
+}
+
+describe('the block cache', () => {
+	it('agrees with a fresh parse at every point in the stream', () => {
+		// Deliberately awkward: a fence that is open for several prefixes before
+		// it closes, a `| … |` line that is a paragraph until its separator
+		// arrives, and a paragraph that keeps growing. Each is a case where the
+		// LAST block means something different a token later.
+		const src = [
+			'Intro line one',
+			'still the same paragraph',
+			'',
+			'```ts',
+			'const x = 1',
+			'const y = 2',
+			'```',
+			'',
+			'| A | B |',
+			'|---|---|',
+			'| 1 | 2 |',
+			'',
+			'- one',
+			'- two',
+			'',
+			'## Heading',
+			'',
+			'trailing prose',
+		].join('\n')
+
+		const cache = createBlockCache()
+		for (const prefix of prefixes(src, 3)) {
+			expect(cache.parse(prefix), `disagreed at ${JSON.stringify(prefix.slice(-24))}`).toEqual(
+				parseMarkdown(prefix),
+			)
+		}
+	})
+
+	it('serves a second, unrelated message without leaking the first', () => {
+		// One cache outlives one message, and this is why the key is the block's
+		// text rather than its position. The pending row is a single mounted
+		// component at a fixed place in the tree: when one streaming reply is
+		// finalized and the next begins, React reuses that instance — same
+		// component, same hooks, same cache — and the text under it is replaced
+		// wholesale rather than appended to.
+		//
+		// A cache keyed on position answers every question in the second message
+		// with the first message's blocks, and is otherwise indistinguishable:
+		// under append-only growth a settled block never moves. This is the case
+		// that separates them.
+		const first = ['# First message', '', 'about one thing', '', '- alpha', '- beta'].join('\n')
+		const second = ['## Second message', '', 'about something else', '', '1. one'].join('\n')
+
+		const cache = createBlockCache()
+		for (const prefix of prefixes(first, 3)) cache.parse(prefix)
+		for (const prefix of prefixes(second, 3)) {
+			expect(cache.parse(prefix), `the previous message leaked into ${prefix.length}`).toEqual(
+				parseMarkdown(prefix),
+			)
+		}
+	})
+
+	it('grows with the document, not with the stream', () => {
+		// The reason the tail is never stored. A block still being written passes
+		// through every one of its own prefixes, so caching it would put an entry
+		// per TOKEN into a structure meant to hold an entry per block — moving the
+		// cost rather than removing it.
+		//
+		// Asserted by delivering the SAME document at two token sizes. A count
+		// against one number would have to be an exact prediction of how the
+		// scanner segments a half-typed table, which is a fact about the fixture;
+		// that the two counts agree is a fact about the cache.
+		const src = document(12)
+		const blocks = parseMarkdown(src).length
+		const coarse = createBlockCache()
+		const fine = createBlockCache()
+		const coarseStream = prefixes(src, 16)
+		const fineStream = prefixes(src, 1)
+		for (const prefix of coarseStream) coarse.parse(prefix)
+		for (const prefix of fineStream) fine.parse(prefix)
+
+		expect(
+			fineStream.length,
+			'the two streams are too alike to tell a per-token cache apart',
+		).toBeGreaterThan(coarseStream.length * 8)
+		expect(fine.size, 'the cache grew with the number of tokens').toBe(coarse.size)
+		expect(fine.size, 'the cache holds more than the document has blocks').toBeLessThanOrEqual(
+			blocks,
+		)
+	})
+})
+
+describe('a message streaming into <Markdown>', () => {
+	/** Stream `src` into a mounted `<Markdown>`, and return what parsing it cost. */
+	function streamCost(
+		src: string,
+		step: number,
+	): { calls: number; inline: number; renders: number } {
+		const stream = prefixes(src, step)
+		parseCalls = 0
+		inlineCalls = 0
+		const first = stream[0] ?? ''
+		const harness = render(<Markdown text={first} />)
+		try {
+			for (const prefix of stream.slice(1)) harness.rerender(<Markdown text={prefix} />)
+		} finally {
+			harness.unmount()
+		}
+		return { calls: parseCalls, inline: inlineCalls, renders: stream.length }
+	}
+
+	it('parses each block once, so the cost tracks tokens rather than tokens × blocks', () => {
+		const src = document(20)
+		const blocks = parseMarkdown(src).length
+		const { calls, inline, renders } = streamCost(src, 16)
+
+		// With the cache: the two-segment tail on every render, plus one parse for
+		// each block as it settles. Without it: every block on every render, which
+		// at twenty blocks is an order of magnitude more.
+		expect(calls, 'the whole message was re-parsed on each token').toBeLessThanOrEqual(
+			renders * 2 + blocks,
+		)
+		// And it is doing the work, rather than returning something stale: the
+		// block currently being written is parsed on every render.
+		expect(calls, 'the pending block stopped being re-parsed').toBeGreaterThanOrEqual(renders)
+		// Half the saving is thrown away if the views re-run over the cached
+		// blocks anyway: `parseInline` is per block, per render, and it is the
+		// more expensive half. A reused block object is what lets the memo hold.
+		expect(inline, 'every block was re-rendered on each token').toBeLessThanOrEqual(
+			renders * 3 + blocks * 2,
+		)
+	})
+
+	it('costs the same per token at four times the document size', () => {
+		// The axis a single fixture hides. Parse calls per token are ~1 with the
+		// cache at any size, and ~blocks/2 without — so an uncached renderer looks
+		// merely expensive on a short document and quadratic only when the two
+		// sizes are compared. Same step, so a token means the same thing in both.
+		const small = streamCost(document(6), 16)
+		const large = streamCost(document(24), 16)
+
+		const smallPerToken = small.calls / small.renders
+		const largePerToken = large.calls / large.renders
+		expect(
+			largePerToken,
+			`cost per token grew with the document: ${smallPerToken.toFixed(2)} → ${largePerToken.toFixed(2)}`,
+		).toBeLessThan(smallPerToken * 1.5)
+
+		const smallInline = small.inline / small.renders
+		const largeInline = large.inline / large.renders
+		expect(
+			largeInline,
+			`inline re-parses per token grew with the document: ${smallInline.toFixed(2)} → ${largeInline.toFixed(2)}`,
+		).toBeLessThan(smallInline * 1.5)
+	})
+})

--- a/packages/cli/src/tui/markdown-block-cache.ts
+++ b/packages/cli/src/tui/markdown-block-cache.ts
@@ -1,0 +1,80 @@
+/**
+ * Parse a growing markdown document without re-parsing what has not changed.
+ *
+ * ## The cost this removes
+ *
+ * A streaming assistant reply is one message whose text grows by a token at a
+ * time, and the row rendering it re-renders on every one of them. Parsing the
+ * whole message each time makes the work quadratic in the reply's length: a
+ * forty-block answer is parsed forty blocks deep on every token, when
+ * thirty-nine of those blocks are byte-for-byte what they were a token ago.
+ *
+ * So the document is scanned into top-level blocks — cheap, one pass over the
+ * lines — and only the blocks that are new are parsed. The rest come back as
+ * **the same objects**, which is the half that matters to the renderer:
+ * `BlockView` is memoised, so an unchanged block is not re-rendered, not
+ * re-split into inline spans, and not turned into fresh elements either.
+ *
+ * ## Why raw text is a sound key
+ *
+ * `parseBlock` reads only the segment it is given: nothing in this markdown
+ * subset makes one block's meaning depend on another (there are no
+ * reference-style link definitions, which is the construct that would). Same
+ * segment ⇒ same block, so a hit cannot differ from a fresh parse. The
+ * `markdownParser` docblock states that property; it is the contract this file
+ * depends on, and it is why there is no "give up on caching when the document
+ * contains X" escape hatch here. There is no such X.
+ *
+ * ## Why the last two blocks are never cached
+ *
+ * Not for correctness — a key is a whole segment, so a block whose text grows
+ * simply misses under its new text and is parsed. It is to keep the cache from
+ * accumulating garbage: a block that is still being written passes through
+ * every one of its own prefixes, and storing them would put an entry per TOKEN
+ * into a structure meant to hold an entry per block. That is the memory the
+ * quadratic parse was costing, moved rather than removed.
+ *
+ * Two, not one, because the block still being written is not always the last
+ * segment. A half-typed table row is not yet a table row — `| 1 | 2` has no
+ * closing pipe — so it scans as a paragraph of its own, and the table above it
+ * becomes the second-to-last segment while still growing a row at a time. One
+ * excluded segment would have cached that table once per row, at increasing
+ * size. The line being typed can reach back exactly one segment and no further:
+ * it can be absorbed by the block above it, and that block is maximal, so there
+ * is nothing for it to reach past.
+ *
+ * The cost of the wider exclusion is one extra parse per block over the life of
+ * the message, against a saving of one per block per token.
+ */
+
+import { type MdBlock, parseBlock, scanBlocks } from './markdownParser.js'
+
+export interface BlockCache {
+	/** Blocks of `src`, reusing the block objects of unchanged segments. */
+	parse(src: string): MdBlock[]
+	/** How many segments are being held. One per completed block. */
+	readonly size: number
+}
+
+export function createBlockCache(): BlockCache {
+	const blocks = new Map<string, MdBlock>()
+	return {
+		parse(src: string): MdBlock[] {
+			const segments = scanBlocks(src)
+			const settled = segments.length - 2
+			return segments.map((segment, i) => {
+				// The tail is where the text is still being written, so it is parsed
+				// every time and stored never.
+				if (i >= settled) return parseBlock(segment)
+				const hit = blocks.get(segment)
+				if (hit) return hit
+				const parsed = parseBlock(segment)
+				blocks.set(segment, parsed)
+				return parsed
+			})
+		},
+		get size() {
+			return blocks.size
+		},
+	}
+}

--- a/packages/cli/src/tui/markdownParser.ts
+++ b/packages/cli/src/tui/markdownParser.ts
@@ -8,6 +8,28 @@
  * use), not a full CommonMark implementation. Syntax highlighting inside
  * code blocks is intentionally out of scope; code is shown in one code
  * color, which reads cleanly without a highlighter dependency.
+ *
+ * ## Two halves, because a streaming reply is re-parsed on every token
+ *
+ * {@link parseMarkdown} is {@link scanBlocks} followed by {@link parseBlock}
+ * per segment, and the split is what makes the per-block cache in
+ * `markdown-block-cache.ts` possible: scanning finds where each top-level
+ * block starts and ends, and parsing turns one block's raw text into one
+ * {@link MdBlock}. The cache can then skip the second half for text it has
+ * already seen.
+ *
+ * **{@link parseBlock} is a pure function of the segment handed to it** —
+ * nothing about a block's meaning depends on another block. That is what makes
+ * a cache keyed on raw text sound rather than merely convenient, and it is a
+ * property to preserve: reference-style link definitions (`[a]: http://…`),
+ * for instance, would make one block's rendering depend on another's presence
+ * and would have to be either implemented across the whole document or not at
+ * all. This subset has no such construct, and nothing here should acquire one
+ * without revisiting the cache.
+ *
+ * There is one classifier, {@link classify}. The scanner uses it to find
+ * boundaries and {@link parseBlock} uses it to dispatch, so "what is this
+ * line" is decided in a single place rather than once per half.
  */
 
 export interface InlineSpan {
@@ -50,76 +72,128 @@ function tableCells(line: string): string[] {
 		.map((c) => c.trim())
 }
 
-/** Parse markdown source into a flat list of block elements. */
-export function parseMarkdown(src: string): MdBlock[] {
-	const lines = src.split('\n')
-	const blocks: MdBlock[] = []
-	let para: string[] = []
+/**
+ * What a line begins, given the line after it.
+ *
+ * The single site for "which construct is this". `'blank'` begins nothing and
+ * `'text'` begins (or continues) a paragraph; the rest name themselves. The
+ * order of the tests is the order the old single-pass parser applied them, and
+ * it is load-bearing: a `| … |` line is a table only when a separator follows,
+ * and falls through to a paragraph otherwise.
+ */
+type BlockKind = 'code' | 'table' | 'heading' | 'bullet' | 'blank' | 'text'
 
-	const flushPara = () => {
-		if (para.length > 0) {
-			blocks.push({ type: 'paragraph', text: para.join(' ') })
-			para = []
+function classify(line: string, next: string | undefined): BlockKind {
+	if (FENCE.test(line)) return 'code'
+	// Table: a `| … |` header row immediately followed by a `|---|` separator.
+	if (TABLE_ROW.test(line) && next !== undefined && TABLE_SEP.test(next)) return 'table'
+	if (HEADING.test(line)) return 'heading'
+	if (BULLET.test(line)) return 'bullet'
+	if (line.trim().length === 0) return 'blank'
+	return 'text'
+}
+
+/**
+ * Split markdown source into the raw text of each top-level block, in order.
+ *
+ * Blank lines separate blocks and belong to none, so they appear in no segment.
+ * Every other line lands in exactly one, which is what lets a segment be used
+ * as a cache key: two runs that produce the same segment produce the same
+ * block, because {@link parseBlock} reads nothing else.
+ */
+export function scanBlocks(src: string): string[] {
+	const lines = src.split('\n')
+	const segments: string[] = []
+	let i = 0
+	while (i < lines.length) {
+		const line = lines[i] ?? ''
+		switch (classify(line, lines[i + 1])) {
+			case 'blank':
+				i++
+				break
+			case 'code': {
+				// Run to the closing fence, or to the end of the text — a reply
+				// still streaming in has an open fence for as long as it is inside
+				// one, and that is a code block with what has arrived so far.
+				let end = i + 1
+				while (end < lines.length && !FENCE.test(lines[end] ?? '')) end++
+				const last = Math.min(end, lines.length - 1)
+				segments.push(lines.slice(i, last + 1).join('\n'))
+				i = end + 1
+				break
+			}
+			case 'table': {
+				let end = i + 2 // header + separator
+				while (end < lines.length && TABLE_ROW.test(lines[end] ?? '')) end++
+				segments.push(lines.slice(i, end).join('\n'))
+				i = end
+				break
+			}
+			case 'heading':
+			case 'bullet':
+				segments.push(line)
+				i++
+				break
+			default: {
+				// A paragraph is every following line that begins nothing else.
+				let end = i
+				while (end < lines.length && classify(lines[end] ?? '', lines[end + 1]) === 'text') end++
+				segments.push(lines.slice(i, end).join('\n'))
+				i = end
+				break
+			}
 		}
 	}
+	return segments
+}
 
-	for (let i = 0; i < lines.length; i++) {
-		const line = lines[i] ?? ''
-		const fence = FENCE.exec(line)
-		if (fence) {
-			flushPara()
-			const lang = fence[1] ? fence[1] : undefined
-			const codeLines: string[] = []
-			i++
-			while (i < lines.length && !FENCE.test(lines[i] ?? '')) {
-				codeLines.push(lines[i] ?? '')
-				i++
+/** Parse one block's raw text — a segment from {@link scanBlocks} — into a block. */
+export function parseBlock(raw: string): MdBlock {
+	const lines = raw.split('\n')
+	const first = lines[0] ?? ''
+	switch (classify(first, lines[1])) {
+		case 'code': {
+			const lang = FENCE.exec(first)?.[1]
+			// The closing fence is part of the segment when the block is closed and
+			// absent while it is still arriving, so it is dropped only if present.
+			// A segment that is nothing but its opening fence reads as closed and
+			// is right either way: there is no body to drop a line from.
+			const closed = FENCE.test(lines[lines.length - 1] ?? '')
+			return {
+				type: 'code',
+				...(lang ? { lang } : {}),
+				lines: closed ? lines.slice(1, -1) : lines.slice(1),
 			}
-			// `i` now points at the closing fence (or end); the for-loop ++ skips it.
-			blocks.push({ type: 'code', lang, lines: codeLines })
-			continue
 		}
-		// Table: a `| … |` header row immediately followed by a `|---|` separator.
-		if (TABLE_ROW.test(line) && i + 1 < lines.length && TABLE_SEP.test(lines[i + 1] ?? '')) {
-			flushPara()
-			const headers = tableCells(line)
-			i += 2 // skip header + separator
-			const rows: string[][] = []
-			while (i < lines.length && TABLE_ROW.test(lines[i] ?? '')) {
-				rows.push(tableCells(lines[i] ?? ''))
-				i++
+		case 'table':
+			return {
+				type: 'table',
+				headers: tableCells(first),
+				rows: lines.slice(2).map(tableCells),
 			}
-			i-- // for-loop ++ will re-advance past the last consumed row
-			blocks.push({ type: 'table', headers, rows })
-			continue
+		case 'heading': {
+			const heading = HEADING.exec(first)
+			return { type: 'heading', level: heading?.[1]?.length ?? 1, text: heading?.[2] ?? '' }
 		}
-		const heading = HEADING.exec(line)
-		if (heading) {
-			flushPara()
-			blocks.push({ type: 'heading', level: heading[1]?.length ?? 1, text: heading[2] ?? '' })
-			continue
-		}
-		const bullet = BULLET.exec(line)
-		if (bullet) {
-			flushPara()
-			const rawMarker = bullet[2] ?? '-'
+		case 'bullet': {
+			const bullet = BULLET.exec(first)
+			const rawMarker = bullet?.[2] ?? '-'
 			const ordered = /\d/.test(rawMarker)
-			blocks.push({
+			return {
 				type: 'bullet',
 				ordered,
 				marker: ordered ? rawMarker.replace(/[.)]$/, '') : '•',
-				text: bullet[3] ?? '',
-			})
-			continue
+				text: bullet?.[3] ?? '',
+			}
 		}
-		if (line.trim().length === 0) {
-			flushPara()
-			continue
-		}
-		para.push(line.trim())
+		default:
+			return { type: 'paragraph', text: lines.map((l) => l.trim()).join(' ') }
 	}
-	flushPara()
-	return blocks
+}
+
+/** Parse markdown source into a flat list of block elements. */
+export function parseMarkdown(src: string): MdBlock[] {
+	return scanBlocks(src).map(parseBlock)
 }
 
 const INLINE = /(`[^`]+`)|(\[[^\]]+\]\([^)]+\))|(\*\*[^*]+\*\*)|(__[^_]+__)|(\*[^*]+\*)|(_[^_]+_)/


### PR DESCRIPTION
The pending transcript row is the only row that re-renders, and it re-parsed the whole message on every token. A forty-block answer was parsed forty blocks deep per token, so streaming a reply cost the square of its length.

## What changed

`parseMarkdown` is now `scanBlocks` followed by `parseBlock` per segment. That split is what makes a per-block cache possible, and `markdown-block-cache.ts` is that cache, keyed on each block's raw text. `BlockView` is memoised on the reused block objects, because `parseInline` runs per block per render and is the more expensive half — without the memo the cache would save the parse and throw the saving away.

## Two things the study that prompted this got wrong here

- **The reference-link guard is not needed.** The reference disables per-block caching when reference-style link definitions are present, because then a block's rendering depends on other blocks. This markdown subset has no such construct, so `parseBlock` is already a pure function of its segment. A guard for a case that cannot arise was not imported; the parser docblock records the property the cache depends on instead.
- **The stated reason for skipping the last block does not hold.** "Appended text reinterprets the final block" is true, and harmless when the key is the block's exact raw text: reinterpretation changes the key, so a stale hit is impossible. The exclusion is still right for a different reason — the growing block passes through every one of its own prefixes, and caching those puts an entry per *token* into a structure meant to hold an entry per block.
- And **one excluded segment is not enough**. A half-typed table row (`| 1 | 2`, no closing pipe) is not a table row yet, so it scans as a paragraph of its own and leaves the table above it second-to-last while still growing a row at a time. Two are excluded; the line being typed can reach back exactly one segment and no further, because that segment is maximal.

## Measured

A twenty-block reply streamed in sixteen-character tokens: **847** block parses before, **148** after. Across a 4x document-size step the per-token cost went **5.71 → 20.93** before and is flat after — the assertion is scale-invariance rather than a single number, because parse calls per token are ~1 with the cache and ~blocks/2 without, so one fixture size can be passed by accident where the two are close.

## Mutation table

| # | mutation | killed by |
|---|---|---|
| M1 | `Markdown` parses uncached | both counting tests (847 vs a bound of 176; 5.71 → 20.93 per token) |
| M2 | cache the tail too | cache-size invariance (212 vs 32), and the parse-count floor |
| M3 | drop `memo` from `BlockView` | inline re-parse count (284 vs 157) and its scale check |
| M4 | scanner: `i = end` after a code fence | existing `markdownParser.test.ts` (2 tests) |
| M5 | `parseBlock`: never drop the closing fence | existing `markdownParser.test.ts` (2 tests) |
| M6 | cache keyed on block **index** instead of raw text | **survived** — see below |

M6 survived the original set, and that was a real gap rather than an equivalent mutant. Under append-only growth a settled block never moves, so position and text agree; they part company when one `<Markdown>` instance serves a *second* message. The pending row is a single mounted component at a fixed position, so when one streaming reply finalizes and the next begins React reuses that instance, hooks and cache included, and the text under it is replaced wholesale. A test that streams two unrelated messages through one cache was added, and it kills M6.

## Gates

`pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm docs:check`, `scripts/audit-external-names.mjs`, and `.github/scripts/verify-public-surface.mjs` (555/555 runtime, 1276/1276 declared — unchanged).

https://claude.ai/code/session_01RppSzAoxqCxKfD4fLYmnzs
