### PR TITLE
fix(sdk): a failed iteration leaves a step, so the ledger has no hole where the failure was

### DIFF
--- a/.changeset/failed-iteration-leaves-a-step.md
+++ b/.changeset/failed-iteration-leaves-a-step.md
@@ -1,0 +1,41 @@
+---
+'@namzu/sdk': major
+---
+
+A failed iteration now leaves a step, so the run ledger has no hole where the failure was
+
+`recordStep` had two call sites and both were on success paths. An iteration
+that threw recorded a span exception and re-threw with nothing written down, so
+a ledger was complete except on the turns that failed — which reads as "nothing
+went wrong" precisely where something did, and a reader could not tell
+iteration N failing from iteration N never happening.
+
+The failing turn now gets a `StepResult` like every other turn, from the same
+writer, so failures and successes sort together. It carries what the iteration
+got as far as knowing: the model asked for, the tokens actually spent, the tool
+calls the model made, and what went wrong.
+
+**Three breaking changes to `StepResult`, all on the read side.**
+
+- `finishReason` gains `'error'` and `'cancelled'`. If you `switch` on it
+  exhaustively, add the two cases. `'error'` means the iteration threw and
+  `failure` says why; `'cancelled'` means a Stop tore the turn down.
+- `messageId` is now optional. It is absent only on a step whose iteration
+  failed before the model's message was announced — a lifecycle hook that
+  threw, a transport error before the first chunk. If you read it
+  unconditionally, guard it. It is still present on every turn that reached the
+  provider, including a stream that died part-way.
+- `toolResults` may now be shorter than `toolCalls` on a step that failed: only
+  outcomes that came back are recorded, because `{output: '', isError: false}`
+  for a tool that never ran reads as an empty success. Pair by `toolCallId`
+  rather than by index if you handle failed steps.
+
+New: `failure?: StepFailure` — `{ message, code, status?, retryable }`,
+classified the same way `run.lastProviderError` is. `code` is `'unknown'` for a
+failure that was not a provider failure at all, which is the honest reading
+rather than a more specific-looking guess.
+
+Also: an iteration records at most one step. A failure landing after the step
+was already recorded — in the advisory phase, or a trailing lifecycle hook —
+leaves that step's own verdict alone rather than adding a second entry that
+would double-count the turn against `run.tokenUsage`.

--- a/.github/scripts/public-surface-baseline.json
+++ b/.github/scripts/public-surface-baseline.json
@@ -1401,6 +1401,7 @@
     "SteeringBinding",
     "SteeringChannel",
     "StepContext",
+    "StepFailure",
     "StepProvenance",
     "StepResult",
     "StepToolResult",

--- a/docs/sdk/runtime/loop-control.md
+++ b/docs/sdk/runtime/loop-control.md
@@ -1,7 +1,7 @@
 ---
 title: Loop Control and Resilience
 description: Stop conditions, step records, provider retry, budgets across resume, compaction triggers and outcomes, and extended thinking and effort in the @namzu/sdk agent loop.
-last_updated: 2026-08-05
+last_updated: 2026-08-10
 status: current
 related_packages: ["@namzu/sdk", "@namzu/anthropic"]
 ---
