### PR TITLE
fix(sdk): a structured answer stops settling on top of tool results nobody read

### DIFF
--- a/.changeset/structured-output-shared-turn.md
+++ b/.changeset/structured-output-shared-turn.md
@@ -1,0 +1,42 @@
+---
+'@namzu/sdk': patch
+---
+
+A structured answer no longer settles a run on top of tool results nobody read
+
+`captureStructuredOutput` ended the run on any successful `structured_output`
+result, without regard for how many calls the turn carried. Its neighbour forty
+lines away, `terminalToolOutput`, refuses exactly that situation and writes the
+argument down: "a model that asked for other work meant to see those results".
+
+The consequence is worse than a discarded answer, because of the order things
+happen in. The batch executes in `runToolReview` *before* either of these is
+consulted — so a model that emitted `structured_output` alongside `write`, a
+delegation, or any other call had those calls run, side effects and all, and
+then the run broke out of the loop. The results went into the transcript and no
+model turn ever read them. Work was spent, nothing consumed it, and nothing
+said so.
+
+There is a second reason, sharper than the neighbour's. The model produced that
+answer in the same turn as a request for information it did not yet have — it
+would not have asked otherwise — so the answer was under-informed by the model's
+own account, and settling shipped it as final.
+
+`structured_output` now settles the run only when it is the only call in its
+turn. Sharing a turn relays: the results already in the transcript go back to
+the model and the next turn produces the answer with them in hand. Refusing to
+*execute* the batch was the other candidate and was rejected — the defect is not
+that the tools ran, it is that nobody read them.
+
+**What you will notice.** A run whose model pairs `structured_output` with
+another call now takes one more turn, and `run.structuredOutput` holds the
+answer formed after those results rather than before them. If your model always
+calls `structured_output` alone, nothing changes. Relays are deliberately *not*
+charged to `structuredOutput.maxRetries`: that budget bounds a model that cannot
+satisfy the schema, and this one did — a run that reads a file per turn while
+optimistically attaching its answer is making progress and must not be reported
+as `structured_output_failed`. `maxIterations` bounds it, as it already bounds
+the same pathology for terminal tools.
+
+`patch`: no exported symbol, type, or default changes. A behaviour that was
+losing requested work is corrected.

--- a/docs/sdk/tools/built-in.md
+++ b/docs/sdk/tools/built-in.md
@@ -1,7 +1,7 @@
 ---
 title: Built-In Tools
 description: Reference for the built-in tools exported by @namzu/sdk, including their purpose, safety shape, deadlines, and common usage patterns.
-last_updated: 2026-08-05
+last_updated: 2026-08-10
 status: current
 related_packages: ["@namzu/sdk", "@namzu/computer-use"]
 ---
@@ -234,6 +234,8 @@ This pattern is especially useful when you want:
 - it is ideal when a final response must match a schema
 
 Use it when you want the model to finish by calling a schema-bound tool instead of producing free-form text.
+
+A successful call ends the run **only when it is the only call in its turn.** A model that emits `structured_output` alongside other tool calls gets those calls executed and their results delivered back to it, and the run continues — the answer was formed in the same turn as a request for information the model had not yet received, so it is not yet the final one. The next turn produces the answer with those results in hand. This costs one extra turn, and a model avoids it by calling `structured_output` on its own. The same rule already governs a tool marked `terminal`.
 
 ## 7. Computer Use Tool
 

