### PR TITLE
fix(sdk): tool retry backs off with full jitter instead of firing again immediately

### DIFF
--- a/.changeset/tool-retry-backs-off.md
+++ b/.changeset/tool-retry-backs-off.md
@@ -1,0 +1,37 @@
+---
+'@namzu/sdk': major
+---
+
+Tool retry now backs off with full jitter instead of re-running immediately
+
+The in-loop tool retry had no delay at all: a failed call went straight back
+into execution, as many times as its budget allowed. The failures worth
+retrying are exactly the ones an immediate retry makes worse — a rate limit
+answers the second call faster than it recovers, a contended lock is still
+held — so the loop was most likely to prolong the condition it was retrying
+against.
+
+Attempts are now spaced on the same curve the provider path has always used,
+from the same implementation: exponential from `initialDelayMs`, doubling per
+attempt, capped at `maxDelayMs`, each wait drawn uniformly from `[0, curve]`.
+The jitter matters here specifically because a batch of the model's parallel
+calls executes together, so calls that fail together against one endpoint
+would be resynchronised by any fixed wait.
+
+**This is a changed default, which is why it is major.** A retryable tool call
+that previously re-ran instantly now waits — 500ms doubling to a 16s ceiling
+before jitter — so any host whose tools declare `maxRetries` sees new latency
+on the retry path. Nothing else waits: a tool that never opted into retrying,
+which is the shipped default of `maxRetries: 0`, never reaches this code.
+
+To keep the old timing exactly, set the wait to zero:
+
+```ts
+query({ toolRetryBackoff: { initialDelayMs: 0, maxDelayMs: 0 } })
+```
+
+`toolRetryBackoff` is new on `query()` and on `ReactiveAgentConfig`, and takes
+a partial `{ initialDelayMs?, maxDelayMs? }`.
+
+A Stop arriving during a wait now ends the retrying and hands the model the
+failure already in hand, rather than leaving that `tool_use` unanswered.

--- a/.github/scripts/public-surface-baseline.json
+++ b/.github/scripts/public-surface-baseline.json
@@ -689,6 +689,7 @@
     "AssistantMessage",
     "AuthConfig",
     "AuthType",
+    "BackoffPolicy",
     "BaseAgentConfig",
     "BaseAgentResult",
     "BaseConnector",

--- a/docs/sdk/runtime/loop-control.md
+++ b/docs/sdk/runtime/loop-control.md
@@ -1,7 +1,7 @@
 ---
 title: Loop Control and Resilience
 description: Stop conditions, step records, provider retry, budgets across resume, compaction triggers and outcomes, and extended thinking and effort in the @namzu/sdk agent loop.
-last_updated: 2026-08-05
+last_updated: 2026-08-10
 status: current
 related_packages: ["@namzu/sdk", "@namzu/anthropic"]
 ---
@@ -750,6 +750,30 @@ retried — a missing file will not appear on the second attempt.
 
 A `post_tool_use` plugin hook returning `{ action: 'retry' }` also re-runs
 the tool, bounded by the same budget.
+
+**Attempts are spaced, with full jitter** — the same discipline §3 applies to
+model calls, from the same implementation. The loop had no delay at all: a
+retryable failure was re-run the instant it failed, which is the pattern most
+likely to prolong the condition being retried against. Waits double per
+attempt from `initialDelayMs`, each drawn uniformly from `[0, curve]`:
+
+```ts
+query({
+  // …
+  toolRetryBackoff: { initialDelayMs: 500, maxDelayMs: 16_000 }, // the defaults
+})
+```
+
+The jitter is not decoration here. A batch of the model's parallel calls runs
+together, so calls that fail together against one rate-limited endpoint would
+be resynchronised by any fixed wait — a thundering herd the loop assembles
+itself.
+
+Only a tool that opted into retrying ever reaches this, so a run whose tools
+all take the default budget of zero never waits. Set `initialDelayMs: 0` to
+restore the retry-immediately behaviour. A Stop during a wait ends the
+retrying and hands the model the failure already in hand, rather than leaving
+the call unanswered.
 
 ## 10. Typed Failures
 

--- a/docs/sdk/tools/README.md
+++ b/docs/sdk/tools/README.md
@@ -1,7 +1,7 @@
 ---
 title: SDK Tools
 description: Define tools, register them in ToolRegistry, and understand built-in tool behavior in @namzu/sdk.
-last_updated: 2026-08-05
+last_updated: 2026-08-10
 status: current
 related_packages: ["@namzu/sdk", "@namzu/computer-use"]
 ---
@@ -433,6 +433,11 @@ silently re-running a write, a `git push` or a payment call is worse than
 never retrying at all. Even opted in, only failures marked `retryable` are
 retried — a missing file will not appear on the second attempt, and burning
 the budget on it just delays the error the model needs to see.