@@ -148,12 +148,62 @@ query({
 | `stepNumber`, `model`, `messageId` | identity |
 | `servedBy` | which provider and model actually answered |
 | `content`, `toolCalls`, `toolResults` | what happened |
-| `finishReason` | why the turn ended |
+| `finishReason` | how the turn ended |
+| `failure` | what went wrong, on a turn that ended in `error` |
 | `usage`, `costDelta` | **this step's** consumption, not the running total |
 | `startedAt`, `durationMs`, `toolExecutionMs` | timing, split by phase |
 
-`toolResults` is ordered by the tool *calls*, so it lines up with
-`toolCalls` index for index.
+`toolResults` is ordered by the tool *calls*. On a turn that completed it
+lines up index for index; on a turn that failed it is shorter, because only
+the outcomes that came back are recorded. Pair by `toolCallId` if you handle
+both.
+
+### The turn that failed
+
+An iteration that throws leaves a step like every other iteration does.
+It used to leave nothing — the loop recorded a span exception and re-threw —
+so a ledger was complete except on the turns that went wrong, which reads as
+"nothing went wrong" precisely where something did.
+
+`finishReason` therefore carries two values no provider reports:
+
+| Value | |
+| --- | --- |
+| `error` | the iteration threw. `failure` says what happened |
+| `cancelled` | a Stop tore the turn down. There is no failure to report |
+
+```ts
+for (const step of run.steps ?? []) {
+  if (step.finishReason !== 'error') continue
+  console.log(step.stepNumber, step.failure?.code, step.failure?.message)
+}
+```
+
+`failure` carries `{ message, code, status?, retryable }`, classified the same
+way `run.lastProviderError` is, so the two agree when the failed step is the
+one that ended the run. `code` is `unknown` when the failure was not a
+provider failure at all — a lifecycle hook that threw, say — which is the
+honest reading rather than a more specific-looking guess.
+
+What such a step carries is what the iteration got as far as knowing:
+
+- `usage` is the same subtraction every step makes. A turn that failed after
+  the model answered carries that answer's tokens; one that failed before it
+  carries the zero it actually spent.
+- `messageId` is present whenever the iteration reached the provider call,
+  including a stream that died part-way — the events carry both
+  `message_started` and `message_completed` for it, so the id is a trail.
+  It is absent when the turn failed before any message was announced.
+- `servedBy` is absent when nothing answered. `run.metadata.servingProvider`
+  is the field that still names the member whose failure ended the run.
+
+At most one step exists per iteration. A failure that lands *after* the step
+was recorded — in the advisory phase, or a trailing lifecycle hook — leaves
+that step's own verdict alone and reaches you as the run's error, rather than
+adding a second entry that would double-count the turn.
+
+Reading them back needs no special path: a failed run settles rather than
+throwing, so `run.steps` carries the ledger including its last, failed entry.
 
 ### What was asked for, and what answered
 

--- a/packages/sdk/src/runtime/query/__tests__/a-failed-iteration-is-still-a-step.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/a-failed-iteration-is-still-a-step.test.ts
@@ -1,0 +1,300 @@
+/**
+ * The turn that failed is the turn the ledger has to keep.
+ *
+ * `recordStep` had two call sites and both were on success paths, so an
+ * iteration that threw recorded a span exception and re-threw with nothing
+ * written down. That is the worst shape an evidence record can take: a run
+ * ledger complete except on the turns that failed reads as "nothing went
+ * wrong" precisely when something did, and a reader cannot tell iteration N
+ * failing from iteration N never happening.
+ *
+ * The assertions below are about the ledger AGAINST A TOTAL wherever they can
+ * be — one step per iteration the events announced, and the token sum
+ * reconciling with the run's own counter — because the defect was an absence,
+ * and an absence is only visible against something that says how much should
+ * be there.
+ */
+
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { removeTempDirs } from '../../../__fixtures__/temp-dir.js'
+import type { PluginLifecycleManager } from '../../../plugin/lifecycle.js'
+import { MockLLMProvider } from '../../../provider/mock.js'
+import { ToolRegistry } from '../../../registry/tool/execute.js'
+import type { SessionId, TenantId } from '../../../types/ids/index.js'
+import { createUserMessage } from '../../../types/message/index.js'
+import type { PluginHookEvent } from '../../../types/plugin/index.js'
+import type { RunEvent } from '../../../types/run/index.js'
+import type { ProjectId, ThreadId } from '../../../types/session/ids.js'
+import { drainQuery } from '../index.js'
+
+function registerEcho(tools: ToolRegistry): void {
+	tools.register({
+		name: 'echo',
+		description: 'Echo the text back.',
+		inputSchema: z.object({}),
+		execute: async () => ({ success: true, output: 'ok' }),
+	})
+}
+
+/**
+ * A plugin manager that fails one lifecycle event.
+ *
+ * `applyLifecycleHookResults` turns an `error` result into a throw, which is
+ * the cheapest way to fail an iteration at a chosen point: `post_llm_call`
+ * lands after the provider answered and its tokens were counted but before
+ * any step is recorded, and `iteration_end` lands after the step already is.
+ */
+function failingAt(event: PluginHookEvent, message: string): PluginLifecycleManager {
+	return {
+		executeHooks: async (fired: PluginHookEvent) =>
+			fired === event ? [{ action: 'error', message }] : [],
+	} as unknown as PluginLifecycleManager
+}
+
+function baseParams(provider: MockLLMProvider, tools: ToolRegistry, workingDirectory: string) {
+	return {
+		provider,
+		tools,
+		runConfig: {
+			model: 'run-model',
+			timeoutMs: 5_000,
+			tokenBudget: 100_000,
+			maxIterations: 4,
+			maxResponseTokens: 256,
+		},
+		agentId: 'agent_fail',
+		agentName: 'Fail Agent',
+		workingDirectory,
+		sessionId: 'ses_fail' as SessionId,
+		threadId: 'thd_fail' as ThreadId,
+		projectId: 'prj_fail' as ProjectId,
+		tenantId: 'tnt_fail' as TenantId,
+		retry: false as const,
+	}
+}
+
+describe('an iteration that failed still leaves a step', () => {
+	let workdirs: string[] = []
+
+	afterEach(async () => {
+		await removeTempDirs(workdirs)
+		workdirs = []
+	})
+
+	async function mkWorkdir(): Promise<string> {
+		const dir = await mkdtemp(join(tmpdir(), 'namzu-failstep-'))
+		workdirs.push(dir)
+		return dir
+	}
+
+	it('records the turn the provider failed on, saying how it ended', async () => {
+		const provider = new MockLLMProvider({
+			turns: [
+				{ toolCalls: [{ id: 'c1', name: 'echo', rawArguments: '{}' }] },
+				{ error: { message: 'upstream refused the request', status: 400 } },
+			],
+		})
+		const tools = new ToolRegistry()
+		registerEcho(tools)
+
+		const run = await drainQuery({
+			...baseParams(provider, tools, await mkWorkdir()),
+			messages: [createUserMessage('hello')],
+		})
+
+		const failed = run.steps?.at(-1)
+		expect(run.steps).toHaveLength(2)
+		expect(failed?.stepNumber).toBe(2)
+		// How it ended, in the field a reader already sorts by.
+		expect(failed?.finishReason).toBe('error')
+		// And WHAT went wrong — a step that only said `error` would leave a
+		// reader back where they started, re-parsing the run's message.
+		expect(failed?.failure?.message).toContain('upstream refused the request')
+		expect(failed?.failure?.status).toBe(400)
+		expect(failed?.failure?.code).toBe('invalid_request')
+		expect(failed?.failure?.retryable).toBe(false)
+	})
+
+	it('gives every iteration the events announced an entry in the ledger', async () => {
+		// Read off the EVENTS rather than a constant. The events are the other
+		// party to the contract `stepNumber` documents itself against, and the
+		// defect was that the two disagreed on exactly the failing turn — the
+		// one iteration that emitted `iteration_started` and no `_completed`.
+		const provider = new MockLLMProvider({
+			turns: [
+				{ toolCalls: [{ id: 'c1', name: 'echo', rawArguments: '{}' }] },
+				{ toolCalls: [{ id: 'c2', name: 'echo', rawArguments: '{}' }] },
+				{ error: { message: 'the third turn died' } },
+			],
+		})
+		const tools = new ToolRegistry()
+		registerEcho(tools)
+		const events: RunEvent[] = []
+
+		const run = await drainQuery(
+			{
+				...baseParams(provider, tools, await mkWorkdir()),
+				messages: [createUserMessage('hello')],
+			},
+			(e) => {
+				events.push(e)
+			},
+		)
+
+		const started = events
+			.filter((e) => e.type === 'iteration_started')
+			.map((e) => (e as { iteration: number }).iteration)
+
+		expect(started).toEqual([1, 2, 3])
+		expect(run.steps?.map((s) => s.stepNumber)).toEqual(started)
+	})
+
+	it('carries the tokens the failed turn spent, so the ledger still reconciles', async () => {
+		// The case the issue is really about: the model was called, the tokens
+		// were counted against the run, and then the iteration died. Without a
+		// step those tokens belong to nothing, and the gap grows with context
+		// length because the expensive turn is the late one.
+		const provider = new MockLLMProvider({
+			turns: [
+				{
+					text: 'an answer nobody gets to keep',
+					usage: { promptTokens: 400, completionTokens: 40, totalTokens: 440 },
+				},
+			],
+		})
+
+		const run = await drainQuery({
+			...baseParams(provider, new ToolRegistry(), await mkWorkdir()),
+			pluginManager: failingAt('post_llm_call', 'the audit hook rejected the reply'),
+			messages: [createUserMessage('hello')],
+		})
+
+		const ledger = (run.steps ?? []).reduce((total, s) => total + s.usage.totalTokens, 0)
+
+		expect(run.tokenUsage.totalTokens).toBe(440)
+		// Summed AND named: a ledger that reconciled while attributing the
+		// spend to some other step would satisfy the first line alone.
+		expect(ledger).toBe(run.tokenUsage.totalTokens)
+		expect(run.steps?.map((s) => s.usage.totalTokens)).toEqual([440])
+		expect(run.steps?.[0]?.finishReason).toBe('error')
+	})
+
+	it('names the message the events carry, on a stream that died part-way', async () => {
+		// The correlation a host needs to see what the failed turn produced.
+		// `streamProviderTurn` returns the id and a throw means the return
+		// never happens, so the loop mints it beforehand — otherwise the one
+		// turn whose partial output is worth finding is the one with no id.
+		const provider = new MockLLMProvider({
+			turns: [{ text: 'a long answer that gets cut off', throwAfterChunks: 1 }],
+		})
+		const events: RunEvent[] = []
+
+		const run = await drainQuery(
+			{
+				...baseParams(provider, new ToolRegistry(), await mkWorkdir()),
+				messages: [createUserMessage('hello')],
+			},
+			(e) => {
+				events.push(e)
+			},
+		)
+
+		const announced = events.find((e) => e.type === 'message_started') as
+			| { messageId: string }
+			| undefined
+		const closed = events.find((e) => e.type === 'message_completed') as
+			| { messageId: string }
+			| undefined
+
+		expect(announced?.messageId).toBeDefined()
+		expect(run.steps?.[0]?.messageId).toBe(announced?.messageId)
+		// Both ends, so the id is a trail rather than a dangling reference.
+		expect(closed?.messageId).toBe(announced?.messageId)
+	})
+
+	it('does not report a tool call that never came back as an empty success', async () => {
+		// `{output: '', isError: false}` is how the success path fills a call
+		// with no outcome, and under a step that says `error` it would claim a
+		// tool ran and returned nothing successfully — the same lie one level
+		// down as the missing step.
+		const provider = new MockLLMProvider({
+			turns: [{ toolCalls: [{ id: 'c1', name: 'echo', rawArguments: '{}' }] }],
+		})
+		const tools = new ToolRegistry()
+		registerEcho(tools)
+
+		const run = await drainQuery({
+			...baseParams(provider, tools, await mkWorkdir()),
+			pluginManager: failingAt('post_llm_call', 'rejected before the tools ran'),
+			messages: [createUserMessage('hello')],
+		})
+
+		const step = run.steps?.[0]
+		// What the model asked for is evidence and is kept.
+		expect(step?.toolCalls.map((tc) => tc.function.name)).toEqual(['echo'])
+		// What came back is nothing, and it says nothing rather than something
+		// that reads as success.
+		expect(step?.toolResults).toEqual([])
+	})
+
+	it('records a cancelled turn as cancelled rather than as a failure', async () => {
+		// A Stop is not an error and the step must not call it one — a host
+		// counting failures would count every cancellation.
+		const controller = new AbortController()
+		const provider = new MockLLMProvider({
+			turns: [{ text: 'the model was talking when the stop arrived', chunkSize: 4 }],
+			onRequest: () => {
+				controller.abort()
+			},
+		})
+
+		const run = await drainQuery({
+			...baseParams(provider, new ToolRegistry(), await mkWorkdir()),
+			signal: controller.signal,
+			messages: [createUserMessage('hello')],
+		})
+
+		expect(run.stopReason).toBe('cancelled')
+		expect(run.steps).toHaveLength(1)
+		expect(run.steps?.[0]?.finishReason).toBe('cancelled')
+		expect(run.steps?.[0]?.failure).toBeUndefined()
+	})
+
+	it('does not add a second entry when the failure lands after the step', async () => {
+		// Both success paths record before the work that follows them, so a
+		// throw from the advisory phase or an `iteration_end` hook arrives at
+		// a catch whose iteration is already in the ledger. Recording again
+		// would double-count that turn against `run.tokenUsage` — the same
+		// class of wrong as dropping it, and harder to notice, because the
+		// ledger looks fuller rather than emptier.
+		const provider = new MockLLMProvider({
+			turns: [
+				{
+					toolCalls: [{ id: 'c1', name: 'echo', rawArguments: '{}' }],
+					usage: { promptTokens: 90, completionTokens: 10, totalTokens: 100 },
+				},
+			],
+		})
+		const tools = new ToolRegistry()
+		registerEcho(tools)
+
+		const run = await drainQuery({
+			...baseParams(provider, tools, await mkWorkdir()),
+			pluginManager: failingAt('iteration_end', 'the trailing hook blew up'),
+			messages: [createUserMessage('hello')],
+		})
+
+		expect(run.steps?.map((s) => s.stepNumber)).toEqual([1])
+		// The turn's own verdict survives; it really did end in tool calls,
+		// and the failure that came afterwards is the run's, not the turn's.
+		expect(run.steps?.[0]?.finishReason).toBe('tool_calls')
+		expect((run.steps ?? []).reduce((t, s) => t + s.usage.totalTokens, 0)).toBe(
+			run.tokenUsage.totalTokens,
+		)
+	})
+})

--- a/packages/sdk/src/runtime/query/__tests__/provider-chain-provenance.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/provider-chain-provenance.test.ts
@@ -171,7 +171,7 @@ describe('the run record names the member that served', () => {
 		expect(run.metadata.servingProvider).toBe(fallback.id)
 	})
 
-	it('names the serving member even when the run dies before a step is recorded', async () => {
+	it('names the serving member when no step can say who served', async () => {
 		const primary = failing('primary', 401)
 		const secondary = failing('secondary', 503)
 
@@ -181,11 +181,19 @@ describe('the run record names the member that served', () => {
 			messages: [createUserMessage('hello')],
 		})
 
-		// Nothing served, so there is no step ledger to read — which is exactly
-		// the case `metadata.servingProvider` exists for. The run still has to be
+		// Nothing served, so no step can carry `servedBy` — which is exactly the
+		// case `metadata.servingProvider` exists for. The run still has to be
 		// able to say whose failure ended it.
+		//
+		// This used to assert an EMPTY ledger, and that assertion was only ever
+		// true because a failed iteration recorded nothing at all. The failing
+		// turn now leaves a step like every other turn does, so the premise is
+		// restated where it actually holds: the step exists and is silent about
+		// provenance, because the chain was exhausted before anyone answered.
 		expect(run.status).toBe('failed')
-		expect(run.steps ?? []).toHaveLength(0)
+		expect(run.steps ?? []).toHaveLength(1)
+		expect(run.steps?.[0]?.servedBy).toBeUndefined()
+		expect(run.steps?.[0]?.finishReason).toBe('error')
 		expect(run.metadata.servingProvider).toBe('secondary')
 	})
 

--- a/packages/sdk/src/runtime/query/iteration/index.ts
+++ b/packages/sdk/src/runtime/query/iteration/index.ts
@@ -32,6 +32,7 @@ import type { AnswerReview } from '../../../types/run/answer-review.js'
 import type {
 	PrepareStepResult,
 	RunEvent,
+	StepFailure,
 	StepProvenance,
 	StepResult,
 	StopReason,
@@ -258,6 +259,30 @@ export class IterationOrchestrator {
 					{},
 					parentContext(this.ctx.rootSpan),
 				)
+
+				// Everything the step record needs, hoisted so the `catch` can
+				// read whatever the iteration got as far as computing.
+				//
+				// The failure path is the one the ledger's own argument was
+				// written for and the one it never reached: an iteration that
+				// threw recorded a span exception and re-threw, so the turn with
+				// no record was exactly the turn that went wrong. A reader could
+				// not tell that from a turn that never happened.
+				//
+				// Declared as `let` with real initial values rather than left
+				// undefined, because a failure BEFORE the snapshot below is
+				// taken has spent nothing, and these are then exact. The success
+				// path is untouched: the assignments inside the try still happen
+				// where they always did, so compaction and the working-memory
+				// refresh stay outside a successful step's window.
+				let stepStartedAt = Date.now()
+				let usageBefore: TokenUsage = { ...runMgr.tokenUsage }
+				let costBefore: CostInfo = { ...runMgr.costInfo }
+				let stepModel = model
+				let stepMessageId: MessageId | undefined
+				let stepResponse: ChatCompletionResponse | undefined
+				let stepServedBy: StepProvenance | undefined
+
 				try {
 					// Tool spans for this turn belong under this iteration. Inside
 					// the try rather than before it: a throw from any of these left
@@ -303,9 +328,9 @@ export class IterationOrchestrator {
 					// tool_use/tool_result blocks.
 					// Snapshot the cumulative counters so the step can report ITS
 					// own usage rather than the run total.
-					const stepStartedAt = Date.now()
-					const usageBefore = { ...runMgr.tokenUsage }
-					const costBefore = { ...runMgr.costInfo }
+					stepStartedAt = Date.now()
+					usageBefore = { ...runMgr.tokenUsage }
+					costBefore = { ...runMgr.costInfo }
 
 					// Shape this step before calling the model. `stopWhen` decides
 					// whether to keep going; this decides HOW. No-op when the host
@@ -320,7 +345,7 @@ export class IterationOrchestrator {
 					// still call any of them by name.
 					this.ctx.toolExecutor.setStepAllowedTools(stepAllowedTools)
 					const enforceToolInputSchema = enforcedModelInputToolNames(this.ctx.tools, llmTools)
-					const stepModel = step.model ?? model
+					stepModel = step.model ?? model
 
 					const baseMessages = forceFinalize
 						? [
@@ -389,6 +414,16 @@ export class IterationOrchestrator {
 					// aggregated `ChatCompletionResponse` for the legacy
 					// downstream paths (assistantMsg construction, working
 					// state extraction, telemetry attribute stamping).
+					//
+					// The message id is minted HERE, immediately before the call
+					// that announces it,
+					// rather than inside that call. The return value never arrives
+					// when the stream throws, so a step recorded from the catch
+					// could otherwise never name the message — and a stream that
+					// died part-way has already emitted both `message_started` and
+					// `message_completed` under this id, which is the trail a
+					// reader wants most on exactly that turn.
+					stepMessageId = generateMessageId()
 					const { response, messageId } = yield* streamProviderTurn(
 						this.ctx.provider,
 						{
@@ -424,7 +459,9 @@ export class IterationOrchestrator {
 						forceFinalize,
 						this.ctx.log,
 						iterSpan,
+						stepMessageId,
 					)
+					stepResponse = response
 
 					// Who answered THIS turn.
 					//
@@ -459,6 +496,7 @@ export class IterationOrchestrator {
 							chainIndex: member.index,
 						}
 					})()
+					stepServedBy = servedBy
 
 					// Main-loop turn: also records the prompt size compaction reads.
 					//
@@ -1014,6 +1052,76 @@ export class IterationOrchestrator {
 					})
 					yield* this.ctx.drainPending()
 				} catch (err) {
+					const cancelled = this.ctx.abortController.signal.aborted
+
+					// This iteration gets a step too, and it is the one the
+					// argument three hundred lines above was actually about.
+					//
+					// That docblock makes the case for a rejected tool batch — "a
+					// run that spent a turn getting its tools refused still spent
+					// the tokens" — and every call site it produced sat on a
+					// success path. So the ledger was complete except on the turns
+					// that failed, which is the worst shape it could have: an
+					// evidence record that goes quiet exactly where something went
+					// wrong reads as "nothing went wrong". A reader could not
+					// distinguish iteration N failing from iteration N never
+					// happening, while the events said plainly that it started.
+					//
+					// Recorded HERE, at the top of the catch, rather than at each
+					// of its exits — the same reasoning the success path already
+					// wrote down for itself. All three exits spend a turn: the
+					// cancellation breaks, the overflow-relief retry continues
+					// under a NEW iteration number (so its tokens belong to no
+					// later step), and the re-throw ends the run.
+					//
+					// What it carries is what the iteration got as far as knowing.
+					// `usage` is the same subtraction a successful step makes, so
+					// a turn that failed after the provider answered carries that
+					// answer's tokens, and one that failed before it carries the
+					// zero it actually spent. Nothing is estimated to fill a gap.
+					//
+					// At most ONE step per iteration. Both success paths record
+					// before the work that follows them — the advisory phase, the
+					// structured-output capture, the `iteration_end` hooks, the
+					// terminal `iteration_completed` — and any of those can throw
+					// into here. A second entry numbered N would double-count that
+					// turn's tokens against `run.tokenUsage`, which is the same
+					// class of wrong as dropping them and harder to notice, since
+					// the ledger would look fuller rather than emptier. That turn's
+					// own verdict is already written down; the failure that
+					// followed it reaches the caller as the run's error.
+					if (this.steps.at(-1)?.stepNumber === iterationNum) {
+						this.ctx.log.warn('Iteration failed after its step was already recorded', {
+							runId: runMgr.id,
+							iteration: iterationNum,
+							error: toErrorMessage(err),
+						})
+					} else {
+						this.recordStep({
+							stepNumber: iterationNum,
+							model: stepModel,
+							...(stepServedBy ? { servedBy: stepServedBy } : {}),
+							...(stepMessageId ? { messageId: stepMessageId } : {}),
+							...(stepResponse ? { response: stepResponse } : {}),
+							// Tool outcomes are produced and returned together by
+							// `runToolReview`, so a throw from inside it leaves none
+							// to salvage: an empty list here means "none came back",
+							// which is what the shorter-than-`toolCalls` contract
+							// says.
+							toolResults: [],
+							toolExecutionMs: 0,
+							startedAt: stepStartedAt,
+							usageBefore,
+							costBefore,
+							unfinished: cancelled
+								? { finishReason: 'cancelled' }
+								: {
+										finishReason: 'error',
+										failure: describeStepFailure(err, this.ctx.provider.id),
+									},
+						})
+					}
+
 					// A Stop that aborted the in-flight turn surfaces here as a
 					// thrown abort (the provider stream was raced against the run
 					// signal). Settle it as a CANCELLATION — mirroring the
@@ -1021,7 +1129,7 @@ export class IterationOrchestrator {
 					// recording it as an SDK failure (error span + failed activity)
 					// and re-throwing. The run then returns cleanly with a
 					// 'cancelled' stop reason instead of propagating an error.
-					if (this.ctx.abortController.signal.aborted) {
+					if (cancelled) {
 						runMgr.setStopReason('cancelled')
 						runMgr.markCancelled()
 						break
@@ -1308,39 +1416,69 @@ export class IterationOrchestrator {
 	private recordStep(input: {
 		stepNumber: number
 		model: string
-		servedBy: StepProvenance
-		messageId: MessageId
-		response: ChatCompletionResponse
+		servedBy?: StepProvenance
+		messageId?: MessageId
+		/**
+		 * The turn's response. Absent only when the iteration failed before
+		 * the provider produced one — see `unfinished`.
+		 */
+		response?: ChatCompletionResponse
 		toolResults: readonly ToolCallOutcome[]
 		toolExecutionMs: number
 		startedAt: number
 		usageBefore: TokenUsage
 		costBefore: CostInfo
+		/**
+		 * Set only by the `catch`, for an iteration that did not finish.
+		 *
+		 * The same writer builds both records on purpose: a failed turn's
+		 * step is a `StepResult` like any other, so a caller reconstructing
+		 * cost or history sorts them together instead of discovering that
+		 * failures live somewhere else.
+		 */
+		unfinished?: { finishReason: 'error' | 'cancelled'; failure?: StepFailure }
 	}): void {
 		const { runMgr } = this.ctx
-		const toolCalls = input.response.message.toolCalls ?? []
+		const toolCalls = input.response?.message.toolCalls ?? []
 		const byId = new Map(input.toolResults.map((r) => [r.toolCallId, r]))
 
 		const step: StepResult = {
 			stepNumber: input.stepNumber,
 			model: input.model,
-			servedBy: input.servedBy,
-			messageId: input.messageId,
-			content: input.response.message.content,
+			...(input.servedBy ? { servedBy: input.servedBy } : {}),
+			...(input.messageId ? { messageId: input.messageId } : {}),
+			content: input.response?.message.content ?? null,
 			toolCalls,
 			// Ordered by the tool CALLS, not by completion, so the record
 			// matches what the model asked for.
-			toolResults: toolCalls.map((tc) => {
+			//
+			// On an unfinished step the calls with no outcome are DROPPED
+			// rather than filled with `{output: '', isError: false}`. That
+			// filler is a reading of "the batch was refused" on the success
+			// path, where every call in a batch shares one verdict; under a
+			// step that says `error` it would say a tool ran and returned
+			// nothing successfully, which is the same lie one level down as
+			// the missing step itself.
+			toolResults: toolCalls.flatMap((tc) => {
 				const outcome = byId.get(tc.id)
-				return {
-					toolCallId: tc.id,
-					toolName: tc.function.name,
-					output: outcome?.output ?? '',
-					isError: outcome?.isError ?? false,
-					durationMs: 0,
-				}
+				if (input.unfinished && !outcome) return []
+				return [
+					{
+						toolCallId: tc.id,
+						toolName: tc.function.name,
+						output: outcome?.output ?? '',
+						isError: outcome?.isError ?? false,
+						durationMs: 0,
+					},
+				]
 			}),
-			finishReason: input.response.finishReason,
+			// The turn's own verdict where there is one. A step that ended in
+			// the catch has none — no provider reported `error` or
+			// `cancelled` — so `unfinished` wins even when a response had
+			// already arrived: a turn that answered and then threw during
+			// tool execution did not end in `tool_calls`.
+			finishReason: input.unfinished?.finishReason ?? input.response?.finishReason ?? 'error',
+			...(input.unfinished?.failure ? { failure: input.unfinished.failure } : {}),
 			usage: subtractUsage(runMgr.tokenUsage, input.usageBefore),
 			costDelta: {
 				...runMgr.costInfo,
@@ -1352,7 +1490,26 @@ export class IterationOrchestrator {
 		}
 
 		this.steps.push(step)
-		this.ctx.onStepFinish?.(step)
+
+		if (!input.unfinished) {
+			this.ctx.onStepFinish?.(step)
+			return
+		}
+
+		// Nothing here is allowed to throw over the failure that is already
+		// unwinding — the same rule `settleCancelledTurn` states for the
+		// cancellation path. A host callback that throws while being told a
+		// turn failed would REPLACE the reason the turn failed, so the run
+		// would report the observer's bug and lose the original.
+		try {
+			this.ctx.onStepFinish?.(step)
+		} catch (err) {
+			this.ctx.log.warn('onStepFinish threw while recording a failed step', {
+				runId: runMgr.id,
+				step: input.stepNumber,
+				error: toErrorMessage(err),
+			})
+		}
 	}
 
 	/** Turns spent asking the model again for a valid structured output. */
@@ -1618,6 +1775,26 @@ export class IterationOrchestrator {
 				error: toErrorMessage(err),
 			})
 		}
+	}
+}
+
+/**
+ * Fold whatever ended an iteration into the record a reader gets.
+ *
+ * Classified through `classifyProviderError` — the same call the catch
+ * already makes to decide whether compaction relief applies — so the step's
+ * verdict and the loop's own decision cannot drift apart. It also handles a
+ * failure that is not a provider failure at all: the code set's `unknown`
+ * means "unclassifiable", which is the true answer for a plugin hook that
+ * threw and is left saying so rather than dressed up as something specific.
+ */
+function describeStepFailure(err: unknown, providerId: string): StepFailure {
+	const classified = classifyProviderError(err, providerId)
+	return {
+		message: toErrorMessage(err),
+		code: classified.code,
+		...(classified.status !== undefined ? { status: classified.status } : {}),
+		retryable: classified.retryable,
 	}
 }
 

--- a/packages/sdk/src/runtime/query/iteration/stream-turn.ts
+++ b/packages/sdk/src/runtime/query/iteration/stream-turn.ts
@@ -134,6 +134,19 @@ export async function* streamProviderTurn(
 	forceFinalize: boolean,
 	log: Logger,
 	parentSpan?: Span,
+	/**
+	 * The id to announce this message under.
+	 *
+	 * Supplied by the loop so a turn that THROWS still leaves the caller
+	 * holding the id it announced. The return value never arrives on a
+	 * failure, so without this the one case where a failed step most wants
+	 * to point at the event stream — a stream that died after
+	 * `message_started`, having already emitted `message_completed` on the
+	 * way out — is precisely the case that could not.
+	 *
+	 * Optional, so a caller with no use for the id is unchanged.
+	 */
+	announceAs?: import('../../../types/ids/index.js').MessageId,
 ): AsyncGenerator<RunEvent, StreamingTurnResult> {
 	// The `chat {model}` span the GenAI conventions require. There was none:
 	// `chatSpanName` existed with zero call sites, so a trace carried no LLM
@@ -151,7 +164,7 @@ export async function* streamProviderTurn(
 		...(params.maxTokens !== undefined ? { [GENAI.REQUEST_MAX_TOKENS]: params.maxTokens } : {}),
 	})
 
-	const messageId = generateMessageId()
+	const messageId = announceAs ?? generateMessageId()
 	await emitEvent({ type: 'message_started', runId, iteration, messageId })
 	yield* drainPending()
 
@@ -194,7 +207,12 @@ export async function* streamProviderTurn(
 	// verbatim — so the map is drained in index order at the end.
 	const reasoningBuckets = new Map<
 		number,
-		{ type: 'thinking' | 'redacted_thinking'; text: string; signature?: string; encrypted?: string }
+		{
+			type: 'thinking' | 'redacted_thinking'
+			text: string
+			signature?: string
+			encrypted?: string
+		}
 	>()
 
 	// Citations arrive as their own deltas, in the order the model made
@@ -205,7 +223,10 @@ export async function* streamProviderTurn(
 	let streamError: string | undefined
 	let streamCause: unknown
 
-	const stream = provider.chatStream({ ...params, stream: true }) as AsyncIterable<StreamChunk>
+	const stream = provider.chatStream({
+		...params,
+		stream: true,
+	}) as AsyncIterable<StreamChunk>
 
 	// Drive the stream manually so each `.next()` can be RACED against the run
 	// abort: a Stop tears the in-flight model request down (the provider got

--- a/packages/sdk/src/types/run/step.ts
+++ b/packages/sdk/src/types/run/step.ts
@@ -1,6 +1,7 @@
 import type { CostInfo, TokenUsage } from '../common/index.js'
 import type { MessageId } from '../ids/index.js'
 import type { ToolCall } from '../message/index.js'
+import type { ProviderErrorCode } from '../provider/errors.js'
 
 /**
  * What one iteration of the agent loop did.
@@ -55,13 +56,56 @@ export interface StepResult {
 	 * it is handed.
 	 */
 	servedBy?: StepProvenance
-	messageId: MessageId
+	/**
+	 * The assistant message this step produced.
+	 *
+	 * Absent only on a step whose iteration ended before the model's message
+	 * was announced — a compaction failure, a lifecycle hook that threw, a
+	 * transport error raised before the first chunk. Absence is left meaning
+	 * "there was no message" rather than filled with an id the event stream
+	 * never carried: a `messageId` a reader cannot find a `message_started`
+	 * for is worse evidence than no id at all, because it invites the
+	 * correlation and then loses it.
+	 *
+	 * Present, and correlatable, on every step whose iteration got as far as
+	 * the provider call — including one that failed mid-stream. The loop
+	 * mints the id before the call that announces it, and a dying stream
+	 * emits `message_completed` on its way out, so the events carry both
+	 * ends of the message a failed step points at.
+	 */
+	messageId?: MessageId
 	/** Assistant text for this step, if any. */
 	content: string | null
 	toolCalls: readonly ToolCall[]
-	/** Tool outcomes, in the same order as `toolCalls`. */
+	/**
+	 * Tool outcomes, in the same order as `toolCalls`.
+	 *
+	 * Shorter than `toolCalls` on a step that ended in failure: only the
+	 * outcomes that exist are recorded, so a call with no entry here reads
+	 * as "never came back" rather than as an empty success. Pair by
+	 * `toolCallId`, not by index.
+	 */
 	toolResults: readonly StepToolResult[]
-	finishReason: 'stop' | 'tool_calls' | 'length' | 'content_filter'
+	/**
+	 * How the turn ended.
+	 *
+	 * `error` and `cancelled` are not provider verdicts — no provider reports
+	 * them — but a step exists for a failed iteration too, and it has to say
+	 * how it ended in the same field a reader already sorts by. `error` comes
+	 * with {@link failure}; `cancelled` means a Stop tore the turn down and
+	 * there is no failure to report.
+	 */
+	finishReason: 'stop' | 'tool_calls' | 'length' | 'content_filter' | 'error' | 'cancelled'
+	/**
+	 * What went wrong, on a step with `finishReason: 'error'`.
+	 *
+	 * Absent everywhere else. A run whose ledger is complete except on the
+	 * turns that failed reads as "nothing went wrong" precisely when
+	 * something did, which is worse than an absent record — so the failed
+	 * turn gets the same record as every other, and this is what makes it
+	 * legible as a failure.
+	 */
+	failure?: StepFailure
 	/** Usage for THIS step, not the run's cumulative total. */
 	usage: TokenUsage
 	/** Cost delta attributable to this step. Zero without a pricing table. */
@@ -86,6 +130,35 @@ export interface StepProvenance {
 	readonly model: string
 	/** 0 is the head, i.e. the provider the run was configured with. */
 	readonly chainIndex: number
+}
+
+/**
+ * Why a step ended in `finishReason: 'error'`.
+ *
+ * The step-level counterpart of the pair a failed run already carries —
+ * {@link import('./entity.js').Run.lastError} and
+ * {@link import('./entity.js').Run.lastProviderError} — and shaped from the
+ * same classification, so the two agree when the failed step is the one that
+ * ended the run. What a run records once, a run of twenty iterations records
+ * per iteration, which is the difference between "this run failed" and "this
+ * turn failed, and the next four succeeded".
+ */
+export interface StepFailure {
+	/** The failure's message, as the iteration's span and log recorded it. */
+	readonly message: string
+	/**
+	 * Where the classifier placed it.
+	 *
+	 * `unknown` for a failure that is not a provider failure at all — a
+	 * plugin hook that threw, a bug in a tool wrapper. That is the honest
+	 * reading of the code's own contract ("unclassifiable"), and it is left
+	 * saying so rather than being given a more specific-looking code.
+	 */
+	readonly code: ProviderErrorCode
+	/** HTTP status, when the failure carried one. */
+	readonly status?: number
+	/** Whether sending the same request again could have worked. */
+	readonly retryable: boolean
 }
 
 export interface StepToolResult {


### PR DESCRIPTION
Closes #372.

## The defect

`recordStep` had two call sites and both were on success paths. An iteration that threw recorded a span exception and re-threw with nothing written down, so a run ledger was complete except on the turns that failed — which reads as "nothing went wrong" precisely where something did. A reader could not tell iteration N failing from iteration N never happening, while the events said plainly that it started.

The reasoning was already in the tree. The docblock above the existing call site argues that even a rejected tool batch must produce a step, because "a run that spent a turn getting its tools refused still spent the tokens". It was never extended past the happy path.

## What a failed iteration's step now contains

The same `StepResult` every other turn gets, from the same writer, recorded at the top of the `catch` and covering all three of its exits — the cancellation, the overflow-relief retry, and the re-throw:

| Field | On a failed turn |
| --- | --- |
| `stepNumber` | the iteration the events announced |
| `model` | the model the step asked for |
| `finishReason` | `error`, or `cancelled` for a Stop |
| `failure` | `{ message, code, status?, retryable }` — new |
| `usage`, `costDelta` | the same subtraction every step makes: the answer's tokens if it failed after the model replied, the zero it really spent if before |
| `messageId` | present whenever the turn reached the provider, including a stream that died part-way |
| `toolCalls` | what the model asked for |
| `toolResults` | only the outcomes that came back |
| `servedBy` | absent when nothing answered |

`failure` is classified through the same `classifyProviderError` call the catch already makes for the overflow-relief decision, so the step's verdict and the loop's own decision cannot drift apart. `code: 'unknown'` for a failure that is not a provider failure — a hook that threw — because that is the code set's own meaning, and it is left saying so rather than dressed up as something specific.

## Three decisions worth reviewing

**The message id is minted in the loop now, not inside `streamProviderTurn`.** The return value never arrives on a throw, so without this the one failure whose partial output is worth finding — a stream that died after `message_started`, having already emitted `message_completed` — was the one with no id. An id the event stream never carried would be worse than none, which is why the field is optional rather than always populated.

**Tool calls with no outcome are dropped rather than filled.** An empty output with `isError: false` is how the success path fills a refused batch; under a step that says `error` it would claim a tool ran and returned nothing successfully, which is the same lie one level down as the missing step.

**One step per iteration.** Both success paths record before the work that follows them, so a throw from the advisory phase or a trailing lifecycle hook arrives at a catch whose iteration is already in the ledger. A second entry would double-count that turn against `run.tokenUsage` — the same class of wrong as dropping it, and harder to notice because the ledger looks fuller rather than emptier.

## Breaking

`major`. Three read-side changes to `StepResult`: `finishReason` widens (an exhaustive `switch` needs two more cases), `messageId` becomes optional, and `toolResults` may be shorter than `toolCalls` on a failed step. The changeset names each and what to do about it.

## Tests

`a-failed-iteration-is-still-a-step.test.ts`, 7 cases, asserting against totals where possible — one step per `iteration_started` event, and the token sum reconciling with `run.tokenUsage` — because the defect was an absence, and an absence is only visible against something that says how much should be there.

Mutation profile, with `every-iteration-is-a-step.test.ts` as the preservation set:

| Mutation | Result |
| --- | --- |
| catch records no step (the pre-fix state) | 6 of 7 killed; the seventh is the duplicate-guard preservation case; all 6 neighbours pass |
| duplicate guard disabled | 1 killed — two entries numbered 1 against one |
| failed step keeps empty tool results | 1 killed |
| message id not passed through | 1 killed — two different ids |
| response's `finishReason` wins over the failure's | 1 killed — `stop` against `error` |
| cancellation recorded as `error` | 1 killed |

`provider-chain-provenance.test.ts` asserted an EMPTY ledger on a run that died before serving. That was only ever true because of this defect; the premise is restated where it holds — the step exists, carries no `servedBy`, and says `error`, which is why `metadata.servingProvider` has to name the member.

## Gates

`typecheck`, `lint`, `test` (359 files, 3232 passed, 7 skipped), `test:proc`, `audit-external-names`, `verify-public-surface` (baseline regenerated for `StepFailure`), `check-sdk-test-presence`, `test:coverage` plus `check-sdk-module-coverage`, `check-docs` — all green locally.

Docs: `docs/sdk/runtime/loop-control.md` section 2.
