### PR TITLE
fix(cli): the sign-in is reachable from the screen that needs it

### DIFF
--- a/.changeset/login-reachable.md
+++ b/.changeset/login-reachable.md
@@ -1,0 +1,35 @@
+---
+'@namzu/cli': minor
+---
+
+Makes the subscription sign-in reachable from the screen that needs it, and
+adds `namzu login` / `namzu logout`.
+
+**The bug this fixes.** The sign-in shipped as `/login`. Slash commands are
+typed into the composer, and the composer does not exist during the provider
+picker — so the one operator who most needs to sign in, the one with no
+credential at all whom namzu routes straight to the picker, was the one
+operator who could not reach it. There was no other route: nothing else writes
+the credential store. The screen listed the sources it scans, offered to take a
+pasted key, and told them to set an environment variable and restart, while a
+working sign-in sat behind a keystroke that did not exist.
+
+- **`l` at the picker** starts the sign-in. namzu opens your browser and picks
+  the result up when the page finishes.
+- **`namzu login`** does the same from a bare shell, and also reads a pasted
+  address from standard input — so a container or a remote machine with no
+  browser can finish the sign-in. `--no-browser` skips the launcher,
+  `--timeout <seconds>` bounds the wait. **`namzu logout`** removes the
+  credential.
+- **The picker's source list now names `~/.namzu/credentials.json`**, which it
+  scanned and did not mention.
+
+There is deliberately no `namzu login --code <value>`: the PKCE verifier lives
+in the process that started the sign-in, so a second invocation could not
+finish the first one's attempt. A flag that looks like it should work and
+cannot is worse than its absence, so the paste is read by the waiting process
+instead.
+
+Two message defects found by running it rather than reading it: a bare Enter at
+the prompt spent the whole attempt on an empty paste, and a failed sign-in in a
+terminal told you to "run /login" — a slash command, in a shell.

--- a/docs/cli/providers.md
+++ b/docs/cli/providers.md
@@ -12,8 +12,22 @@ namzu is **credential-first**: on launch it discovers credentials already presen
 
 ## Signing in with a subscription
 
