### PR TITLE
fix(cli): /cost stops calling an unpriced run a free one

### DIFF
--- a/.changeset/cli-cost-says-what-it-knows.md
+++ b/.changeset/cli-cost-says-what-it-knows.md
@@ -1,0 +1,29 @@
+---
+'@namzu/cli': patch
+---
+
+`/cost` and the status bar stop reporting an unpriced run as a free one
+
+The kernel now prices runs from a built-in catalogue and reports
+`costInfo.unpricedTokens` when it cannot. The CLI was still narrowing that
+record to a single number and printing
+`'$0.0000 (this provider reported no price)'` for any total not above zero —
+so the operator-facing surface kept making the claim the kernel had just
+stopped making.
+
+Two things were wrong with that line beyond the number. A run on local
+inference costs nothing and is not the same event as a run nobody can price,
+and both landed on the same sentence. And the sentence asserted something
+about the provider that no code had checked: what is known is that namzu has
+no rate for the model, which is a statement about this side of the wire and
+points at a different fix.
+
+`/cost` now distinguishes three states — a real cost, a measured zero, and not
+known — and marks a partly-priced run as a floor rather than an answer. The
+status bar shows `$?` rather than omitting the figure, because a missing cost
+on a line read at a glance is read as no cost.
+
+`patch`: no exported symbol changes. The internal `AgentEvent` usage variant
+carries the kernel's `CostInfo` whole instead of a flattened `costUsd`, but
+neither it nor the renderers are part of `@namzu/cli`'s public barrel — the
+package exports a CLI, and its behaviour is corrected, not extended.

--- a/docs/cli/tui.md
+++ b/docs/cli/tui.md
@@ -66,9 +66,29 @@ guessed window, so it climbed with turn count and read full on a conversation
 with room to spare. `/cost` names which one it is printing for that reason.
 
 Where the status bar abbreviates (`12.3k tok`), `/cost` prints the figure
-(`12,345`) — you asked on purpose, so you get the number. A provider that
-reports no price shows `$0.0000 (this provider reported no price)` rather than
-implying the run was free.
+(`12,345`) — you asked on purpose, so you get the number.
+
+**Three states, and two of them are not the same zero.** A run that cost
+nothing and a run nobody could price both report a total of `0`, so `/cost`
+says which it is:
+
+| What you see | What it means |
+|---|---|
+| `Cost:   $0.0731` | Every token was charged at a known rate. |
+| `Cost:   $0.0000` + *a measured zero* | The model that served the run bills nothing per token — local inference. |
+| `Cost:   not known` | Some or all of the run ran on a model namzu has no rate for. This is **not** a claim that it was free. |
+| `Cost:   $0.5000 and counting` | Partly priced. The figure is a floor, not the answer. |
+
+The status bar shows `$?` for the third and fourth, deliberately not a number:
+the one thing that must not happen on a line read at a glance is a figure
+standing in for a figure nobody has.
+
+This previously printed `$0.0000 (this provider reported no price)` for every
+total that was not above zero, which was wrong twice over — it collapsed the
+free run into the unpriced one, and it asserted something about the provider
+that nothing had checked. What is actually known is that *namzu* has no rate
+for the model, which is a statement about this side of the wire and points at a
+different fix. Declare a rate to price those tokens.
 
 ### Switching model
 

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -11,7 +11,7 @@
  *      empty-state mode (explains where to put credentials).
  */
 
