### PR TITLE
feat(sdk): a supervisor can be held to a schema, like the archetype beside it

### DIFF
--- a/.changeset/supervisor-structured-output.md
+++ b/.changeset/supervisor-structured-output.md
@@ -1,0 +1,41 @@
+---
+'@namzu/sdk': minor
+---
+
+A supervisor can be held to a schema, like the archetype beside it
+
+`ReactiveAgent` has forwarded `structuredOutput` since the field existed.
+`SupervisorAgentConfig` never declared it, and nothing in that file said why —
+in a file where `maxDepth`, `allowDelegation`, `maxToolConcurrency` and
+`siblingFailurePolicy` each carry a paragraph of argument for what they do and
+do not cover. The kernel path is archetype-blind: `drainQuery` registers
+`structured_output` from this config and the iteration loop captures it, so the
+capability was always reachable through the raw kernel entry point and only the
+hop from the surface hosts construct was missing.
+
+Two hops were missing, in fact. `SupervisorAgent`'s result literal also did not
+copy `run.structuredOutput`, while `ReactiveAgent`'s does —
+`BaseAgentResult.structuredOutput` names "an archetype's result literal did not
+copy it" as one of the defects it was written to close, and that defect was
+still live in the sibling nobody checked. Wiring only the config would have
+produced a settable field whose answer the host could not read.
+
+**What this buys, stated plainly, because it is less than it sounds like.**
+Structured output is terminal and exclusive by policy: `setStructuredOutput`
+overwrites the run's result behind a sticky flag and the run ends on the turn
+that produces the value. So this gives a supervisor a schema-constrained **final
+answer** and nothing more. It does not shape a delegated child's answer — a
+child carries its own config, so a host wanting typed worker results sets the
+schema on the workers. It is not a return type for the fan-out, and it does not
+arrive alongside prose.
+
+One consequence a supervisor host in particular should know: because the answer
+decides the run, delegated work still running when it lands is walked away from
+rather than waited for. It is recorded — the run names it on `abandonedTaskIds`
+— but no further turn delivers it. A supervisor that must read every child
+before answering should wait for them and call `structured_output` after.
+
+`minor`: additive. `SupervisorAgentConfig.structuredOutput` is optional and
+`SupervisorAgentResult.structuredOutput` was already declared on
+`BaseAgentResult`, so nothing narrows, nothing is renamed, and a supervisor
+configured without a schema runs the path it ran before.

--- a/docs/sdk/agents/README.md
+++ b/docs/sdk/agents/README.md
@@ -1,7 +1,7 @@
 ---
 title: Agents and Orchestration
 description: Choose the right SDK agent class, understand delegation boundaries, and wire orchestration surfaces safely in @namzu/sdk.
-last_updated: 2026-08-06
+last_updated: 2026-08-10
 status: current
 related_packages: ["@namzu/sdk"]
 ---
@@ -287,6 +287,29 @@ and must still delegate to nobody — and comparing the roster against the
 executing agent fails in exactly that arrangement, because the ids differ. A
 supervisor whose roster holds one specialist and a run that *is* that specialist
 are indistinguishable in the roster alone.
+
+### Holding a supervisor to a schema
+
+`SupervisorAgentConfig.structuredOutput` takes the same
+`{ schema, maxRetries? }` as `ReactiveAgentConfig.structuredOutput`. The
+supervisor registers `structured_output` from it, the run is held to it, and the
+validated value arrives on `SupervisorAgentResult.structuredOutput` — the value
+is also serialized into `result`, so a text-shaped consumer needs no second
+serialization.
+
+Read what it covers narrowly. Structured output is **terminal and exclusive**:
+the run ends on the turn that produces the value, and the value overwrites the
+run's result. So this constrains the supervisor's **own final answer** and
+nothing else. It does not shape a delegated child's answer — a child carries its
+own config, so a host wanting typed worker results sets the schema on the
+workers — and it is not a return type for the fan-out.
+
+One consequence specific to a supervisor: because the answer decides the run,
+delegated work still running when it lands is walked away from rather than
+waited for. It is not lost from the record — the run names it on
+`abandonedTaskIds` — but no further turn delivers it. If a supervisor must see
+every child's result before answering, have it wait for the children first and
+call `structured_output` after.
 
 Two properties worth knowing:
 

--- a/packages/sdk/src/agents/SupervisorAgent.ts
+++ b/packages/sdk/src/agents/SupervisorAgent.ts
@@ -342,6 +342,11 @@ export class SupervisorAgent extends AbstractAgent<SupervisorAgentConfig, Superv
 					// corrected for twice.
 					...(config.steering ? { steering: config.steering } : {}),
 					...(config.verificationGate ? { verificationGate: config.verificationGate } : {}),
