### PR TITLE
fix(sdk): a structured answer does not settle a turn that also asked something

### DIFF
--- a/.changeset/structured-output-shares-a-turn.md
+++ b/.changeset/structured-output-shares-a-turn.md
@@ -1,0 +1,28 @@
+---
+'@namzu/sdk': patch
+---
+
+A structured answer is no longer accepted while the model is still waiting on
+its own question.
+
+When the model called `structured_output` **and another tool in the same turn**,
+the run settled immediately: the other tools had already executed, their results
+went to no reader, and the answer recorded as final was the one the model
+composed *before* it saw them. Side effects fired into a void, and the run was
+graded on an answer formed while a question was outstanding.
+
+A shared turn now relays instead — the results go back and the model answers
+again with them in hand. This is the guard `terminalToolOutput` has always
+applied to the identical situation two methods away; the two settle rules simply
+disagreed.
+
+**What changes for a caller.** A run that produced a shared turn used to end
+there and now spends one more turn, so it costs slightly more and returns the
+later answer rather than the earlier one. That later answer is the point: the
+earlier one was formed without information the model itself asked for. Runs
+whose model calls `structured_output` on its own — essentially all of them —
+are byte-identical, including the immediate settle.
+
+Still bounded by `maxIterations`, like every other non-settling turn. The prose
+retry limit deliberately does not apply: a turn that shares is not a turn that
+refused to answer.

--- a/packages/sdk/src/runtime/query/__tests__/structured-output.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/structured-output.test.ts
@@ -261,6 +261,71 @@ describe('structured final output', () => {
 		expect(h.structured()).toEqual({ verdict: 'fail', notes: 'second try' })
 	})
 