-import type { ImageAttachment, Message } from '@namzu/sdk'
+import type { CostInfo, ImageAttachment, Message } from '@namzu/sdk'
 import { Box, Text, useApp, useInput } from 'ink'
 import { relative } from 'node:path'
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -155,7 +155,7 @@ export function App({ ctx }: AppProps) {
 	// per keypress is a cost nobody asked for. A file added mid-session is
 	// picked up by `/model` (which re-hydrates) or a restart.
 	const [userCommands, setUserCommands] = useState<readonly UserCommand[]>([])
-	const [usage, setUsage] = useState<{ totalTokens: number; costUsd: number } | null>(null)
+	const [usage, setUsage] = useState<{ totalTokens: number; cost: CostInfo } | null>(null)
 	// Context fill, straight from the kernel and held apart from `usage` —
 	// they are different quantities and conflating them is what made the
 	// gauge climb with turn count instead of with context.
@@ -957,7 +957,7 @@ export function App({ ctx }: AppProps) {
 					break
 				}
 				case 'usage':
-					setUsage({ totalTokens: event.totalTokens, costUsd: event.costUsd })
+					setUsage({ totalTokens: event.totalTokens, cost: event.cost })
 					// Mirrored verbatim, absences included. A run that reports no
 					// window clears the gauge rather than leaving the last one up:
 					// a stale bar is read as current, and this bar's whole defect

--- a/packages/cli/src/tui/StatusBar.tsx
+++ b/packages/cli/src/tui/StatusBar.tsx
@@ -6,6 +6,7 @@
  * so the eye can find the help-text without parsing the whole line.
  */
 
+import type { CostInfo } from '@namzu/sdk'
 import { Text, useStdout } from 'ink'
 
 import { theme } from './theme.js'
@@ -30,7 +31,7 @@ export interface StatusBarProps {
 	readonly model: string | null
 	readonly state: 'idle' | 'thinking' | 'tool' | 'awaiting-permission'
 	readonly hint?: string
-	readonly usage?: { totalTokens: number; costUsd: number } | null
+	readonly usage?: { totalTokens: number; cost: CostInfo } | null
 	/** Kernel-reported context fill — drives the gauge. */
 	readonly context?: ContextFill | null
 }
@@ -110,12 +111,21 @@ function colorForState(state: StatusBarProps['state']): string {
 	}
 }
 