+					// The one hop between the config and the tool. `drainQuery`
+					// registers `structured_output` from this and the loop
+					// captures it, so the kernel never cared which archetype it
+					// came from — only `ReactiveAgent` was passing it.
+					...(config.structuredOutput ? { structuredOutput: config.structuredOutput } : {}),
 					...(config.sandboxProvider ? { sandboxProvider: config.sandboxProvider } : {}),
 					// Working-memory / compaction seam (optional; absent => unchanged
 					// run path, byte-identical for every existing consumer).
@@ -368,6 +373,13 @@ export class SupervisorAgent extends AbstractAgent<SupervisorAgentConfig, Superv
 				durationMs: Date.now() - startTime,
 				messages: run.messages,
 				result: run.result,
+				// `BaseAgentResult.structuredOutput` names "an archetype's result
+				// literal did not copy it" as a defect it was written to close.
+				// This literal still did not copy it, so the same defect was live
+				// in the one archetype nobody checked: the value would have been
+				// produced, recorded on the run, serialized into `result`, and
+				// absent from the type a supervisor host actually reads.
+				structuredOutput: run.structuredOutput,
 				lastError: run.lastError,
 				taskResults,
 				completedTasks,

--- a/packages/sdk/src/agents/__tests__/a-supervisor-can-be-held-to-a-schema.test.ts
+++ b/packages/sdk/src/agents/__tests__/a-supervisor-can-be-held-to-a-schema.test.ts
@@ -1,0 +1,154 @@
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { MockLLMProvider, registerMock } from '../../provider/index.js'
+import { ToolRegistry } from '../../registry/index.js'
+import { STRUCTURED_OUTPUT_TOOL_NAME } from '../../tools/builtins/structuredOutput.js'
+import type { SupervisorAgentResult } from '../../types/agent/index.js'
+import type { AgentManagerContract } from '../../types/agent/manager.js'
+import type { AgentTask, AgentTaskState } from '../../types/agent/task.js'
+import type { TaskId } from '../../types/ids/index.js'
+import { SupervisorAgent } from '../SupervisorAgent.js'
+
+/**
+ * Two archetypes sit on one base and only one could be held to a schema.
+ *
+ * `ReactiveAgent` has forwarded `structuredOutput` since the field existed;
+ * `SupervisorAgentConfig` never declared it, and nothing in that file said
+ * why — in a file where every other narrowing carries a paragraph of
+ * argument. The kernel path is archetype-blind, so the capability was there
+ * the whole time and only the hop was missing.
+ *
+ * There are TWO hops, and this drives both. The config has to reach
+ * `drainQuery` (or `structured_output` is never registered and the model's
+ * call comes back an error), and `run.structuredOutput` has to reach the
+ * result literal (or the value is produced, recorded, and invisible to the
+ * host). `BaseAgentResult.structuredOutput` names the second as a defect it
+ * was written to close, and it was still open here.
+ */
+
+registerMock()
+
+const VERDICT = z.object({
+	verdict: z.enum(['ship', 'hold']),
+	reason: z.string(),
+})
+
+const ANSWER = { verdict: 'hold' as const, reason: 'the fan-out disagreed with itself' }
+
+/** No children are launched here; the supervisor answers on its own. */
+class IdleManager implements AgentManagerContract {
+	async sendMessage(): Promise<AgentTask> {
+		throw new Error('this supervisor delegates to nobody')
+	}
+	cancel(): void {}
+	async waitForCompletion(): Promise<void> {}
+	getInstance(_taskId: TaskId): AgentTask | undefined {
+		return undefined
+	}
+	cancelAll(): void {}
+	async continueTask(): Promise<void> {}
+	queueMessage(): void {}
+	drainMessages() {
+		return []
+	}
+	listByParent(): AgentTask[] {
+		return []
+	}
+	listActive(): AgentTask[] {
+		return []
+	}
+	getState(): AgentTaskState | undefined {
+		return undefined
+	}
+	on(): void {}
+	off(): void {}
+	cleanup(): void {}
+	dispose(): void {}
+}
+
+async function supervise(opts: {
+	provider: MockLLMProvider
+	withSchema: boolean
+}): Promise<SupervisorAgentResult> {
+	const agent = new SupervisorAgent({
+		id: 'sup_schema',
+		name: 'Supervisor',
+		version: '1',
+		category: 'test',
+		description: 'coordinates workers',
+	})
+
+	return (await agent.run(
+		{
+			messages: [{ role: 'user', content: 'decide', timestamp: 1 }],
+			workingDirectory: await mkdtemp(join(tmpdir(), 'namzu-sup-schema-')),
+		} as never,
+		{
+			provider: opts.provider,
+			agentIds: ['worker'],
+			agentManager: new IdleManager(),
+			tools: new ToolRegistry(),
+			systemPrompt: 'You coordinate.',
+			model: 'mock-model',
+			tokenBudget: 100_000,
+			timeoutMs: 30_000,
+			maxIterations: 4,
+			sessionId: 'ses_schema',
+			threadId: 'thd_schema',
+			projectId: 'prj_schema',
+			tenantId: 'tnt_schema',
+			...(opts.withSchema ? { structuredOutput: { schema: VERDICT } } : {}),
+		} as never,
+	)) as SupervisorAgentResult
+}
+
+describe('a supervisor can be held to a schema', () => {
+	it('registers the tool from its own config and hands the value to its caller', async () => {
+		const provider = new MockLLMProvider({
+			turns: [{ toolCalls: [{ name: STRUCTURED_OUTPUT_TOOL_NAME, args: ANSWER }] }],
+		})
+
+		const result = await supervise({ provider, withSchema: true })
+
+		// The forwarding hop: without it `drainQuery` never registers
+		// `structured_output`, the call comes back an error, and nothing is
+		// captured. `result` carries the serialization the kernel performs
+		// when it records the value, so this fails first and names which hop
+		// broke.
+		expect(result.result).toBe(JSON.stringify(ANSWER))
+
+		// The result-literal hop: the value exists on the run either way, and
+		// this is the surface a supervisor host actually reads.
+		expect(result.structuredOutput).toEqual(ANSWER)
+	}, 60_000)
+
+	it('holds the supervisor to it — prose is sent back, not accepted', async () => {
+		// The demand has to be in force inside the kernel, not merely
+		// round-tripped. A model that answers in prose gets the re-prompt, and
+		// the answer that counts is the schema-bound one that follows.
+		const provider = new MockLLMProvider({
+			turns: [
+				{ text: 'I think we should hold.' },
+				{ toolCalls: [{ name: STRUCTURED_OUTPUT_TOOL_NAME, args: ANSWER }] },
+			],
+		})
+
+		const result = await supervise({ provider, withSchema: true })
+
+		expect(result.structuredOutput).toEqual(ANSWER)
+		expect(result.result).not.toContain('I think we should hold')
+	}, 60_000)
+
+	it('changes nothing for a supervisor that was not given a schema', async () => {
+		const provider = new MockLLMProvider({ turns: [{ text: 'plain coordination answer' }] })
+
+		const result = await supervise({ provider, withSchema: false })
+
+		expect(result.structuredOutput).toBeUndefined()
+		expect(result.result).toContain('plain coordination answer')
+	}, 60_000)
+})

