### PR TITLE
fix(sdk): a tool pause can be answered after the process that raised it is gone

### DIFF
--- a/.changeset/tool-pause-survives-the-process.md
+++ b/.changeset/tool-pause-survives-the-process.md
@@ -1,0 +1,17 @@
+---
+'@namzu/sdk': major
+---
+
+A pause raised from a tool through `ToolContext.requestPause` can now be answered after the process that raised it is gone. It could not before, on any surface, and the failure was silent.
+
+Three things stood between the pause and its answer, and all three are fixed.
+
+**The resume gate could not open.** A pause is identified by `<toolUseId>:<name>` — the name is there so one call can ask "which environment" and then "are you sure" without the second answer landing on the first question. The gate that decides whether a parked answer belongs to this turn compared that whole id against a raw tool-use id, which it can never equal. So every cross-process resume of such a pause was refused, and the run fell through to the repair that strips the parked turn and asks the model to decide again — turning a human's answer into "ask again and hope". The gate now matches the call portion while the full id continues to route the answer.
+
+**The pause wrote nothing durable unless you used `SupervisorAgent`.** The recorder and the answer channel arrived only from the `questionParks` and `pendingAnswers` run parameters, and neither type is exported, so no host could supply them. On `ReactiveAgent`, `drainQuery` or `resumeRun` the pause was an in-process `await` that reported itself as durable. A run now supplies its own when the host supplies none.
+
+**What changes for you.** If you call `requestPause` on any surface other than `SupervisorAgent` and you have a `checkpointStore` configured, that pause now writes a real checkpoint and emits `user_question_asked` / `user_question_answered`, where it previously wrote and emitted nothing. An approval queue built on `findPendingCheckpoint` or `listDurableRuns` will start listing these runs as parked — which is the point, and is also new rows in a view you may already be rendering.
+
+There is no flag to keep the old behaviour, because the old behaviour was the defect: a pause that reports itself durable and is not. If you do not want a durable park, do not call `requestPause`.
+
+**If you built your own durability around this,** threading a recorder into a private tool builder to work around the missing seam, remove it. The run records the park itself now, and a host recorder plus the run's own records it twice — two checkpoints for one question, and an approval queue that serves the second after the first is answered.

