### PR TITLE
feat(cli): keep the last transcript rows redrawable

### DIFF
--- a/.changeset/young-moons-argue.md
+++ b/.changeset/young-moons-argue.md
@@ -1,0 +1,19 @@
+---
+'@namzu/cli': minor
+---
+
+`Ctrl+O` expands collapsed tool output in place again, for the rows still on
+screen.
+
+The last few transcript entries are now drawn live rather than printed once, so
+pressing `Ctrl+O` replaces the `… +6 lines` hint with the lines it was hiding —
+in the row where it already is, with nothing printed twice. Pressing it again
+closes them.
+
+How far back it reaches is bounded by your terminal's height, because the live
+region has to stay well inside the viewport. On a terminal roughly under thirty
+rows there is no room for one, and `Ctrl+O` says so and points at `/expand`
+rather than doing nothing. `/expand <n>` is unchanged and remains the way to
+reach anything older; it still appends the full body as a new entry.
+
+Nothing changes for a caller: no exported type, flag or route moved.

--- a/docs/cli/tui.md
+++ b/docs/cli/tui.md
@@ -1,7 +1,7 @@
 ---
 title: The TUI
 description: Launching namzu, the transcript and composer, slash commands, message queuing, /resume, /expand, and interrupting a running turn.
-last_updated: 2026-08-09
+last_updated: 2026-08-10
 status: current
 related_packages: ["@namzu/cli"]
 ---