+	/**
+	 * The answer is not final while the model is still waiting to hear back.
+	 *
+	 * A terminal tool that shares its turn relays instead of settling
+	 * (`terminalToolOutput`), on the reasoning that the model asked for the
+	 * other work and should see it. The output tool had no such guard, so a
+	 * turn holding the answer AND a question ended the run: the other tools
+	 * ran, their results went nowhere, and the accepted answer was the one
+	 * the model composed BEFORE reading them.
+	 */
+	it('does not settle when the output call shares its turn with other work', async () => {
+		const provider = new MockLLMProvider({
+			turns: [
+				{
+					toolCalls: [
+						{ name: STRUCTURED_OUTPUT_TOOL_NAME, args: { verdict: 'pass', notes: 'guessed' } },
+						{ name: 'read' },
+					],
+				},
+				{
+					toolCalls: [
+						{
+							name: STRUCTURED_OUTPUT_TOOL_NAME,
+							args: { verdict: 'fail', notes: 'after reading' },
+						},
+					],
+				},
+			],
+		})
+		const h = harness({ provider, structuredOutput: { schema: SCHEMA } })
+
+		await drain(h.orchestrator)
+
+		// The answer formed AFTER the read, not the one composed beside it.
+		expect(h.structured()).toEqual({ verdict: 'fail', notes: 'after reading' })
+		expect(h.stopReason()).toBe('end_turn')
+		// A second model turn was actually paid for — which is what "the model
+		// saw the result" means. Asserting only that `read ok` is in the
+		// transcript proves nothing: the batch runs before the capture, so the
+		// result is in the message log either way. That assertion passes on the
+		// unfixed code, and a check that cannot fail is worse than none.
+		expect(h.iterations()).toBe(2)
+		expect(h.messages.some((m) => JSON.stringify(m.content).includes('read ok'))).toBe(true)
+	})
+
+	it('still settles a lone output call that arrives with nothing else', async () => {
+		// The guard must not cost the ordinary case a turn.
+		const provider = new MockLLMProvider({
+			turns: [
+				{
+					toolCalls: [
+						{ name: STRUCTURED_OUTPUT_TOOL_NAME, args: { verdict: 'pass', notes: 'alone' } },
+					],
+				},
+				{ text: 'should never be reached' },
+			],
+		})
+		const h = harness({ provider, structuredOutput: { schema: SCHEMA } })
+
+		await drain(h.orchestrator)
+
+		expect(h.structured()).toEqual({ verdict: 'pass', notes: 'alone' })
+		expect(h.iterations()).toBe(1)
+	})
+
 	it('is inert when no structured output was requested', async () => {
 		const provider = new MockLLMProvider({ turns: [{ text: 'plain answer' }] })
 		const h = harness({ provider })

--- a/packages/sdk/src/runtime/query/iteration/index.ts
+++ b/packages/sdk/src/runtime/query/iteration/index.ts
@@ -873,7 +873,7 @@ export class IterationOrchestrator {
 					// A successful `structured_output` call IS the answer, so the
 					// run ends here rather than paying for another turn whose only
 					// job would be to restate it.
-					if (this.captureStructuredOutput(reviewOutcome.results)) {
+					if (this.captureStructuredOutput(reviewOutcome.results, response)) {
 						this.ctx.log.info('Structured output produced — ending run', {
 							runId: runMgr.id,
 							iteration: iterationNum,
@@ -1415,10 +1415,48 @@ export class IterationOrchestrator {
 		return hit
 	}
 
-	private captureStructuredOutput(results: readonly ToolCallOutcome[]): boolean {
+	/**
+	 * Take the model's answer, unless it asked something in the same breath.
+	 *
+	 * The shared-turn guard is the same one `terminalToolOutput` applies two
+	 * methods up, and it was missing here — which made the two settle rules
+	 * disagree about the identical situation. A turn holding the answer AND
+	 * another call ended the run: the other tools had already executed, their
+	 * results went to no reader, and the accepted answer was the one the model
+	 * composed BEFORE it saw them.
+	 *
+	 * That is the part worth being precise about. The cost is not the wasted
+	 * call — it is that an answer formed while a question was outstanding was
+	 * recorded as final. The model asked for that information; it does not get
+	 * to be judged as having had it.
+	 *
+	 * So a shared turn relays instead: the results go back, and the model
+	 * answers again with them in hand. It costs one turn in a case that should
+	 * be rare, and only in that case — a lone call still settles immediately,
+	 * which is the path essentially every run takes.
+	 *
+	 * Bounded like every other non-settling turn, by `maxIterations`. The prose
+	 * retry limit does not apply, because this turn DID call the tool; a model
+	 * that shares every turn is not refusing to answer, it is refusing to stop
+	 * working, and that is what the iteration cap is for.
+	 */
+	private captureStructuredOutput(
+		results: readonly ToolCallOutcome[],
+		response: ChatCompletionResponse,
+	): boolean {
 		if (!this.needsStructuredOutput()) return false
 		const hit = results.find((r) => r.toolName === STRUCTURED_OUTPUT_TOOL_NAME && !r.isError)
 		if (!hit) return false
+
+		const structuredCallsInTurn = response.message.toolCalls?.length ?? 0
+		if (structuredCallsInTurn > 1) {
+			this.ctx.log.info('Structured output shared its turn — relaying instead of settling', {
+				runId: this.ctx.runMgr.id,
+				callsInTurn: structuredCallsInTurn,
+			})
+			return false
+		}
+
 		try {
 			this.ctx.runMgr.setStructuredOutput(JSON.parse(hit.output))
 		} catch {


### PR DESCRIPTION
Found while researching the owner's question about whether an agent can return prose and structure together. Independent of that design question — this is a plain defect.

## The bug

When the model calls `structured_output` **and another tool in the same turn**, the run settles there. The other tools have already executed, so:

- their results reach **no reader** — the run ends before another model call
- the answer recorded as final is the one the model composed **before** it saw them

The wasted call is the smaller half. The real defect is that **an answer formed while a question was outstanding was accepted as final.** The model asked for that information; it doesn't get to be graded as having had it.

## It's an inconsistency, not a novel rule

`terminalToolOutput` — **two methods up in the same file** — already guards exactly this:

```ts
if (callCount > 1) {
    this.ctx.log.info('Terminal tool shared its turn — relaying instead of settling', …)
    return undefined
}
```

`captureStructuredOutput` had no such check. Two settle rules, identical situation, opposite behaviour, and only one of them had been thought through. This adds the missing half.

**A lone output call still settles immediately** — the path essentially every run takes is byte-identical, including the immediate settle. Only a shared turn relays.

Bounded by `maxIterations` like every other non-settling turn. The prose retry limit deliberately does *not* apply: a turn that shares is not a turn that refused to answer, and spending the retry budget on a model that is working rather than stalling would be the wrong reading.

## Mutation table — 6 applied, 6 killed

| # | Claim | Verdict |
|---|---|---|
| G1 | the guard exists at all | killed |
| G2 | the boundary is "more than one", not "more than two" | killed |
| G3 | a relayed turn reports NOT-captured, so the loop continues | killed |
| G4 | a lone call still settles — the guard doesn't fire on one | killed |
| G5 | the count comes from the turn, not an assumption | killed |
| G6 | the call site passes the live response | killed |

## Three near misses worth recording

These are the reason I'd rather write this section than claim a clean run.

**1. The first mutation harness was aiming at the wrong function.** Its anchors (`if (callCount > 1) {`, `const callCount = …`) also match `terminalToolOutput` *earlier in the same file*. `String.replace` takes the first match, so three mutations ran against the sibling and reported **SURVIVED** — for a function this spec doesn't cover. An ambiguous anchor doesn't fail loudly; it silently aims elsewhere.

Fixed both ways: the variable is now named for what it counts (`structuredCallsInTurn`), and the harness **refuses to run** an anchor matching more than once. That refusal immediately caught a second bad anchor I'd written.

**2. One of my new tests could not fail.** It asserted the other tool's result appears in the transcript — true either way, because the batch executes *before* the capture, so the result is in the message log whether or not the run then ends. It passed on the unfixed code. Replaced with the claim that actually means "the model saw it": a second model turn was paid for.

**3. A mid-work `git checkout` on the file reverted the fix**, and the grep that appeared to confirm it was still present was matching the sibling guard's identical line. Confirm by the distinctive line, not the shared one.

## Gates

`pnpm build` · `pnpm typecheck` · `pnpm lint` (0 errors) · `pnpm test` (**3219 sdk**, 916 cli) · `docs:check` · external-name audit · `verify-public-surface` (intact) · SDK test-presence — all pass.

## Changeset

`@namzu/sdk` **patch** — a defect fix, no API change. The changeset names the one visible consequence: a run that produced a shared turn now spends one more turn and returns the later answer rather than the earlier one.

## Not in scope

Two related gaps I found and deliberately left alone, both flagged to the owner and coordinator: `SupervisorAgentConfig` has no `structuredOutput` field while `ReactiveAgent` does, and `responseFormat` is declared and forwarded by four drivers with zero producers. Neither is mine to decide.
