### PR TITLE
fix(sdk): the compaction window table said 200k for models that are 1M

### DIFF
--- a/.changeset/wide-windows-resolve-wide.md
+++ b/.changeset/wide-windows-resolve-wide.md
@@ -1,0 +1,19 @@
+---
+'@namzu/sdk': major
+---
+
+Compaction's model table reported 200k for every Claude model, including the ones whose context window is 1M.
+
+`resolveContextWindow` (and `lookupContextWindow` under it) now answers 1,000,000 for `claude-fable-5`, `claude-mythos-*`, `claude-opus-5`, `claude-sonnet-5`, `claude-opus-4-6`, `claude-opus-4-7`, `claude-opus-4-8` and `claude-sonnet-4-6`. It still answers 200,000 for the 4.5 generation (`claude-opus-4-5`, `claude-sonnet-4-5`, `claude-haiku-4-5`), for the 3.x models, and for any unlisted `claude-` id.
+
+**What changes for you.** The compaction trigger measures fullness against this window and fires at 0.7 of it. On a 1M model that threshold moves from ~140k to ~700k, so a long run now compacts once where it used to compact several times — and stops discarding its prompt-cache prefix to do it. This is the intended correction: at 200k the trigger was firing at about 14% of the real window.
+
+**If you were relying on the old number,** pass the window explicitly — `contextWindowTokens` on the run config takes precedence over the table and always has:
+
+```ts
+{ contextWindowTokens: 200_000 }
+```
+
+Do that if your endpoint caps the window below the model's published maximum (an older gateway, a proxy, or a tenant limit). Without it, a run against such an endpoint will now build a larger context than the endpoint accepts and fail with `context_length_exceeded` rather than compacting — which is the case this bump is `major` for.
+
+The values are read off the published model comparison. The durable fix is for a driver to ask the provider for the window per model id instead of consulting a table that drifts every release; this change does not do that.

