### PR TITLE
fix(ci): classify the pricing module, which main is currently red on

### DIFF
--- a/packages/sdk/coverage-config.json
+++ b/packages/sdk/coverage-config.json
@@ -12,6 +12,7 @@
 			"directory",
 			"manager",
 			"plugin",
+			"pricing",
 			"probe",
 			"provider",
 			"rag",


### PR DESCRIPTION
`packages/sdk/src/pricing/` landed in #354 without an entry in the SDK's `coverage-config.json`, so the **test-presence gate fails on `main` and on every PR based on it**. #358 hit it; so will everything else until this lands.

The gate is behaving exactly as designed — a new folder under `src/` must be classified, precisely so nobody adds a module and leaves "is this tested?" unanswered. The answer was simply never given.

**`required`, not an exemption**, because the folder already ships `__tests__/catalogue.test.ts`. That is the honest classification rather than the convenient one: `baselineExempt` exists for modules with no tests yet, and filing a tested module there would put a false entry on the list whose entire purpose is to name the remaining debt.

One line. Verified locally:

```
✓ test-presence gate passed
  required:       20 modules, all have tests
  baselineExempt: 13 modules (future coverage debt)
  exempt:         5 declarative folders
```

No changeset — a CI classification file is not published.