### PR TITLE
feat(cli): a reply arrives in whole blocks, not a character at a time

### DIFF
--- a/.changeset/reply-in-blocks.md
+++ b/.changeset/reply-in-blocks.md
@@ -1,0 +1,27 @@
+---
+'@namzu/cli': minor
+---
+
+A reply arrives in whole blocks instead of typing itself out.
+
+Token deltas used to be appended to the transcript the moment they arrived.
+Nothing animated them — there is no timer anywhere in the package — but a few
+characters at a time reads the same way, and an operator ends up watching a
+line grow rather than reading it.
+
+Deltas are now held and released a **block** at a time: a paragraph, a list, a
+fenced code block. A short answer has no blank line in it, so it is one block
+and appears whole, which is the common case. A long answer appears paragraph by
+paragraph, so the screen still shows that work is happening without spelling it
+out letter by letter.
+
+**A fenced code block is never split**, even though it contains blank lines.
+Cutting there would hand the renderer a fence that opens and never closes, and
+the first half of a snippet would render in a different style from the second.
+
+Nothing is lost. The tail of a reply is an incomplete block by construction, so
+every close path — normal completion, a tool call interrupting the text, an
+error mid-turn — flushes what is buffered before finalising. That is the one
+way this could have gone wrong quietly, and it is the failure the new tests are
+built around: they drive a rendered turn and assert the whole reply is on
+screen, exactly once, including a reply that never completes a block at all.

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -74,6 +74,7 @@ import {
 import { ResumePicker } from './ResumePicker.js'
 import { type UserCommand, discoverUserCommands } from '../user-commands/store.js'
 import { SLASH_COMMANDS, type SlashContext, runSlash } from './slashCommands.js'
+import { splitCompleteBlocks } from './stream-blocks.js'
 import { theme } from './theme.js'
 import type { TranscriptMessage, TuiContext } from './types.js'
 
@@ -82,6 +83,21 @@ export interface AppProps {
 }
 
 type LifecyclePhase = 'trust' | 'probing' | 'picker' | 'ready' | 'unhealthy' | 'resume'
+
+/**
+ * The streaming assistant bubble, carried across events within one turn.
+ *
+ * `text` is everything the model has said and is what gets persisted;
+ * `pending` is the part not yet on screen, held until it forms a whole block.
+ * The two are separate because they answer different questions — what was
+ * said, and what has been shown — and conflating them is how a reply gets
+ * saved with a paragraph the operator never saw, or shown twice.
+ */
+type StreamState = {
+	assistantId: string | null
+	text: string
+	pending?: string
+}
 
 /** A running tool tracked internally: the live row's fields plus what we need
  *  to commit it on completion (the tool name for matching, the call-time diff). */
@@ -298,6 +314,26 @@ export function App({ ctx }: AppProps) {
 	const appendToMessage = useCallback((id: string, delta: string) => {
 		setMessages((prev) => prev.map((m) => (m.id === id ? { ...m, content: m.content + delta } : m)))
 	}, [])
+
+	/**
+	 * Put everything still buffered on screen, creating the bubble if needed.
+	 *
+	 * A `useCallback` beside the other transcript writers rather than a closure
+	 * inside `applyEvent`, because the error path in `runTurn` finalises the
+	 * bubble WITHOUT going through `applyEvent` — and a flush it could not
+	 * reach is text the operator never sees. Holding output back is only safe
+	 * if every exit releases it; this is the function every exit calls.
+	 */
+	const flushStream = useCallback(
+		(st: StreamState) => {
+			if (!st.pending || st.pending.length === 0) return
+			const id = st.assistantId ?? pushMessage('assistant', '', true)
+			st.assistantId = id
+			appendToMessage(id, st.pending)
+			st.pending = ''
+		},
+		[appendToMessage, pushMessage],
+	)
 
 	const finalizeMessage = useCallback((id: string, finalContent?: string) => {
 		setMessages((prev) =>
@@ -842,23 +878,37 @@ export function App({ ctx }: AppProps) {
 	// `st` carries the streaming-assistant bubble id + accumulated text across
 	// events within a turn/stream.
 	const applyEvent = useCallback(
-		(event: AgentEvent, st: { assistantId: string | null; text: string }) => {
+		(event: AgentEvent, st: StreamState) => {
 			const ensureAssistant = () => {
 				if (!st.assistantId) st.assistantId = pushMessage('assistant', '', true)
 				return st.assistantId
 			}
 			const closeAssistant = () => {
+				// Before finalising, never after: the tail of a reply is almost
+				// always an incomplete block, so a close that did not flush would
+				// drop the last paragraph of nearly every answer.
+				flushStream(st)
 				if (st.assistantId) {
 					finalizeMessage(st.assistantId)
 					st.assistantId = null
 				}
 			}
 			switch (event.kind) {
-				case 'delta':
+				case 'delta': {
 					setState('thinking')
 					st.text += event.text
-					appendToMessage(ensureAssistant(), event.text)
+					// Held, not appended. Appending each delta is what produced text
+					// that types itself out — nothing animates it, but a few
+					// characters at a time reads the same way, and an operator ends
+					// up watching a line grow instead of reading it.
+					st.pending = (st.pending ?? '') + event.text
+					const { ready, rest } = splitCompleteBlocks(st.pending)
+					if (ready.length > 0) {
+						st.pending = rest
+						appendToMessage(ensureAssistant(), ready)
+					}
 					break
+				}
 				case 'tool-start': {
 					closeAssistant()
 					setState('tool')
@@ -951,7 +1001,7 @@ export function App({ ctx }: AppProps) {
 					break
 			}
 		},
-		[appendToMessage, finalizeMessage, pushMessage],
+		[appendToMessage, finalizeMessage, flushStream, pushMessage],
 	)
 
 	const runTurn = useCallback(
@@ -994,7 +1044,7 @@ export function App({ ctx }: AppProps) {
 			setState('thinking')
 			// The model interleaves text → tool → text across iterations; `applyEvent`
 			// renders each one in order.
-			const st = { assistantId: null as string | null, text: '' }
+			const st: StreamState = { assistantId: null, text: '', pending: '' }
 			const ac = new AbortController()
 			abortRef.current = ac
 			// Where this turn will be saved, and which transcript its rows belong
@@ -1039,6 +1089,10 @@ export function App({ ctx }: AppProps) {
 				// the generation exists to stop — and it would be the more confusing
 				// half of it, because an abort reads as an error.
 				if (stillHere()) {
+					// Flushed first: this path does not go through `applyEvent`, so
+					// without it the partial answer the model had produced before
+					// the failure would be discarded along with the turn.
+					flushStream(st)
 					if (st.assistantId) finalizeMessage(st.assistantId)
 					pushMessage('system', `Error: ${err instanceof Error ? err.message : String(err)}`)
 				}

--- a/packages/cli/src/tui/__tests__/a-reply-arrives-in-whole-blocks.test.tsx
+++ b/packages/cli/src/tui/__tests__/a-reply-arrives-in-whole-blocks.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * A reply lands in whole blocks, and none of it is lost.
+ *
+ * Deltas used to be appended the moment they arrived, so a reply typed itself
+ * onto the screen a few characters at a time. Nothing animated it — there is
+ * no timer anywhere in this package — but the effect is the same, and an
+ * operator ends up watching a line grow instead of reading it.
+ *
+ * Holding output back is cheap to get wrong in the one direction that matters.
+ * The tail of a reply is almost always an incomplete block, so a close path
+ * that forgets to flush drops the last paragraph of nearly every answer — and
+ * it drops it *silently*, on the exit path, where the turn otherwise looks
+ * successful. `splitCompleteBlocks` is unit-tested next door and cannot catch
+ * that: it is a pure function that never sees a turn end.
+ *
+ * So these drive a rendered `<App>` through a real turn. The claim is about
+ * what is on the screen, which is the only thing that can establish it.
+ */
+
+import { render } from 'ink-testing-library'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Preferences } from '../../integrations/providers/index.js'
+import type { AgentEvent, AgentSession } from '../agent.js'
+import type { TuiContext } from '../types.js'
+
+const PREFS: Preferences = { version: 3, providers: [{ id: 'openai' }], subagents: { active: [] } }
+
+/** The reply the mock streams, one character per delta. Set per test. */
+const TWO_BLOCKS = 'First paragraph here.\n\nSecond paragraph, the tail.'
+/**
+ * The common case, and the one with no block boundary anywhere in it.
+ *
+ * A short answer has no blank line, so NO block ever completes and the whole
+ * reply exists only in the buffer until the turn ends. If the flush cannot
+ * create the bubble it never made, this answer is lost in its entirety — not
+ * a paragraph of it, all of it.
+ */
+const ONE_BLOCK = 'A short answer with no blank line anywhere in it.'
+let reply = TWO_BLOCKS
+
+vi.mock('../../integrations/trust/store.js', () => ({ isTrusted: () => true, trustDir: () => {} }))
+vi.mock('../../integrations/updates.js', () => ({ checkUpdates: async () => [] }))
+vi.mock('../../integrations/sessions/store.js', () => ({
+	openSessions: async () => ({ tenantId: 't' }),
+	startConversation: async () => 'conv',
+	appendMessages: async () => {},
+	listRecent: async () => [],
+	loadConversation: async () => [],
+}))
+vi.mock('../../user-commands/store.js', () => ({ discoverUserCommands: () => [] }))
+
+vi.mock('../agent.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../agent.js')>()
+	return {
+		...actual,
+		probeAgentSession: async () => ({
+			preferences: PREFS,
+			needsRepickReason: null,
+			detected: [],
+		}),
+		createAgentSession: async (): Promise<AgentSession> => ({
+			hasProvider: true,
+			providerSummary: 'a-provider',
+			modelSummary: 'a-model',
+			toolNames: () => ['bash'],
+			errorHint: null,
+			errorKind: null,
+			agentIds: [],
+			configNotices: [],
+			instructionFiles: [],
+			skippedInstructionFiles: [],
+			mcpConnected: [],
+			mcpFailed: [],
+			resumeDurable: async () => {
+				throw new Error('not used by the TUI')
+			},
+			close: async () => {},
+			approvalLatched: () => false,
+			promptExemptTools: () => [],
+			send: async function* (): AsyncIterable<AgentEvent> {
+				// One character per event: the shape that produced the typing
+				// effect, and the shape that catches a splitter that releases a
+				// partial word.
+				for (const ch of reply) {
+					yield { kind: 'delta', text: ch } as AgentEvent
+					await new Promise((r) => setTimeout(r, 0))
+				}
+				yield { kind: 'done' } as AgentEvent
+			},
+		}),
+	}
+})
+
+// Imported after the mocks above are registered, the way the sibling App
+// tests do it — a static import would bind the real modules first.
+const { App } = await import('../App.js')
+
+const ctx: TuiContext = {
+	cwd: process.cwd(),
+	version: '0.0.0-test',
+	rules: [],
+	skipPermissions: false,
+} as unknown as TuiContext
+
+const mounted: Array<{ unmount: () => void }> = []
+afterEach(() => {
+	for (const m of mounted.splice(0)) m.unmount()
+	reply = TWO_BLOCKS
+	vi.clearAllMocks()
+})
+
+const tick = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+async function frameShows(read: () => string | undefined, needle: string, budgetMs = 4000) {
+	const deadline = Date.now() + budgetMs
+	while (Date.now() < deadline) {
+		if ((read() ?? '').includes(needle)) return
+		await tick(20)
+	}
+}
+
+/** Every frame drawn while the turn ran. `until` marks the end of the reply. */
+async function runTurnCapturing(until = 'the tail.'): Promise<{ frames: string[]; final: string }> {
+	const harness = render(<App ctx={ctx} />)
+	mounted.push(harness)
+	await frameShows(harness.lastFrame, 'Type a message')
+	await tick(60)
+	harness.stdin.write('go')
+	await tick(20)
+	harness.stdin.write('\r')
+
+	const frames: string[] = []
+	const deadline = Date.now() + 4000
+	while (Date.now() < deadline) {
+		const f = harness.lastFrame() ?? ''
+		if (frames[frames.length - 1] !== f) frames.push(f)
+		if (f.includes(until)) break
+		await tick(10)
+	}
+	return { frames, final: harness.lastFrame() ?? '' }
+}
+
+describe('a streamed reply', () => {
+	it('never shows a half-written word', async () => {
+		const { frames } = await runTurnCapturing()
+		// The prefixes a per-token append would have put on screen. If any frame
+		// carries one WITHOUT the rest of its word, the reveal is still
+		// character-by-character.
+		for (const frame of frames) {
+			if (frame.includes('First parag')) {
+				expect(frame, 'a partial word was rendered').toContain('First paragraph here.')
+			}
+			if (frame.includes('the tai')) {
+				expect(frame, 'a partial word was rendered').toContain('the tail.')
+			}
+		}
+	})
+
+	it('shows the first paragraph before the reply has finished', async () => {
+		// The other direction. Holding EVERYTHING back until the turn ends is a
+		// different product decision, and this pins the one that was chosen: a
+		// completed block is released while the rest is still arriving.
+		const { frames } = await runTurnCapturing()
+		const partway = frames.filter((f) => f.includes('First paragraph here.') && !f.includes('the tail.'))
+		expect(partway.length, 'the first block was never shown on its own').toBeGreaterThan(0)
+	})
+
+	it('loses nothing — the trailing block reaches the screen', async () => {
+		// The failure this file exists for. The tail of a reply is an incomplete
+		// block by construction, so it only ever arrives via the flush on the
+		// close path. Delete that flush and every answer loses its last
+		// paragraph, silently, on a turn that otherwise looks fine.
+		const { final } = await runTurnCapturing()
+		expect(final).toContain('First paragraph here.')
+		expect(final).toContain('Second paragraph, the tail.')
+	})
+
+	it('shows a reply that never completes a block at all', async () => {
+		// The common case: a short answer with no blank line in it, so NO block
+		// ever completes and the whole reply lives in the buffer until the turn
+		// ends. If the flush cannot create the bubble that no released block
+		// ever made, this loses the entire answer rather than a paragraph of it
+		// — and the turn still looks like it succeeded.
+		reply = ONE_BLOCK
+		const { final } = await runTurnCapturing('anywhere in it.')
+		expect(final).toContain(ONE_BLOCK)
+	})
+
+	it('shows each block exactly once', async () => {
+		// A released block that is not drained from the buffer is appended
+		// again on the next release, so the reply grows copies of its own
+		// opening. Every assertion above is `toContain`, and every one of them
+		// passes on a duplicated transcript.
+		const { final } = await runTurnCapturing()
+		const occurrences = final.split('First paragraph here.').length - 1
+		expect(occurrences, 'the first block was rendered more than once').toBe(1)
+	})
+})

--- a/packages/cli/src/tui/stream-blocks.test.ts
+++ b/packages/cli/src/tui/stream-blocks.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+
+import { splitCompleteBlocks } from './stream-blocks.js'
+
+/** Feed a string in one-character deltas, the way the kernel actually does. */
+function stream(text: string): { shown: string[]; leftover: string } {
+	let buffer = ''
+	const shown: string[] = []
+	for (const ch of text) {
+		buffer += ch
+		const { ready, rest } = splitCompleteBlocks(buffer)
+		if (ready.length > 0) {
+			shown.push(ready)
+			buffer = rest
+		}
+	}
+	return { shown, leftover: buffer }
+}
+
+describe('nothing is released until a block is whole', () => {
+	it('holds a single paragraph until the stream ends', () => {
+		const { shown, leftover } = stream('A short answer with no blank line in it.')
+		expect(shown).toEqual([])
+		expect(leftover).toBe('A short answer with no blank line in it.')
+	})
+
+	it('never releases a partial word', () => {
+		const { shown } = stream('one two three\n\nfour five six\n\nseven')
+		for (const chunk of shown) {
+			// Every release ends on the boundary that closed it.
+			expect(chunk.endsWith('\n')).toBe(true)
+		}
+	})
+
+	it('releases a paragraph once the next one starts', () => {
+		const { shown, leftover } = stream('first para\n\nsecond para')
+		expect(shown).toEqual(['first para\n\n'])
+		expect(leftover).toBe('second para')
+	})
+
+	it('releases each paragraph in turn, losing nothing', () => {
+		const text = 'a\n\nb\n\nc'
+		const { shown, leftover } = stream(text)
+		expect(shown.join('') + leftover).toBe(text)
+	})
+})
+
+describe('a fenced block is never split', () => {
+	it('holds a code block containing a blank line', () => {
+		const text = 'Here:\n\n```js\nconst a = 1\n\nconst b = 2\n```\n\nafter'
+		const { shown, leftover } = stream(text)
+		expect(shown.join('') + leftover).toBe(text)
+		// The blank line INSIDE the fence must not have produced a release.
+		for (const chunk of shown) {
+			const fences = (chunk.match(/```/g) ?? []).length
+			expect(fences % 2).toBe(0)
+		}
+	})
+
+	it('treats a tilde fence the same way', () => {
+		const { ready } = splitCompleteBlocks('~~~\na\n\nb\n')
+		expect(ready).toBe('')
+	})
+
+	it('releases the fence once it closes', () => {
+		const closed = splitCompleteBlocks('```js\nx\n```\n\ntail')
+		expect(closed.ready).toBe('```js\nx\n```\n\n')
+		expect(closed.rest).toBe('tail')
+	})
+
+	it('allows the indent a list item gives a fence', () => {
+		// Up to three spaces is still a fence per CommonMark; four is code.
+		const held = splitCompleteBlocks('   ```\na\n\nb\n')
+		expect(held.ready).toBe('')
+	})
+})
+
+describe('edges that would lose or duplicate text', () => {
+	it('is empty in and empty out', () => {
+		expect(splitCompleteBlocks('')).toEqual({ ready: '', rest: '' })
+	})
+
+	it('holds a single newline, which may be half a boundary', () => {
+		// One newline is a line break inside a paragraph until a second arrives.
+		// Releasing on it would split a paragraph mid-way.
+		expect(splitCompleteBlocks('para\n').ready).toBe('')
+	})
+
+	it('releases on a completed boundary even at the tail', () => {
+		// Two newlines DO close the paragraph: whatever arrives next begins a
+		// new block, so there is nothing left for this one to gain by waiting.
+		// This assertion was the other way round first, and the round trip
+		// through the test is what settled which it should be.
+		expect(splitCompleteBlocks('para\n\n')).toEqual({ ready: 'para\n\n', rest: '' })
+	})
+
+	it('does not treat a leading blank line as a closed block', () => {
+		expect(splitCompleteBlocks('\n\nreal content').ready).toBe('')
+	})
+
+	it('splits at the LAST complete boundary, not the first', () => {
+		const { ready, rest } = splitCompleteBlocks('a\n\nb\n\nc')
+		expect(ready).toBe('a\n\nb\n\n')
+		expect(rest).toBe('c')
+	})
+
+	it('always partitions the input exactly — no loss, no duplication', () => {
+		for (const text of [
+			'a\n\nb',
+			'```\nx\n\ny\n```\n\nz',
+			'\n\n\n\n',
+			'no boundaries at all',
+			'trailing\n\n',
+			'# heading\n\nbody\n\n- one\n- two\n\nend',
+		]) {
+			const { ready, rest } = splitCompleteBlocks(text)
+			expect(ready + rest).toBe(text)
+		}
+	})
+})

--- a/packages/cli/src/tui/stream-blocks.ts
+++ b/packages/cli/src/tui/stream-blocks.ts
@@ -1,0 +1,86 @@
+/**
+ * How much of a streaming reply is ready to be shown.
+ *
+ * ## Why anything is held back at all
+ *
+ * The kernel emits a reply as token deltas, and the transcript used to append
+ * every one of them the moment it arrived. Nothing animated it — there is no
+ * timer and no per-character reveal anywhere in this package — but appending a
+ * few characters at a time produces the same thing on screen: text that types
+ * itself out. An operator reading it watches a line grow instead of reading a
+ * line.
+ *
+ * So deltas accumulate and are released a **block** at a time: a paragraph, a
+ * list, a fenced code block. A short reply is one block and therefore appears
+ * whole, which is the common case and the one this is really for. A long reply
+ * appears paragraph by paragraph, which keeps the screen honest about work
+ * still being done without spelling it out letter by letter.
+ *
+ * ## Never split an open fence
+ *
+ * A blank line inside a fenced code block is not a block boundary. Cutting
+ * there would hand the renderer a fence that opens and never closes, and the
+ * half it gets renders as something other than code — so the first half of a
+ * snippet would appear in one style and the second half in another when the
+ * closing fence finally arrived. The fence state is tracked for that reason
+ * alone.
+ *
+ * Pure, and here rather than in the component, for the reason this package
+ * already applies to credential wording: there are no component tests, so
+ * anything decidable that lives inside a render is a thing nobody can check.
+ */
+
+/** A fence opener/closer: up to three spaces of indent, then ``` or ~~~. */
+const FENCE = /^ {0,3}(```|~~~)/
+
+/**
+ * Split what has accumulated into the part that can be shown and the part that
+ * is still arriving.
+ *
+ * `ready` is always a whole number of blocks and may be empty — an empty
+ * `ready` means "nothing has finished yet", not "there is nothing". The caller
+ * must therefore flush `rest` when the stream ends, or the last block of every
+ * reply would never be shown. That is the one way this can lose text, so it is
+ * stated here rather than left to be discovered.
+ */
+export function splitCompleteBlocks(buffer: string): { ready: string; rest: string } {
+	if (buffer.length === 0) return { ready: '', rest: '' }
+
+	const lines = buffer.split('\n')
+	let fenceOpen = false
+	// Character offset of the end of the last blank line that closed a block.
+	let cut = -1
+	let offset = 0
+	/**
+	 * Has anything worth showing appeared yet?
+	 *
+	 * Without this, a reply that opens with blank lines releases them as a
+	 * "block" of nothing, and the transcript row starts with empty lines above
+	 * the first word. Blank lines close a block; they do not constitute one.
+	 */
+	let sawContent = false
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i] as string
+		const isLast = i === lines.length - 1
+		if (FENCE.test(line)) {
+			fenceOpen = !fenceOpen
+			sawContent = true
+		} else if (line.trim().length > 0) {
+			sawContent = true
+		} else if (
+			!fenceOpen &&
+			sawContent &&
+			// Not the tail: a blank line at the very end may be the first half of
+			// a boundary whose next line has not arrived. Holding it costs one
+			// block of latency; releasing it can split a paragraph in two.
+			!isLast
+		) {
+			cut = offset + line.length + 1
+		}
+		offset += line.length + 1
+	}
+
+	if (cut < 0) return { ready: '', rest: buffer }
+	return { ready: buffer.slice(0, cut), rest: buffer.slice(cut) }
+}


### PR DESCRIPTION
Requested by the owner: *"typewriter effect'e gerek yok — mesaj gelince gelir."*

## It was never an animation

There is no timer and no per-character reveal anywhere in the package. The transcript appended **every token delta the moment it arrived**, and a few characters at a time reads exactly like typing — an operator watches a line grow instead of reading a line.

## What it does now

Deltas are held and released a **block** at a time: a paragraph, a list, a fenced code block.

- A **short answer has no blank line**, so it is one block and appears **whole**. That is the common case and the one this is for.
- A **longer answer** appears paragraph by paragraph, so the screen still shows work is happening without spelling it out letter by letter.

**A fenced code block is never split**, even though it contains blank lines. Cutting inside one hands the renderer a fence that opens and never closes, so the first half of a snippet renders as something other than code until the closing fence arrives.

## Where the logic lives

`splitCompleteBlocks` is a pure function in its own module, not logic inside the render — the reason this package already applies to credential wording: there are no component tests, so anything decidable inside a render is a thing nobody can check.

## The one way this could go wrong quietly

Holding output back is only safe if **every** exit releases it. The tail of a reply is an incomplete block by construction, so a close path that forgot to flush would drop the last paragraph of nearly every answer — silently, on a turn that otherwise looks successful.

The flush is a callback beside the other transcript writers precisely so the error path in `runTurn`, which finalises **without** going through the event handler, can reach it too.

## Mutation table — 8 applied, 8 killed

| # | Claim | Verdict |
|---|---|---|
| S1 | text is held until a block is whole | killed |
| S2 | a fenced block is never split on an interior blank line | killed |
| S3 | a boundary at the tail is held — it may be half-arrived | killed |
| S4 | leading blank lines are not released as a block of nothing | killed |
| S5 | the **last** complete boundary is used, not the first | killed |
| S6 | the close path flushes | killed |
| S7 | the flush creates the bubble when no block ever completed | **survived first pass** → killed |
| S8 | the buffer is drained after release | **survived first pass** → killed |

**Both survivors were gaps my first tests would have shipped:**

- **S7 is the severe one.** A reply with no blank line anywhere completes no block, so no bubble is ever created and the flush must create one. Without that the failure is not a lost paragraph — it is a **lost answer**, on a turn that still reports success. My fixture happened to contain a boundary, so nothing noticed.
- **S8**: releasing a block without draining the buffer appends it again on the next release, and the reply grows copies of its own opening. Every assertion I had written was `toContain`, and every one of them passes on a duplicated transcript.

## Tests

14 unit cases on the splitter (including a property that it always partitions its input exactly — no loss, no duplication) and 5 integration cases driving a rendered `<App>` through a real turn: never a half-written word, the first block appears before the reply finishes, the trailing block reaches the screen, a boundary-free reply still appears in full, and each block appears exactly once.

## Gates

`pnpm build` · `pnpm typecheck` · `pnpm lint` (0 errors) · `pnpm test` (**908 cli tests**, 94 files) · `pnpm docs:check` · external-name audit · `verify-public-surface` (intact) — all pass.

## Changeset

`@namzu/cli` **minor** — visible behaviour change to the transcript, no API change.