--- a/packages/sdk/src/runtime/query/__tests__/tool-pause-resume.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/tool-pause-resume.test.ts
@@ -1,0 +1,430 @@
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import { removeTempDirs } from '../../../__fixtures__/temp-dir.js'
+
+import { MockLLMProvider, registerMock } from '../../../provider/index.js'
+import { ToolRegistry } from '../../../registry/index.js'
+import { InMemoryCheckpointStore } from '../../../store/run/checkpoint-memory.js'
+import { defineTool } from '../../../tools/defineTool.js'
+import type {
+	CheckpointId,
+	HITLDecisionRequest,
+	HITLResumeDecision,
+	IterationCheckpoint,
+} from '../../../types/hitl/index.js'
+import type { RunId, SessionId, TenantId } from '../../../types/ids/index.js'
+import { createAssistantMessage, createUserMessage } from '../../../types/message/index.js'
+import type { Message } from '../../../types/message/index.js'
+import type { ProjectId, ThreadId } from '../../../types/session/ids.js'
+import type { ToolPauseOutcome } from '../../../types/tool/index.js'
+import type { Logger } from '../../../utils/logger.js'
+import { drainQuery } from '../index.js'
+import { PendingAnswers, QuestionParkBinding } from '../question-park.js'
+import { planPendingResume } from '../resume-pending.js'
+import { resumeRun } from '../resume-run.js'
+import type { RunStateScope } from '../run-state.js'
+import { pauseId } from '../tool-pause.js'
+
+/**
+ * A pause raised through `ToolContext.requestPause` could not be resumed
+ * across a process, and the machinery it needs was all present and correct.
+ *
+ * Three breaks, all of them the same shape — a capability whose writer and
+ * whose reader can both be named, with no road between them:
+ *
+ *  1. The gate. `createToolPause` parks under `<toolUseId>:<name>` and the
+ *     resume gate compared that against a raw tool-call id, so it could
+ *     never open. Every durable resume of a general-seam pause logged "The
+ *     parked question does not belong to any unanswered call in this turn"
+ *     and fell through to the repair that strips the turn.
+ *  2. No recorder. The seam only got one when the host passed
+ *     `questionParks`, and `SupervisorAgent` is the only caller in the
+ *     repository that does. `QuestionParkBinding` is not public, so no host
+ *     could pass one — the pause wrote no checkpoint at all.
+ *  3. No answer channel. `pendingAnswers` had exactly the same shape, so the
+ *     recorded answer could not be handed back to the re-entered tool.
+ *
+ * The narrow path — the built-in `ask_user_question`, which parks under the
+ * bare tool-use id and is handed both objects by `SupervisorAgent` — worked
+ * throughout, which is why this shipped. `durable-question-park.test.ts`
+ * covers that path and passes against the unfixed code; every case here is
+ * about the general one.
+ */
+
+registerMock()
+
+const SCOPE: RunStateScope = {
+	tenantId: 'tnt_pause' as TenantId,
+	projectId: 'prj_pause' as ProjectId,
+	sessionId: 'ses_pause' as SessionId,
+	runId: 'run_pause' as RunId,
+	threadId: 'thd_pause' as ThreadId,
+}
+
+const PAUSE = {
+	name: 'target_environment',
+	prompt: 'which environment should this run against?',
+	options: [
+		{ id: 'staging', label: 'Staging' },
+		{ id: 'production', label: 'Production' },
+	],
+}
+
+/** The id `createToolPause` mints for {@link PAUSE} on call `call_1`. */
+const PAUSED_ON_CALL_1 = pauseId('call_1', PAUSE.name)
+
+const answerWith = (questionId: string, option: string): HITLResumeDecision => ({
+	action: 'answer_question',
+	questionId,
+	selectedOptionIds: [option],
+})
+
+let workdirs: string[] = []
+
+afterEach(async () => {
+	await removeTempDirs(workdirs)
+	workdirs = []
+})
+
+async function mkWorkdir(): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), 'namzu-tool-pause-resume-'))
+	workdirs.push(dir)
+	return dir
+}
+
+describe('the resume gate, on the id the general seam actually parks under', () => {
+	function makeLogger(): Logger {
+		const self = {
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			debug: vi.fn(),
+		} as unknown as Logger
+		;(self as { child: (ctx: unknown) => Logger }).child = vi.fn(() => self)
+		return self
+	}
+
+	const parkedTurn = (): Message[] => [
+		createUserMessage('deploy it'),
+		{
+			...createAssistantMessage(''),
+			toolCalls: [
+				{ id: 'call_1', type: 'function' as const, function: { name: 'deploy', arguments: '{}' } },
+				{ id: 'call_2', type: 'function' as const, function: { name: 'read', arguments: '{}' } },
+			],
+		} as Message,
+	]
+
+	const checkpoint = (questionId: string): IterationCheckpoint =>
+		({
+			id: 'cp_1' as CheckpointId,
+			messages: parkedTurn(),
+			pending: {
+				parkedAt: 0,
+				request: {
+					type: 'user_question',
+					runId: SCOPE.runId,
+					checkpointId: 'cp_1' as CheckpointId,
+					question: {
+						questionId,
+						question: PAUSE.prompt,
+						options: [],
+						multiSelect: false,
+						allowFreeText: true,
+					},
+				},
+			},
+		}) as unknown as IterationCheckpoint
+
+	it('takes over a pause parked under <toolUseId>:<name>', () => {
+		// The whole defect in one assertion. `call_1:target_environment` is
+		// what is on disk, `call_1` is what is in the turn, and equality
+		// between them returned null here — so the answer a human had already
+		// given was discarded and the turn stripped.
+		const plan = planPendingResume(
+			checkpoint(PAUSED_ON_CALL_1),
+			answerWith(PAUSED_ON_CALL_1, 'staging'),
+			makeLogger(),
+		)
+
+		expect(plan).not.toBeNull()
+		// The whole batch is re-executed, which is HOW the asking tool is
+		// re-entered at all.
+		expect(plan?.response.message.toolCalls).toHaveLength(2)
+	})
+
+	it('carries the answer under the full pause id, not the call id', () => {
+		// Routing stays keyed on the whole composite: the tool asks
+		// `PendingAnswers` for `call_1:target_environment`, so filing the
+		// answer under `call_1` would leave it unreachable.
+		const plan = planPendingResume(
+			checkpoint(PAUSED_ON_CALL_1),
+			answerWith(PAUSED_ON_CALL_1, 'staging'),
+			makeLogger(),
+		)
+
+		expect(plan?.answers?.take(PAUSED_ON_CALL_1)).toBeDefined()
+		expect(plan?.answers?.take('call_1')).toBeUndefined()
+	})
+
+	it('still takes over the bare id the built-in question tool parks under', () => {
+		// The preservation case. The narrow path was the only one that ever
+		// worked and it has to keep working.
+		const plan = planPendingResume(
+			checkpoint('call_1'),
+			answerWith('call_1', 'staging'),
+			makeLogger(),
+		)
+
+		expect(plan).not.toBeNull()
+		expect(plan?.answers?.take('call_1')).toBeDefined()
+	})
+
+	it('still refuses a pause raised from a call that is not in this turn', () => {
+		// Widening the match must not widen it to everything: a stale client
+		// answering an earlier turn would otherwise have its answer delivered
+		// to whatever tool now holds that slot.
+		const stale = pauseId('call_9', PAUSE.name)
+
+		expect(
+			planPendingResume(checkpoint(stale), answerWith(stale, 'staging'), makeLogger()),
+		).toBeNull()
+	})
+})
+
+describe('a pause raised from a host-authored tool survives the process', () => {
+	/**
+	 * A tool that parks on its own question, recording what the seam handed
+	 * back so the test can read it from outside the run.
+	 */
+	function deployTool(seen: { outcome?: ToolPauseOutcome }): ToolRegistry {
+		const tools = new ToolRegistry()
+		tools.register(
+			defineTool({
+				name: 'deploy',
+				description: 'deploy tool',
+				inputSchema: z.object({}),
+				category: 'custom',
+				permissions: [],
+				readOnly: false,
+				destructive: true,
+				concurrencySafe: false,
+				execute: async (_input, context) => {
+					seen.outcome = await context.requestPause?.(PAUSE)
+					return { success: true, output: `pause: ${seen.outcome?.status ?? 'no seam'}` }
+				},
+			}),
+		)
+		return tools
+	}
+
+	async function baseParams(store: InMemoryCheckpointStore) {
+		return {
+			checkpointStore: store,
+			runConfig: {
+				model: 'mock-model',
+				timeoutMs: 30_000,
+				tokenBudget: 100_000,
+				maxIterations: 3,
+				maxResponseTokens: 256,
+			},
+			agentId: 'agent_pause',
+			agentName: 'Pause Agent',
+			workingDirectory: await mkWorkdir(),
+			sessionId: SCOPE.sessionId,
+			threadId: SCOPE.threadId,
+			projectId: SCOPE.projectId,
+			tenantId: SCOPE.tenantId,
+		}
+	}
+
+	/**
+	 * Run the tool once, far enough that its pause is recorded, and leave the
+	 * park outstanding.
+	 *
+	 * The checkpoint is entirely the run's own — its messages, its tool-call
+	 * ids and, the part that matters, the `questionId` `createToolPause`
+	 * actually minted. Only `resolvedAt` is stripped afterwards, which is
+	 * precisely what a process killed between `record` and `resolve` leaves
+	 * behind: the human was still looking at the card. Simulating the kill
+	 * this way rather than by aborting mid-await keeps the test from being
+	 * one that can hang, which is a result that is not a result.
+	 *
+	 * Nothing here passes `questionParks` or `pendingAnswers`. That is the
+	 * point: neither type is public, so no host can, and before this change
+	 * the store came back empty from this function.
+	 */
+	async function parkOnce(store: InMemoryCheckpointStore): Promise<IterationCheckpoint> {
+		const seen: { outcome?: ToolPauseOutcome } = {}
+
+		await drainQuery({
+			...(await baseParams(store)),
+			runId: SCOPE.runId,
+			provider: new MockLLMProvider({
+				turns: [
+					{ toolCalls: [{ id: 'call_1', name: 'deploy', args: {} }], finishReason: 'tool_calls' },
+					{ text: 'deployed' },
+				],
+			}),
+			tools: deployTool(seen),
+			messages: [{ role: 'user', content: 'deploy it' }],
+			// Nobody answers: this stands in for the process that went away
+			// while the question was on somebody's screen.
+			resumeHandler: async () => ({ action: 'continue' }) as HITLResumeDecision,
+		} as never)
+
+		const parked = (await store.listCheckpoints(SCOPE)).find(
+			(cp) => cp.pending?.request.type === 'user_question',
+		)
+		if (!parked?.pending) {
+			throw new Error('the pause recorded no checkpoint, so there is nothing to resume from')
+		}
+
+		const { resolvedAt: _neverArrived, ...outstanding } = parked.pending
+		const stillParked = { ...parked, pending: outstanding } as IterationCheckpoint
+		await store.writeCheckpoint(SCOPE, stillParked)
+		return stillParked
+	}
+
+	it('records a durable park with no host-supplied recorder', async () => {
+		const store = new InMemoryCheckpointStore()
+		const parked = await parkOnce(store)
+
+		// Break 2. Without the run's own binding this wrote nothing at all,
+		// so a host queue had no question to show and a resume had no
+		// checkpoint to find — the pause was an in-process `await` and
+		// nothing said so.
+		expect(parked.pending?.request.type).toBe('user_question')
+	})
+
+	it('parks under the composite id, which is what makes the gate matter', async () => {
+		const store = new InMemoryCheckpointStore()
+		const parked = await parkOnce(store)
+		const request = parked.pending?.request
+
+		// Asserted from the durable record rather than from `pauseId`, so
+		// this stays true about what is ON DISK and not about the helper.
+		expect(request?.type === 'user_question' && request.question.questionId).toBe(
+			'call_1:target_environment',
+		)
+	})
+
+	it('delivers the answer to the re-entered tool in a fresh runtime', async () => {
+		const store = new InMemoryCheckpointStore()
+		const parked = await parkOnce(store)
+		const request = parked.pending?.request
+		const questionId = request?.type === 'user_question' ? request.question.questionId : ''
+
+		// A second runtime: new provider, new registry, new tool instance,
+		// nothing carried in memory from the run that parked. The store and
+		// the decision are the only things that cross.
+		const seen: { outcome?: ToolPauseOutcome } = {}
+		const asked = vi.fn()
+
+		const outcome = await resumeRun({
+			...(await baseParams(store)),
+			scope: SCOPE,
+			provider: new MockLLMProvider({ turns: [{ text: 'deployed' }] }),
+			tools: deployTool(seen),
+			pendingDecision: answerWith(questionId, 'staging'),
+			resumeHandler: async (request: HITLDecisionRequest) => {
+				asked(request.type)
+				return { action: 'continue' } as HITLResumeDecision
+			},
+		} as never)
+
+		expect(outcome.resumed).toBe(true)
+		// The consequence that cannot happen without every hop: the tool was
+		// re-entered, its pause found the recorded answer, and the option a
+		// human chose came back to the tool that asked.
+		expect(seen.outcome).toEqual({ status: 'answered', selectedOptionIds: ['staging'] })
+		// And it was not asked a second time. Re-asking would put a question
+		// the user already answered back in front of them, and headless would
+		// resolve it with the no-consent sentinel.
+		expect(asked).not.toHaveBeenCalledWith('user_question')
+	})
+
+	it('binds the recorder the host supplied, and releases it when the run settles', async () => {
+		// The run owning a fallback must not mean the run ignoring the host.
+		// `SupervisorAgent`'s built-in question tool closed over THIS object
+		// before the run existed, so a run that quietly bound its own instead
+		// would stop recording that tool's parks — and every test of that
+		// tool builds the coordinator directly, so none of them would notice.
+		//
+		// Written because the mutation "the run ignores a host-supplied
+		// recorder" survived the whole suite.
+		const parks = new QuestionParkBinding()
+		const bind = vi.spyOn(parks, 'bind')
+		const unbind = vi.spyOn(parks, 'unbind')
+
+		await drainQuery({
+			...(await baseParams(new InMemoryCheckpointStore())),
+			runId: SCOPE.runId,
+			questionParks: parks,
+			provider: new MockLLMProvider({ turns: [{ text: 'nothing to deploy' }] }),
+			tools: new ToolRegistry(),
+			messages: [{ role: 'user', content: 'status' }],
+			resumeHandler: async () => ({ action: 'continue' }) as HITLResumeDecision,
+		} as never)
+
+		expect(bind).toHaveBeenCalledTimes(1)
+		// Released on the way out, so a later run cannot write into a
+		// finished one through the same object.
+		expect(unbind).toHaveBeenCalledTimes(1)
+	})
+
+	it('reads a carried answer out of the channel the host supplied', async () => {
+		// The other half of the same rule, and the same mutation survived it:
+		// a run that answers only out of its own channel strands every answer
+		// a host filled in before calling.
+		const answers = new PendingAnswers()
+		answers.set(PAUSED_ON_CALL_1, answerWith(PAUSED_ON_CALL_1, 'production'))
+
+		const seen: { outcome?: ToolPauseOutcome } = {}
+		const asked = vi.fn()
+
+		await drainQuery({
+			...(await baseParams(new InMemoryCheckpointStore())),
+			runId: SCOPE.runId,
+			pendingAnswers: answers,
+			provider: new MockLLMProvider({
+				turns: [
+					{ toolCalls: [{ id: 'call_1', name: 'deploy', args: {} }], finishReason: 'tool_calls' },
+					{ text: 'deployed' },
+				],
+			}),
+			tools: deployTool(seen),
+			messages: [{ role: 'user', content: 'deploy it' }],
+			resumeHandler: async (request: HITLDecisionRequest) => {
+				asked(request.type)
+				return { action: 'continue' } as HITLResumeDecision
+			},
+		} as never)
+
+		expect(seen.outcome).toEqual({ status: 'answered', selectedOptionIds: ['production'] })
+		expect(asked).not.toHaveBeenCalledWith('user_question')
+	})
+
+	it('refuses an answer addressed to a pause this turn never raised', async () => {
+		const store = new InMemoryCheckpointStore()
+		await parkOnce(store)
+
+		const seen: { outcome?: ToolPauseOutcome } = {}
+
+		await resumeRun({
+			...(await baseParams(store)),
+			scope: SCOPE,
+			provider: new MockLLMProvider({ turns: [{ text: 'deployed' }] }),
+			tools: deployTool(seen),
+			// A stale client answering some other run's question. The widened
+			// gate must not have widened into accepting this.
+			pendingDecision: answerWith(pauseId('call_7', PAUSE.name), 'production'),
+			resumeHandler: async () => ({ action: 'continue' }) as HITLResumeDecision,
+		} as never)
+
+		expect(seen.outcome?.status).not.toBe('answered')
+	})
+})