--- a/packages/sdk/src/runtime/query/__tests__/structured-output.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/structured-output.test.ts
@@ -53,6 +53,9 @@ function harness(opts: {
 	const outputTool = createStructuredOutputTool(SCHEMA)
 	const registry = new Map<string, unknown>([[STRUCTURED_OUTPUT_TOOL_NAME, outputTool]])
 
+	/** Every tool that actually reached `execute`, in order — the side effects. */
+	const executedTools: string[] = []
+
 	const tools = {
 		get: vi.fn(
 			(name: string) =>
@@ -64,6 +67,7 @@ function harness(opts: {
 				},
 		),
 		execute: vi.fn(async (name: string, input: unknown) => {
+			executedTools.push(name)
 			if (name === STRUCTURED_OUTPUT_TOOL_NAME) {
 				const parsed = SCHEMA.safeParse(input)
 				if (!parsed.success) {
@@ -166,6 +170,7 @@ function harness(opts: {
 	return {
 		orchestrator,
 		messages,
+		executedTools,
 		stopReason: () => stopReason,
 		structured: () => structured,
 		iterations: () => iteration,
@@ -259,6 +264,132 @@ describe('structured final output', () => {
 		await drain(h.orchestrator)
 
 		expect(h.structured()).toEqual({ verdict: 'fail', notes: 'second try' })
+	})
+
+	/**
+	 * `terminalToolOutput` refuses to settle when a terminal call shared its
+	 * turn, because "a model that asked for other work meant to see those
+	 * results". `captureStructuredOutput` had no such guard, and the batch
+	 * executes BEFORE either is consulted — so a shared turn ran the other
+	 * tools, side effects and all, and then ended the run before any model
+	 * turn could read what came back.
+	 */
+	describe('when it shared its turn with other calls', () => {
+		it('hands the batch to the model instead of settling on top of it', async () => {
+			const provider = new MockLLMProvider({
+				turns: [
+					{
+						toolCalls: [
+							{ name: 'inspect_build' },
+							{
+								name: STRUCTURED_OUTPUT_TOOL_NAME,
+								// Attached in the same breath as the request, so it
+								// cannot have been informed by the answer.
+								args: { verdict: 'pass', notes: 'guessed before looking' },
+							},
+						],
+					},
+					{
+						toolCalls: [
+							{
+								name: STRUCTURED_OUTPUT_TOOL_NAME,
+								args: { verdict: 'fail', notes: 'inspect_build came back' },
+							},
+						],
+					},
+				],
+			})
+			const h = harness({ provider, structuredOutput: { schema: SCHEMA } })
+
+			await drain(h.orchestrator)
+
+			// The premise, and the reason this is worse than a discarded
+			// answer: the other tool ALREADY ran. Its side effects happened.
+			expect(h.executedTools).toContain('inspect_build')
+
+			// The defect: nothing consumed them. They now ride out in the very
+			// next request to the model, which is the only thing that makes
+			// having run them worth anything.
+			const secondRequest = provider.requests[1]
+			expect(secondRequest, 'the run settled instead of taking another turn').toBeDefined()
+			const relayed = (secondRequest?.messages ?? []).filter((m) => m.role === 'tool')
+			expect(JSON.stringify(relayed)).toContain('inspect_build ok')
+
+			// And the answer the caller receives is the one formed after that
+			// result, not the one the model attached before asking for it.
+			expect(h.structured()).toEqual({ verdict: 'fail', notes: 'inspect_build came back' })
+			expect(h.stopReason()).toBe('end_turn')
+			expect(h.iterations()).toBe(2)
+		})
+
+		it('does not spend a schema retry on a turn that produced a valid answer', async () => {
+			// `maxRetries: 1` allows one re-prompt. Charging these relays to
+			// that budget would kill the run on the second one, reported as
+			// `structured_output_failed` — a schema failure that did not
+			// happen, on a model that is visibly making progress.
+			const provider = new MockLLMProvider({
+				turns: [
+					{
+						toolCalls: [
+							{ name: 'read_a' },
+							{ name: STRUCTURED_OUTPUT_TOOL_NAME, args: { verdict: 'pass', notes: 'after a' } },
+						],
+					},
+					{
+						toolCalls: [
+							{ name: 'read_b' },
+							{ name: STRUCTURED_OUTPUT_TOOL_NAME, args: { verdict: 'pass', notes: 'after b' } },
+						],
+					},
+					{
+						toolCalls: [
+							{
+								name: STRUCTURED_OUTPUT_TOOL_NAME,
+								args: { verdict: 'pass', notes: 'alone at last' },
+							},
+						],
+					},
+				],
+			})
+			const h = harness({
+				provider,
+				structuredOutput: { schema: SCHEMA, maxRetries: 1 },
+				maxIterations: 10,
+			})
+
+			await drain(h.orchestrator)
+
+			expect(h.executedTools).toEqual(expect.arrayContaining(['read_a', 'read_b']))
+			expect(h.stopReason()).toBe('end_turn')
+			expect(h.structured()).toEqual({ verdict: 'pass', notes: 'alone at last' })
+		})
+
+		it('is bounded by maxIterations when the model never stops pairing', async () => {
+			// The pathology the paragraph above accepts, pinned: a model that
+			// pairs forever ends on the iteration ceiling rather than looping,
+			// hanging, or settling on an under-informed answer. This is the
+			// same bound `terminalToolOutput` relies on for its own relay.
+			const provider = new MockLLMProvider({
+				turns: [
+					{
+						toolCalls: [
+							{ name: 'again' },
+							{
+								name: STRUCTURED_OUTPUT_TOOL_NAME,
+								args: { verdict: 'pass', notes: 'never alone' },
+							},
+						],
+					},
+				],
+			})
+			const h = harness({ provider, structuredOutput: { schema: SCHEMA }, maxIterations: 4 })
+
+			await drain(h.orchestrator)
+
+			expect(h.iterations()).toBeLessThanOrEqual(5)
+			expect(h.structured()).toBeUndefined()
+			expect(h.stopReason()).toBe('max_iterations')
+		})
 	})
 
 	it('is inert when no structured output was requested', async () => {

--- a/packages/sdk/src/runtime/query/iteration/index.ts
+++ b/packages/sdk/src/runtime/query/iteration/index.ts
@@ -872,8 +872,9 @@ export class IterationOrchestrator {
 
 					// A successful `structured_output` call IS the answer, so the
 					// run ends here rather than paying for another turn whose only
-					// job would be to restate it.
-					if (this.captureStructuredOutput(reviewOutcome.results)) {
+					// job would be to restate it — unless it shared its turn with
+					// other calls, which relays instead. See the method.
+					if (this.captureStructuredOutput(reviewOutcome.results, response)) {
 						this.ctx.log.info('Structured output produced — ending run', {
 							runId: runMgr.id,
 							iteration: iterationNum,
@@ -1368,14 +1369,6 @@ export class IterationOrchestrator {
 	}
 
 	/**
-	 * Record the structured output if this batch produced one.
-	 *
-	 * The tool validates against the Zod schema before its `execute` runs,
-	 * so reaching here successfully means the value is already valid — a
-	 * failed parse comes back as an error result and simply does not
-	 * satisfy the demand, which sends the loop round again.
-	 */
-	/**
 	 * The answer a terminal tool produced, or `undefined` to keep looping.
 	 *
 	 * Deliberately narrow. A terminal call decides the run only when it is
@@ -1415,10 +1408,67 @@ export class IterationOrchestrator {
 		return hit
 	}
 
-	private captureStructuredOutput(results: readonly ToolCallOutcome[]): boolean {
+	/**
+	 * Record the structured output if this batch produced one.
+	 *
+	 * The tool validates against the Zod schema before its `execute` runs,
+	 * so reaching here successfully means the value is already valid — a
+	 * failed parse comes back as an error result and simply does not
+	 * satisfy the demand, which sends the loop round again.
+	 *
+	 * Narrow in the same way {@link terminalToolOutput} is, for its stated
+	 * reason and one that is sharper here. The neighbour refuses a shared
+	 * turn because "a model that asked for other work meant to see those
+	 * results". That applies unchanged. But the batch has ALREADY executed
+	 * by the time this runs — `runToolReview` settles it, side effects
+	 * included, before either of these is consulted — so settling here is
+	 * worse than discarding an answer the model wanted: the work happened,
+	 * its results went into the transcript, and the run ended before any
+	 * model turn could read them. Nothing consumed what was spent, and
+	 * nothing said so.
+	 *
+	 * Sharper, too, because of WHEN this value was produced. The model
+	 * emitted its final answer in the same turn as a request for
+	 * information it had not yet received — it would not have asked
+	 * otherwise — so the answer is under-informed on the model's own
+	 * account, and settling ships it as final.
+	 *
+	 * So: relay, do not settle. The results are already in the transcript,
+	 * the demand is still unsatisfied, and the next turn produces the
+	 * answer with them in hand. Refusing to EXECUTE the batch was the other
+	 * candidate and is wrong — the defect is not that the tools ran, it is
+	 * that nobody read them, and denying a model work it asked for to
+	 * protect an answer it has not finished forming gives up a real
+	 * capability for nothing. The price is one extra turn when the paired
+	 * call was a pure side effect whose result the model did not need;
+	 * that is the price `terminalToolOutput` already pays, and a model
+	 * avoids it by not pairing.
+	 *
+	 * NOT charged to `maxRetries`. That budget bounds a model that cannot
+	 * satisfy the SCHEMA, and this one did. A run reading two files a turn
+	 * while optimistically attaching its answer is making progress, and it
+	 * must not die reported as `structured_output_failed` — a failure that
+	 * did not happen. `maxIterations` is the bound for a model that keeps
+	 * doing work, and it is the bound the neighbour relies on for the
+	 * identical pathology.
+	 */
+	private captureStructuredOutput(
+		results: readonly ToolCallOutcome[],
+		response: ChatCompletionResponse,
+	): boolean {
 		if (!this.needsStructuredOutput()) return false
 		const hit = results.find((r) => r.toolName === STRUCTURED_OUTPUT_TOOL_NAME && !r.isError)
 		if (!hit) return false
+
+		const callCount = response.message.toolCalls?.length ?? 0
+		if (callCount > 1) {
+			this.ctx.log.info('Structured output shared its turn — relaying instead of settling', {
+				runId: this.ctx.runMgr.id,
+				callsInTurn: callCount,
+			})
+			return false
+		}
+
 		try {
 			this.ctx.runMgr.setStructuredOutput(JSON.parse(hit.output))
 		} catch {


### PR DESCRIPTION
## The defect

`captureStructuredOutput` (`packages/sdk/src/runtime/query/iteration/index.ts`)
ended the run on any successful `structured_output` result, with no regard for
how many calls the turn carried. Its neighbour forty lines away,
`terminalToolOutput`, refuses exactly that situation and writes the argument
down: "a model that asked for other work meant to see those results, and
settling here would throw away answers it requested."

The order of operations makes it worse than a thrown-away answer.
`runToolReview` executes the whole batch at `:843`, before either check is
consulted at `:876` / `:899`. So on a shared turn:

1. the other tools **ran**, side effects included;
2. their results were pushed into the transcript and onto the `StepResult`;
3. the run broke out of the loop.

No model turn ever read them. Work was spent, nothing consumed it, and nothing
reported it.

## The behaviour decision, and why

Three candidates. **Relay** is what this ships.

- **Refuse the batch** (deny execution when `structured_output` is paired) —
  rejected. The defect is not that the tools ran, it is that nobody read them.
  Denying a model work it asked for, to protect an answer it has not finished
  forming, gives up a real capability for nothing, and it would need a new
  interception in the review phase rather than the guard the neighbour already
  established.
- **Run and deliver before settling** — this *is* relay, once you ask who the
  delivery is to. There is no consumer for a tool result on a run that is ending.
- **Relay: do not settle, let the loop go round.** The results are already in
  the transcript, `needsStructuredOutput()` is still true, and the next turn
  produces the answer with them in hand.

There is a reason here sharper than the neighbour's, and it is the deciding one:
the model emitted its final answer **in the same turn as a request for
information it had not yet received**. It would not have asked otherwise. So the
answer is under-informed on the model's own account, and settling shipped it as
final.

Relays are deliberately **not** charged to `structuredOutput.maxRetries`. That
budget bounds a model that cannot satisfy the *schema*, and this one did — a run
that reads a file per turn while optimistically attaching its answer is making
progress, and must not die reported as `structured_output_failed`, a failure
that did not happen. `maxIterations` is the bound for a model that keeps doing
work, and it is the bound `terminalToolOutput` already relies on for the
identical pathology.

The price is one extra turn when the paired call was a pure side effect whose
result the model did not need. That is the price `terminalToolOutput` already
pays, and a model avoids it by calling `structured_output` alone.

## Tests

Three, in `packages/sdk/src/runtime/query/__tests__/structured-output.test.ts`.
The first drives a turn where the model calls `structured_output` **together
with** another tool and asserts what happens to the other tool:

- it **executed** (the premise: the side effect already fired);
- its result **appears in the next request to the model** (asserted against
  `MockLLMProvider.requests[1]`, not merely "the loop continued");
- the delivered answer is the one formed **after** that result, not the one
  attached before asking for it.

The other two pin the retry-budget decision and the `maxIterations` bound.

### Mutation profile

| # | mutation | outcome | killed by |
| --- | --- | --- | --- |
| M1 | guard disabled — the pre-fix state | killed | all 3 new; 5 preservation tests pass |
| M2 | boundary off-by-one (`callCount > 2`) | killed | all 3 new |
| M3 | record the stale value, then relay | killed | the `maxIterations` test **only** |
| M4 | relay but mark the demand satisfied | killed | 2 of 3 |
| M5a | charge relay to `maxRetries`, set the reason, do not halt | **survived** | unfaithful mutant: it leaves a stop reason the loop overwrites, a state no honest implementation reaches |
| M5b | charge relay to `maxRetries` and halt (faithful) | killed | 2 of 3 |

M3 is why the `maxIterations` test earns its place: it is the only assertion that
catches a stale answer being written to the run.

## Gates

build, typecheck, lint, `pnpm test` (exit 0; sdk 356 files, cli 95, no unhandled
rejections), `docs:check` (0 problems), `audit-external-names.mjs`,
`verify-public-surface.mjs` (560 / 1284 unchanged), `check-sdk-test-presence.mjs`.
No new folder under `packages/sdk/src`, so `coverage-config.json` is untouched.

`patch`: no exported symbol, type, or default changes.