--- a/packages/sdk/src/types/agent/supervisor.ts
+++ b/packages/sdk/src/types/agent/supervisor.ts
@@ -6,6 +6,7 @@ import type { LLMProvider } from '../provider/index.js'
 import type { TaskRouterConfig } from '../router/index.js'
 import type { SandboxProvider } from '../sandbox/index.js'
 import type { Skill } from '../skills/index.js'
+import type { StructuredOutputConfig } from '../structured-output/index.js'
 import type { ToolRegistryContract } from '../tool/index.js'
 import type { VerificationGateConfig } from '../verification/index.js'
 import type { BaseAgentConfig, BaseAgentResult } from './base.js'
@@ -171,6 +172,35 @@ export interface SupervisorAgentConfig extends BaseAgentConfig {
 	 * silently truncating.
 	 */
 	compactionConfig?: CompactionConfig
+
+	/**
+	 * Demand that the supervisor's own final answer match a schema.
+	 *
+	 * `ReactiveAgent` has forwarded this since the field existed and the
+	 * supervisor never took it, with nothing in this file saying why —
+	 * which in a file where `maxDepth`, `allowDelegation`,
+	 * `maxToolConcurrency` and `siblingFailurePolicy` each carry a
+	 * paragraph of argument is the signature of an oversight, not of a
+	 * decision. The kernel path is archetype-blind: `drainQuery` registers
+	 * `structured_output` from this config and the loop captures it, so the
+	 * capability was always there and only the hop was missing.
+	 *
+	 * **What it buys, exactly.** Structured output is terminal and
+	 * exclusive by policy: `setStructuredOutput` overwrites `Run.result`
+	 * behind a sticky flag and the run ends on the turn that produces it.
+	 * So this gives a supervisor a schema-constrained FINAL ANSWER and
+	 * nothing more. It does not shape a delegated child's answer — a child
+	 * carries its own config — it does not run alongside prose, and it is
+	 * not a return type for the fan-out. A host wanting typed results from
+	 * the workers sets the schema on the workers.
+	 *
+	 * One consequence a supervisor host in particular should know: the
+	 * answer decides the run, so delegated work still running when it lands
+	 * is walked away from rather than waited for. It is recorded — the run
+	 * names it on `abandonedTaskIds` — but it is not delivered. That is the
+	 * same precedence a terminal tool has, stated in the iteration loop.
+	 */
+	structuredOutput?: StructuredOutputConfig
 
 	/**
 	 * Optional neutral working-memory seam. When set, the SDK re-renders the


### PR DESCRIPTION
## The omission, and the check the brief asked for

`SupervisorAgentConfig` has no `structuredOutput`, while `ReactiveAgent`
forwards it. The brief asked me to look for a reason the supervisor genuinely
should not take a schema before closing it, because that would be the more
valuable finding.

There is none, and `packages/sdk/src/types/agent/supervisor.ts` is the strongest
possible evidence for that. Every other narrowing in that file carries a
paragraph of argument — `maxDepth` ("not consulted; the limit lives on
`AgentManagerConfig`"), `allowDelegation` ("it cannot be derived"),
`maxToolConcurrency`, `siblingFailurePolicy`. An unexplained absence in a file
that explains everything else is an oversight.

The kernel path is archetype-blind: `drainQuery` registers `structured_output`
from `params.structuredOutput` (`runtime/query/index.ts:803`) and the iteration
loop captures it. So the capability was reachable through the raw kernel entry
point the whole time, and only the hop from the surface hosts construct was
missing.

## A second gap, found while verifying the first

`SupervisorAgent`'s result literal did not copy `run.structuredOutput` either,
while `ReactiveAgent`'s does (`ReactiveAgent.ts:160`).
`BaseAgentResult.structuredOutput`'s own docstring names *"an archetype's result
literal did not copy it"* as one of the defects it was written to close — and
that defect was still live in the archetype nobody checked. Wiring the config
alone would have produced a settable field whose answer the host cannot read:
the value would be validated, recorded on the run, serialized into `result`, and
absent from the type a supervisor host actually holds.

So this PR is two hops, not one.

## What it buys, stated plainly

Structured output is **terminal and exclusive by policy**: `setStructuredOutput`
overwrites the run's result behind a sticky flag and the run ends on the turn
that produces the value. So this gives a supervisor a schema-constrained **final
answer** and nothing more.

- It does **not** shape a delegated child's answer — a child carries its own
  config, so a host wanting typed worker results sets the schema on the workers.
- It is **not** a return type for the fan-out.
- Because the answer decides the run, delegated work still running when it lands
  is walked away from rather than waited for. It is recorded — the run names it
  on `abandonedTaskIds` — but no further turn delivers it. That precedence is
  stated in the iteration loop and is not changed here.

All of that is written into the config docstring, the changeset, and
`docs/sdk/agents/README.md`, rather than left for a reader to infer.

## Tests

`packages/sdk/src/agents/__tests__/a-supervisor-can-be-held-to-a-schema.test.ts`
drives a real `SupervisorAgent.run()`, so it exercises both hops end to end
rather than asserting a field exists.

| # | mutation | outcome | killed by |
| --- | --- | --- | --- |
| M1 | forwarding hop to `drainQuery` disabled | killed | tests 1 and 2 — the failure names `result` undefined, i.e. the *registration* hop |
| M2 | `structuredOutput` dropped from the result literal | killed | tests 1 and 2 — the failure names only `structuredOutput`, i.e. the *surfacing* hop |
| M3 | config field removed | compile error; `typecheck` is the gate |

The two assertions in test 1 are deliberately split so the failure says which
hop broke, and the mutation run confirms they do.

**Disclosed:** test 2 ("prose is sent back") kills nothing test 1 does not, under
every mutation aimable at this diff. It is kept because it is the only test that
drives the structured-output re-prompt branch through the supervisor archetype
at all — reported rather than claimed as discriminating.

## Gates

build, typecheck, lint, `pnpm test` (exit 0; sdk 356 → 357 files, cli 95, no
unhandled rejections), `docs:check` (0 problems), `audit-external-names.mjs`,
`verify-public-surface.mjs` (560 / 1284 unchanged — an optional interface member
does not move either count), `check-sdk-test-presence.mjs`. No new folder under
`packages/sdk/src`, so `coverage-config.json` is untouched.

`minor`: additive. The config field is optional and
`SupervisorAgentResult.structuredOutput` was already declared on
`BaseAgentResult`; nothing narrows, nothing is renamed, and a supervisor
configured without a schema runs the path it ran before.

Independent of #364 — different files, no conflict — though the two meet in
practice: a supervisor is the archetype most likely to emit several tool calls
in a turn, so #364 is what stops a schema-configured supervisor from settling on
top of a fan-out it just launched.