--- a/packages/sdk/src/compaction/__tests__/context-window.test.ts
+++ b/packages/sdk/src/compaction/__tests__/context-window.test.ts
@@ -15,13 +15,36 @@ import {
 
 describe('lookupContextWindow', () => {
 	it('resolves dated model ids through their family prefix', () => {
-		expect(lookupContextWindow('claude-opus-5-20260514')).toBe(200_000)
-		expect(lookupContextWindow('claude-sonnet-5')).toBe(200_000)
+		expect(lookupContextWindow('claude-opus-5-20260514')).toBe(1_000_000)
+		expect(lookupContextWindow('claude-sonnet-5')).toBe(1_000_000)
 	})
 
 	it('resolves namespaced ids from Bedrock and OpenRouter', () => {
-		expect(lookupContextWindow('us.anthropic.claude-sonnet-5-v1:0')).toBe(200_000)
-		expect(lookupContextWindow('anthropic/claude-opus-5')).toBe(200_000)
+		expect(lookupContextWindow('us.anthropic.claude-sonnet-5-v1:0')).toBe(1_000_000)
+		expect(lookupContextWindow('anthropic/claude-opus-5')).toBe(1_000_000)
+	})
+
+	// The window is not a property of the family. Within one family and one
+	// major version, 4.5 is 200k and 4.6+ is 1M, so a key covering the whole
+	// family gets one of the two wrong. The table shipped with exactly that
+	// bug: a bare `claude-opus-4` key answered 200k for every 4.x, which
+	// made a 1M run compact at ~14% full.
+	it('separates the 1M models from the 200k ones inside the same family', () => {
+		expect(lookupContextWindow('claude-opus-4-8')).toBe(1_000_000)
+		expect(lookupContextWindow('claude-opus-4-7')).toBe(1_000_000)
+		expect(lookupContextWindow('claude-opus-4-6')).toBe(1_000_000)
+		expect(lookupContextWindow('claude-sonnet-4-6')).toBe(1_000_000)
+
+		expect(lookupContextWindow('claude-opus-4-5-20251101')).toBe(200_000)
+		expect(lookupContextWindow('claude-sonnet-4-5-20250929')).toBe(200_000)
+		expect(lookupContextWindow('claude-haiku-4-5-20251001')).toBe(200_000)
+	})
+
+	it('keeps an unlisted Claude id on the conservative 200k floor', () => {
+		// Over-stating kills a run with `context_length_exceeded` and nothing
+		// recoverable; under-stating costs one summarization pass. An id this
+		// table has never seen takes the survivable error.
+		expect(lookupContextWindow('claude-something-unreleased')).toBe(200_000)
 	})
 
 	it('is case-insensitive', () => {
@@ -52,7 +75,7 @@ describe('resolveContextWindow', () => {
 
 	it('falls back to the model table', () => {
 		expect(resolveContextWindow(undefined, 'claude-opus-5')).toEqual({
-			tokens: 200_000,
+			tokens: 1_000_000,
 			source: 'model-table',
 		})
 	})

--- a/packages/sdk/src/compaction/__tests__/context-window.test.ts
+++ b/packages/sdk/src/compaction/__tests__/context-window.test.ts
@@ -27,8 +27,8 @@ describe('lookupContextWindow', () => {
 	// The window is not a property of the family. Within one family and one
 	// major version, 4.5 is 200k and 4.6+ is 1M, so a key covering the whole
 	// family gets one of the two wrong. The table shipped with exactly that
-	// bug: a bare `claude-opus-4` key answered 200k for every 4.x, which
-	// made a 1M run compact at ~14% full.
+	// bug: a family-level key answered 200k for every 4.x, which made a
+	// 1M run compact at ~14% full. The ids below are the assertion.
 	it('separates the 1M models from the 200k ones inside the same family', () => {
 		expect(lookupContextWindow('claude-opus-4-8')).toBe(1_000_000)
 		expect(lookupContextWindow('claude-opus-4-7')).toBe(1_000_000)

--- a/packages/sdk/src/compaction/context-window.ts
+++ b/packages/sdk/src/compaction/context-window.ts
@@ -13,6 +13,21 @@
  *
  * The table is a floor, not an oracle: a host that knows better passes
  * `contextWindowTokens` explicitly and this file is never consulted.
+ *
+ * "Floor" governs the model we do NOT recognise — that is what
+ * `DEFAULT_ASSUMED_CONTEXT_WINDOW` is for. It does not license a wrong
+ * number for a model the table names. Every entry below carried 200k for
+ * the whole Claude family, including the models whose window is 1M, and
+ * understating a window by 5x is not caution: the trigger fires at 0.7 x
+ * the divisor, so a 1M-window run compacted at ~14% full. Each of those
+ * runs paid a summarization pass it did not need and threw away the prompt
+ * cache prefix to do it.
+ *
+ * The values are read off the published model comparison rather than
+ * recalled. The durable fix is to ask the provider — the Models API
+ * reports a window per model id — which would end the drift this table
+ * accumulates every release. Until a driver does that, an entry here is
+ * only ever as fresh as the day someone checked it.
  */
 
 /**
@@ -31,10 +46,20 @@ export const DEFAULT_ASSUMED_CONTEXT_WINDOW = 128_000
  * over a shorter one that also prefixes it.
  */
 const WINDOWS: ReadonlyArray<readonly [prefix: string, tokens: number]> = [
-	['claude-fable-5', 200_000],
-	['claude-opus-5', 200_000],
-	['claude-sonnet-5', 200_000],
+	['claude-fable-5', 1_000_000],
+	['claude-mythos', 1_000_000],
+	['claude-opus-5', 1_000_000],
+	['claude-sonnet-5', 1_000_000],
+	['claude-opus-4-8', 1_000_000],
+	['claude-opus-4-7', 1_000_000],
+	['claude-opus-4-6', 1_000_000],
+	['claude-sonnet-4-6', 1_000_000],
+	// The 4.5 generation is 200k, so the two 4.5 keys have to out-rank the
+	// bare `claude-opus-4` / `claude-sonnet-4` entries below AND stay
+	// distinct from their 1M siblings above. Longest-key-wins does that.
 	['claude-haiku-4-5', 200_000],
+	['claude-sonnet-4-5', 200_000],
+	['claude-opus-4-5', 200_000],
 	['claude-opus-4', 200_000],
 	['claude-sonnet-4', 200_000],
 	['claude-3-7-sonnet', 200_000],


### PR DESCRIPTION
The compaction trigger measures fullness against a model table and fires at
0.7 of the window it finds. The table answered 200,000 for every Claude
model, including the ones published at 1M — so a 1M-window run compacted at
about 14% full, paying a summarization pass it did not need and discarding
its prompt-cache prefix each time.

## The shape of the bug

The window is not a property of the family. Within one family and one major
version, the 4.5 generation is 200k and 4.6 onward is 1M. The table carried
bare `claude-opus-4` and `claude-sonnet-4` keys, which answer for models on
both sides of that line, so one side was always wrong.

Now 1M: `claude-fable-5`, `claude-mythos-*`, `claude-opus-5`,
`claude-sonnet-5`, `claude-opus-4-6`, `claude-opus-4-7`, `claude-opus-4-8`,
`claude-sonnet-4-6`.

Still 200k: the 4.5 generation, the 3.x models, and any unlisted `claude-`
id. Values were read off the published model comparison rather than recalled.

## Why the existing reasoning did not cover this

The docblock says under-stating is the safe direction, and that is true — of
a model the table does not recognise, which is what
`DEFAULT_ASSUMED_CONTEXT_WINDOW` exists for. It does not license a wrong
number for a model the table names. Understating by 5x is not caution. The
docblock now says so where the old reasoning was.

## Tests

Two additions, both aimed at what a family-wide key gets wrong: the
generation boundary inside a single family (4.5 = 200k, 4.6+ = 1M), and the
unlisted-id floor. The floor test states the asymmetry it is protecting —
over-stating dies with `context_length_exceeded` and nothing recoverable,
under-stating costs one pass.

## Bump

`major`. Not for effort: a consumer whose endpoint caps below the model's
published maximum (an older gateway, a proxy, a tenant limit) will now build
a context larger than the endpoint accepts and fail rather than compact. The
escape hatch is `contextWindowTokens` on the run config, which takes
precedence over the table and always has; the changeset names it.

## Not in this change

A driver asking the provider for the window per model id. That is the
durable fix — this table drifts every release, and this PR is the drift being
paid down by hand.

Second site checked per `one-site-is-not-every-site`: the Anthropic driver's
`OFFLINE_MODEL_CATALOGUE` carries 200k for Sonnet 4.5, Opus 4.1 and Haiku
4.5, which is correct. Noted separately and not fixed here — that offline
menu offers only 2025-era models, so an operator choosing from it never sees
a current one.

Gates: typecheck 0, lint 0, test 0 (sdk and cli green).