### PR TITLE
fix(sdk): classify pricing for the coverage gate

### DIFF
--- a/packages/sdk/coverage-config.json
+++ b/packages/sdk/coverage-config.json
@@ -1,5 +1,6 @@
 {
 	"$comment": "Coverage gate config for @namzu/sdk. Consumed by .github/scripts/check-sdk-module-coverage.mjs and check-sdk-test-presence.mjs. The bucket rules were ratified in ses_006-test-coverage-sprint.",
+	"$comment_pricing": "`pricing` is `required` with a measured floor, and the floor only means anything because its generated rate table is excluded from coverage in vitest.config.ts. Measured with the table IN: 299 lines, 282 of them the generated data, all counted covered the moment anything imports the module — so the aggregate read 100% while describing almost nothing, and the resolver could have lost a third of its lines and still cleared 97%. Measured with it OUT: 17 lines and 10 branches, all in index.ts, 100%/100%. Floor is measured minus 3 per the policy in check-sdk-module-coverage.mjs. Note the module is small enough that 3 points is less than one branch, so any uncovered branch in the resolver fails this gate — that is intended, not an accident of rounding.",
 	"modules": {
 		"required": [
 			"__fixtures__",
@@ -12,6 +13,7 @@
 			"directory",
 			"manager",
 			"plugin",
+			"pricing",
 			"probe",
 			"provider",
 			"rag",
@@ -65,6 +67,10 @@
 		"directory": {
 			"line": 85,
 			"branch": 82
+		},
+		"pricing": {
+			"line": 97,
+			"branch": 97
 		},
 		"rag": {
 			"line": 92,

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -21,6 +21,20 @@ export default defineConfig({
 				'src/**/__tests__/**',
 				'src/**/__fixtures__/**',
 				'src/types/**',
+				// Generated rate data: one exported array of literals, zero
+				// branches and zero functions. Same category as `types/` above
+				// — there is no behaviour in it to leave untested.
+				//
+				// This SHARPENS the gate rather than loosening it, which is
+				// worth stating because an exclusion usually does the
+				// opposite. The file is 282 of the module's 299 lines, and
+				// every one of them counts as covered the moment anything
+				// imports the module. Left in, the module reads 94% covered
+				// with its resolver entirely untested, and losing a third of
+				// that resolver's lines still clears a 97% floor. Taken out,
+				// the floor is measured against the 17 lines that actually
+				// decide something.
+				'src/pricing/catalogue.generated.ts',
 			],
 			all: true,
 			clean: true,


### PR DESCRIPTION
Main is red. The test-presence gate requires every folder under `packages/sdk/src/` to be classified into `required | baselineExempt | exempt`, and #354's new `pricing/` module was not:

```
✗ src/ folders missing from coverage-config.json:
  - packages/sdk/src/pricing/ (add to required | baselineExempt | exempt)
```

**Nothing published.** The release workflow runs the full gate before publish, so the omission was caught before it reached the registry.

Worth stating plainly: **this gate caught a real omission that eight other green checks did not.** It is doing exactly what it was built for, and it is the reason a mistake stayed a red build rather than becoming a release.

## The classification: `required`

`pricing/` holds a resolver with real behaviour — vendor lookup, id normalisation, the unmetered short-circuit — and a test file that drives it. That is precisely what `required` asserts, and it is the honest bucket. `baselineExempt` is for modules carried without a measured floor; `exempt` is for declarative folders. Neither describes this one.

## The generated data, and why it changed the answer

The folder is mostly generated data, and that genuinely bore on the decision — so here is the measurement rather than an assertion.

| | files | lines | branches |
|---|---|---|---|
| generated rate table | 1 | 282 / 282 | 0 / 0 |
| resolver (`index.ts`) | 1 | 17 / 17 | 10 / 10 |
| **aggregate as it stood** | **2** | **299 / 299 (100%)** | **10 / 10** |

The table is **94% of the module's line count and contributes no branches at all**, and every one of its lines counts as covered the moment anything imports the module. So a line floor over that aggregate is a number that barely moves with the thing it is supposed to measure: with the resolver **entirely untested** the aggregate still reads 94.3%, and losing a third of the resolver's lines still clears a 97% floor. That is a floor that cannot fail for the reason it exists.

So the fix is not to pick a bucket around the problem but to remove it: **the generated table is excluded from coverage** in `vitest.config.ts`, alongside `src/types/**`, which it matches exactly in kind — zero branches, zero functions, nothing to leave untested. Re-measured after the exclusion, `pricing` is 17 lines and 10 branches, all resolver, 100% / 100%.

**This exclusion sharpens the gate rather than loosening it**, and that deserves saying out loud because an exclusion normally does the opposite and this repository has a convention against filtering a verification down to something that can read green. The filtered metric is *more* sensitive, not less: the floor now sits over 17 lines instead of 299, so losing five resolver lines fails where it previously passed comfortably.

## The floor

Set from measurement per the policy in `check-sdk-module-coverage.mjs` — measured − 3:

```json
"pricing": { "line": 97, "branch": 97 }
```

One property worth flagging rather than discovering later: the module is small enough that **3 percentage points is less than one branch**, so any uncovered branch in the resolver fails this gate. That is intended, not an artefact of rounding, and it is recorded in the config next to the entry.

## The gates that never ran

A job stops at the first red step, so the failure said nothing about the steps after it. All of them run here, on this branch:

| gate | result |
|---|---|
| `pnpm build` | ✓ |
| `pnpm typecheck` | ✓ |
| `pnpm lint` | ✓ |
| `pnpm test` | ✓ 4 700+ across 13 packages |
| `pnpm docs:check` | ✓ |
| `audit-external-names.mjs` | ✓ |
| process-level tests | ✓ 12 |
| installer parses as POSIX sh | ✓ |
| evals | ✓ exit 0 |
| SDK coverage floor gate | ✓ (table below) |
| SDK test-presence gate | ✓ 20 required, 13 baselineExempt, 5 exempt |
| publish-metadata gate | ✓ 14 packages |
| public-surface regression | ✓ 560 runtime / 1284 declared, intact |
| publint --strict | ✓ |
| model price catalogue drift | ✓ |

```
module     files lines                  branches
pricing    1     100.0% / 97% ✓         100.0% / 97% ✓
```

**One gate I could not run to completion locally, reported rather than skipped:** `verify-consumer-install.sh` fails on this machine at `SDK_VERSION=$(node -p "require('$WORKSPACE_ROOT/packages/sdk/package.json').version")`. `$WORKSPACE_ROOT` carries Windows backslashes, which are escape sequences inside that double-quoted JS string, so the require throws `MODULE_NOT_FOUND`, `SDK_VERSION` comes back empty, and the version-skip below it does not match. Reproduced the same line with a forward-slash path and it returns `21.1.0` fine. It is a platform artefact of running a Linux-CI script under Git Bash, independent of anything in #354 — the step reads a version this change does not touch — and it runs on `ubuntu-latest` in CI. Not fixed here: it is a release-critical script and unrelated to this failure.

## Not addressed here

The `cost_unmeasurable` / `describeCost` follow-up for the CLI is a separate PR, as is the mutation-convention amendment that was pushed to #354 after the merge had already landed.