--- a/packages/sdk/src/runtime/query/__tests__/tool-pause.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/tool-pause.test.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../utils/id.js'
 import { drainQuery } from '../index.js'
 import { PendingAnswers, QuestionParkBinding } from '../question-park.js'
-import { createToolPause, pauseId } from '../tool-pause.js'
+import { createToolPause, isPauseForCall, pauseId } from '../tool-pause.js'
 
 /**
  * The pause machinery is durable and excellent, and it was reachable from
@@ -152,6 +152,72 @@ describe('a pause raised from inside a tool', () => {
 		})
 
 		expect(await pause(request)).toEqual({ status: 'answered', selectedOptionIds: ['staging'] })
+	})
+})
+
+describe('the id a resume gate matches on', () => {
+	// The mint and the match are one scheme, and they disagreed: the gate
+	// compared a whole pause id against a raw tool-use id. A composite can
+	// never equal one, so the general seam's every cross-process resume was
+	// refused while the built-in question tool sailed through.
+
+	it('matches the bare tool-use id the built-in question tool parks under', () => {
+		// The narrow path, and the reason the defect stayed invisible: this
+		// is the only shape that ever passed the old gate.
+		expect(isPauseForCall('t1', 't1')).toBe(true)
+	})
+
+	it('matches a composite against the call it was raised from', () => {
+		expect(isPauseForCall(pauseId('call_1', 'target_environment'), 'call_1')).toBe(true)
+	})
+
+	it('does not match a composite against a different call in the turn', () => {
+		// The misdirection this gate exists for. Membership must not become
+		// "any pause matches any call".
+		expect(isPauseForCall(pauseId('call_1', 'target_environment'), 'call_2')).toBe(false)
+	})
+
+	it('does not match a call id that is only a textual prefix', () => {
+		// `call_1` is a prefix of `call_12` as text and not as an id. The
+		// separator is what makes the difference, so the check is for
+		// `call_1:` rather than for `call_1`.
+		expect(isPauseForCall(pauseId('call_12', 'confirm'), 'call_1')).toBe(false)
+	})
+
+	it('survives a tool-use id that contains the separator', () => {
+		// Why this is a prefix test against ids that are really there and
+		// not `split(':')[0]`. Splitting yields `call`, which is nobody's
+		// call, so the pause would be refused for a reason that has nothing
+		// to do with the run.
+		const pause = pauseId('call:9', 'confirm')
+
+		expect(isPauseForCall(pause, 'call:9')).toBe(true)
+		expect(isPauseForCall(pause, 'call_9')).toBe(false)
+	})
+
+	it('can also match a call whose id is a colon-prefix of the real one', () => {
+		// Recorded rather than papered over, because the first draft of the
+		// docblock claimed the opposite and this case is what disproved it.
+		//
+		// The exposure is bounded. While `call:9` is in the turn the verdict
+		// is right anyway — the pause does belong to a call there. When it is
+		// not, the answer ends up filed under a key no tool asks for, so the
+		// tool asks again: a resume that re-asks, never one that misdelivers,
+		// because `PendingAnswers` routes on the whole id.
+		expect(isPauseForCall(pauseId('call:9', 'confirm'), 'call')).toBe(true)
+	})
+
+	it('keeps two pauses on one call apart, which is what the composite is for', () => {
+		// Membership is not routing. Both pauses belong to `call_1`, so both
+		// pass this gate — and `PendingAnswers` still keys on the whole id,
+		// so "are you sure" cannot be answered with the reply to "which
+		// environment".
+		const first = pauseId('call_1', 'target_environment')
+		const second = pauseId('call_1', 'confirm')
+
+		expect(isPauseForCall(first, 'call_1')).toBe(true)
+		expect(isPauseForCall(second, 'call_1')).toBe(true)
+		expect(first).not.toBe(second)
 	})
 })
 

--- a/packages/sdk/src/runtime/query/index.ts
+++ b/packages/sdk/src/runtime/query/index.ts
@@ -98,7 +98,7 @@ import { isWorkingMemoryMessage } from './iteration/phases/working-memory.js'
 import { applyLifecycleHookResults } from './plugin-hooks.js'
 import { PromptBuilder } from './prompt.js'
 import type { PromptSegments } from './prompt.js'
-import type { PendingAnswers, QuestionParkBinding } from './question-park.js'
+import { PendingAnswers, QuestionParkBinding } from './question-park.js'
 import { ResultAssembler } from './result.js'
 import {
 	type PendingResumePlan,
@@ -168,14 +168,20 @@ export interface QueryParams {
 	emergencySave?: boolean
 
 	/**
-	 * Durability for questions raised from inside a tool.
+	 * Durability for questions raised by a tool that closed over its
+	 * binding before the run existed.
 	 *
-	 * The tool that asks is built before the run exists, so the binding is
-	 * created by whoever builds the tools and attached here — that is what
-	 * lets one tool instance be durable inside a run and inert outside one.
-	 * Without it, a question park exists only as a suspended `await`: kill
-	 * the process while somebody is looking at the card and the answer can
-	 * never be applied.
+	 * The built-in `ask_user_question` is built with the agent's tool
+	 * registry, so only whoever builds the tools can hand it one — that is
+	 * what lets a single tool instance be durable inside a run and inert
+	 * outside one. Without it, THAT tool's park is only a suspended
+	 * `await`: kill the process while somebody is looking at the card and
+	 * the answer can never be applied.
+	 *
+	 * Not required for `ToolContext.requestPause`. The run builds that
+	 * seam per call and binds its own recorder when none is passed, so a
+	 * pause raised from a host-authored tool is durable on every surface
+	 * rather than only on the one agent class that supplies this.
 	 */
 	questionParks?: QuestionParkBinding
 