@@ -209,15 +209,19 @@ Tool diffs and command output collapse to six lines with a hint that names itsel
  ▏ … +6 lines · /expand 3
 ```
 
+There are two ways in, and which one you get depends on how far back the output is.
+
+### `Ctrl+O` — reopen it where it is
+
+The last few entries of the transcript stay **redrawable**. `Ctrl+O` opens every collapsed body among them in place: the hint line is replaced by the lines it was hiding, nothing is printed twice, and pressing it again closes them.
+
+How far back it reaches depends on your terminal's height, because the redrawable window is bounded by how much of the screen it can occupy. On a short terminal — roughly under thirty rows — there is no room for one, and `Ctrl+O` says so and points you at `/expand` rather than quietly doing nothing.
+
+### `/expand [n]` — reach anything older
+
 `/expand 3` prints that body in full, and `/expand` on its own takes the most recent one. The full text arrives as a **new entry below**, so the collapsed one stays where it was and your scrollback keeps both.
 
-That is the mechanism, not a stylistic choice. Finalized transcript entries are written straight to the terminal's own scrollback and are never redrawn — which is what keeps a long session from growing without bound, and what makes your terminal's native scroll and text selection work over the whole conversation. Nothing can reach back and change an entry that has already been printed, so an expansion has to be something new on the end.
-
-### `Ctrl+O` is deprecated
-
-`Ctrl+O` used to be the way in, and it is still bound: pressing it tells you what to use instead. It no longer expands anything.
-
-It was advertised as toggling full expansion for everything, and against output already on screen it did nothing — for the reason above. Pressing it *before* a tool finished did work, in that the result printed in full when it arrived, but that meant deciding you wanted the output before you could see it had been truncated, and nothing said so. `/expand` reaches output the key never could.
+That is the mechanism, not a stylistic choice. Once an entry has scrolled past the redrawable window it is written straight to the terminal's own scrollback and is never redrawn — which is what keeps a long session from growing without bound, and what makes your terminal's native scroll and text selection work over the whole conversation. Nothing can reach back and change an entry that has already been printed, so an expansion of one has to be something new on the end.
 
 ## Sessions & resume
 

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -50,7 +50,8 @@ import { PermissionOverlay } from './PermissionOverlay.js'
 import { approvalIsDeliberate } from './consent-timing.js'
 import { Picker } from './Picker.js'
 import { type ContextFill, StatusBar } from './StatusBar.js'
-import { Transcript, renderedDetailLines, willCollapse } from './Transcript.js'
+import { Transcript, willCollapse } from './Transcript.js'
+import { liveWindow, transcriptLines } from './live-window.js'
 import { createAssistantMessage, createUserMessage } from '@namzu/sdk'
 import {
 	type CliSessions,
@@ -90,34 +91,15 @@ type RunningTool = ActiveTool & {
 }
 
 /**
- * Every line the finalized transcript will print, for the spacer to measure.
+ * Rows the live region occupies apart from the transcript window: the activity
+ * line, the composer frame and its padding, the status bar.
  *
- * Exported so the wiring is testable rather than only typecheckable. The
- * spacer's own docblock states the asymmetry it depends on: over-count the
- * content and the composer merely floats, under-count it and the composer is
- * pushed off the bottom. The caller used to pass each row's `content` alone,
- * which counted a six-line collapsed tool body as nothing at all — the estimate
- * ran low by six per tool call, in the direction that costs the usability
- * rather than the feature. `/expand` makes it acute: a row whose entire
- * substance is a two-hundred-line body would have been handed over as one line.
- *
- * A pending row is excluded because it is not in the static log yet; the
- * spacer's `liveRows` covers the live region.
+ * Counted generously, because over-counting costs a gap under the composer and
+ * under-counting costs the composer itself — and, now that a window of live
+ * rows sits above this furniture, under-counting also lets that window grow
+ * until the renderer gives up on incremental repaint. See `live-window.ts`.
  */
-export function spacerTranscript(messages: readonly TranscriptMessage[]): readonly string[] {
-	const finalized = messages.filter((m) => !m.pending)
-	return finalized.flatMap((m, i) => [
-		// The blank row `MessageRow` puts above every entry but the first and the
-		// `⎿` result rows. One row per entry sounds negligible and is not: forty
-		// entries is forty rows, which on most terminals is the whole viewport.
-		...(i > 0 && m.glyph !== '⎿' ? [''] : []),
-		// Indented by the two-column glyph gutter the content renders beside, so
-		// a long line is measured against the width it actually has.
-		`  ${m.content}`,
-		...renderedDetailLines(m),
-	])
-}
-
+const LIVE_FURNITURE_ROWS = 10
 
 export function App({ ctx }: AppProps) {
 	const { exit } = useApp()
@@ -167,6 +149,15 @@ export function App({ ctx }: AppProps) {
 	const [activeTools, setActiveTools] = useState<readonly ActiveTool[]>([])
 	// Bumped to reset the <Static> transcript log (on /clear and /resume).
 	const [resetKey, setResetKey] = useState<number>(0)
+	/**
+	 * How many finalized rows have been printed to scrollback.
+	 *
+	 * The floor under the live window, carried between renders so the split can
+	 * only ever move forward. Reset with the static log itself — after `/clear`
+	 * nothing has been printed under the new log, and a floor left behind would
+	 * hold the window shut for the length of the next conversation.
+	 */
+	const settledRef = useRef<number>(0)
 	// Messages typed while a turn is running — auto-sent when it settles.
 	const [queued, setQueued] = useState<readonly string[]>([])
 	const [resumeList, setResumeList] = useState<readonly RecentConversation[]>([])
@@ -255,6 +246,10 @@ export function App({ ctx }: AppProps) {
 	// cleaned of, one layer up.
 	const resetTranscript = useCallback(() => {
 		if (process.stdout.isTTY) process.stdout.write('\x1b[2J\x1b[3J\x1b[H')
+		// The scrollback floor goes with the log it counted. <Static> is remounted
+		// by the key below and has emitted nothing again; a floor that survived
+		// would keep the next conversation's rows out of the live window.
+		settledRef.current = 0
 		setResetKey((k) => k + 1)
 	}, [])
 
@@ -558,18 +553,37 @@ export function App({ ctx }: AppProps) {
 		void runProbe()
 	}, [ctx.cwd, runProbe])
 
+	const finalized = messages.filter((m) => !m.pending)
+	// How much of the transcript is still redrawable. Computed here rather than
+	// inside <Transcript> because the same split decides what the bottom spacer
+	// measures: rows in scrollback are content it has to make room for, rows in
+	// the window are part of the live region it is padding above. Two
+	// computations of one split would drift, and the direction they would drift
+	// in is a composer pushed off the screen.
+	//
+	// A ref, and mutated during render, because the split has to be MONOTONIC:
+	// a row that has been printed to scrollback can never come back, and `max`
+	// is idempotent, so a repeated render reaches the same answer.
+	const window = liveWindow({
+		messages: finalized,
+		rows: process.stdout.rows,
+		columns: process.stdout.columns,
+		furnitureRows: LIVE_FURNITURE_ROWS,
+		settled: settledRef.current,
+	})
+	settledRef.current = window.settled
+
 	// Blank rows above the composer, while the transcript is short enough that
-	// the answer is knowable. `liveRows` is the fixed furniture beneath the
-	// transcript — activity line, composer frame, status bar and their padding —
-	// counted generously, because over-counting costs a gap and under-counting
-	// costs the composer.
+	// the answer is knowable. `liveRows` is the furniture beneath the transcript
+	// PLUS the live window above it — the window is part of the live region, and
+	// leaving it out would have the spacer padding room that is already taken.
 	const spacerRows =
 		phase === 'ready'
 			? bottomSpacerRows({
 					rows: process.stdout.rows,
 					columns: process.stdout.columns,
-					transcript: spacerTranscript(messages),
-					liveRows: 10,
+					transcript: transcriptLines(finalized.slice(0, window.settled)),
+					liveRows: LIVE_FURNITURE_ROWS + window.rows,
 				})
 			: 0
 
@@ -1463,30 +1477,48 @@ export function App({ ctx }: AppProps) {
 				pushMessage('system', 'Interrupted.')
 				return
 			}
-			// Ctrl+O is deprecated, still bound, and now says so.
+			// Ctrl+O expands the collapsed bodies that are still redrawable.
 			//
 			// It was advertised — on every collapsed body — as toggling full
 			// expansion for everything, and in that use it did nothing: finalized
-			// rows go through `<Static>`, which renders `items.slice(index)` and
+			// rows went through `<Static>`, which renders `items.slice(index)` and
 			// calls the render function only for items it has not emitted yet, so
-			// output already on screen was beyond its reach.
+			// output already on screen was beyond its reach. Measured, with a
+			// twelve-line body up: pressing it produced one further frame whose
+			// transcript region was byte-identical to the one before.
 			//
-			// It was NOT inert, though, and the difference matters enough to have
-			// changed this design. `<Static>` calls the CURRENT render closure for
-			// each newly appended item, so pressing the key while a tool was
-			// running made that tool's result print in full when it arrived. A
-			// working behaviour — undiscoverable, unadvertised, and the opposite of
-			// what the hint under the row promised: you had to decide you wanted
-			// the output before you had seen that it was truncated.
-			//
-			// So it is not deleted out from under anyone. It stays bound for a
-			// release and answers with the reason and the replacement, which is
-			// more than it gave in the case an operator would actually try it.
+			// The rows at the end of the transcript are now drawn live rather than
+			// printed once, so for those the key does what it always claimed —
+			// flipping the flag re-renders the row where it already is. It reaches
+			// exactly as far back as the window does, and says so when that is
+			// nowhere. It does not quietly fall back to appending a copy: `/expand`
+			// is that, deliberately and visibly, and a key that sometimes redraws
+			// in place and sometimes prints a second copy further down would be two
+			// commands wearing one name.
 			if (key.ctrl && input === 'o') {
-				pushMessage(
-					'system',
-					'Ctrl+O is deprecated and no longer expands anything. It could never reopen output already on screen — finalized rows are printed once and never redrawn. Use /expand <n>; the number is in the hint under each collapsed body, and /expand on its own takes the most recent.',
-				)
+				// Taken outside the updater so both branches use the same one, as
+				// `/expand` does.
+				const id = nextId()
+				setMessages((prev) => {
+					const live = prev.filter((m) => !m.pending).slice(settledRef.current)
+					const collapsible = live.filter((m) => willCollapse(m.detail))
+					if (collapsible.length === 0) {
+						return [
+							...prev,
+							{
+								id,
+								role: 'system' as const,
+								content:
+									'Nothing on screen can be expanded in place. Only the last few rows stay redrawable; anything older has been printed to the terminal’s own scrollback, which cannot be rewritten. Use /expand <n> for those — the number is in the hint under each collapsed body, and /expand on its own takes the most recent.',
+							},
+						]
+					}
+					// Expanded unless they are all open already, in which case this
+					// closes them again — the toggle it was always described as.
+					const expanding = collapsible.some((m) => m.detailExpanded !== true)
+					const ids = new Set(collapsible.map((m) => m.id))
+					return prev.map((m) => (ids.has(m.id) ? { ...m, detailExpanded: expanding } : m))
+				})
 				return
 			}
 			if (key.ctrl && input === 'c') {
@@ -1552,10 +1584,11 @@ export function App({ ctx }: AppProps) {
 					<>
 						<TranscriptFrame>
 							<Transcript
-								messages={messages.filter((m) => !m.pending)}
+								messages={finalized}
 								pending={messages.find((m) => m.pending) ?? null}
 								state={state}
-																resetKey={resetKey}
+								settled={window.settled}
+								resetKey={resetKey}
 								header={
 									phase === 'ready' ? (
 										<Banner

--- a/packages/cli/src/tui/Transcript.tsx
+++ b/packages/cli/src/tui/Transcript.tsx
@@ -8,18 +8,34 @@
 
 import { Box, Static, Text } from 'ink'
 import type { ReactNode } from 'react'
-import { useEffect, useState } from 'react'
+import { memo, useEffect, useState } from 'react'
 
 import { Markdown } from './Markdown.js'
 import { theme } from './theme.js'
 import type { TranscriptMessage } from './types.js'
 
 export interface TranscriptProps {
-	/** Finalized messages — rendered once via <Static> (printed to scrollback). */
+	/** Finalized messages, oldest first. */
 	readonly messages: readonly TranscriptMessage[]
 	/** The in-progress streaming message, re-rendered live below the static log. */
 	readonly pending: TranscriptMessage | null
 	readonly state: 'idle' | 'thinking' | 'tool' | 'awaiting-permission'
+	/**
+	 * How many of `messages` have been handed to scrollback.
+	 *
+	 * `messages[0, settled)` go through `<Static>`, which prints a row once and
+	 * never redraws it; the rest are drawn live and can still change — which is
+	 * what makes expanding a body already on screen possible at all. The caller
+	 * decides how many that is, because the answer depends on the terminal's
+	 * height and on the spacer's arithmetic; see `live-window.ts`. Passing
+	 * `messages.length` is the everything-is-static behaviour.
+	 *
+	 * It must never decrease for a given `resetKey`. `<Static>` counts what it
+	 * has emitted and renders only past that count, so a shrinking prefix leaves
+	 * rows unprinted, and a row already drawn live would be printed a second
+	 * time on its way back out.
+	 */
+	readonly settled: number
 	/** Bump to reset the static log (e.g. /clear, /resume). */
 	readonly resetKey: number
 	/**
@@ -43,22 +59,37 @@ type StaticRow =
 			readonly prev: TranscriptMessage | undefined
 	  }
 
-export function Transcript({ messages, pending, state, resetKey, header }: TranscriptProps) {
+export function Transcript({
+	messages,
+	pending,
+	state,
+	settled,
+	resetKey,
+	header,
+}: TranscriptProps) {
 	const spinner = useSpinner(state !== 'idle')
 
+	const inScrollback = Math.min(Math.max(settled, 0), messages.length)
 	// The banner is row 0 so it prints to the very top of scrollback; messages
 	// follow it. <Static> renders each row exactly once and never re-renders it,
-	// keeping memory + per-frame work bounded (the whole transcript was
-	// previously re-rendered on every spinner tick / token, which OOM'd long
-	// sessions) and removing flicker.
+	// so everything behind the live window costs nothing per frame — the whole
+	// transcript was once re-rendered on every spinner tick, which exhausted
+	// memory on long sessions.
 	const rows: StaticRow[] = [
 		...(header ? [{ kind: 'header' as const }] : []),
-		...messages.map((message, i) => ({
+		...messages.slice(0, inScrollback).map((message, i) => ({
 			kind: 'message' as const,
 			message,
 			prev: messages[i - 1],
 		})),
 	]
+	// The live window. Memoised per row, and that is what keeps this affordable:
+	// the spinner ticks about twelve times a second and every tick re-renders
+	// this component, so an unmemoised window would re-render its rows — parse
+	// their markdown, rebuild their elements — on each one. The rows themselves
+	// are unchanged objects between ticks, so the memo holds; the row that just
+	// changed is the only one that renders.
+	const live = messages.slice(inScrollback)
 	return (
 		<Box flexDirection="column">
 			<Static key={resetKey} items={rows}>
@@ -70,6 +101,14 @@ export function Transcript({ messages, pending, state, resetKey, header }: Trans
 					)
 				}
 			</Static>
+			{live.map((message, i) => (
+				<LiveRow
+					key={message.id}
+					message={message}
+					prev={messages[inScrollback + i - 1]}
+					spinner=""
+				/>
+			))}
 			{pending ? (
 				<MessageRow
 					message={pending}
@@ -87,6 +126,23 @@ export function Transcript({ messages, pending, state, resetKey, header }: Trans
 		</Box>
 	)
 }
+
+/**
+ * A row in the live window.
+ *
+ * Memoised on the whole props object rather than on a hand-picked key. React's
+ * default shallow compare over `{message, prev, spinner}` is already exactly
+ * "has anything about this row changed": the transcript is held as immutable
+ * rows, so an update rebuilds only the rows it touches and leaves every other
+ * object identical. A `(id, detailExpanded)` key would be the same answer for
+ * two fields and silently the wrong one for every other field a row has.
+ *
+ * Terminal width is deliberately NOT part of it. Nothing in a row's element
+ * tree depends on the width — wrapping is done by the layout engine from the
+ * same tree, and a resize re-lays-out without re-rendering — so a width key
+ * would be a prop that drives nothing.
+ */
+const LiveRow = memo(MessageRow)
 
 function MessageRow({
 	message,
@@ -141,12 +197,23 @@ function MessageRow({
 /**
  * Collapsible tool diff / output, aligned under the content gutter.
  *
- * `expanded` comes from the ROW, not from a view-wide setting, because a
- * view-wide setting reaches the wrong rows: `<Static>` renders each item once,
- * calling the CURRENT render function for items it has not emitted yet — so a
- * flag flipped now applies to rows that have not happened and to none of the
- * rows on screen. `/expand` therefore pushes a new row with the flag already
- * set, rather than trying to flip one on a row that has been printed.
+ * `expanded` comes from the ROW, and that is now load-bearing in the opposite
+ * direction from the reason it was written.
+ *
+ * It used to say that a view-wide setting could not work, because every
+ * finalized row went through `<Static>`: that renders each item once and calls
+ * the CURRENT render function only for items it has not emitted yet, so a flag
+ * flipped now would apply to rows that have not happened and to none of the
+ * rows on screen. True of a row in scrollback, and it is why `/expand` pushes a
+ * new row carrying the same lines rather than reopening the old one.
+ *
+ * It is not true of the live window. Those rows are re-rendered from state on
+ * every frame, so flipping this flag on one of them redraws that row in place —
+ * which is what the expand key now does, for the rows an operator is actually
+ * looking at. The flag stays on the row rather than becoming view-wide because
+ * the two mechanisms have to coexist: `/expand` still appends for anything that
+ * has settled into scrollback, and a view-wide flag would mean something
+ * different to each half.
  */
 function DetailBlock({
 	lines,

--- a/packages/cli/src/tui/__tests__/a-body-is-counted-and-numbered.test.ts
+++ b/packages/cli/src/tui/__tests__/a-body-is-counted-and-numbered.test.ts
@@ -22,9 +22,9 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { spacerTranscript } from '../App.js'
 import { renderedDetailLines } from '../Transcript.js'
 import { estimateRenderedLines } from '../bottom-spacer.js'
+import { transcriptLines } from '../live-window.js'
 import type { TranscriptMessage } from '../types.js'
 
 const body = (n: number) => Array.from({ length: n }, (_, i) => `line-${i + 1}`)
@@ -81,7 +81,7 @@ describe('renderedDetailLines', () => {
 
 describe('what the spacer is given', () => {
 	it('includes the body under a tool call, not just the line above it', () => {
-		const lines = spacerTranscript([row({ detail: body(12) })])
+		const lines = transcriptLines([row({ detail: body(12) })])
 		// The call line plus six shown plus the hint.
 		expect(lines).toHaveLength(8)
 		expect(lines[0]).toContain('Bash(ls)')
@@ -91,13 +91,13 @@ describe('what the spacer is given', () => {
 		// `MessageRow` puts one above every entry but the first and the `⎿`
 		// results. Forty entries is forty rows — a whole viewport on most
 		// terminals, silently absent from the estimate.
-		const two = spacerTranscript([row({ id: 'a' }), row({ id: 'b' })])
+		const two = transcriptLines([row({ id: 'a' }), row({ id: 'b' })])
 		expect(two).toHaveLength(3)
 		expect(two[1]).toBe('')
 	})
 
 	it('does not count a gap before a result row, which hugs its call', () => {
-		const hugging = spacerTranscript([row({ id: 'a' }), row({ id: 'b', glyph: '⎿' })])
+		const hugging = transcriptLines([row({ id: 'a' }), row({ id: 'b', glyph: '⎿' })])
 		expect(hugging).toHaveLength(2)
 	})
 
@@ -107,13 +107,13 @@ describe('what the spacer is given', () => {
 			detail: body(200),
 			detailExpanded: true,
 		})
-		const measured = estimateRenderedLines(spacerTranscript([expanded]), 80)
+		const measured = estimateRenderedLines(transcriptLines([expanded]), 80)
 		expect(measured).toBeGreaterThan(200)
 	})
 
 	it('leaves out the row still streaming, which is not in the static log yet', () => {
 		// The live region is covered by the spacer's `liveRows`, so counting a
 		// pending row here would count it twice.
-		expect(spacerTranscript([row({ pending: true, detail: body(12) })])).toEqual([])
+		expect(transcriptLines([row({ pending: true, detail: body(12) })])).toEqual([])
 	})
 })

--- a/packages/cli/src/tui/__tests__/a-body-reopens-where-it-is.test.tsx
+++ b/packages/cli/src/tui/__tests__/a-body-reopens-where-it-is.test.tsx
@@ -1,0 +1,283 @@
+/**
+ * The expand key reopens a body where it already is.
+ *
+ * ## What it could not do before, and how that was established
+ *
+ * Every finalized row went through `<Static>`, which prints a row once and
+ * never redraws it. So the key advertised on every collapsed body could not
+ * reach the body: measured with a twelve-line body up, pressing it produced one
+ * further frame whose transcript region was byte-identical to the previous one.
+ * That is why expansion had to become a command appending a second copy of the
+ * output further down.
+ *
+ * The rows at the end of the transcript are now drawn live, so for those the
+ * key does what it always claimed.
+ *
+ * ## Why this is on the screen surface
+ *
+ * A frame string cannot tell "printed again below" from "rewritten in place",
+ * and that distinction is the whole of this change. The emulated terminal can:
+ * the row that showed the hint is asked what it shows now, an anchor above it
+ * is asked whether it moved, and the buffer is asked how many copies of the
+ * body it holds. An assertion that the hidden lines are "visible somewhere"
+ * would pass for the appending command that already exists.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Preferences } from '../../integrations/providers/index.js'
+import type { AgentEvent, AgentSession } from '../agent.js'
+import { SAFETY_ROWS } from '../bottom-spacer.js'
+import type { TuiContext } from '../types.js'
+import { type Screen, renderToScreen } from './support/screen.js'
+
+const PREFS: Preferences = { version: 3, providers: [{ id: 'openai' }], subagents: { active: [] } }
+
+vi.mock('../../integrations/trust/store.js', () => ({ isTrusted: () => true, trustDir: () => {} }))
+vi.mock('../../integrations/updates.js', () => ({ checkUpdates: async () => [] }))
+vi.mock('../../integrations/sessions/store.js', () => ({
+	openSessions: async () => ({ tenantId: 't' }),
+	startConversation: async () => 'conv',
+	appendMessages: async () => {},
+	listRecent: async () => [],
+	loadConversation: async () => [],
+}))
+vi.mock('../../user-commands/store.js', () => ({ discoverUserCommands: () => [] }))
+
+/** Twelve lines: six print, six hide behind the hint. */
+const RESULT_DETAIL = Array.from({ length: 12 }, (_, i) => `result-line-${i + 1}`)
+
+vi.mock('../agent.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../agent.js')>()
+	return {
+		...actual,
+		probeAgentSession: async () => ({
+			preferences: PREFS,
+			needsRepickReason: null,
+			detected: [],
+		}),
+		createAgentSession: async (): Promise<AgentSession> => ({
+			hasProvider: true,
+			providerSummary: 'a-provider',
+			modelSummary: 'a-model',
+			toolNames: () => ['bash'],
+			errorHint: null,
+			errorKind: null,
+			instructionFiles: [],
+			skippedInstructionFiles: [],
+			mcpConnected: [],
+			mcpFailed: [],
+			agentIds: [],
+			configNotices: [],
+			resumeDurable: async () => {
+				throw new Error('not used by the TUI')
+			},
+			close: async () => {},
+			approvalLatched: () => false,
+			promptExemptTools: () => [],
+			send: async function* (): AsyncIterable<AgentEvent> {
+				yield { kind: 'tool-start', toolUseId: 'u1', toolName: 'bash', summary: 'ls' } as AgentEvent
+				yield {
+					kind: 'tool-end',
+					toolUseId: 'u1',
+					toolName: 'bash',
+					summary: 'ok',
+					isError: false,
+					detail: RESULT_DETAIL,
+				} as AgentEvent
+				yield { kind: 'done', stopReason: 'end_turn' } as AgentEvent
+			},
+		}),
+	}
+})
+
+const { App } = await import('../App.js')
+
+const ctx: TuiContext = { cwd: '/w', version: '0.0.0-test' }
+
+/**
+ * The terminal both the emulator and the app are told about.
+ *
+ * The app sizes its live window from `process.stdout`, so a screen of one size
+ * driving an app that believes another would be a fixture unlike production in
+ * exactly the dimension under test. Tall enough that the expansion fits without
+ * the viewport scrolling, which is what makes a row-index assertion meaningful.
+ */
+const COLS = 100
+const ROWS = 60
+
+const restore: Array<() => void> = []
+
+function pinTerminal(): void {
+	for (const key of ['rows', 'columns'] as const) {
+		const had = Object.getOwnPropertyDescriptor(process.stdout, key)
+		restore.push(() => {
+			if (had) Object.defineProperty(process.stdout, key, had)
+			else Reflect.deleteProperty(process.stdout, key)
+		})
+	}
+	Object.defineProperty(process.stdout, 'rows', { value: ROWS, configurable: true })
+	Object.defineProperty(process.stdout, 'columns', { value: COLS, configurable: true })
+}
+
+const mounted: Screen[] = []
+
+afterEach(async () => {
+	for (const screen of mounted) await screen.unmount()
+	mounted.length = 0
+	for (const undo of restore.splice(0).reverse()) undo()
+	vi.restoreAllMocks()
+})
+
+/** Poll rather than sleep: this suite transforms TypeScript on the way in, and
+ *  a fixed wait that passes alone goes red inside the full parallel run. */
+async function screenShows(screen: Screen, text: string, timeoutMs = 8_000): Promise<void> {
+	const started = performance.now()
+	while (performance.now() - started < timeoutMs) {
+		await screen.waitForRender()
+		if (screen.viewport().some((line) => line.includes(text))) return
+		await new Promise((resolve) => setTimeout(resolve, 20))
+	}
+}
+
+/** Index of the viewport row containing `text`, or -1. */
+function rowOf(screen: Screen, text: string): number {
+	return screen.viewport().findIndex((line) => line.includes(text))
+}
+
+/** Render, run the turn, and stop with one collapsed twelve-line body on screen. */
+async function aCollapsedBody(): Promise<Screen> {
+	pinTerminal()
+	const screen = await renderToScreen(<App ctx={ctx} />, { cols: COLS, rows: ROWS, scrollback: 400 })
+	mounted.push(screen)
+	// The composer's placeholder draws from the first frame while the composer
+	// is still disabled, so it is not readiness. The connect line only exists
+	// once the session is up.
+	await screenShows(screen, 'Connected to a-provider')
+	screen.press('go')
+	await screen.waitForRender()
+	screen.press('\r')
+	await screenShows(screen, 'result-line-6')
+	expect(screen.viewport().join('\n'), 'the turn never produced output').toContain('result-line-6')
+	return screen
+}
+
+describe('the expand key, on a body that is still on screen', () => {
+	it('opens it where it is, rather than printing a second copy below', async () => {
+		const screen = await aCollapsedBody()
+
+		const before = screen.viewport().join('\n')
+		expect(before, 'the body was not collapsed to begin with').toContain('… +6 lines')
+		expect(before, 'the hidden lines were visible before the key was pressed').not.toContain(
+			'result-line-7',
+		)
+		const hintRow = rowOf(screen, '… +6 lines')
+		const anchorRow = rowOf(screen, 'result-line-1')
+		expect(hintRow, 'the hint is not on screen').toBeGreaterThan(-1)
+
+		screen.press('\x0f') // Ctrl+O
+		await screenShows(screen, 'result-line-7')
+
+		// The rows above did not move, so the row indexes below mean something.
+		// If this fails the viewport scrolled, and the test says so rather than
+		// quietly asserting about a different row.
+		expect(rowOf(screen, 'result-line-1'), 'the viewport scrolled under the assertion').toBe(
+			anchorRow,
+		)
+		// The row that carried the hint now carries the seventh line of the body.
+		// This is the assertion a frame string cannot make.
+		expect(
+			screen.row(hintRow),
+			'the row that advertised the hidden lines is not the row that now shows them',
+		).toContain('result-line-7')
+		// And the hint is gone rather than still sitting above a copy.
+		expect(screen.viewport().join('\n'), 'the collapsed row was left behind').not.toContain(
+			'… +6 lines',
+		)
+		// One copy of the body on screen, not two. An appended expansion leaves
+		// the collapsed rows above its copy and would satisfy every "the hidden
+		// lines are visible somewhere" assertion.
+		//
+		// Read from the viewport rather than the whole buffer: a terminal that
+		// has scrolled keeps the frames that scrolled off, and those are the
+		// operator's history rather than the screen they are looking at.
+		//
+		// `endsWith`, because `result-line-1` is a prefix of `result-line-12` and
+		// a substring match counts the same body four times.
+		const copies = screen.viewport().filter((line) => line.endsWith('result-line-1'))
+		expect(copies, 'the body was printed a second time instead of reopened').toHaveLength(1)
+	}, 30_000)
+
+	it('leaves the composer near the foot of the screen, not floating above it', async () => {
+		// The spacer's arithmetic, from the other side of the split. Rows in the
+		// window are part of the LIVE REGION the spacer pads above, not content
+		// above it — hand it the whole transcript and it counts the window twice,
+		// pads that much less, and the composer stops sitting where this feature
+		// exists to put it.
+		//
+		// The bar is not asked to be exactly on the bottom row: the spacer holds
+		// back a safety margin by design, and the window's own height is
+		// deliberately over-counted on top of it, because over-padding is what
+		// pushes the composer out of view. The measured float is eleven rows —
+		// the margin plus the allowance on two windowed rows — against
+		// twenty-four when the window is counted twice.
+		const screen = await aCollapsedBody()
+
+		const viewport = screen.viewport()
+		const bar = viewport.findIndex((line) => line.includes('Ctrl+C ×2 to exit'))
+		expect(bar, 'the status bar is not on screen').toBeGreaterThan(-1)
+		const fromBottom = viewport.length - 1 - bar
+		expect(
+			fromBottom,
+			`the composer floated ${fromBottom} rows above the foot of the screen`,
+		).toBeLessThanOrEqual(SAFETY_ROWS + 6)
+	}, 30_000)
+
+	it('still reaches the rows of the conversation after /clear', async () => {
+		// `/clear` empties the transcript and remounts the static log, and the
+		// window has to come back with it.
+		//
+		// Honest about what this does NOT pin: dropping `settledRef` in
+		// `resetTranscript` leaves this green — verified by mutation. A stale
+		// floor is self-correcting, because it is clamped to the transcript's
+		// length and the window reopens as the new conversation grows past it,
+		// and this fixture's second conversation is already longer than the
+		// floor the first one left. What it does pin is the outcome an operator
+		// would notice: the key still reaches a body after the screen has been
+		// cleared under it.
+		const screen = await aCollapsedBody()
+
+		screen.press('/clear')
+		await screen.waitForRender()
+		screen.press('\r')
+		await screenShows(screen, 'Type a message')
+		expect(screen.viewport().join('\n'), 'the transcript was not cleared').not.toContain(
+			'result-line-6',
+		)
+
+		screen.press('go')
+		await screen.waitForRender()
+		screen.press('\r')
+		await screenShows(screen, 'result-line-6')
+
+		screen.press('\x0f')
+		await screenShows(screen, 'result-line-7')
+		expect(
+			screen.viewport().join('\n'),
+			'the key stopped reaching anything once the transcript had been cleared',
+		).toContain('result-line-7')
+	}, 30_000)
+
+	it('closes it again, because it is a toggle', async () => {
+		const screen = await aCollapsedBody()
+
+		screen.press('\x0f')
+		await screenShows(screen, 'result-line-7')
+		screen.press('\x0f')
+		await screenShows(screen, '… +6 lines')
+
+		const frame = screen.viewport().join('\n')
+		expect(frame, 'the key only ever opened').toContain('… +6 lines')
+		expect(frame, 'the body stayed open').not.toContain('result-line-7')
+	}, 30_000)
+})

--- a/packages/cli/src/tui/__tests__/a-long-transcript-costs-a-window.test.tsx
+++ b/packages/cli/src/tui/__tests__/a-long-transcript-costs-a-window.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * A live window costs the window, not the transcript.
+ *
+ * This is the risk in keeping any finalized rows redrawable, and it is the one
+ * the previous design paid `<Static>` to remove: the whole transcript was once
+ * re-rendered on every spinner tick, which exhausted memory on long sessions.
+ * The claim being made now is that the incident was **allocation churn** rather
+ * than retention — the transcript is held in component state either way, so
+ * what a window adds is a few rows of rendered output and what it must not add
+ * is per-frame work proportional to the session.
+ *
+ * ## Why the numbers are per frame, and measured at two lengths
+ *
+ * An assertion like "expansion works" would pass for an implementation that
+ * keeps every row live, which is the failure this file exists to catch. So what
+ * is measured is the cost of ONE frame: inline re-parses, which is real render
+ * work, and bytes written, which is what the renderer actually put on the wire.
+ *
+ * Both are measured at a hundred rows and at a thousand. One length cannot tell
+ * "bounded" from "small so far" — the two answers differ by a factor of ten
+ * only when the lengths do.
+ *
+ * ## Why the frames are driven rather than waited for
+ *
+ * The incident names the spinner, and the spinner is a timer — so the obvious
+ * harness lets half a second of ticks go by and divides. That was the first
+ * version of this file and it was too blunt to see anything: the renderer emits
+ * several stdout chunks per frame, so dividing by chunks diluted a window of
+ * six rows re-rendering into "2.3 per frame", which sat comfortably under every
+ * bound. Removing the memo changed nothing a reader could see.
+ *
+ * A token arriving re-renders this component exactly as a spinner tick does, so
+ * the frames are driven one at a time instead, each awaited. The denominator is
+ * then a number this file chose rather than one the machine's load decided, and
+ * there is no duration anywhere in it.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { liveWindow } from '../live-window.js'
+import type { TranscriptMessage } from '../types.js'
+import { renderToScreen } from './support/screen.js'
+
+/** Real render work, counted where it happens. */
+let inlineCalls = 0
+vi.mock('../markdownParser.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../markdownParser.js')>()
+	return {
+		...actual,
+		parseInline: (text: string) => {
+			inlineCalls++
+			return actual.parseInline(text)
+		},
+	}
+})
+
+const { Transcript } = await import('../Transcript.js')
+
+const TERMINAL_ROWS = 60
+const TERMINAL_COLS = 80
+const FURNITURE = 10
+
+function transcript(n: number): TranscriptMessage[] {
+	return Array.from({ length: n }, (_, i) => ({
+		id: `m${i}`,
+		role: 'assistant' as const,
+		content: `turn ${i}: a reply with **bold** and \`code\` in it`,
+	}))
+}
+
+/** The reply being streamed, after `tokens` of it have arrived. */
+function pendingAfter(tokens: number): TranscriptMessage {
+	return {
+		id: 'pending',
+		role: 'assistant',
+		content: `still writing${' more'.repeat(tokens)}`,
+		pending: true,
+	}
+}
+
+/** Frames driven, so the denominator is not a guess about the machine. */
+const FRAMES = 8
+
+interface FrameCost {
+	readonly inlinePerFrame: number
+	readonly bytesPerFrame: number
+	readonly live: number
+}
+
+/** Mount a transcript of `n` rows and measure what one frame of streaming costs. */
+async function costPerFrame(n: number): Promise<FrameCost> {
+	const messages = transcript(n)
+	// The production split, so a change to the window's bounds reaches this
+	// test rather than being reproduced by it.
+	const { settled } = liveWindow({
+		messages,
+		rows: TERMINAL_ROWS,
+		columns: TERMINAL_COLS,
+		furnitureRows: FURNITURE,
+		settled: 0,
+	})
+	const view = (tokens: number) => (
+		<Transcript
+			messages={messages}
+			pending={pendingAfter(tokens)}
+			// Idle, so the only thing re-rendering this component is the token
+			// below. A running spinner would add frames on a timer, and the
+			// measurement would be back to dividing by a number the machine chose.
+			state="idle"
+			settled={settled}
+			resetKey={0}
+		/>
+	)
+	const screen = await renderToScreen(view(0), {
+		cols: TERMINAL_COLS,
+		rows: TERMINAL_ROWS,
+		scrollback: 200,
+	})
+	try {
+		// Everything before this point is the one-off cost of printing the
+		// backlog into scrollback, which is not what is being measured.
+		const fromBytes = screen.bytesWritten()
+		const fromInline = inlineCalls
+		for (let i = 1; i <= FRAMES; i++) {
+			screen.rerender(view(i))
+			await screen.waitForRender()
+		}
+		return {
+			inlinePerFrame: (inlineCalls - fromInline) / FRAMES,
+			bytesPerFrame: (screen.bytesWritten() - fromBytes) / FRAMES,
+			live: messages.length - settled,
+		}
+	} finally {
+		await screen.unmount()
+	}
+}
+
+describe('a session with a thousand rows', () => {
+	it('costs the same per frame as one with a hundred', async () => {
+		const hundred = await costPerFrame(100)
+		const thousand = await costPerFrame(1000)
+
+		// It is a window rather than the whole transcript, and rather than
+		// nothing — "bounded" asserted about an empty set is not an assertion,
+		// and neither of the numbers below can discriminate if the window holds
+		// one row.
+		expect(hundred.live, 'nothing was kept live, so nothing is being bounded').toBeGreaterThan(2)
+		expect(thousand.live).toBe(hundred.live)
+
+		// Render work per frame: the row being written, and nothing else. The
+		// finalized rows in the window are unchanged objects between frames, so
+		// the memo on them holds; without it this is one per windowed row.
+		expect(
+			thousand.inlinePerFrame,
+			`inline re-parses per frame: ${hundred.inlinePerFrame.toFixed(1)} at a hundred rows, ${thousand.inlinePerFrame.toFixed(1)} at a thousand`,
+		).toBeLessThan(hundred.inlinePerFrame + 1)
+		expect(
+			thousand.inlinePerFrame,
+			'a frame re-rendered more than the row that changed',
+		).toBeLessThan(2)
+
+		// Bytes per frame: what the renderer actually wrote. This is the memory
+		// argument made checkable — the failure being guarded against is the
+		// renderer giving up on incremental repaint and rewriting the session.
+		expect(
+			thousand.bytesPerFrame,
+			`bytes per frame: ${Math.round(hundred.bytesPerFrame)} at a hundred rows, ${Math.round(thousand.bytesPerFrame)} at a thousand`,
+		).toBeLessThan(hundred.bytesPerFrame * 1.5 + 200)
+	}, 30_000)
+
+	it('leaves the transcript in scrollback rather than taking the alternate screen', async () => {
+		// A window that redraws rows must not be a window that owns the screen:
+		// everything behind it still has to survive where the operator scrolls.
+		const messages = transcript(100)
+		const { settled } = liveWindow({
+			messages,
+			rows: TERMINAL_ROWS,
+			columns: TERMINAL_COLS,
+			furnitureRows: FURNITURE,
+			settled: 0,
+		})
+		const screen = await renderToScreen(
+			<Transcript
+				messages={messages}
+				pending={null}
+				state="idle"
+				settled={settled}
+				resetKey={0}
+			/>,
+			{ cols: TERMINAL_COLS, rows: TERMINAL_ROWS, scrollback: 400 },
+		)
+		try {
+			expect(screen.bufferType()).toBe('normal')
+			const all = screen.scrollback().join('\n')
+			expect(all, 'a row that scrolled away was never printed').toContain('turn 10:')
+			// And exactly once — a row handed from the window to scrollback must
+			// not be printed a second time on the way out.
+			const printed = screen.scrollback().filter((line) => line.includes('turn 10:'))
+			expect(printed, 'a row was printed twice').toHaveLength(1)
+		} finally {
+			await screen.unmount()
+		}
+	}, 30_000)
+})