-If you pay for a plan rather than for API usage, `/login` gets you a credential
-without an API key and without installing anything else.
+If you pay for a plan rather than for API usage, signing in gets you a
+credential without an API key and without installing anything else. There are
+three ways in, because there are three places you can be standing:
+
+| Where you are | What to do |
+|---|---|
+| At the provider picker with no credential | press **`l`** |
+| In a chat session | type **`/login`** |
+| At a shell, no TUI — a container, a script, SSH | run **`namzu login`** |
+
+`namzu login` is the one that always works: it prints the address, waits for
+your browser, and also reads a pasted address from standard input, so a machine
+with no browser at all is not stranded. `namzu logout` removes the credential.
+
+The rest of this section describes the in-session command; the other two
+behave the same way.
 
 ```
 /login

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -16,6 +16,7 @@ import { Command, CommanderError } from 'commander'
 import { doctorCommand } from './commands/doctor.js'
 import { drainCommand } from './commands/drain.js'
 import { evalCommand } from './commands/eval.js'
+import { loginCommand, logoutCommand } from './commands/login.js'
 import { registerAll } from './commands/registry.js'
 import {
 	historyCommand,
@@ -103,6 +104,8 @@ export async function runCli(opts: RunCliOptions): Promise<number> {
 		[
 			doctorCommand,
 			runCommand,
+			loginCommand,
+			logoutCommand,
 			drainCommand,
 			evalCommand,
 			runStreamCommand,

--- a/packages/cli/src/commands/__tests__/login.test.ts
+++ b/packages/cli/src/commands/__tests__/login.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+
+import { describeLoginOutcome, describeLoginStart } from '../../tui/login-prompt.js'
+import { loginCommand, logoutCommand, parseLoginFlags } from '../login.js'
+
+describe('parseLoginFlags', () => {
+	it('defaults to launching a browser and waiting five minutes', () => {
+		const flags = parseLoginFlags([])
+		expect(flags.noBrowser).toBe(false)
+		expect(flags.timeoutMs).toBe(300_000)
+		expect(flags.unknown).toEqual([])
+	})
+
+	it('takes --no-browser, which is the container case', () => {
+		expect(parseLoginFlags(['--no-browser']).noBrowser).toBe(true)
+	})
+
+	it('takes a timeout in seconds', () => {
+		expect(parseLoginFlags(['--timeout', '30']).timeoutMs).toBe(30_000)
+	})
+
+	it('refuses a timeout it cannot read rather than falling back to the default', () => {
+		// `--timeout 5m` means something specific to whoever wrote it. Waiting
+		// the default instead makes a flag look honoured when it was discarded.
+		for (const bad of ['5m', '', '-1', '0', 'abc']) {
+			expect(parseLoginFlags(['--timeout', bad]).unknown.length).toBeGreaterThan(0)
+		}
+	})
+
+	it('refuses an unrecognised flag rather than ignoring it', () => {
+		expect(parseLoginFlags(['--code', 'abc']).unknown).toContain('--code')
+	})
+})
+
+describe('the commands are reachable and describe themselves', () => {
+	it('login renders its own help, because passThrough turns commander’s off', () => {
+		expect(loginCommand.passThrough).toBe(true)
+		expect(loginCommand.help).toBeDefined()
+		expect(loginCommand.help).toContain('namzu login')
+	})
+
+	it('logout takes no arguments to misread', () => {
+		expect(logoutCommand.passThrough).not.toBe(true)
+	})
+
+	it('names itself for what an operator is trying to do', () => {
+		expect(loginCommand.name).toBe('login')
+		expect(logoutCommand.name).toBe('logout')
+	})
+})
+
+/**
+ * Instructions must name the surface they are printed on.
+ *
+ * This is the defect that made the sign-in unreachable, in miniature: a
+ * message telling someone to type a slash command works only where a composer
+ * exists, and both of the surfaces below have none.
+ */
+describe('a surface names its own spelling of the command', () => {
+	it('the terminal tells you to run namzu login, not to type a slash command', () => {
+		const text = describeLoginOutcome(
+			{ ok: false, reason: 'Something failed.' },
+			{ retry: 'namzu login', remove: 'namzu logout' },
+		)
+		expect(text).toContain('namzu login')
+		expect(text).not.toContain('/login')
+	})
+
+	it('and names namzu logout on success', () => {
+		const text = describeLoginOutcome(
+			{ ok: true, credential: { accessToken: 'zzz-secret' }, storedAt: '/p/credentials.json' },
+			{ retry: 'namzu login', remove: 'namzu logout' },
+		)
+		expect(text).toContain('namzu logout')
+		expect(text).not.toContain('/logout')
+		expect(text).not.toContain('zzz-secret')
+	})
+
+	it('keeps the chat spelling when no surface says otherwise', () => {
+		expect(describeLoginOutcome({ ok: false, reason: 'x' })).toContain('/login')
+	})
+
+	it('the completion hint is the surface’s own, not the chat’s', () => {
+		const terminal = describeLoginStart({
+			url: 'https://example.invalid/a',
+			loopback: true,
+			browserOpened: false,
+			completionHint: 'paste it here and press enter',
+		})
+		expect(terminal).toContain('paste it here and press enter')
+		expect(terminal).not.toContain('/login <')
+	})
+})

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -1,0 +1,211 @@
+/**
+ * `namzu login` / `namzu logout` — sign in without a running TUI.
+ *
+ * ## Why this exists, having been argued against
+ *
+ * When the sign-in shipped, a standalone command was declined: the TUI already
+ * offered `/login`, and a second entry point is a second thing to document.
+ * That reasoning had a hole, and an operator found it on the first day.
+ *
+ * `/login` is a slash command, slash commands are typed into the composer, and
+ * **the composer does not exist during the provider picker.** So the one
+ * operator who most needs to sign in — the one with no credential at all, whom
+ * namzu routes straight to the picker — is the one operator who cannot reach
+ * the command. There was no other route: nothing else writes the credential
+ * store. A capability with no reachable entry point is not a capability, and
+ * "it is reachable from the screen you cannot get to" is the shape this
+ * repository has spent its time removing.
+ *
+ * The picker now offers it too. This command remains, because it is the
+ * answer for the case that has no screen at all: a container, a provisioning
+ * script, a machine being set up over SSH before anyone opens a session.
+ *
+ * ## Finishing without a browser on this machine
+ *
+ * The verifier lives in this process and nowhere else — that is what makes the
+ * exchange safe — so a second invocation cannot finish what a first one
+ * started. There is no `--code` flag for that reason: it would look like it
+ * should work and could not.
+ *
+ * Instead this waits on BOTH routes at once. The loopback listener takes the
+ * browser that lands on this machine; standard input takes the address pasted
+ * back from a browser somewhere else. Whichever answers first wins.
+ */
+
+import { createInterface } from 'node:readline'
+
+import { EXIT_FAIL, EXIT_OK, EXIT_USAGE } from '../exit-codes.js'
+import {
+	type LoginOutcome,
+	beginSubscriptionLogin,
+	clearStoredSubscriptionCredential,
+	credentialsPath,
+	readStoredSubscriptionCredential,
+} from '../integrations/providers/index.js'
+import { describeLoginOutcome, describeLoginStart, describeLogout } from '../tui/login-prompt.js'
+import { openInBrowser } from '../tui/open-browser.js'
+import type { CommandDef } from './types.js'
+
+const LOGIN_HELP = `Usage: namzu login [options]
+
+Sign in with a provider subscription and store the credential on this machine.
+
+Options:
+  --no-browser        Do not try to launch a browser; just print the address.
+  --timeout <seconds> Give up waiting after this long (default: 300).
+  -h, --help          Show this help.
+
+namzu prints an address to open. Finish the sign-in in a browser and namzu
+picks it up automatically; if your browser is on another machine, paste the
+address it lands on into this terminal and press enter.
+
+The credential is written to ~/.namzu/credentials.json, readable only by your
+account. Run 'namzu logout' to remove it.`
+
+const DEFAULT_TIMEOUT_SECONDS = 300
+
+interface LoginFlags {
+	readonly noBrowser: boolean
+	readonly timeoutMs: number
+	readonly unknown: readonly string[]
+}
+
+export function parseLoginFlags(argv: readonly string[]): LoginFlags {
+	let noBrowser = false
+	let timeoutMs = DEFAULT_TIMEOUT_SECONDS * 1_000
+	const unknown: string[] = []
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i]
+		if (arg === '--no-browser') {
+			noBrowser = true
+			continue
+		}
+		if (arg === '--timeout') {
+			const value = argv[++i]
+			const seconds = Number(value)
+			// Refused rather than defaulted. A caller who wrote `--timeout 5m`
+			// meant something specific, and silently waiting five minutes
+			// because `NaN` fell through to the default is the reading that
+			// makes a flag look honoured when it was discarded.
+			if (!Number.isFinite(seconds) || seconds <= 0) {
+				unknown.push(`--timeout ${value ?? ''}`.trim())
+				continue
+			}
+			timeoutMs = seconds * 1_000
+			continue
+		}
+		if (arg !== undefined) unknown.push(arg)
+	}
+	return { noBrowser, timeoutMs, unknown }
+}
+
+/**
+ * Resolve with the first NON-BLANK line standard input offers, or never.
+ *
+ * Two deliberate choices, both found by running this rather than by reading it.
+ *
+ * **Blank lines are ignored, not answered.** `once('line')` took a bare Enter
+ * — the keystroke a person makes while waiting, and the one a piped empty
+ * stdin delivers immediately — and spent the sign-in on it: the empty string
+ * went to `completeWithPastedCode`, came back "that does not contain an
+ * authorization code", and the attempt was over before the browser had loaded
+ * the page.
+ *
+ * **A closed or absent stream never resolves.** This is raced against the
+ * loopback listener and a timeout, so a stdin that is not there (a service,
+ * `< /dev/null`) must not read as "the operator declined" and cancel a browser
+ * sign-in still in progress.
+ */
+function firstStdinLine(signal: AbortSignal): Promise<string> {
+	return new Promise((resolve) => {
+		if (!process.stdin.readable) return
+		const rl = createInterface({ input: process.stdin })
+		const done = () => {
+			rl.close()
+		}
+		signal.addEventListener('abort', done, { once: true })
+		rl.on('line', (line) => {
+			if (line.trim().length === 0) return
+			signal.removeEventListener('abort', done)
+			rl.close()
+			resolve(line)
+		})
+	})
+}
+
+export const loginCommand: CommandDef = {
+	name: 'login',
+	description: 'Sign in with a provider subscription and store the credential.',
+	passThrough: true,
+	help: LOGIN_HELP,
+	handler: async ({ ctx, rawArgs }) => {
+		const flags = parseLoginFlags(rawArgs)
+		if (flags.unknown.length > 0) {
+			ctx.formatter.print({
+				text: `Unrecognised argument(s): ${flags.unknown.join(', ')}\n\n${LOGIN_HELP}`,
+			})
+			return EXIT_USAGE
+		}
+
+		let login: Awaited<ReturnType<typeof beginSubscriptionLogin>>
+		try {
+			login = await beginSubscriptionLogin()
+		} catch (err) {
+			ctx.formatter.print({
+				text: `Could not start a sign-in: ${err instanceof Error ? err.message : String(err)}`,
+			})
+			return EXIT_FAIL
+		}
+
+		ctx.formatter.print({
+			text: describeLoginStart({
+				url: login.url,
+				loopback: login.loopback,
+				browserOpened: flags.noBrowser ? false : openInBrowser(login.url),
+				completionHint: 'paste it here and press enter',
+			}),
+		})
+
+		const stop = new AbortController()
+		const timeout = new Promise<LoginOutcome>((resolve) =>
+			setTimeout(
+				() =>
+					resolve({
+						ok: false,
+						reason: 'Timed out waiting for the sign-in to finish. Nothing was stored.',
+					}),
+				flags.timeoutMs,
+			).unref(),
+		)
+		const pasted = firstStdinLine(stop.signal).then((line) => login.completeWithPastedCode(line))
+		const callback = login.waitForCallback()
+
+		const outcome = await Promise.race(callback ? [callback, pasted, timeout] : [pasted, timeout])
+		stop.abort()
+		login.cancel()
+
+		ctx.formatter.print({
+			text: describeLoginOutcome(outcome, { retry: 'namzu login', remove: 'namzu logout' }),
+		})
+		return outcome.ok ? EXIT_OK : EXIT_FAIL
+	},
+}
+
+export const logoutCommand: CommandDef = {
+	name: 'logout',
+	description: 'Remove the subscription credential namzu stored on this machine.',
+	handler: async ({ ctx }) => {
+		const path = credentialsPath()
+		const had = readStoredSubscriptionCredential() !== null
+		try {
+			clearStoredSubscriptionCredential()
+		} catch (err) {
+			ctx.formatter.print({
+				text: `Could not remove ${path}: ${err instanceof Error ? err.message : String(err)}`,
+			})
+			return EXIT_FAIL
+		}
+		ctx.formatter.print({ text: describeLogout(path, had) })
+		return EXIT_OK
+	},
+}

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -482,6 +482,57 @@ export function App({ ctx }: AppProps) {
 		[pushMessage],
 	)
 
+	/**
+	 * Sign in from the PICKER, where the transcript does not exist.
+	 *
+	 * Separate from `startOrFinishLogin` for one reason, and it is the reason
+	 * the sign-in was unreachable in the first place: during this phase the
+	 * picker replaces the transcript, so `pushMessage` writes to a surface
+	 * nobody can see. Everything this path says goes into `pickerNotice`, which
+	 * the picker renders.
+	 *
+	 * It uses the browser route only. There is no paste input on this screen,
+	 * and rather than invent one — a second text field beside the credential
+	 * one, on the screen an operator reaches when they are already stuck — the
+	 * no-browser case is handed to `namzu login`, which reads the pasted
+	 * address from standard input and exists for exactly that machine.
+	 */
+	const startLoginFromPicker = useCallback(async () => {
+		loginRef.current?.cancel()
+		loginRef.current = null
+		let start: SubscriptionLogin
+		try {
+			start = await beginSubscriptionLogin()
+		} catch (err) {
+			setPickerNotice(
+				`Could not start a sign-in: ${err instanceof Error ? err.message : String(err)}`,
+			)
+			return
+		}
+		loginRef.current = start
+		setPickerNotice(
+			describeLoginStart({
+				url: start.url,
+				loopback: start.loopback,
+				browserOpened: openInBrowser(start.url),
+				// Named for THIS screen. Telling someone at the picker to type a
+				// slash command is what made the feature unreachable; telling them
+				// to run a command in another terminal is something they can do
+				// from where they are sitting.
+				completionHint: 'run "namzu login" in a terminal and paste it there',
+			}),
+		)
+		const waiting = start.waitForCallback()
+		if (!waiting) return
+		const outcome = await waiting
+		if (loginRef.current !== start) return
+		loginRef.current = null
+		start.cancel()
+		if (!outcome.ok && outcome.reason.includes('cancelled')) return
+		setPickerNotice(describeLoginOutcome(outcome))
+		if (outcome.ok) await runProbeRef.current?.()
+	}, [])
+
 	const runProbe = useCallback(async () => {
 		try {
 			const probe = await probeAgentSession()
@@ -1577,6 +1628,7 @@ export function App({ ctx }: AppProps) {
 						onSubmit={handlePickerSubmit}
 						onCancel={handlePickerCancel}
 						onCredential={handleTypedCredential}
+						onLogin={() => void startLoginFromPicker()}
 						keyEntryFor={keyEntryFor}
 						notice={pickerNotice}
 					/>

--- a/packages/cli/src/tui/Picker.tsx
+++ b/packages/cli/src/tui/Picker.tsx
@@ -53,6 +53,19 @@ export interface PickerProps {
 	 */
 	readonly onCredential?: (credential: DetectedProvider, disposition: string) => void
 	/**
+	 * Start a subscription sign-in from this screen. Absent means this picker
+	 * cannot start one.
+	 *
+	 * It has to be here, and the reason is the defect it repairs. The sign-in
+	 * shipped as `/login`, a slash command; slash commands are typed into the
+	 * composer; **the composer does not exist during this phase.** So the one
+	 * operator who most needs it — no credential at all, routed straight here —
+	 * was the one operator who could not reach it. The screen listed the
+	 * sources it scans, offered a key to paste, and said to restart, while a
+	 * working sign-in sat one unreachable keystroke away.
+	 */
+	readonly onLogin?: () => void
+	/**
 	 * Seam for tests: how a typed key is checked. Defaulted to the real thing,
 	 * so no production caller knows this exists.
 	 *
@@ -118,6 +131,7 @@ export function Picker({
 	onCancel,
 	describeModels = describeProviderModels,
 	onCredential,
+	onLogin,
 	verify = verifyCredential,
 	keyEntryFor,
 	notice,
@@ -216,6 +230,16 @@ export function Picker({
 		// at a list that named every provider except a way to fix the one they
 		// chose. The letter does not collide with anything: navigation is arrows
 		// and digits.
+		// `l` starts a subscription sign-in, on exactly the screens `k` is live
+		// on and for the same reason: these are the two states an operator
+		// reaches with nothing usable. Checked BEFORE `k` only in the sense of
+		// sitting beside it — the letters do not collide, and navigation is
+		// arrows and digits.
+		if ((detected.length === 0 || keyEntryFor) && onLogin && (input === 'l' || input === 'L')) {
+			onLogin()
+			return
+		}
+
 		if (
 			(detected.length === 0 || keyEntryFor) &&
 			onCredential &&
@@ -397,10 +421,15 @@ export function Picker({
 						{' '}
 						· env vars (ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY, …)
 					</Text>
-					{/* The summary line on the populated screen names three sources; this
-					    list is the same set and must not name fewer. It is the screen
-					    shown to the person with no credential, so an omission here is a
-					    source they are never told to try. */}
+					{/* The summary line on the populated screen names the same sources;
+					    this list is the same set and must not name fewer. It is the
+					    screen shown to the person with no credential, so an omission
+					    here is a source they are never told to try — which is exactly
+					    what happened to the store below when the sign-in shipped. */}
+					<Text color={theme.text.muted}>
+						{' '}
+						· a subscription signed in to from namzu (~/.namzu/credentials.json)
+					</Text>
 					<Text color={theme.text.muted}>
 						{' '}
 						· macOS Keychain (an existing OAuth sign-in; macOS only)
@@ -410,11 +439,14 @@ export function Picker({
 						· local servers (Ollama localhost:11434, LM Studio localhost:1234)
 					</Text>
 				</Box>
-				<Box paddingTop={1}>
-					<Text color={theme.text.secondary}>
-						Set one of the env vars above (or start a local server), then restart namzu.
-					</Text>
-				</Box>
+				{onLogin ? (
+					<Box paddingTop={1}>
+						<Text color={theme.text.primary}>
+							Press <Text color={theme.accent.system}>l</Text> to sign in with a subscription —
+							no API key, and namzu keeps it for next time.
+						</Text>
+					</Box>
+				) : null}
 				<Box paddingTop={1}>
 					<Text color={theme.text.primary}>
 						Or press <Text color={theme.accent.system}>k</Text> to paste a credential now and use
@@ -422,7 +454,14 @@ export function Picker({
 					</Text>
 				</Box>
 				<Box paddingTop={1}>
-					<Text color={theme.text.muted}>k: enter a credential · esc: exit picker</Text>
+					<Text color={theme.text.secondary}>
+						You can also set one of the env vars above (or start a local server) and restart.
+					</Text>
+				</Box>
+				<Box paddingTop={1}>
+					<Text color={theme.text.muted}>
+						{onLogin ? 'l: sign in · ' : ''}k: enter a credential · esc: exit picker
+					</Text>
 				</Box>
 			</Box>
 		)
@@ -456,7 +495,8 @@ export function Picker({
 				    message whose advice cannot be followed, one size down. */}
 				<Text color={theme.text.muted}>
 					↑↓ or 1-9 navigate · enter accept
-					{entryTarget ? ` · k enter a credential for ${entryTarget.label}` : ''} · esc cancel
+					{entryTarget ? ` · k enter a credential for ${entryTarget.label}` : ''}
+					{keyEntryFor && onLogin ? ' · l sign in with a subscription' : ''} · esc cancel
 				</Text>
 				{errorHint ? <Text color={theme.status.warn}>{errorHint}</Text> : null}
 			</Box>

--- a/packages/cli/src/tui/__tests__/credential-prompt-draws.test.tsx
+++ b/packages/cli/src/tui/__tests__/credential-prompt-draws.test.tsx
@@ -51,12 +51,57 @@ describe('the no-credential screen', () => {
 	it('offers the key entry rather than only telling you to restart', async () => {
 		const { lastFrame, unmount } = open()
 		expect(lastFrame()).toContain('No providers detected')
-		// The cliff this closes: the screen used to end at "restart namzu".
-		expect(lastFrame()).toContain('restart namzu')
+		// The cliff this closes: the screen used to end at restarting.
+		expect(lastFrame()).toContain('restart')
 		// "credential" and not "key": the screen accepts a subscription token as
 		// well, and a field labelled for one of the two kinds is a field the
 		// holder of the other kind will not use.
 		expect(lastFrame()).toMatch(/press .*k.* to paste a credential|k: enter a credential/s)
+		unmount()
+	})
+
+	/**
+	 * The screen an operator with nothing reaches has to name every way out.
+	 *
+	 * It shipped naming three sources and two exits while a working sign-in
+	 * existed, because the sign-in was a slash command and this screen has no
+	 * composer to type one into. The operator was told to set an environment
+	 * variable and restart.
+	 */
+	it('offers the sign-in, which is the only exit that needs no credential at all', async () => {
+		const onLogin = vi.fn()
+		const { lastFrame, stdin, unmount } = open({ onLogin })
+		expect(lastFrame()).toMatch(/press .*l.* to sign in|l: sign in/s)
+		stdin.write('l')
+		await flush()
+		expect(onLogin).toHaveBeenCalledTimes(1)
+		unmount()
+	})
+
+	it('accepts the capital, because a person reading "press l" may hold shift', async () => {
+		const onLogin = vi.fn()
+		const { stdin, unmount } = open({ onLogin })
+		stdin.write('L')
+		await flush()
+		expect(onLogin).toHaveBeenCalledTimes(1)
+		unmount()
+	})
+
+	it('does not offer a sign-in it cannot start', async () => {
+		// No handler means no route, and a key hint for a keystroke that does
+		// nothing is worse than no hint: it spends the one attempt an operator
+		// makes before concluding the screen is broken.
+		const { lastFrame, unmount } = open()
+		expect(lastFrame()).not.toMatch(/l: sign in/)
+		unmount()
+	})
+
+	it('names the credential store among the sources it scans', async () => {
+		// The list is what an operator is told to try. The store the sign-in
+		// writes was missing from it for a release, so the screen scanned a
+		// source it never mentioned.
+		const { lastFrame, unmount } = open()
+		expect(lastFrame()).toContain('.namzu/credentials.json')
 		unmount()
 	})
 })

--- a/packages/cli/src/tui/login-prompt.ts
+++ b/packages/cli/src/tui/login-prompt.ts
@@ -27,6 +27,18 @@ export function describeLoginStart(start: {
 	readonly url: string
 	readonly loopback: boolean
 	readonly browserOpened: boolean
+	/**
+	 * How the operator hands the result back HERE, in the surface they are
+	 * looking at.
+	 *
+	 * A parameter because the answer is different in each one — a slash command
+	 * in the chat, a keypress at the picker, a line of standard input at a bare
+	 * terminal — and this sentence is the one an operator with no browser
+	 * follows. Printing the chat's answer on the picker would send them to a
+	 * composer that is not on screen, which is the defect that made a shipped
+	 * sign-in unreachable.
+	 */
+	readonly completionHint?: string
 }): string {
 	const lines = [
 		start.browserOpened
@@ -38,26 +50,38 @@ export function describeLoginStart(start: {
 	]
 	lines.push(
 		start.loopback
-			? 'When the page finishes, namzu will pick it up automatically. If your browser is somewhere this machine cannot be reached from — a container, a remote shell — copy the address it lands on and run:'
+			? 'When the page finishes, namzu will pick it up automatically. If your browser is somewhere this machine cannot be reached from — a container, a remote shell — copy the address it lands on:'
 			: // Said plainly. The listener is what makes the automatic path work,
 				// and an operator who is not told it is missing will sit waiting for
 				// something that is never going to happen.
-				'The automatic hand-back is not available in this session (the port is in use, or this environment does not allow listening), so finish it by hand. Copy the address the browser lands on and run:',
+				'The automatic hand-back is not available in this session (the port is in use, or this environment does not allow listening), so finish it by hand. Copy the address the browser lands on:',
 	)
-	lines.push('', '  /login <the address, or just the code>')
+	lines.push('', `  ${start.completionHint ?? '/login <the address, or just the code>'}`)
 	return lines.join('\n')
 }
 
-/** What the operator reads when the attempt ends, either way. */
-export function describeLoginOutcome(outcome: LoginOutcome): string {
+/**
+ * What the operator reads when the attempt ends, either way.
+ *
+ * `retryHint` and `removeHint` name the commands as THIS surface spells them,
+ * for the same reason `completionHint` exists above. A failed sign-in run from
+ * a bare terminal used to end with "Run /login to try again" — a slash command,
+ * in a shell, where the thing to type is `namzu login`. Instructions that name
+ * another surface's spelling are the defect that made the sign-in unreachable
+ * from the picker; it is not any better in an error message.
+ */
+export function describeLoginOutcome(
+	outcome: LoginOutcome,
+	hints: { readonly retry?: string; readonly remove?: string } = {},
+): string {
 	if (!outcome.ok) {
-		return `${outcome.reason}\n\nRun /login to try again.`
+		return `${outcome.reason}\n\nRun ${hints.retry ?? '/login'} to try again.`
 	}
 	return [
 		'Signed in. The credential is stored on this machine, readable only by your account:',
 		`  ${outcome.storedAt}`,
 		'',
-		'namzu will refresh it as it expires, and will find it again next time it starts. Run /logout to remove it.',
+		`namzu will refresh it as it expires, and will find it again next time it starts. Run ${hints.remove ?? '/logout'} to remove it.`,
 	].join('\n')
 }
 


### PR DESCRIPTION
**The sign-in shipped unreachable by the only operator who needs it.** Found by the owner on 8.4.0, on first use.

## What happened

`/login` is a slash command. Slash commands are typed into the composer. **The composer does not exist during the provider picker.** So an operator with no credential — routed straight to the picker by design — could not reach the sign-in. There was no second route either: nothing else writes the credential store, and I had argued *against* a standalone `namzu login` on the grounds that a second entry point is a second thing to document. That reasoning is what removed the escape hatch.

What they saw: a screen naming three credential sources, offering `k` to paste a key they do not have, and telling them to set an environment variable and restart — with a working sign-in one keystroke away that did not exist.

```
 │ Set one of the env vars above (or start a local server), then restart namzu.
 │ Or press k to paste a credential now and use it for this session.
 │ k: enter a credential · esc: exit picker