@@ -192,10 +198,11 @@ export interface QueryParams {
 	/**
 	 * The registry a re-entered `ask_user_question` reads its answer from.
 	 *
-	 * Same shape as {@link questionParks}: the tool is built before the run
-	 * exists, so the instance is created by whoever builds the tools and
-	 * filled here on the resume path. Without it a resumed run re-asks a
-	 * question the user already answered.
+	 * Same shape, same reason and same limit as {@link questionParks}: it
+	 * exists for a tool that closed over the instance before the run did,
+	 * and without it a resumed run re-asks that tool's question. A pause
+	 * from `ToolContext.requestPause` needs none, because the run fills
+	 * its own on the resume path.
 	 */
 	pendingAnswers?: PendingAnswers
 
@@ -874,6 +881,25 @@ export async function* query(params: QueryParams): AsyncGenerator<RunEvent, Run>
 		? []
 		: withDeferredDiscoveryTool(params.tools, params.allowedTools)
 
+	// The two halves of a durable pause, owned by the RUN when the host
+	// does not own them.
+	//
+	// `SupervisorAgent` builds both before the run exists, because the
+	// tools it builds close over them, and it passes them in. Nothing else
+	// could: neither type is exported from `public-runtime.ts`, so a host
+	// on `ReactiveAgent`, `drainQuery` or `resumeRun` had no way to supply
+	// either — and `ToolContext.requestPause`, which every tool author is
+	// handed, silently wrote no checkpoint and could receive no answer on
+	// those surfaces. Which agent class the host happened to pick is not
+	// visible at the call site, so the degradation was invisible too.
+	//
+	// A run-local pair is enough for the general seam because `query()`
+	// builds its `createToolPause` itself, below, and can hand it the
+	// run's own. Pinned by the "a pause is durable on any surface" cases
+	// in `__tests__/tool-pause-resume.test.ts`.
+	const questionParks = params.questionParks ?? new QuestionParkBinding()
+	const pendingAnswers = params.pendingAnswers ?? new PendingAnswers()
+
 	//  is null only when the run has no disk layout (tests,
 	// in-memory hosts); the budget then degrades to middle-elision.
 	const runDirForTools = ctx.runMgr.getRunDir()
@@ -915,8 +941,8 @@ export async function* query(params: QueryParams): AsyncGenerator<RunEvent, Run>
 					runId: ctx.runId,
 					toolUseId,
 					parkHandler: params.resumeHandler,
-					...(params.questionParks ? { recorder: params.questionParks } : {}),
-					...(params.pendingAnswers ? { pendingAnswers: params.pendingAnswers } : {}),
+					recorder: questionParks,
+					pendingAnswers,
 				}),
 		},
 		ctx.activityStore,