-function formatUsage(usage: { totalTokens: number; costUsd: number }): string {
+function formatUsage(usage: { totalTokens: number; cost: CostInfo }): string {
 	const tok =
 		usage.totalTokens >= 1000
 			? `${(usage.totalTokens / 1000).toFixed(1)}k tok`
 			: `${usage.totalTokens} tok`
-	return usage.costUsd > 0 ? `${tok} · $${usage.costUsd.toFixed(2)}` : tok
+	// The bar has room for a figure, not for a sentence, so the unknown case
+	// gets a mark rather than an explanation and `/cost` carries the words.
+	//
+	// Showing tokens alone — what this did for any total not above zero — is
+	// the same claim the `/cost` page was making in longer form: an operator
+	// reads a missing cost as no cost. `$?` is deliberately not a number,
+	// because the one thing that must not happen here is a figure standing in
+	// for a figure nobody has.
+	if (usage.cost.unpricedTokens > 0) return `${tok} · $?`
+	return usage.cost.totalCost > 0 ? `${tok} · $${usage.cost.totalCost.toFixed(2)}` : tok
 }
 
 const GAUGE_WIDTH = 8

--- a/packages/cli/src/tui/__tests__/status-bar-does-not-imply-free.test.tsx
+++ b/packages/cli/src/tui/__tests__/status-bar-does-not-imply-free.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * The bar must not show a run nobody could price as a run that cost nothing.
+ *
+ * `/cost` is asked; the status bar is merely seen, which makes it the surface
+ * more likely to be believed without thinking. It printed the token count alone
+ * whenever the total was not above zero — and since nothing fed the kernel's
+ * cost calculation, that was every run. An operator reads a missing cost as no
+ * cost.
+ *
+ * Rendered rather than unit-tested against `formatUsage`, which is not
+ * exported: the question here is what reaches the screen, and a helper test
+ * would prove the string is BUILT, which was never the part in doubt.
+ */
+
+import type { CostInfo } from '@namzu/sdk'
+import { render } from 'ink-testing-library'
+import { describe, expect, it } from 'vitest'
+
+import { StatusBar } from '../StatusBar.js'
+
+const cost = (totalCost: number, over: Partial<CostInfo> = {}): CostInfo => ({
+	totalCost,
+	cacheDiscount: 0,
+	unpricedTokens: 0,
+	...over,
+})
+
+function frameFor(usage: { totalTokens: number; cost: CostInfo }): string {
+	const { lastFrame, unmount } = render(
+		<StatusBar cwd="/w" provider="p" model="m" state="idle" usage={usage} />,
+	)
+	const frame = lastFrame() ?? ''
+	unmount()
+	return frame
+}
+
+describe('the status bar and an unpriced run', () => {
+	it('marks the cost as unknown rather than omitting it', () => {
+		const frame = frameFor({ totalTokens: 2_000, cost: cost(0, { unpricedTokens: 2_000 }) })
+
+		expect(frame).toContain('$?')
+		// The one thing that must not happen: a figure standing in for a figure
+		// nobody has.
+		expect(frame).not.toContain('$0.00')
+	})
+
+	it('shows a genuinely free run differently from an unpriced one', () => {
+		// Both totals are zero. A test looking at either alone would pass
+		// against the behaviour being replaced, which gave them one rendering.
+		const free = frameFor({ totalTokens: 2_000, cost: cost(0) })
+		const unknown = frameFor({ totalTokens: 2_000, cost: cost(0, { unpricedTokens: 2_000 }) })
+
+		expect(free).not.toBe(unknown)
+		expect(free).not.toContain('$?')
+	})
+
+	it('still prints a real total when the run was fully priced', () => {
+		// Guards the change from being "always show $?": the ordinary case has
+		// to keep working, and a mutation that returned the marker
+		// unconditionally would otherwise pass the two cases above.
+		expect(frameFor({ totalTokens: 2_000, cost: cost(1.234) })).toContain('$1.23')
+	})
+
+	it('marks a partly-priced run as unknown rather than quoting the floor alone', () => {
+		// A total above zero AND unpriced tokens. Quoting `$0.50` here reads as
+		// the answer when it is only a floor, so the bar defers to `/cost`.
+		const frame = frameFor({ totalTokens: 2_000, cost: cost(0.5, { unpricedTokens: 400 }) })
+
+		expect(frame).toContain('$?')
+		expect(frame).not.toContain('$0.50')
+	})
+})

--- a/packages/cli/src/tui/__tests__/to-agent-event.test.ts
+++ b/packages/cli/src/tui/__tests__/to-agent-event.test.ts
@@ -216,12 +216,13 @@ describe('toAgentEvent labels a delegation with the label it required', () => {
  * one are not the same as carrying it.
  */
 describe('toAgentEvent carries the context figures across', () => {
+	const COST = { totalCost: 0.5, cacheDiscount: 0, unpricedTokens: 0 }
 	const usageEvent = (extra: Record<string, unknown>) =>
 		toAgentEvent({
 			type: 'token_usage_updated',
 			runId,
 			usage: { totalTokens: 90 },
-			cost: { totalCost: 0.5 },
+			cost: COST,
 			...extra,
 		} as unknown as RunEvent)
 
@@ -236,7 +237,7 @@ describe('toAgentEvent carries the context figures across', () => {
 		).toEqual({
 			kind: 'usage',
 			totalTokens: 90,
-			costUsd: 0.5,
+			cost: COST,
 			contextTokens: 12_000,
 			contextMeasuredBy: 'provider',
 			contextWindowTokens: 200_000,
@@ -251,7 +252,7 @@ describe('toAgentEvent carries the context figures across', () => {
 		// to show no proportion at all.
 		const mapped = usageEvent({})
 
-		expect(mapped).toEqual({ kind: 'usage', totalTokens: 90, costUsd: 0.5 })
+		expect(mapped).toEqual({ kind: 'usage', totalTokens: 90, cost: COST })
 		expect(mapped).not.toHaveProperty('contextTokens')
 		expect(mapped).not.toHaveProperty('contextWindowTokens')
 	})

--- a/packages/cli/src/tui/agent.test.ts
+++ b/packages/cli/src/tui/agent.test.ts
@@ -118,10 +118,32 @@ describe('toAgentEvent', () => {
 			toAgentEvent({
 				type: 'token_usage_updated',
 				usage: { totalTokens: 1234 },
-				cost: { totalCost: 0.0456 },
+				cost: { totalCost: 0.0456, cacheDiscount: 0, unpricedTokens: 0 },
 				...env,
 			} as unknown as RunEvent),
-		).toEqual({ kind: 'usage', totalTokens: 1234, costUsd: 0.0456 })
+			// The cost record travels whole. Narrowing it to a single number
+			// here is what left every surface downstream unable to tell a run
+			// that cost nothing from one nobody could price.
+		).toEqual({
+			kind: 'usage',
+			totalTokens: 1234,
+			cost: { totalCost: 0.0456, cacheDiscount: 0, unpricedTokens: 0 },
+		})
+	})
+
+	it('carries unpriced tokens across the seam rather than zeroing them', () => {
+		// The case above cannot see this: its fixture has `unpricedTokens: 0`,
+		// so a mapping that hardcoded zero would satisfy it exactly. This is the
+		// only field on the record whose loss is silent — every surface
+		// downstream would keep rendering, and would render "free".
+		expect(
+			toAgentEvent({
+				type: 'token_usage_updated',
+				usage: { totalTokens: 4210 },
+				cost: { totalCost: 0, cacheDiscount: 0, unpricedTokens: 4210 },
+				...env,
+			} as unknown as RunEvent),
+		).toMatchObject({ cost: { unpricedTokens: 4210 } })
 	})
 
 	it('returns null for events the chat surface ignores', () => {

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -24,6 +24,7 @@
 import {
 	type CheckpointStore,
 	type ClaimFence,
+	type CostInfo,
 	DiskMemoryStore,
 	DiskTaskStore,
 	type DurableRunEntry,
@@ -117,7 +118,18 @@ export type AgentEvent =
 			readonly kind: 'usage'
 			/** CUMULATIVE run spend. Grows every turn; never a context size. */
 			readonly totalTokens: number
-			readonly costUsd: number
+			/**
+			 * The kernel's cost record, carried whole.
+			 *
+			 * This was `costUsd: number`, narrowed from the same object at the
+			 * mapping site, and the number on its own cannot answer the
+			 * question the screen asks. A total of zero means two different
+			 * things — the run cost nothing, or nobody could price it — and
+			 * `unpricedTokens` is what separates them. Passing only the total
+			 * left every surface downstream to guess, and both of them guessed
+			 * "free".
+			 */
+			readonly cost: CostInfo
 			/**
 			 * How full the context is NOW, and how full it may get.
 			 *
@@ -1625,7 +1637,7 @@ export function toAgentEvent(event: RunEvent): AgentEvent | null {
 			return {
 				kind: 'usage',
 				totalTokens: event.usage.totalTokens,
-				costUsd: event.cost.totalCost,
+				cost: event.cost,
 				...(event.contextTokens !== undefined ? { contextTokens: event.contextTokens } : {}),
 				...(event.contextMeasuredBy !== undefined
 					? { contextMeasuredBy: event.contextMeasuredBy }

--- a/packages/cli/src/tui/slashCommands.test.ts
+++ b/packages/cli/src/tui/slashCommands.test.ts
@@ -1,3 +1,4 @@
+import type { CostInfo } from '@namzu/sdk'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -8,6 +9,17 @@ import {
 	parseSlash,
 	runSlash,
 } from './slashCommands.js'
+
+/**
+ * A cost record, built the way the kernel builds one.
+ *
+ * `unpricedTokens` defaults to 0 — "nothing is unaccounted for" — so a case
+ * that does not mention it is asserting a fully-priced run rather than
+ * accidentally describing an unknown one.
+ */
+function cost(totalCost: number, over: Partial<CostInfo> = {}): CostInfo {
+	return { totalCost, cacheDiscount: 0, unpricedTokens: 0, ...over }
+}
 
 /**
  * The permission half of a context, for the same reason `context` exists below:
@@ -177,24 +189,82 @@ describe('/cost', () => {
 	})
 
 	it('prints exact figures rather than the status bar abbreviation', () => {
-		const r = runSlash('/cost', context({ usage: { totalTokens: 12_345, costUsd: 0.0731 } }))
+		const r = runSlash('/cost', context({ usage: { totalTokens: 12_345, cost: cost(0.0731) } }))
 		expect(r?.kind).toBe('message')
 		if (r?.kind === 'message') {
 			// `12,345`, not `12.3k` — someone who asked wants the number.
 			expect(r.content).toContain('12,345')
+			// Four decimals, not `$0.07`. The kernel's own `describeCost` rounds
+			// above a cent, which is why this command does not use it.
 			expect(r.content).toContain('$0.0731')
 		}
 	})
 
-	it('names a zero price as unreported rather than as free', () => {
-		const r = runSlash('/cost', context({ usage: { totalTokens: 900, costUsd: 0 } }))
-		if (r?.kind === 'message') expect(r.content).toContain('reported no price')
+	// The three states this command has to keep apart. Two of them used to
+	// print the same sentence, and it was the wrong sentence for both.
+	it('reports a measured zero as free, not as a missing price', () => {
+		const r = runSlash('/cost', context({ usage: { totalTokens: 900, cost: cost(0) } }))
+		if (r?.kind === 'message') {
+			expect(r.content).toContain('measured zero')
+			expect(r.content).toContain('bills nothing')
+			// The old line said this about every zero, including this one.
+			expect(r.content).not.toContain('no price')
+		}
+	})
+
+	it('reports an unpriced run as not known, and says it is not a claim of free', () => {
+		const r = runSlash(
+			'/cost',
+			context({ usage: { totalTokens: 900, cost: cost(0, { unpricedTokens: 900 }) } }),
+		)
+		if (r?.kind === 'message') {
+			expect(r.content).toContain('not known')
+			expect(r.content).toContain('900 tokens')
+			// The whole clause, not the word `not` — which appears in the
+			// neighbouring sentence too, so asserting it alone held against a
+			// version with this disclaimer deleted. Matched against the prose
+			// with its wrapping collapsed: the sentence is the property, and
+			// where the line happens to break is not.
+			expect(r.content.replace(/\s+/g, ' ')).toContain('not a claim that they were free')
+			// It must not read as the free case.
+			expect(r.content).not.toContain('measured zero')
+			// And it must not assert something about the provider that nothing
+			// checked. The old copy did exactly that.
+			expect(r.content).not.toContain('provider reported')
+		}
+	})
+
+	it('gives the free and the unknown run different answers', () => {
+		// The assertion the old code could not have passed: both runs have a
+		// total of zero, and a reader has to be able to tell them apart. A test
+		// that only checked one of them in isolation would have passed against
+		// the single sentence that used to serve both.
+		const free = runSlash('/cost', context({ usage: { totalTokens: 900, cost: cost(0) } }))
+		const unknown = runSlash(
+			'/cost',
+			context({ usage: { totalTokens: 900, cost: cost(0, { unpricedTokens: 900 }) } }),
+		)
+		if (free?.kind === 'message' && unknown?.kind === 'message') {
+			expect(free.content).not.toBe(unknown.content)
+		}
+	})
+
+	it('says a partly-priced run is a floor rather than the answer', () => {
+		const r = runSlash(
+			'/cost',
+			context({ usage: { totalTokens: 1_000, cost: cost(0.5, { unpricedTokens: 400 }) } }),
+		)
+		if (r?.kind === 'message') {
+			expect(r.content).toContain('$0.5000')
+			expect(r.content).toContain('400 tokens')
+			expect(r.content).toContain('see below')
+		}
 	})
 
 	it('says the number is spend and not context fill', () => {
 		// The two were conflated once, in the gauge. A command that prints one
 		// without naming which it is invites the same misreading back.
-		const r = runSlash('/cost', context({ usage: { totalTokens: 10, costUsd: 1 } }))
+		const r = runSlash('/cost', context({ usage: { totalTokens: 10, cost: cost(1) } }))
 		if (r?.kind === 'message') {
 			expect(r.content).toContain('Cumulative')
 			expect(r.content).toContain('how full')

--- a/packages/cli/src/tui/slashCommands.ts
+++ b/packages/cli/src/tui/slashCommands.ts
@@ -23,7 +23,7 @@
  * to "does block 4 exist" in two places at once.
  */
 
-import type { VerificationRule } from '@namzu/sdk'
+import type { CostInfo, VerificationRule } from '@namzu/sdk'
 
 import { type UserCommand, expandCommand } from '../user-commands/store.js'
 import { isCompletionArgument } from './login-prompt.js'
@@ -93,7 +93,7 @@ export interface SlashContext {
 	 * figures — an abbreviation is right for a bar that must fit and wrong for
 	 * a question someone asked on purpose.
 	 */
-	readonly usage: { readonly totalTokens: number; readonly costUsd: number } | null
+	readonly usage: { readonly totalTokens: number; readonly cost: CostInfo } | null
 	/** What decides a tool call right now — flags, config, and session state. */
 	readonly permissions: {
 		/** `--yolo` / `--dangerously-skip-permissions`. */
@@ -444,16 +444,56 @@ export function renderCost(usage: SlashContext['usage']): string {
 	if (usage === null) {
 		return 'No usage reported yet. The kernel emits it as a turn runs, so this fills in after the first exchange.'
 	}
-	const cost =
-		usage.costUsd > 0 ? `$${usage.costUsd.toFixed(4)}` : '$0.0000 (this provider reported no price)'
-	return [
+
+	// Three states, and the third used to read as the first.
+	//
+	// This printed `'$0.0000 (this provider reported no price)'` for any total
+	// that was not above zero — which was every run, because nothing fed the
+	// kernel's cost calculation at all. Two things were wrong with it beyond
+	// the number. A run on a local model costs nothing and is NOT the same
+	// event as a run nobody can price; and the parenthetical asserted a fact
+	// about the provider that no code had checked. What was actually known is
+	// that this side has no rate for the model — a statement about namzu, not
+	// about the vendor, and the difference decides who the operator goes to.
+	//
+	// The kernel exports `describeCost` for exactly this distinction and it is
+	// deliberately NOT used here: it renders through `formatCost`, which rounds
+	// to two decimals above a cent, and this command exists to print exact
+	// figures (see `SlashContext.usage`). Rounding `$0.0731` to `$0.07` to
+	// reuse a helper would trade the property someone asked for against tidy
+	// code. The status bar, which must fit, is where the short form belongs.
+	const amount = `$${usage.cost.totalCost.toFixed(4)}`
+	const unpriced = usage.cost.unpricedTokens > 0
+	const lines = [
 		`Tokens: ${usage.totalTokens.toLocaleString('en-US')}`,
-		`Cost:   ${cost}`,
+		`Cost:   ${unpriced && usage.cost.totalCost === 0 ? 'not known' : amount}${
+			unpriced && usage.cost.totalCost > 0 ? ' and counting — see below' : ''
+		}`,
+		'',
+	]
+
+	if (unpriced) {
+		lines.push(
+			`${usage.cost.unpricedTokens.toLocaleString('en-US')} tokens ran on a model namzu has no rate`,
+			'for, so what they cost is not in this figure and cannot be. This is not',
+			'a claim that they were free. Declare the rate to price them.',
+		)
+	} else if (usage.cost.totalCost === 0) {
+		lines.push(
+			'A measured zero, not a missing figure: the model that served this run',
+			'bills nothing per token.',
+		)
+	} else {
+		lines.push('Every token in this run was charged at a known rate.')
+	}
+
+	lines.push(
 		'',
 		'Cumulative for this run, across every turn. Not a measure of how full',
 		'the context is — that is a different quantity and it goes down when the',
 		'conversation is compacted, while this only ever grows.',
-	].join('\n')
+	)
+	return lines.join('\n')
 }
 
 /** What decides a tool call, in the order it actually decides it. */


### PR DESCRIPTION
#354 made the kernel stop reporting `$0.00` for work that cost money. `slashCommands.ts` kept reporting it anyway:

```ts
usage.costUsd > 0 ? `$${usage.costUsd.toFixed(4)}` : '$0.0000 (this provider reported no price)'
```

Ship that behind an SDK that now prices runs properly and **the operator-facing surface is still lying** — which would have made this the seventh instance of a defect class this repository has removed six times in three days, and one we would have created ourselves in the same release.

## Two things were wrong, and only one of them was the number

**It collapsed two different events into one sentence.** A run on local inference costs nothing; a run on a model with no rate cannot be priced. Both report a total of `0`, and both got the same line.

**It asserted something nothing had checked.** "this provider reported no price" is a claim about the vendor. No code asked a provider anything — what was actually known is that *namzu* has no rate for the model. That is a statement about this side of the wire, and it points at a different fix (declare the rate) than the one the sentence implies (change provider). The sentence was the bug in miniature: a fact stated with more confidence than it was held.

## The change

The usage event now carries the kernel's `CostInfo` **whole** instead of flattening it to `costUsd` at the seam. The total on its own cannot answer the question the screen asks, and narrowing it left every surface downstream to guess — both of them guessed "free".

`/cost`:

| What you see | When |
|---|---|
| `Cost:   $0.0731` | every token charged at a known rate |
| `Cost:   $0.0000` + *a measured zero, not a missing figure* | the model bills nothing per token |
| `Cost:   not known` + *this is not a claim that they were free* | some or all of the run had no rate |
| `Cost:   $0.5000 and counting — see below` | partly priced; the figure is a floor |

The status bar gets `$?` for the last two — deliberately not a number, because the one thing that must not happen on a line read at a glance is a figure standing in for a figure nobody has. It previously printed the token count alone, which is the same claim in quieter form.

**`describeCost` is deliberately not used for the figure on `/cost`, and that is a departure from the instruction worth flagging.** It renders through `formatCost`, which rounds to two decimals above a cent, and `/cost` exists to print exact figures — `SlashContext.usage` says so in a comment, and a test pins `$0.0731`. Rounding to `$0.07` to reuse a helper would trade the property someone asked for against tidier code. The distinction logic the helper encodes is what mattered and it is reproduced in one place; the status bar is where a short form belongs, and there `$?` is shorter than anything the helper produces.

## Tests

The requirement was a test that fails against the current line, not one that merely exercises the new one. Two mutations restore the old behaviour exactly:

- **M1** — restore `'$0.0000 (this provider reported no price)'` for every non-positive total → **killed**
- **M2** — treat an unpriced run as free → **killed**

Plus the assertion the old code could not have passed under any circumstance: `free.content !== unknown.content` for two runs that both total zero. Checking either in isolation passes against the single sentence that used to serve both.

## Mutation table: 10 written, 9 killed

Round two was written to find gaps rather than confirm round one, per the convention amended in #357. It found four survivors, three of them real holes in my own tests:

| | mutation | first run | now |
|---|---|---|---|
| M3 | StatusBar: drop the unknown marker | **SURVIVED** | killed |
| M4 | agent.ts: flatten the record at the seam again | **SURVIVED** | killed |
| M6 | drop the "not a claim of free" sentence | **SURVIVED** | killed |
| M7 | StatusBar: show `$0.00` where there is none | **SURVIVED** | killed |

- M3/M7: I had changed `StatusBar` with no test at all. Now rendered through the real component (`formatUsage` is not exported, and the question is what reaches the screen).
- M4: my seam test used a fixture with `unpricedTokens: 0`, so a mapping that hardcoded zero satisfied it exactly. That is the one field whose loss is silent — everything downstream keeps rendering, and renders "free".
- M6: I had asserted `toContain('not')`, and the word appears in the neighbouring sentence. Now the whole clause, matched with wrapping collapsed since the sentence is the property and the line break is not.

**One survivor, reported rather than closed: M10** — `App.tsx` keeping the first usage rather than the newest is caught by nothing. It is App-level state with no harness here and the same non-coverage existed before this change; closing it needs an App render test that does not exist yet, and the exposure is a stale figure rather than a wrong claim about a fresh one.

## Gates

build · typecheck · lint · test (897 CLI, 4 700+ total across 13 packages) · docs:check · audit-external-names · process-level · public-surface intact · test-presence · catalogue drift · installer parses — all green.

`docs/cli/tui.md` documented the old sentence verbatim; updated in the same change with the three states in a table.

## Bump

`patch`. No exported symbol changes — the `AgentEvent` usage variant and both renderers are internal, and `@namzu/cli`'s barrel does not carry them. The package exports a CLI whose behaviour is corrected, not extended.

## Base

Replaces #360, which was opened against `fix/classify-pricing-for-coverage` while main was red and could not be retargeted once that branch was deleted on merge — GitHub closes a PR whose base disappears, and a closed PR's base cannot be changed. Same head branch, same commit content, rebased onto `main` at `1797bf12`.

Rebased across #358, which also edits `App.tsx`. The hunks do not overlap and the rebase was clean, but "clean rebase" is not a verification, so the whole suite was re-run on the combination: 95 CLI test files, 4 700+ tests across 13 packages, and the mutation set re-run to confirm the two mutations that restore the old line still kill after the rebase.