--- a/packages/cli/src/tui/__tests__/app-draft-survives.test.tsx
+++ b/packages/cli/src/tui/__tests__/app-draft-survives.test.tsx
@@ -100,8 +100,19 @@ vi.mock('../agent.js', async (importOriginal) => {
 					])
 					return
 				}
-				// Long enough for the test to type into a live composer.
-				await new Promise((r) => setTimeout(r, 120))
+				// The prompt opens when the test says it has finished typing, not
+				// after a duration.
+				//
+				// It used to wait 120ms, described as "long enough for the test to
+				// type into a live composer" — which made "was the composer still
+				// live" a question about how loaded the machine was. Under the full
+				// parallel suite the prompt could open first, the keystrokes were
+				// dropped by a composer that is disabled while a prompt is up, and
+				// the failure reported was "the draft never reached the composer": a
+				// true statement about a composer that was never asked. It is the
+				// same defect the branch above already fixed by waiting on the abort
+				// signal instead of a clock.
+				await permissionGate
 				const req: PermissionRequest = {
 					toolCalls: [{ id: 'c1', name: 'bash', summary: 'rm -rf build', isDestructive: true }],
 				}
@@ -141,10 +152,24 @@ async function frameShows(
 let nowMs = 1_000_000
 const mounted: { unmount: () => void }[] = []
 
+/**
+ * Held closed until the test has finished typing into the live composer.
+ *
+ * The permission prompt disables the composer, so every keystroke a test wants
+ * to leave in a draft has to land before the prompt opens. Sequencing that on a
+ * timer makes the test a race against the machine; the mocked turn waits on
+ * this instead, and {@link letThePromptOpen} is the test saying it is ready.
+ */
+let permissionGate: Promise<void> = Promise.resolve()
+let letThePromptOpen: () => void = () => {}
+
 beforeEach(() => {
 	decisions.length = 0
 	askPermission = true
 	nowMs = 1_000_000
+	permissionGate = new Promise<void>((resolve) => {
+		letThePromptOpen = resolve
+	})
 	vi.spyOn(Date, 'now').mockImplementation(() => nowMs)
 })
 
@@ -178,6 +203,8 @@ async function turnRunningWithDraft(draft: string) {
 	harness.stdin.write(draft)
 	await frameShows(harness.lastFrame, draft)
 	expect(harness.lastFrame(), 'the draft never reached the composer').toContain(draft)
+	// The draft is in. The prompt may open now.
+	letThePromptOpen()
 	return harness
 }
 
@@ -204,16 +231,20 @@ describe('a draft while a permission prompt comes and goes', () => {
 		// notice after sending an incomplete message.
 		const harness = render(<App ctx={ctx} />)
 		mounted.push(harness)
-		await tick(80)
+		await frameShows(harness.lastFrame, 'Type a message')
+		await tick(60)
 		harness.stdin.write('go')
 		await tick(20)
 		harness.stdin.write('\r')
-		await tick(40)
+		// The turn's first delta, so the submit has been processed and the
+		// composer is free again. A fixed wait here is a guess about the machine.
+		await frameShows(harness.lastFrame, 'working')
 		// A newline in one keypress is held as a paste chip.
 		harness.stdin.write('first line\nsecond line')
-		await tick(40)
+		await frameShows(harness.lastFrame, 'Pasted text')
 		expect(harness.lastFrame(), 'the paste chip never appeared').toContain('Pasted text')
 
+		letThePromptOpen()
 		await frameShows(harness.lastFrame, 'wants to run')
 		expect(harness.lastFrame()).toContain('wants to run')
 		harness.stdin.write('\x1B')

--- a/packages/cli/src/tui/__tests__/expand-emits-a-row.test.tsx
+++ b/packages/cli/src/tui/__tests__/expand-emits-a-row.test.tsx
@@ -265,23 +265,38 @@ describe('a body that fits', () => {
 	})
 })
 
-describe('Ctrl+O, which used to be the way', () => {
-	it('is still bound, and says what to press instead', async () => {
-		// It is not deleted out from under anyone. Advertised for a long time as
-		// toggling full expansion, it never could reopen output already drawn —
-		// but it was not inert either: it pre-armed rows that had not arrived yet.
-		// So it keeps answering, and what it answers is the replacement.
-		const harness = await twoCollapsedBlocks()
+describe('Ctrl+O, where it cannot reach', () => {
+	it('says so, and names the command that can', async () => {
+		// The key reopens collapsed bodies in place, but only for rows still in
+		// the live window. On a terminal with no room for one — here, one too
+		// short to hold a row above the composer and the status bar — every row
+		// has been printed to scrollback, and a printed row cannot be rewritten.
+		//
+		// Refusing is the whole point. A key that silently appended a copy when
+		// it could not redraw would be two commands wearing one name, and the
+		// operator would have no way to tell which one they just got.
+		const rows = Object.getOwnPropertyDescriptor(process.stdout, 'rows')
+		Object.defineProperty(process.stdout, 'rows', { value: 16, configurable: true })
+		try {
+			const harness = await twoCollapsedBlocks()
 
-		harness.stdin.write('\x0f') // Ctrl+O
-		await frameShows(harness.lastFrame, 'Ctrl+O is deprecated')
+			harness.stdin.write('\x0f') // Ctrl+O
+			await frameShows(harness.lastFrame, 'Nothing on screen can be expanded in place')
 
-		const frame = harness.lastFrame() ?? ''
-		expect(frame, 'the key went back to being silent').toContain('Ctrl+O is deprecated')
-		expect(frame, 'said it was gone without saying what replaced it').toContain('/expand')
-		// And it must not have expanded anything: the whole point is that it
-		// cannot, and a notice plus a silent expansion would be two answers.
-		expect(frame, 'the deprecated key expanded something anyway').not.toContain('result-line-12')
+			const frame = harness.lastFrame() ?? ''
+			expect(frame, 'the key went back to being silent').toContain(
+				'Nothing on screen can be expanded in place',
+			)
+			expect(frame, 'refused without saying what does work').toContain('/expand')
+			// And it must not have expanded anything: a notice plus a silent
+			// expansion would be two answers to one press.
+			expect(frame, 'the key expanded something it said it could not').not.toContain(
+				'result-line-12',
+			)
+		} finally {
+			if (rows) Object.defineProperty(process.stdout, 'rows', rows)
+			else Reflect.deleteProperty(process.stdout, 'rows')
+		}
 	})
 })
 

--- a/packages/cli/src/tui/bottom-spacer.ts
+++ b/packages/cli/src/tui/bottom-spacer.ts
@@ -51,17 +51,31 @@ export interface SpacerInput {
 	/** Terminal width, for wrapping. `undefined` falls back to 80. */
 	readonly columns: number | undefined
 	/**
-	 * The finalized transcript lines, as emitted — before ink renders them.
+	 * The lines of the transcript that have been printed to scrollback, as
+	 * emitted — before ink renders them.
 	 *
-	 * Every line a row will print, including the collapsed body under a tool
-	 * call. The caller used to pass each row's `content` alone, which counted an
-	 * eight-row tool result as one row: the estimate then ran low by seven, and
-	 * the asymmetry above says exactly what running low costs. `/expand` makes a
-	 * row whose whole substance is its body, so a caller that passed content
-	 * alone would hand a two-hundred-line row over as a single line.
+	 * Every line such a row will print, including the collapsed body under a
+	 * tool call. The caller used to pass each row's `content` alone, which
+	 * counted an eight-row tool result as one row: the estimate then ran low by
+	 * seven, and the asymmetry above says exactly what running low costs.
+	 * `/expand` makes a row whose whole substance is its body, so a caller that
+	 * passed content alone would hand a two-hundred-line row over as a single
+	 * line.
+	 *
+	 * Rows still in the live window belong in {@link liveRows}, not here. They
+	 * are two different quantities — content above the live region, and the live
+	 * region's own height — and this one is only the first.
 	 */
 	readonly transcript: readonly string[]
-	/** Rows the live region occupies: activity, composer frame, status bar. */
+	/**
+	 * Rows the live region occupies: the window of transcript rows that are
+	 * still redrawable, then the activity line, composer frame and status bar.
+	 *
+	 * A constant until the live window existed. It is now a function of what is
+	 * in that window, because an expanded body in it is thirty rows of live
+	 * region rather than eight, and a spacer that kept assuming the old constant
+	 * would pad the composer straight off the bottom. See `live-window.ts`.
+	 */
 	readonly liveRows: number
 }
 

--- a/packages/cli/src/tui/live-window.test.ts
+++ b/packages/cli/src/tui/live-window.test.ts
@@ -1,0 +1,139 @@
+/**
+ * How much of the transcript stays redrawable.
+ *
+ * The window's whole job is to be SMALL — small enough that the live region
+ * never reaches the viewport's height, because at that point the renderer stops
+ * repainting incrementally and rewrites the entire session's static output on
+ * every frame. So most of what is asserted here is a refusal: no terminal, a
+ * short terminal, a row taller than the budget, a floor already past the end.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { SAFETY_ROWS } from './bottom-spacer.js'
+import { MAX_LIVE_ROWS, liveWindow, transcriptLines } from './live-window.js'
+import type { TranscriptMessage } from './types.js'
+
+const FURNITURE = 10
+
+function row(over: Partial<TranscriptMessage> = {}): TranscriptMessage {
+	return { id: 'm1', role: 'assistant', content: 'a short line', ...over }
+}
+
+function rows(n: number): TranscriptMessage[] {
+	return Array.from({ length: n }, (_, i) => row({ id: `m${i}`, content: `line ${i}` }))
+}
+
+function split(
+	messages: readonly TranscriptMessage[],
+	terminalRows: number | undefined,
+	settled = 0,
+) {
+	return liveWindow({
+		messages,
+		rows: terminalRows,
+		columns: 80,
+		furnitureRows: FURNITURE,
+		settled,
+	})
+}
+
+describe('liveWindow', () => {
+	it('holds nothing when there is no terminal to measure', () => {
+		// Piped output. Nothing is being redrawn, so nothing gains from staying
+		// live, and the height that would bound it is unknown.
+		expect(split(rows(20), undefined).settled).toBe(20)
+	})
+
+	it('holds nothing on a terminal with no room to spare', () => {
+		// Furniture plus the safety margin already exceed the height, so the
+		// budget is negative and the window is empty — which is exactly the
+		// behaviour before there was a window.
+		expect(split(rows(20), FURNITURE + SAFETY_ROWS).settled).toBe(20)
+	})
+
+	it('holds the most recent rows on a terminal with room', () => {
+		const { settled } = split(rows(20), 60)
+		expect(settled).toBeLessThan(20)
+		expect(20 - settled).toBeGreaterThan(0)
+	})
+
+	it('never holds more than the cap, however tall the terminal', () => {
+		// The budget alone would put thirty short rows in the live region on a
+		// tall screen: thirty rows re-laid-out per spinner tick to make expansion
+		// available on output nobody is looking at.
+		const { settled } = split(rows(200), 400)
+		expect(200 - settled).toBe(MAX_LIVE_ROWS)
+	})
+
+	it('holds fewer rows when the rows are taller', () => {
+		// The bound is height, not count. Two transcripts of the same length hold
+		// different numbers of rows, and the tall one holds fewer.
+		const short = split(rows(20), 60)
+		const tall = split(
+			Array.from({ length: 20 }, (_, i) =>
+				row({
+					id: `m${i}`,
+					content: `line ${i}`,
+					detail: Array.from({ length: 40 }, (_, j) => `d${j}`),
+					detailExpanded: true,
+				}),
+			),
+			60,
+		)
+		expect(20 - tall.settled).toBeLessThan(20 - short.settled)
+	})
+
+	it('holds nothing when even the most recent row is taller than the budget', () => {
+		// A two-hundred-line expanded body. Refusing is the safe direction: the
+		// operator loses retroactive expansion of that row and keeps the session.
+		const huge = [
+			...rows(3),
+			row({
+				id: 'big',
+				detail: Array.from({ length: 200 }, (_, i) => `d${i}`),
+				detailExpanded: true,
+			}),
+		]
+		expect(split(huge, 40).settled).toBe(huge.length)
+	})
+
+	it('keeps the live region inside the budget it was given', () => {
+		// The number handed to the spacer as `liveRows`, which is what stops the
+		// composer being padded into a live region that is already full.
+		const { rows: height } = split(rows(200), 60)
+		expect(height).toBeLessThanOrEqual(60 - FURNITURE - SAFETY_ROWS)
+	})
+
+	it('never reaches back past what has already been printed', () => {
+		// The monotonic floor. `<Static>` counts what it has emitted and renders
+		// only past that count, so a window that reopened a printed row would
+		// leave later rows unprinted — and the row itself would be drawn twice.
+		const messages = rows(20)
+		const wide = split(messages, 400)
+		expect(20 - wide.settled).toBe(MAX_LIVE_ROWS)
+
+		const floored = split(messages, 400, 19)
+		expect(floored.settled).toBe(19)
+		expect(20 - floored.settled).toBe(1)
+	})
+
+	it('is idempotent, so a repeated render reaches the same split', () => {
+		// It runs during render and writes its answer back to a ref. React may
+		// render the same state twice; the second pass has to agree with the
+		// first or the window would creep shut a row at a time.
+		const messages = rows(20)
+		const once = split(messages, 60)
+		const twice = split(messages, 60, once.settled)
+		expect(twice.settled).toBe(once.settled)
+		expect(twice.rows).toBe(once.rows)
+	})
+})
+
+describe('transcriptLines', () => {
+	it('leaves out the row still streaming, which is not in the static log yet', () => {
+		// The live region is covered by the spacer's `liveRows`, so counting a
+		// pending row here would count it twice.
+		expect(transcriptLines([row({ pending: true, detail: ['a', 'b'] })])).toEqual([])
+	})
+})

--- a/packages/cli/src/tui/live-window.ts
+++ b/packages/cli/src/tui/live-window.ts
@@ -1,0 +1,169 @@
+/**
+ * How much of the transcript is still ALIVE — redrawable — and how much has
+ * already been handed to the terminal's own scrollback.
+ *
+ * ## Why there is a window at all
+ *
+ * Every finalized row used to go straight into `<Static>`, which prints a row
+ * once and never redraws it. That kept per-frame work bounded, and it also made
+ * changing a row that is already on screen impossible by construction: an
+ * expand key could not reopen a collapsed body, so expansion had to become a
+ * command that appends a second copy of the output further down.
+ *
+ * A small window of the most recent rows is kept live instead. Inside it a row
+ * can be redrawn in place, so expansion works where an operator actually looks;
+ * `/expand <n>` remains the way to reach anything older, and the hint under a
+ * collapsed body already degrades correctly when a row has no number.
+ *
+ * ## Why the window is bounded by HEIGHT, not by a count of rows
+ *
+ * This is the constraint the whole design turns on, and it is a property of the
+ * renderer rather than a preference. When the live region's height reaches the
+ * viewport's, ink stops doing an incremental repaint and instead writes
+ * `clearTerminal` followed by **the entire static output it has accumulated
+ * this session** plus the frame. On a long session that is the whole transcript,
+ * re-serialized on every spinner tick — which is the allocation churn that
+ * pushed `<Static>` to swallow everything in the first place.
+ *
+ * So the window takes rows from the end only while their estimated height fits
+ * a budget the live furniture and a safety margin are already subtracted from.
+ * A single row taller than the budget leaves the window empty, and an empty
+ * window is exactly the previous behaviour — the failure direction is "no
+ * retroactive expansion", never "repaint the session".
+ *
+ * ## Why it only ever moves one way
+ *
+ * `settled` is a floor the caller carries between renders. `<Static>` keeps an
+ * index of how many items it has emitted and renders only what is past it, so a
+ * shrinking item list would leave rows unprinted; and a row that has already
+ * been drawn live must not be handed back to a mechanism that would print it
+ * again. Rows therefore leave the window in one direction, oldest first, and a
+ * row that has settled never comes back.
+ */
+
+import { renderedDetailLines } from './Transcript.js'
+import { SAFETY_ROWS, estimateRenderedLines } from './bottom-spacer.js'
+import type { TranscriptMessage } from './types.js'
+
+/**
+ * The most rows the window will ever hold, whatever the terminal's height.
+ *
+ * A cap on top of the height budget, because the budget alone would put thirty
+ * short rows in the live region on a tall terminal — thirty rows re-laid-out
+ * per spinner tick to make retroactive expansion available on output nobody is
+ * still looking at. Six covers what an operator is working with: a tool call,
+ * its result, and the exchange around them.
+ */
+export const MAX_LIVE_ROWS = 6
+
+export interface LiveWindowInput {
+	/** Finalized rows, oldest first. The pending row is not one of these. */
+	readonly messages: readonly TranscriptMessage[]
+	/** Terminal height. `undefined` when not a TTY. */
+	readonly rows: number | undefined
+	/** Terminal width, for wrapping. `undefined` falls back to 80. */
+	readonly columns: number | undefined
+	/** Rows the live region occupies apart from the window: activity, composer, status bar. */
+	readonly furnitureRows: number
+	/** How many rows have already settled into scrollback. The window never reaches back past this. */
+	readonly settled: number
+}
+
+export interface LiveWindow {
+	/** `messages[0, settled)` are in scrollback; the rest are drawn live. */
+	readonly settled: number
+	/** The live rows' estimated height, for the bottom spacer to account for. */
+	readonly rows: number
+}
+
+/**
+ * Every line one row will print, including the body under a tool call.
+ *
+ * The blank row `MessageRow` puts above every entry but the first and the `⎿`
+ * result rows is counted, because one row per entry is not negligible: forty
+ * entries is forty rows, which on most terminals is the whole viewport. The
+ * content is indented by the two-column glyph gutter it renders beside, so a
+ * long line is measured against the width it actually has.
+ */
+function messageLines(message: TranscriptMessage, hasPrev: boolean): string[] {
+	return [
+		...(hasPrev && message.glyph !== '⎿' ? [''] : []),
+		`  ${message.content}`,
+		...renderedDetailLines(message),
+	]
+}
+
+/**
+ * Every line the finalized transcript will print, for a height estimate.
+ *
+ * Exported so the wiring is testable rather than only typecheckable. The
+ * spacer's own docblock states the asymmetry it depends on: over-count the
+ * content and the composer merely floats, under-count it and the composer is
+ * pushed off the bottom. The caller used to pass each row's `content` alone,
+ * which counted a six-line collapsed tool body as nothing at all — the estimate
+ * ran low by six per tool call, in the direction that costs the usability
+ * rather than the feature. `/expand` makes it acute: a row whose entire
+ * substance is a two-hundred-line body would have been handed over as one line.
+ *
+ * A pending row is excluded because it is not in the static log yet; the
+ * spacer's `liveRows` covers the live region.
+ */
+export function transcriptLines(messages: readonly TranscriptMessage[]): readonly string[] {
+	const finalized = messages.filter((m) => !m.pending)
+	return finalized.flatMap((message, i) => messageLines(message, i > 0))
+}
+
+/**
+ * Rows added to each windowed row's estimate.
+ *
+ * `estimateRenderedLines` is deliberately an UNDER-count, because for the
+ * bottom spacer counting low leaves more apparent room and the safety margin
+ * absorbs the difference. Here the asymmetry runs the other way: under-count a
+ * live row and the window takes more of the viewport than it was budgeted, and
+ * the price of exceeding the viewport is the whole-session repaint this window
+ * exists to stay clear of. Over-count and the window merely holds one row
+ * fewer.
+ *
+ * Two per row covers what the line estimate cannot see — the rule a code block
+ * draws around itself, the blank line markdown puts between blocks — without
+ * needing to model any of it.
+ */
+const ROW_HEIGHT_ALLOWANCE = 2
+
+/** How tall one row is expected to render, rounded UP. */
+function messageHeight(
+	message: TranscriptMessage,
+	hasPrev: boolean,
+	columns: number | undefined,
+): number {
+	return estimateRenderedLines(messageLines(message, hasPrev), columns) + ROW_HEIGHT_ALLOWANCE
+}
+
+/**
+ * How much of the transcript stays live, given the room there is for it.
+ *
+ * Returns `settled === messages.length` — everything in scrollback, nothing
+ * redrawable — whenever the answer is not knowable: no TTY, an implausible
+ * height, or a most-recent row too tall to hold. That is the previous
+ * behaviour, and it is the safe direction.
+ */
+export function liveWindow(input: LiveWindowInput): LiveWindow {
+	const { messages, rows, columns, furnitureRows, settled } = input
+	const floor = Math.min(Math.max(settled, 0), messages.length)
+
+	if (rows === undefined || !Number.isFinite(rows)) return { settled: messages.length, rows: 0 }
+	const budget = rows - furnitureRows - SAFETY_ROWS
+	if (budget < 1) return { settled: messages.length, rows: 0 }
+
+	let height = 0
+	let held = 0
+	for (let i = messages.length - 1; i >= floor && held < MAX_LIVE_ROWS; i--) {
+		const message = messages[i]
+		if (!message) break
+		const next = height + messageHeight(message, i > 0, columns)
+		if (next > budget) break
+		height = next
+		held += 1
+	}
+	return { settled: messages.length - held, rows: height }
+}


### PR DESCRIPTION
Every finalized transcript row went into `<Static>`, which prints a row once and never redraws it. That kept per-frame work bounded and made changing a row already on screen **impossible by construction** — which is why the expand key had to become a command that appends a second copy of the output further down, and it is behind the composer-spacing defect.

A small window of the most recent rows now stays live, memoised per row. Inside it a row redraws in place; `/expand <n>` still reaches anything older.

## The measurement this turns on, which I did not take on trust

ink 7.0.3, `renderInteractiveFrame`: when the live region's height reaches the viewport's, it stops repainting incrementally and writes

```js
stdout.write(ansiEscapes.clearTerminal + this.fullStaticOutput + output)
```

`fullStaticOutput` is the whole session's static output, accumulated unconditionally on the line above regardless of what any of this does. Two things follow, and both support the brief's argument:

- **Retention is already O(N) and unaffected.** The renderer holds the transcript as a string whatever we do, and the app holds every message in component state. A window adds one rendered-string array per windowed row.
- **The incident was allocation churn, and it has a specific trigger.** Exceeding the viewport re-serializes the entire session *every frame*. So the window must be bounded by **height**, not by a count of rows — that is the whole shape of the design, and it is a property of the renderer rather than a preference.

Measured with the screen harness — bytes actually written per frame:

| transcript | bounded window | every row live |
|---|---|---|
| 100 rows | 459 | 1,578 |
| 1000 rows | 465 | 15,978 |

Flat against a 10x transcript, versus linear in it. Render work per frame is **1** row — the one being written — against **7** when the windowed rows are not memoised.

## Design decisions, and where they diverge from the brief

- **The split is computed in `App`, not in `Transcript`.** The same split decides what the spacer measures: rows in scrollback are content *above* the live region, rows in the window are part of it. Two computations of one split would drift, and the direction they drift in is a composer pushed off the screen. `Transcript` takes `settled` as a prop.
- **It is monotonic**, carried in a ref. `<Static>` renders only past what it has emitted, so a shrinking prefix leaves rows unprinted; and a row already drawn live must not be handed back to something that would print it again.
- **Memoised on the whole props object, not on `(id, detailExpanded, width)`.** The rows are immutable, so React's default shallow compare already *is* "has anything about this row changed" — a two-field key would be the same answer for two fields and silently the wrong one for every other. **Width is deliberately not a key**: nothing in a row's element tree depends on it (wrapping is done by the layout engine from the same tree), so a width key would be a prop that drives nothing — `docs/conventions/declared-but-undriven.md`.
- **The window's height estimate over-counts**, by two rows per row, where the spacer's under-counts. The asymmetry is genuinely reversed here: under-count a live row and the window takes more viewport than budgeted, and the price of exceeding the viewport is the whole-session repaint.
- **`Ctrl+O` is un-deprecated** and expands in place, but **refuses rather than degrading** when the window is empty — on a terminal under roughly thirty rows there is no room for one. It does not silently fall back to appending: `/expand` is that, deliberately and visibly, and a key that sometimes redraws in place and sometimes prints a copy further down would be two commands wearing one name.
- **The collapsed-body hint still names only `/expand <n>`.** It would have to know whether its own row is live to advertise `Ctrl+O`, and the hint it prints today is true for every row.

## Mutation table

| # | mutation | killed by |
|---|---|---|
| MB1 | no bound at all (every row live) | **7 tests, 4 files** — the unit cap/budget/floor tests, the cost test (1000 vs 100 live), the row-index assertion in the reopen test, and the pre-existing spacer test (blank run 25, bound 4) |
| MB2 | drop `memo` on the live rows | inline re-parses per frame: 7 against a bound of 2 — **but see below** |
| MB6 | spacer's `liveRows` ignores the window's height | 2 tests: the reopen test's scroll anchor, and the pre-existing spacer test |
| MB7 | spacer counts the window in its `transcript` too | **survived** until a composer-position assertion was added — see below |
| MB8 | `Ctrl+O` reaches rows already in scrollback | the refusal test in `expand-emits-a-row` |
| MB9 | the scrollback floor survives `/clear` | **nothing** — see below |

**MB2 survived the first version of the cost test**, and the reason is worth recording: it divided by `screen.writes().length`, and the renderer emits several stdout chunks per frame. Six windowed rows re-rendering diluted to "2.3 per frame", comfortably under every bound. The frames are now *driven* — a token at a time, each awaited — so the denominator is a number the test chose rather than one the machine's load decided, and there is no duration anywhere in the file.

**MB7 survived** the original set. Double-counting the window makes the spacer over-count content, which is the *safe* direction by `bottom-spacer`'s own asymmetry — the composer floats rather than vanishing — so nothing red. It is still a regression in the feature the spacer exists for: the composer floated **24** rows above the foot of the screen against **11** correct (the safety margin plus the deliberate over-count on two windowed rows). A composer-position assertion now covers it.

**MB9 survives, and stays uncovered.** A floor left behind after `/clear` is clamped to the transcript's length, so the window reopens as the new conversation grows past it — self-correcting, and the only fixture that could discriminate is a session longer than one this suite can afford to drive through `<App>`. The reset is still correct and stays; the `/clear` test says in its own comment that it does not pin it, rather than implying it does.

## Not in scope

Replacing the renderer wholesale. It would buy exact rendered height — deleting the spacer's estimator and the composer defect with it — and it costs every `.tsx` under `src/tui/` plus reimplementing scrolling, selection and clipboard that the terminal gives for free.

## One thing I fixed that was not mine

`app-draft-survives.test.tsx` went red under the added load, twice, in different tests. It is not a flake my change introduced so much as one it exposed: the mocked turn opened its permission prompt **120ms** after starting, commented "long enough for the test to type into a live composer". The prompt disables the composer, so under load the keystrokes were dropped and the failure read "the draft never reached the composer" — a true statement about a composer that was never asked. It now waits for the test to say it has finished typing, exactly as the branch beside it already waits on the abort signal for the same reason. Verified: clean `main` is green, my branch without the fix goes red, with the fix it is green three runs in a row.

## Gates

`pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm test` (872 in `@namzu/cli`, 3,178 in the SDK, all packages green), `pnpm docs:check`, `scripts/audit-external-names.mjs`, and `.github/scripts/verify-public-surface.mjs` (555/555 runtime, 1276/1276 declared — unchanged).

https://claude.ai/code/session_01RppSzAoxqCxKfD4fLYmnzs