+
+Attempts are spaced by an exponential backoff with full jitter, defaulting to
+500ms doubling to a 16s ceiling. Tune it per run with
+`query({ toolRetryBackoff })`, or set `initialDelayMs: 0` to retry
+immediately. See [Loop Control §9](../runtime/loop-control.md#per-tool-retry-budget).
 
 **Repairing a malformed call.** `query({ repairToolCall })` gets a last
 look before the error reaches the model, and may rewrite the arguments and

--- a/packages/sdk/src/agents/ReactiveAgent.ts
+++ b/packages/sdk/src/agents/ReactiveAgent.ts
@@ -82,6 +82,9 @@ export class ReactiveAgent extends AbstractAgent<ReactiveAgentConfig, ReactiveAg
 				...(config.retry !== undefined ? { retry: config.retry } : {}),
 				...(config.emergencySave !== undefined ? { emergencySave: config.emergencySave } : {}),
 				...(config.toolTimeoutMs !== undefined ? { toolTimeoutMs: config.toolTimeoutMs } : {}),
+				...(config.toolRetryBackoff !== undefined
+					? { toolRetryBackoff: config.toolRetryBackoff }
+					: {}),
 				...(config.maxToolConcurrency !== undefined
 					? { maxToolConcurrency: config.maxToolConcurrency }
 					: {}),

--- a/packages/sdk/src/provider/retry.ts
+++ b/packages/sdk/src/provider/retry.ts
@@ -1,15 +1,20 @@
 import { classifyProviderError, isAbortError } from '../types/provider/errors.js'
 import type { ChatCompletionParams, LLMProvider, StreamChunk } from '../types/provider/index.js'
+import { type BackoffPolicy, backoffWithJitter, sleep } from '../utils/backoff.js'
 import type { Logger } from '../utils/logger.js'
 import { isProviderRequestError } from './errors.js'
 
-export interface ProviderRetryConfig {
+/**
+ * `BackoffPolicy` plus the provider-specific parts: how many attempts, and
+ * how long a server-directed wait may be honoured for.
+ *
+ * The curve itself lives in `utils/backoff.ts` and is shared with the tool
+ * executor's in-loop retry — which had no backoff at all while this one was
+ * being careful about jitter two directories away.
+ */
+export interface ProviderRetryConfig extends BackoffPolicy {
 	/** Retry attempts AFTER the initial try. `0` disables retrying. */
 	readonly maxRetries: number
-	/** First backoff, doubled each attempt. */
-	readonly initialDelayMs: number
-	/** Ceiling for a single backoff, before jitter. */
-	readonly maxDelayMs: number
 	/**
 	 * Cap on a server-directed `Retry-After`. A provider asking for 15
 	 * minutes should not silently park an interactive run for 15 minutes;
@@ -32,36 +37,6 @@ export const DEFAULT_PROVIDER_RETRY: ProviderRetryConfig = {
 	initialDelayMs: 500,
 	maxDelayMs: 16_000,
 	maxRetryAfterMs: 60_000,
-}
-
-/**
- * Full jitter (AWS's formulation): sleep a uniform random amount in
- * `[0, backoff]` rather than `backoff` exactly. Equal-jitter and no-jitter
- * both keep a fleet of clients that failed together retrying together;
- * full jitter is what actually spreads a thundering herd.
- */
-function backoffWithJitter(attempt: number, config: ProviderRetryConfig, random: () => number) {
-	const exponential = Math.min(config.initialDelayMs * 2 ** attempt, config.maxDelayMs)
-	return Math.round(random() * exponential)
-}
-
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-	if (ms <= 0) return Promise.resolve()
-	return new Promise<void>((resolve, reject) => {
-		if (signal?.aborted) {
-			reject(signal.reason)
-			return
-		}
-		const timer = setTimeout(() => {
-			signal?.removeEventListener('abort', onAbort)
-			resolve()
-		}, ms)
-		const onAbort = () => {
-			clearTimeout(timer)
-			reject(signal?.reason)
-		}
-		signal?.addEventListener('abort', onAbort, { once: true })
-	})
 }
 
 export interface WithProviderRetryOptions {

--- a/packages/sdk/src/public-runtime.ts
+++ b/packages/sdk/src/public-runtime.ts
@@ -357,6 +357,11 @@ export type {
 	WithProviderFallbackOptions,
 	WithProviderRetryOptions,
 } from './provider/index.js'
+// The curve `ProviderRetryConfig` extends and `query({ toolRetryBackoff })`
+// takes a partial of. Both public surfaces name it, so a consumer has to be
+// able to name it too — a type reachable only through an inline `import(...)`
+// in a `.d.ts` is not a type anyone writes down.
+export type { BackoffPolicy } from './utils/backoff.js'
 
 export {
 	assertIsolation,

--- a/packages/sdk/src/runtime/query/__tests__/tool-repair-retry.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/tool-repair-retry.test.ts
@@ -58,6 +58,12 @@ function makeExecutor(
 			permissionMode: 'auto',
 			env: {},
 			abortSignal: new AbortController().signal,
+			// These cases are about WHICH failures are retried and how many
+			// times, not about the wait between attempts — and the wait is
+			// real. `tool-retry-backs-off.test.ts` owns the delay, on fake
+			// timers; leaving the default on here would spend seconds of the
+			// suite's runtime re-proving it slowly.
+			toolRetryBackoff: { initialDelayMs: 0, maxDelayMs: 0 },
 			...extra,
 		},
 		new ActivityStore(RUN_ID, { enabled: false, trackToolCalls: false, trackLlmTurns: false }),

--- a/packages/sdk/src/runtime/query/__tests__/tool-retry-backoff-reaches-the-executor.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/tool-retry-backoff-reaches-the-executor.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Reachability is its own property.
+ *
+ * `tool-retry-backs-off.test.ts` drives `ToolExecutor` directly, which proves
+ * the backoff and proves nothing about whether a host can ask for one. That
+ * hop has been the defect here before: `toolTimeoutMs` and its neighbours sat
+ * on `QueryParams` and stopped there, unreachable for anyone using the Agent
+ * classes, and a policy a consumer cannot set is a policy that does not exist
+ * for them.
+ *
+ * So this file asks one question — does the value a caller passes arrive in
+ * the config `query()` builds the executor from — and answers it structurally
+ * rather than by timing anything. A stopwatch would have to sleep to
+ * discriminate, and the difference between "reached" and "did not reach" is
+ * not a duration; it is a field.
+ */
+
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+
+import { removeTempDirs } from '../../../__fixtures__/temp-dir.js'
+import { MockLLMProvider } from '../../../provider/mock.js'
+import { ToolRegistry } from '../../../registry/tool/execute.js'
+import type { SessionId, TenantId } from '../../../types/ids/index.js'
+import { createUserMessage } from '../../../types/message/index.js'
+import type { ProjectId, ThreadId } from '../../../types/session/ids.js'
+import type { ToolDefinition } from '../../../types/tool/index.js'
+import type { ToolExecutorConfig } from '../executor.js'
+
+/** Every config an executor was constructed with during a run. */
+const built: ToolExecutorConfig[] = []
+
+vi.mock('../executor.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../executor.js')>()
+	return {
+		...actual,
+		ToolExecutor: class extends actual.ToolExecutor {
+			constructor(...args: ConstructorParameters<typeof actual.ToolExecutor>) {
+				built.push(args[0])
+				super(...args)
+			}
+		},
+	}
+})
+
+const { drainQuery } = await import('../index.js')
+
+function echoTool(): ToolDefinition {
+	return {
+		name: 'echo',
+		description: 'Echo the text back.',
+		inputSchema: z.object({}),
+		execute: async () => ({ success: true, output: 'ok' }),
+	} as unknown as ToolDefinition
+}
+
+describe('the tool-retry backoff a caller sets reaches the executor', () => {
+	let workdirs: string[] = []
+
+	beforeEach(() => {
+		built.length = 0
+	})
+
+	afterEach(async () => {
+		await removeTempDirs(workdirs)
+		workdirs = []
+	})
+
+	async function run(extra: Record<string, unknown>) {
+		const dir = await mkdtemp(join(tmpdir(), 'namzu-backoff-reach-'))
+		workdirs.push(dir)
+		const tools = new ToolRegistry()
+		tools.register(echoTool())
+
+		return drainQuery({
+			provider: new MockLLMProvider({ turns: [{ text: 'done' }] }),
+			tools,
+			runConfig: {
+				model: 'run-model',
+				timeoutMs: 30_000,
+				tokenBudget: 100_000,
+				maxIterations: 2,
+				maxResponseTokens: 256,
+			},
+			agentId: 'agent_reach',
+			agentName: 'Reach Agent',
+			workingDirectory: dir,
+			sessionId: 'ses_reach' as SessionId,
+			threadId: 'thd_reach' as ThreadId,
+			projectId: 'prj_reach' as ProjectId,
+			tenantId: 'tnt_reach' as TenantId,
+			retry: false as const,
+			messages: [createUserMessage('hello')],
+			...extra,
+		} as never)
+	}
+
+	it('carries the policy through to the executor the run builds', async () => {
+		await run({ toolRetryBackoff: { initialDelayMs: 0, maxDelayMs: 0 } })
+
+		expect(built.length).toBeGreaterThan(0)
+		expect(built[0]?.toolRetryBackoff).toEqual({ initialDelayMs: 0, maxDelayMs: 0 })
+	})
+
+	it('leaves it absent when the caller said nothing, so the shipped default applies', async () => {
+		// The other half of the same fact. A config that arrived populated
+		// whatever the caller passed would satisfy the case above while
+		// telling a reader nothing.
+		await run({})
+
+		expect(built.length).toBeGreaterThan(0)
+		expect(built[0]?.toolRetryBackoff).toBeUndefined()
+	})
+})

--- a/packages/sdk/src/runtime/query/__tests__/tool-retry-backs-off.test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/tool-retry-backs-off.test.ts
@@ -1,0 +1,240 @@
+/**
+ * A retried tool call waits, and the wait is jittered.
+ *
+ * The in-loop retry was `for (let attempt = 1; ; attempt++)` calling straight
+ * back into execution with no delay between attempts, while
+ * `provider/retry.ts` one directory away implemented exponential backoff with
+ * full jitter. The failures worth retrying are exactly the ones an immediate
+ * retry makes worse — a rate limit, a contended lock, a connection that has
+ * not finished opening — so the loop was most likely to prolong the condition
+ * it was retrying against.
+ *
+ * Every delay here is measured on FAKE timers. A suite that spends real
+ * seconds proving a wait gets deleted by the next person who reads its runtime,
+ * and the assertions are exact rather than approximate for the same reason:
+ * with the clock under control there is no measurement noise to leave slack
+ * for, so a margin of one millisecond is a decision, not a coin toss.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+
+import { ToolRegistry } from '../../../registry/tool/execute.js'
+import { ActivityStore } from '../../../store/activity/memory.js'
+import type { RunId } from '../../../types/ids/index.js'
+import type { ChatCompletionResponse } from '../../../types/provider/index.js'
+import type { ToolDefinition, ToolResult } from '../../../types/tool/index.js'
+import type { Logger } from '../../../utils/logger.js'
+import { ToolExecutor, type ToolExecutorConfig } from '../executor.js'
+
+const RUN_ID = 'run_backoff' as RunId
+
+function makeLogger(): Logger {
+	const stub = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+	return { ...stub, child: vi.fn(() => ({ ...stub, child: vi.fn() })) } as unknown as Logger
+}
+
+function response(name: string, args: string): ChatCompletionResponse {
+	return {
+		id: 'resp_1',
+		model: 'mock',
+		message: {
+			role: 'assistant',
+			content: null,
+			toolCalls: [{ id: 'call_1', type: 'function', function: { name, arguments: args } }],
+		},
+		finishReason: 'tool_calls',
+		usage: {
+			promptTokens: 0,
+			completionTokens: 0,
+			totalTokens: 0,
+			cachedTokens: 0,
+			cacheWriteTokens: 0,
+		},
+	}
+}
+
+function makeExecutor(registry: ToolRegistry, extra: Partial<ToolExecutorConfig> = {}) {
+	return new ToolExecutor(
+		{
+			tools: registry,
+			runId: RUN_ID,
+			workingDirectory: process.cwd(),
+			permissionMode: 'auto',
+			env: {},
+			abortSignal: new AbortController().signal,
+			...extra,
+		},
+		new ActivityStore(RUN_ID, { enabled: false, trackToolCalls: false, trackLlmTurns: false }),
+		() => Promise.resolve(),
+		makeLogger(),
+	)
+}
+
+/** A tool that fails retryably `failures` times, then succeeds. */
+function flakyTool(opts: { failures: number; maxRetries: number }) {
+	const attempts: number[] = []
+	const tool = {
+		name: 'fetch_page',
+		description: 'Fetch a page',
+		inputSchema: z.object({ url: z.string() }),
+		maxRetries: opts.maxRetries,
+		execute: (): Promise<ToolResult> => {
+			attempts.push(attempts.length + 1)
+			if (attempts.length <= opts.failures) {
+				return Promise.resolve({
+					success: false,
+					output: '',
+					error: 'rate limited',
+					retryable: true,
+				})
+			}
+			return Promise.resolve({ success: true, output: `fetched on attempt ${attempts.length}` })
+		},
+	} as unknown as ToolDefinition
+	return { tool, attempts }
+}
+
+const CALL = () => response('fetch_page', '{"url":"x"}')
+
+/**
+ * Run `body`, then always let the batch finish.
+ *
+ * The finally is the point. Every case below asserts part-way through a
+ * pending `executeBatch`, so a mutation that makes the wait LONGER than the
+ * case expects would leave that promise parked forever and the case would die
+ * on the suite's timeout — and a timeout is a verdict on nothing at all, which
+ * is exactly the outcome a mutation table must not fold into "killed". Winding
+ * the clock right forward on the way out turns every such mutation into a
+ * named assertion failure instead.
+ */
+async function draining<T>(pending: Promise<T>, body: () => Promise<void>): Promise<void> {
+	try {
+		await body()
+	} finally {
+		await vi.advanceTimersByTimeAsync(120_000)
+		await pending
+	}
+}
+
+let registry: ToolRegistry
+
+beforeEach(() => {
+	registry = new ToolRegistry()
+	vi.useFakeTimers()
+})
+
+afterEach(() => {
+	vi.useRealTimers()
+	vi.restoreAllMocks()
+})
+
+describe('a retried tool call waits before trying again', () => {
+	it('does not fire the second attempt until the backoff has elapsed', async () => {
+		// Full jitter draws from `[0, curve]`, so pinning `Math.random` at 1
+		// asks for the whole curve — the shipped `initialDelayMs` of 500.
+		vi.spyOn(Math, 'random').mockReturnValue(1)
+		const { tool, attempts } = flakyTool({ failures: 1, maxRetries: 1 })
+		registry.register(tool)
+
+		const done = makeExecutor(registry).executeBatch(CALL())
+
+		await draining(done, async () => {
+			// The first attempt has run and failed. Nothing else may happen
+			// while the clock has not moved past the wait — this is the
+			// assertion the old loop, which re-entered immediately, could not
+			// pass.
+			await vi.advanceTimersByTimeAsync(499)
+			expect(attempts).toHaveLength(1)
+
+			await vi.advanceTimersByTimeAsync(1)
+			expect(attempts).toHaveLength(2)
+		})
+
+		expect((await done).results[0]?.output).toBe('fetched on attempt 2')
+	})
+
+	it('draws the wait from the jitter rather than sleeping the curve exactly', async () => {
+		// The property a fixed backoff does not have, and the reason it
+		// matters here: `executeBatch` runs a whole batch of the model's
+		// parallel calls at once, so a fixed wait would resynchronise a batch
+		// that failed together against the endpoint that rate-limited it —
+		// a thundering herd this loop assembles itself.
+		vi.spyOn(Math, 'random').mockReturnValue(0.25)
+		const { tool, attempts } = flakyTool({ failures: 1, maxRetries: 1 })
+		registry.register(tool)
+
+		const done = makeExecutor(registry, {
+			toolRetryBackoff: { initialDelayMs: 1_000 },
+		}).executeBatch(CALL())
+
+		await draining(done, async () => {
+			// A quarter of the 1s curve. An implementation that slept the
+			// curve itself would still be waiting here.
+			await vi.advanceTimersByTimeAsync(249)
+			expect(attempts).toHaveLength(1)
+
+			await vi.advanceTimersByTimeAsync(1)
+			expect(attempts).toHaveLength(2)
+		})
+	})
+
+	it('doubles the wait each attempt, up to the ceiling', async () => {
+		vi.spyOn(Math, 'random').mockReturnValue(1)
+		const { tool, attempts } = flakyTool({ failures: 2, maxRetries: 2 })
+		registry.register(tool)
+
+		const done = makeExecutor(registry, {
+			toolRetryBackoff: { initialDelayMs: 1_000, maxDelayMs: 1_500 },
+		}).executeBatch(CALL())
+
+		await draining(done, async () => {
+			await vi.advanceTimersByTimeAsync(1_000)
+			expect(attempts).toHaveLength(2)
+
+			// Doubling would ask for 2s; the ceiling holds it to 1.5s, so the
+			// third attempt lands before an uncapped curve would allow it.
+			await vi.advanceTimersByTimeAsync(1_499)
+			expect(attempts).toHaveLength(2)
+
+			await vi.advanceTimersByTimeAsync(1)
+			expect(attempts).toHaveLength(3)
+		})
+	})
+
+	it('never waits for a tool that did not opt into retrying', async () => {
+		// The shipped default is zero retries, so an ordinary run must not
+		// have acquired a delay it never had. Nothing here advances the
+		// clock: if the executor slept, this call would not settle.
+		const { tool, attempts } = flakyTool({ failures: 1, maxRetries: 0 })
+		registry.register(tool)
+
+		const batch = await makeExecutor(registry).executeBatch(CALL())
+
+		expect(attempts).toHaveLength(1)
+		expect(batch.results[0]?.isError).toBe(true)
+	})
+
+	it('stops retrying when the run is stopped mid-backoff, and still answers the call', async () => {
+		// An abort thrown from inside the wait would escape `executeSingle`
+		// and leave this `tool_use` unanswered in the transcript, which is
+		// the one invariant the executor is not allowed to break. The failure
+		// already in hand is a perfectly good answer to give.
+		vi.spyOn(Math, 'random').mockReturnValue(1)
+		const controller = new AbortController()
+		const { tool, attempts } = flakyTool({ failures: 1, maxRetries: 1 })
+		registry.register(tool)
+
+		const done = makeExecutor(registry, { abortSignal: controller.signal }).executeBatch(CALL())
+
+		await vi.advanceTimersByTimeAsync(100)
+		controller.abort()
+		const batch = await done
+
+		expect(attempts).toHaveLength(1)
+		expect(batch.results).toHaveLength(1)
+		expect(batch.results[0]?.toolCallId).toBe('call_1')
+		expect(batch.results[0]?.isError).toBe(true)
+		expect(batch.results[0]?.output).toContain('rate limited')
+	})
+})

--- a/packages/sdk/src/runtime/query/executor.ts
+++ b/packages/sdk/src/runtime/query/executor.ts
@@ -34,6 +34,7 @@ import type {
 	ToolCallRepairReason,
 } from '../../types/tool/repair.js'
 import { abortReasonText } from '../../utils/abort.js'
+import { type BackoffPolicy, backoffWithJitter, sleep } from '../../utils/backoff.js'
 import { toErrorMessage } from '../../utils/error.js'
 import type { Logger } from '../../utils/logger.js'
 import { compressShellOutput } from '../../utils/shell-compress.js'
@@ -75,6 +76,33 @@ export const DEFAULT_TOOL_CONCURRENCY = 8
 export const HOOK_RETRY_BUDGET = 1
 
 /**
+ * Wait between in-loop tool retry attempts.
+ *
+ * There was none. A tool that declared itself retryable was re-run the
+ * instant it failed, as many times as its budget allowed — and the failures
+ * worth retrying are the ones an immediate retry makes worse: a rate limit
+ * answers the second call faster than it recovers, a contended lock is still
+ * held, a connection that has not finished opening has not finished opening.
+ *
+ * The numbers are the provider policy's, deliberately, and not because a tool
+ * is a model call. Nothing here has been measured against tools specifically,
+ * and inventing a second curve to look considered would be a guess wearing
+ * different digits; the shared one is at least the curve this codebase has
+ * already run in anger. Full jitter draws each wait from `[0, curve]`, so the
+ * first retry of a tool with the shipped budget waits under half a second on
+ * average.
+ *
+ * The ceiling is inert at the budgets anyone sets — a tool declaring
+ * `maxRetries: 3` never reaches 2s — and binds only a host that sets a large
+ * one. Override with {@link ToolExecutorConfig.toolRetryBackoff}; set
+ * `initialDelayMs: 0` for the previous no-wait behaviour.
+ */
+export const DEFAULT_TOOL_RETRY_BACKOFF: BackoffPolicy = {
+	initialDelayMs: 500,
+	maxDelayMs: 16_000,
+}
+
+/**
  * An empty arguments string means "no arguments", not "malformed" — the
  * shape a no-parameter tool arrives in.
  */
@@ -95,6 +123,16 @@ export interface ToolExecutorConfig {
 	pluginManager?: PluginLifecycleManager
 	/** Run-level default deadline; per-tool `timeoutMs` overrides it. */
 	toolTimeoutMs?: number
+	/**
+	 * Wait between in-loop retries of a failed tool call. Defaults to
+	 * {@link DEFAULT_TOOL_RETRY_BACKOFF}.
+	 *
+	 * Applies only to a tool that opted into retrying at all
+	 * ({@link ToolDefinition.maxRetries}) or to a `post_tool_use` hook that
+	 * asked for one, so a run whose tools all take the shipped default of
+	 * zero retries never sleeps here.
+	 */
+	toolRetryBackoff?: Partial<BackoffPolicy>
 	/** Max concurrently-executing concurrency-safe tools. */
 	maxToolConcurrency?: number
 
@@ -648,6 +686,10 @@ export class ToolExecutor {
 		// because the SDK cannot know a tool is idempotent — silently
 		// re-running a write or a payment is worse than never retrying.
 		const maxRetries = Math.max(0, this.config.tools.get(toolName)?.maxRetries ?? 0)
+		const backoff: BackoffPolicy = {
+			...DEFAULT_TOOL_RETRY_BACKOFF,
+			...this.config.toolRetryBackoff,
+		}
 		for (let attempt = 1; ; attempt++) {
 			// A missing file will not appear on the second attempt; burning
 			// the budget on it only delays the error the model needs to see.
@@ -664,14 +706,46 @@ export class ToolExecutor {
 			const budget = post.retry ? Math.max(maxRetries, HOOK_RETRY_BUDGET) : maxRetries
 			if (attempt > budget) break
 
+			// Wait before trying again, on the curve the provider path has
+			// used all along. This loop had NO delay: a tool failing on a
+			// transient condition — a rate-limited HTTP call, a lock, a cold
+			// connection — was re-run immediately, several times, which is the
+			// pattern most likely to prolong the very condition it is retrying
+			// against.
+			//
+			// Full jitter rather than a fixed wait, and the concurrency that
+			// makes it matter is one this loop creates itself: a model emits a
+			// batch of parallel calls, `executeBatch` runs up to
+			// DEFAULT_TOOL_CONCURRENCY of them at once, they hit the same
+			// rate-limited endpoint and fail together. A fixed backoff would
+			// resynchronise that batch on every attempt.
+			//
+			// `attempt` is 1-based here and `backoffWithJitter` is 0-based, so
+			// the first retry draws from `[0, initialDelayMs]`.
+			const delayMs = backoffWithJitter(attempt - 1, backoff)
+
 			this.log.info('Retrying a failed tool call', {
 				runId: this.config.runId,
 				tool: toolName,
 				attempt,
 				budget,
 				requestedByHook: post.retry,
+				delayMs,
 				error: result.error,
 			})
+
+			try {
+				await sleep(delayMs, this.config.abortSignal)
+			} catch {
+				// Stopped mid-backoff. Give up retrying and let the failure
+				// already in `result` be this call's answer, rather than
+				// throwing: every `tool_use` must be answered by a
+				// `tool_result` with the same id, and an abort escaping from
+				// here would leave this one open in the transcript for a
+				// resume to trip over.
+				break
+			}
+
 			result = await this.runOnce(toolName, input, toolContext)
 			post = await this.runPostToolHook(toolName, input, result)
 		}

--- a/packages/sdk/src/runtime/query/index.ts
+++ b/packages/sdk/src/runtime/query/index.ts
@@ -83,6 +83,7 @@ import type { TaskStore } from '../../types/task/index.js'
 import type { ToolRegistryContract } from '../../types/tool/index.js'
 import type { RepairToolCall } from '../../types/tool/repair.js'
 import type { VerificationGateConfig } from '../../types/verification/index.js'
+import type { BackoffPolicy } from '../../utils/backoff.js'
 import type { ModelPricing } from '../../utils/cost.js'
 import { getRootLogger } from '../../utils/logger.js'
 import { VerificationGate } from '../../verification/gate.js'
@@ -201,6 +202,17 @@ export interface QueryParams {
 
 	/** Default per-tool execution deadline. See {@link ToolDefinition.timeoutMs}. */
 	toolTimeoutMs?: number
+
+	/**
+	 * Wait between in-loop retries of a failed tool call, with full jitter.
+	 * Defaults to {@link DEFAULT_TOOL_RETRY_BACKOFF}.
+	 *
+	 * Only reached by a tool that opted into retrying
+	 * ({@link ToolDefinition.maxRetries}) or a `post_tool_use` hook that asked
+	 * for one. Set `initialDelayMs: 0` for the retry-immediately behaviour
+	 * this loop had before it had any backoff at all.
+	 */
+	toolRetryBackoff?: Partial<BackoffPolicy>
 
 	/** Max concurrently-executing concurrency-safe tools in one batch. */
 	maxToolConcurrency?: number
@@ -891,6 +903,9 @@ export async function* query(params: QueryParams): AsyncGenerator<RunEvent, Run>
 			invocationState: params.invocationState,
 			pluginManager: params.pluginManager,
 			...(params.toolTimeoutMs !== undefined ? { toolTimeoutMs: params.toolTimeoutMs } : {}),
+			...(params.toolRetryBackoff !== undefined
+				? { toolRetryBackoff: params.toolRetryBackoff }
+				: {}),
 			...(params.maxToolConcurrency !== undefined
 				? { maxToolConcurrency: params.maxToolConcurrency }
 				: {}),

--- a/packages/sdk/src/runtime/query/tooling.ts
+++ b/packages/sdk/src/runtime/query/tooling.ts
@@ -6,6 +6,7 @@ import type { PermissionMode } from '../../types/permission/index.js'
 import type { RunEvent } from '../../types/run/index.js'
 import type { RequestToolPause, ToolRegistryContract } from '../../types/tool/index.js'
 import type { RepairToolCall } from '../../types/tool/repair.js'
+import type { BackoffPolicy } from '../../utils/backoff.js'
 import type { Logger } from '../../utils/logger.js'
 import { ToolExecutor } from './executor.js'
 
@@ -22,6 +23,7 @@ export interface ToolingBootstrapConfig {
 	invocationState?: InvocationState
 	pluginManager?: PluginLifecycleManager
 	toolTimeoutMs?: number
+	toolRetryBackoff?: Partial<BackoffPolicy>
 	maxToolConcurrency?: number
 	maxToolOutputChars?: number
 	maxToolContentBytes?: number
@@ -50,6 +52,9 @@ export class ToolingBootstrap {
 				invocationState: config.invocationState,
 				pluginManager: config.pluginManager,
 				...(config.toolTimeoutMs !== undefined ? { toolTimeoutMs: config.toolTimeoutMs } : {}),
+				...(config.toolRetryBackoff !== undefined
+					? { toolRetryBackoff: config.toolRetryBackoff }
+					: {}),
 				...(config.maxToolConcurrency !== undefined
 					? { maxToolConcurrency: config.maxToolConcurrency }
 					: {}),

--- a/packages/sdk/src/types/agent/reactive.ts
+++ b/packages/sdk/src/types/agent/reactive.ts
@@ -86,6 +86,7 @@ export interface ReactiveAgentConfig extends BaseAgentConfig {
 	retry?: QueryParams['retry']
 	emergencySave?: boolean
 	toolTimeoutMs?: number
+	toolRetryBackoff?: QueryParams['toolRetryBackoff']
 	maxToolConcurrency?: number
 	maxToolOutputChars?: number
 	/**

--- a/packages/sdk/src/utils/backoff.ts
+++ b/packages/sdk/src/utils/backoff.ts
@@ -1,0 +1,70 @@
+/**
+ * Exponential backoff with full jitter, and an abortable sleep.
+ *
+ * Both were private to `provider/retry.ts`, which is where they were needed
+ * first and is not where they stop being needed. The tool executor's in-loop
+ * retry re-ran a failed call immediately, several times, which is the pattern
+ * most likely to prolong the very condition it is retrying against — and the
+ * correct implementation was one directory away, already reviewed, already
+ * doing the hard part right.
+ *
+ * So they live here, in one copy, and both retry loops call them. A second
+ * implementation of a backoff curve is a second thing to get wrong, and the
+ * two would drift on exactly the axis nobody re-derives: jitter.
+ */
+
+/** The shape a backoff curve needs. */
+export interface BackoffPolicy {
+	/** First backoff, doubled each attempt. */
+	readonly initialDelayMs: number
+	/** Ceiling for a single backoff, before jitter. */
+	readonly maxDelayMs: number
+}
+
+/**
+ * Full jitter (AWS's formulation): sleep a uniform random amount in
+ * `[0, backoff]` rather than `backoff` exactly. Equal-jitter and no-jitter
+ * both keep a fleet of clients that failed together retrying together;
+ * full jitter is what actually spreads a thundering herd.
+ *
+ * `attempt` is 0-based: attempt 0 draws from `[0, initialDelayMs]`.
+ *
+ * The concurrency this matters for is not hypothetical on the tool path. A
+ * model emits a batch of parallel calls, they hit one rate-limited endpoint
+ * together, and they fail together — so a fixed delay would resynchronise
+ * them on every attempt, which is a herd this loop creates itself.
+ */
+export function backoffWithJitter(
+	attempt: number,
+	policy: BackoffPolicy,
+	random: () => number = Math.random,
+): number {
+	const exponential = Math.min(policy.initialDelayMs * 2 ** attempt, policy.maxDelayMs)
+	return Math.round(random() * exponential)
+}
+
+/**
+ * Sleep, unless the signal says not to.
+ *
+ * Rejects with the signal's reason when aborted — before sleeping if it is
+ * already aborted, and mid-sleep otherwise. A caller that must not throw over
+ * an abort catches it; a caller that wants the abort to propagate does not.
+ */
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+	if (ms <= 0) return Promise.resolve()
+	return new Promise<void>((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(signal.reason)
+			return
+		}
+		const timer = setTimeout(() => {
+			signal?.removeEventListener('abort', onAbort)
+			resolve()
+		}, ms)
+		const onAbort = () => {
+			clearTimeout(timer)
+			reject(signal?.reason)
+		}
+		signal?.addEventListener('abort', onAbort, { once: true })
+	})
+}


### PR DESCRIPTION
Closes #373.

## The defect

The in-loop tool retry was `for (let attempt = 1; ; attempt++)` calling straight back into execution with no delay at all, while `packages/sdk/src/provider/retry.ts` one directory away implemented exponential backoff with full jitter. The failures worth retrying are exactly the ones an immediate retry makes worse — a rate limit answers the second call faster than it recovers, a contended lock is still held, a connection that has not finished opening has not finished opening.

## Reused, not rewritten

`backoffWithJitter` and `sleep` were private to `provider/retry.ts`. They move to `utils/backoff.ts` in one copy; both retry loops call them, and `ProviderRetryConfig` now `extends BackoffPolicy`. The provider path is behaviourally untouched.

The extraction is deliberate rather than importing from `provider/retry.js`: a generic sleep reached through the provider decorator's module would couple the tool path to it for no reason. One implementation was the requirement; where it lives is the smaller question, and a shared primitive belongs in `utils/`.

That the two really do share it is testable, and tested: a mutation that ignores the jitter kills a case on each side of the tree.

## Why jitter, on this path specifically

`executeBatch` runs a whole batch of the model's parallel calls at once, up to `DEFAULT_TOOL_CONCURRENCY`. Calls that hit the same rate-limited endpoint fail together, so a fixed wait would resynchronise the batch on every attempt — a thundering herd the loop assembles itself. Full jitter draws each wait from `[0, curve]`.

## The default, honestly

`{ initialDelayMs: 500, maxDelayMs: 16_000 }` — the provider policy's numbers. Not because a tool call is a model call, but because nothing here has been measured against tools specifically, and inventing a second curve to look considered would be a guess wearing different digits. The code says so. The ceiling is inert at the budgets anyone sets and binds only a host that sets a large one.

## Three things a reviewer should look at

**It had to be threaded through three places, not one.** `query()` builds the executor through `ToolingBootstrap.init`, whose config type enumerates its fields, so the key was being dropped in the middle — and TypeScript said nothing, because a spread in an object literal skips excess-property checking. The reachability test in this PR is what found it, and a timing test could not have without sleeping.

**A Stop during a wait breaks out rather than throwing.** An abort escaping `executeSingle` would leave that `tool_use` unanswered in the transcript for a resume to trip over, and the failure already in hand is a perfectly good answer to give.

**Nothing waits that did not already retry.** Only a tool declaring `maxRetries`, or a `post_tool_use` hook asking for a retry, ever reaches this code, so a run on the shipped default of `maxRetries: 0` is unchanged.

## Breaking

`major`, because it changes an observable default: a retryable tool call that used to re-run instantly now waits. `toolRetryBackoff` is new on `query()` and `ReactiveAgentConfig`; `{ initialDelayMs: 0, maxDelayMs: 0 }` restores the old timing exactly. The changeset names the value that changed and what a caller does about it.

## Tests

`tool-retry-backs-off.test.ts` — 5 cases on fake timers, 13ms for the file. Assertions are exact rather than approximate because with the clock under control there is no measurement noise to leave slack for.

Every case runs its assertions inside a `draining()` wrapper whose `finally` winds the clock forward and awaits the pending batch. That was added after the no-jitter mutation killed the jitter case by SUITE TIMEOUT rather than by assertion — a timeout is a verdict on nothing at all, and it arrives looking exactly like one. With the drain in place the same mutation reads `expected [ 1 ] to have a length of 2`.

| Mutation | Result |
| --- | --- |
| no delay at all (the pre-fix state) | 4 of 5 killed; the fifth is the never-opted-in preservation case; the 12 retry-semantics cases in `tool-repair-retry.test.ts` all pass |
| fixed backoff, jitter ignored | 1 killed here AND the provider's own jitter case |
| ceiling removed from the curve | 1 killed |
| `attempt` not decremented (off by one) | 3 killed, all three delay cases |
| abort re-thrown from the wait instead of breaking | 1 killed — the abort escapes the executor |

`tool-retry-backoff-reaches-the-executor.test.ts` asks the reachability question structurally — does the value a caller passes arrive in the config the run builds — because the difference between "reached" and "did not reach" is a field, not a duration.

The pre-existing retry cases in `tool-repair-retry.test.ts` are given a zero wait: they are about which failures are retried and how many times, and leaving the default on would have spent seconds of the suite re-proving the delay slowly.

## Gates

`typecheck`, `lint`, `test` (359 files, 3232 passed, 7 skipped), `test:proc`, `audit-external-names`, `verify-public-surface` (baseline regenerated for `BackoffPolicy`), `check-sdk-test-presence`, `test:coverage` plus `check-sdk-module-coverage`, `check-docs` — all green locally.

Docs: `docs/sdk/runtime/loop-control.md` section 9 and `docs/sdk/tools/README.md` section 7c.