```

## The fix — three routes, one per place you can be standing

| Where you are | What to do |
|---|---|
| At the picker with no credential | press **`l`** |
| In a chat session | type **`/login`** |
| At a shell with no TUI | run **`namzu login`** |

`namzu login` is the one that always works: prints the address, waits for the browser, **and** reads a pasted address from standard input, so a container or a remote machine with no browser is not stranded. `--no-browser`, `--timeout <seconds>`. `namzu logout` removes the credential.

**The picker's source list now names `~/.namzu/credentials.json`** — a source it had been reading and not mentioning. The comment directly above that list warns that "an omission here is a source they are never told to try"; the sign-in committed exactly that omission to the list the comment guards.

## Three things worth a reviewer's attention

**The picker's sign-in writes to the picker's notice, not the transcript.** The transcript is not rendered during that phase, so `pushMessage` there would put the address on a surface nobody can see — the same defect one layer down.

**Both message builders now take the calling surface's spelling.** A message telling someone to type a slash command works only where a composer exists, and neither the picker nor a shell has one. The failure path in a terminal was ending with "Run /login to try again".

**There is deliberately no `namzu login --code <value>`.** The PKCE verifier lives in the process that started the attempt — that is what makes the exchange safe — so a second invocation cannot finish the first one's sign-in. A flag that looks like it should work and cannot is worse than its absence, so the waiting process reads the paste instead.

## Two defects found by running it, not reading it

- **A bare Enter spent the whole attempt.** `once('line')` took the empty string — the keystroke a waiting person makes, and what a piped empty stdin delivers instantly — sent it as an authorization code, and the sign-in was over before the browser had loaded the page. Blank lines are now ignored rather than answered.
- **The terminal's failure message named the chat's command.** Fixed by the surface-hint parameter above.

## Tests

Six new picker/command assertions, including the two that pin the reachability itself: `l` invokes the handler, and the hint is **absent** when no handler is wired — a key hint for a keystroke that does nothing spends the one attempt an operator makes before concluding the screen is broken.

## Gates

`pnpm build` · `pnpm typecheck` · `pnpm lint` (0 errors) · `pnpm test` (**889 cli tests**, 92 files) · `pnpm docs:check` (0 problems) · external-name audit · `verify-public-surface` (intact) — all pass.

Also smoke-run as a real binary: `namzu login --help`, a timed-out attempt, and `namzu logout`.

## Changeset

`@namzu/cli` **minor** — new commands and a new key on an existing screen.