@@ -1130,7 +1156,7 @@ export async function* query(params: QueryParams): AsyncGenerator<RunEvent, Run>
 		// the checkpoint did not exist: nothing on disk said a human owed
 		// this run an answer, and a remote host could not observe the
 		// question at all.
-		params.questionParks?.bind({
+		questionParks.bind({
 			record: async (question) => {
 				try {
 					const checkpoint = await checkpointMgr.create(ctx.runMgr, ctx.runMgr.currentIteration)
@@ -1537,9 +1563,9 @@ export async function* query(params: QueryParams): AsyncGenerator<RunEvent, Run>
 				// closed over its registry when the agent was constructed,
 				// long before this run existed, so the answers are copied in
 				// rather than passed down.
-				if (pendingResume.answers && params.pendingAnswers) {
+				if (pendingResume.answers) {
 					for (const [questionId, answer] of pendingResume.answers.entries()) {
-						params.pendingAnswers.set(questionId, answer)
+						pendingAnswers.set(questionId, answer)
 					}
 				}
 
@@ -1642,7 +1668,7 @@ export async function* query(params: QueryParams): AsyncGenerator<RunEvent, Run>
 			// Same reasoning for the question channel: the tools outlive the
 			// run that bound them, so leaving it attached would have a later
 			// run's question written into this run's checkpoint store.
-			params.questionParks?.unbind()
+			questionParks.unbind()
 
 			// Offer what the run learned to whoever decides what is worth
 			// keeping. In `finally` and awaited: a run that failed still

--- a/packages/sdk/src/runtime/query/resume-pending.ts
+++ b/packages/sdk/src/runtime/query/resume-pending.ts
@@ -9,6 +9,7 @@ import type { ChatCompletionResponse } from '../../types/provider/index.js'
 import type { Logger } from '../../utils/logger.js'
 import type { PriorToolResults, ToolCallDenials, ToolExecutor } from './executor.js'
 import { PendingAnswers } from './question-park.js'
+import { isPauseForCall } from './tool-pause.js'
 
 /**
  * Apply a decision collected out-of-band to the tool calls a run parked on.
@@ -154,7 +155,15 @@ function planQuestionResume(
 	// otherwise have its answer delivered to whatever tool now holds that
 	// slot — the misdirection the asking tool's own id guard exists to
 	// prevent, checked here too because by then the tool has been entered.
-	if (!assistant.toolCalls.some((tc) => tc.id === questionId)) {
+	//
+	// Through `isPauseForCall` rather than by equality, because a parked
+	// question id is not a call id. The general seam appends the tool
+	// author's pause name to it, so equality compared
+	// `call_1:target_environment` against `call_1`, could never hold, and
+	// refused every cross-process resume of a host-authored pause. Only
+	// the built-in question tool got through, and only because it parks
+	// under the bare tool-use id.
+	if (!assistant.toolCalls.some((tc) => isPauseForCall(questionId, tc.id))) {
 		log.error('The parked question does not belong to any unanswered call in this turn', {
 			checkpointId: checkpoint.id,
 			questionId,

--- a/packages/sdk/src/runtime/query/tool-pause.ts
+++ b/packages/sdk/src/runtime/query/tool-pause.ts
@@ -32,6 +32,43 @@ import type { PendingAnswers, QuestionParkRecorder } from './question-park.js'
  */
 export const pauseId = (toolUseId: string, name: string): string => `${toolUseId}:${name}`
 
+/**
+ * Does this pause id belong to `callId`?
+ *
+ * The other half of the scheme above, and it lives beside the mint rather
+ * than at the gate that asks it, so the two cannot drift apart again. They
+ * already had: the resume gate compared the whole parked id against a raw
+ * tool-use id, which a composite can never equal, so a pause raised
+ * through {@link createToolPause} was refused by every cross-process
+ * resume — while the built-in question tool, whose `questionId` IS the raw
+ * id, passed the same gate and worked.
+ *
+ * Asked against an id actually present in the turn rather than by
+ * splitting the composite on `:`. The left half is the provider's tool-use
+ * id and nothing forbids a colon in it, so a split takes `call:9:confirm`
+ * apart at the wrong place and then compares against `call` — a string no
+ * provider minted. Testing a `<callId>:` prefix asks about candidates that
+ * exist instead.
+ *
+ * It is not exact, and the inexactness is bounded rather than absent: a
+ * call whose id is literally `call` matches a pause raised on `call:9`.
+ * That costs nothing while the real call is also in the turn, because the
+ * pause does belong to a call there; and when it is not, the answer is
+ * filed under a key no tool asks for, so the tool asks again. A resume
+ * that re-asks, never one that misdelivers — routing below is still an
+ * exact key match.
+ *
+ * Membership only — is there a call in this turn that this pause was
+ * raised from. The full composite still ROUTES the answer, by exact key in
+ * `PendingAnswers`, which is what keeps a call that pauses twice from
+ * delivering its second answer against its first question.
+ *
+ * Every sentence above that names a condition and an outcome is pinned in
+ * `__tests__/tool-pause.test.ts`, under "the id a resume gate matches on".
+ */
+export const isPauseForCall = (pause: string, callId: string): boolean =>
+	pause === callId || pause.startsWith(`${callId}:`)
+
 interface ToolPauseDeps {
 	readonly runId: RunId
 	readonly toolUseId: string


### PR DESCRIPTION
Closes #370.

## What was broken

`createToolPause` parks under `<toolUseId>:<name>`. The name is load-bearing: a call may pause more than once — "which environment", then "are you sure" — and keying on the call alone would deliver the second answer to the first question.

The resume gate compared that whole id against a raw tool-use id:

```ts
if (!assistant.toolCalls.some((tc) => tc.id === questionId))
```

`call_1:target_environment` is never `call_1`, so the gate could not open. Every cross-process resume of a pause raised through `ToolContext.requestPause` logged *"The parked question does not belong to any unanswered call in this turn"*, returned `null`, and fell through to the repair path that strips the parked turn and asks the model to decide again — so a human's answer became "ask again and hope it asks for the same thing".

The built-in `ask_user_question` sets `questionId` to the raw tool-use id, so the older, narrower path passed the same gate and worked. That is why this shipped.

## Two more breaks behind it

Writing a test that resumes a `createToolPause` pause end to end runs into two more, both the same shape and both invisible at the call site:

- **No recorder.** The seam only received one when the host passed `questionParks`, and `SupervisorAgent` is the only caller in the repository that does. `QuestionParkBinding` is not exported, so a host on `ReactiveAgent`, `drainQuery` or `resumeRun` could not supply one — its pause wrote **no checkpoint at all** while reporting itself durable.
- **No answer channel.** `pendingAnswers` had exactly the same shape, so the recorded answer could not be handed to the re-entered tool.

Fixing only the gate would leave the honest answer to "is the general seam reachable?" as *"yes, if you happen to use `SupervisorAgent`"* — the invisible degradation `docs/conventions/refuse-do-not-degrade.md` is about, since which agent class the host chose is not visible from `requestPause`.

## The change

- `isPauseForCall(pause, callId)` in `tool-pause.ts`, beside `pauseId`, so the mint and the match cannot drift apart again. The gate matches the **call portion**; the full composite still **routes** the answer by exact key in `PendingAnswers`, so two pauses on one call still get their own answers.
- Matched against ids actually present in the turn rather than by `split(':')`, because the left half is the provider's tool-use id and nothing forbids a colon in it. This is not exact, and the docblock says exactly how far the inexactness reaches — with a test for it, after the first version of that sentence claimed more than the code delivered and its own test disproved it.
- `query()` owns a `QuestionParkBinding` and a `PendingAnswers` when the host supplies neither, and still binds the host's when there is one.
- Corrected the two `QueryParams` docstrings, which claimed a durability that only ever held for one agent class.

## Is the general seam reachable end to end?

Yes. `a pause raised from a host-authored tool survives the process > delivers the answer to the re-entered tool in a fresh runtime` is the test that proves it: a host-authored tool parks through `context.requestPause` with **no** `questionParks` and **no** `pendingAnswers`; the park is read back from the store as a real checkpoint; a second runtime with a new provider, new registry and new tool instance resumes it through `resumeRun`, with only the store and the decision crossing between them; and the option a human chose arrives back inside the tool that asked, without the resume handler being called again.

## Mutation

Twelve mutations, two rounds, the whole `@namzu/sdk` suite each time, single-match anchors enforced.

**Reverting the gate (M1) kills three of the new tests and none of the fifteen in `durable-question-park.test.ts`** — the narrow path is independently covered and passes against the unfixed code, so the new cases are about the general seam and nothing else. Widening the gate to match everything (M5) kills a **pre-existing** narrow-path test, which is what keeps the widening honest.

Round two, written against round one rather than to confirm it, produced **three survivors** — all on the host-supplied side of the two fallbacks just written, which round one never entered. Two tests driving `query()` with host-supplied instances close all three.

## Gates

`typecheck`, `lint`, `test` (sdk 358 files / 3242 passed / 7 skipped, cli 95 / 916 / 4, exit 0), `test:proc` (3 / 12), `audit-external-names`, `verify-public-surface` (intact, 560/560 runtime), `check-sdk-test-presence`, `test:coverage` + `check-sdk-module-coverage`, `check-docs` (0 problems) — all run, all green.

## Bump

`major`. The public surface is unchanged, but the default is: on every surface other than `SupervisorAgent`, a `requestPause` pause now writes a real checkpoint and emits `user_question_asked` / `user_question_answered` where it previously emitted nothing, so an approval queue built on `findPendingCheckpoint` or `listDurableRuns` gains rows. The changeset names that, and names what a host with its own hand-rolled durability should remove.

## On #371

**No change, and no second PR.** The defect it names does not exist on `main`: `parseCheckpoint` reads `migrate<unknown>(SCHEMA, JSON.parse(content))`, and has since `935b8f3e`, the commit that introduced the schema mechanism. Every other line number the issue cites matches this revision exactly, so it was written against this code and the one claim about that line is mistaken.

Measured rather than argued: replacing that call with a bare cast kills exactly one test — `refuses a record from a future version rather than reading it partially` — and leaves the other eight in the file green. A future-version checkpoint is already refused by name with a `SchemaVersionError` carrying the found and supported versions, the reasoning is already written above `migrate`, and nothing swallows the throw. #371 should be closed as already fixed.
