### PR TITLE
fix(sandbox): the egress boundary decides by resolved address

### DIFF
--- a/.changeset/egress-screens-the-address.md
+++ b/.changeset/egress-screens-the-address.md
@@ -1,0 +1,54 @@
+---
+'@namzu/sandbox': major
+---
+
+The egress boundary now decides by resolved address, not only by hostname
+
+`EgressProxy` allowed or refused on the client-supplied **name**, and nothing
+in the package resolved or inspected an address. An allowlisted name whose DNS
+the caller controls — or that simply has an inward-pointing record — resolved
+to loopback, to the private network the sandbox host sits on, or to the
+link-local address cloud metadata services answer on, and the proxy connected.
+
+On the plain-HTTP path the brokered credential is stamped onto the outbound
+headers **before** the request goes out, so the credential-brokering design
+that is the proxy's whole reason for existing was the delivery mechanism: the
+token reached whatever the name resolved to. `BrokeredCredential.host` exists
+to stop exactly that, and it could not while its scope was a name.
+
+Both paths now screen the address. Refused, whatever the allowlist says:
+loopback, private (`10/8`, `172.16/12`, `192.168/16`), link-local
+(`169.254.0.0/16` — the metadata block), shared address space
+(`100.64.0.0/10`), unspecified, multicast and reserved on v4; `::1`,
+`fc00::/7`, `fe80::/10` and `ff00::/8` on v6; and a v4 address wearing a v6
+spelling in any of its forms, since a v4-only screen is a known way through
+this kind of filter.
+
+**This denies configurations that worked before, which is why it is major.**
+A sandbox whose allowlist names a host on a private network — a registry, an
+artifact cache, a service on the host's own LAN — starts getting `403` with a
+reason naming the address kind. That is the intended behaviour, and the remedy
+is per host:
+
+```ts
+createSandboxProvider({
+  backend: {
+    tier: 'container',
+    image: 'namzu/sandbox:latest',
+    allowInwardFor: ['.internal.example', 'registry.corp'],
+  },
+  layout,
+})
+```
+
+Matched by the allowlist's own rules, so `.internal.example` covers
+subdomains. There is deliberately no switch that turns the screen off: one
+would hand every other allowlisted name the same reach, which is the hole the
+screen exists to close. `EgressProxyOptions.allowInwardFor` is the same knob
+when constructing `EgressProxy` directly.
+
+One limit stated rather than implied: on the `CONNECT` path this bounds where
+the tunnel terminates and nothing more. The bytes inside it are opaque to the
+proxy, including the name the caller puts in its own TLS handshake, so a
+tunnel to an allowlisted host is not a guarantee that only allowlisted traffic
+crosses it.

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -206,6 +206,66 @@ typing the host differently.
 A policy that cannot be read **denies**. An allowlist that fails open is
 not an allowlist.
 
+### Where the name goes, not just what it is called
+
+An allowlist entry names a host. **DNS decides where that host is**, and the
+caller may control it — so an allowlisted name is a permitted *spelling*
+until something has looked at the address behind it. `api.example.com` with
+an `A` record pointing at `169.254.169.254` is the instance metadata service
+wearing a permitted name, and on the plain-HTTP path the brokered credential
+goes on the request *before* it is sent. Without an address check the
+credential-brokering design is the delivery mechanism.
+
+So the boundary refuses these, whatever the allowlist says:
+
+| Refused | v4 | v6 |
+| --- | --- | --- |
+| loopback | `127.0.0.0/8` | `::1` |
+| private | `10/8`, `172.16/12`, `192.168/16` | `fc00::/7` unique-local |
+| link-local (metadata) | `169.254.0.0/16` | `fe80::/10` |
+| carrier / shared | `100.64.0.0/10` | — |
+| unspecified, multicast, reserved | `0/8`, `224/4`, `240/4` | `::`, `ff00::/8` |
+
+A v4 address written as IPv6 — `::ffff:169.254.169.254`, `::ffff:a9fe:a9fe`,
+or the same thing written out in full — is the same address and is refused
+the same way. A v4-only screen passes all three, which is a known way through
+this kind of filter rather than an oversight.
+
+**The screening happens inside the resolution the socket performs**, not
+before it. Resolve-check-then-connect leaves the socket free to resolve a
+second time, and the second answer is the one that decides where the bytes
+go — so a name that alternates records walks through a check that passed a
+moment earlier. Every address in the record set is screened, not just the one
+that would have been used, because a set mixing a public address with an
+inward one is the ordinary shape of this and screening only the winner makes
+the outcome depend on resolver ordering. The host stays the **name** on the
+request, so SNI and certificate validation still check the name the allowlist
+approved.
+
+### When the private address is the point
+
+Some deployments genuinely proxy to a service on a private network. Name it:
+
+```ts
+allowInwardFor: ['.internal.example'],
+```
+
+Per host, matched by the same rules as the allowlist. There is deliberately
+no switch that turns the screen off — one would hand every other allowlisted
+name the same reach, which is the hole the screen exists to close.
+
+A refusal says which kind of address it was (`loopback`, `link-local`,
+`private`), because those are different mistakes with different fixes, and it
+reaches `onDenied` as well as the requester.
+
+**On the tunnel path this bounds the destination and nothing more.** The
+allowlist reads the name in the `CONNECT` line — the only part of that
+exchange ever in clear text — and the address screen makes that a real bound
+on where the tunnel terminates. What travels inside it afterwards is opaque
+to this process, including the name the caller puts in its own TLS handshake.
+A tunnel to an allowlisted host is not a guarantee that only allowlisted
+traffic crosses it.
+
 ### Changing the policy while the sandbox runs
 
 `sandbox.setNetworkPolicy({ allowedHosts })` narrows or widens a live
@@ -245,4 +305,5 @@ would let the proxy read every byte the agent sends anywhere. That is a
 strictly larger risk than the one being mitigated, so it is not built. A
 workload that needs brokering speaks plain HTTP to the proxy and lets it
 upgrade to HTTPS upstream. The allowlist is still enforced on CONNECT,
-because the target names the host in clear text.
+because the target names the host in clear text — and so is the address
+screen, so a permitted name cannot be a route inward.

--- a/packages/sandbox/src/backends/docker/__tests__/hardening.test.ts
+++ b/packages/sandbox/src/backends/docker/__tests__/hardening.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolveNetwork } from '../index.js'
+import { egressProxyOptions, resolveNetwork } from '../index.js'
 
 /**
  * `EgressPolicy` was accepted by the type, threaded through the options,
@@ -39,5 +39,47 @@ describe('resolveNetwork', () => {
 
 	it('names what it can do, so the failure is actionable', () => {
 		expect(() => resolveNetwork('bridge', { kind: 'static', allowedHosts: [] })).toThrow(/deny-all/)
+	})
+})
+
+/**
+ * The knobs a host sets have to arrive at the boundary.
+ *
+ * Everything past this function needs a running Docker daemon, so a config
+ * field that never reached `EgressProxy` would be caught by an operator
+ * watching production traffic get denied — with no way to fix it, because the
+ * escape hatch they were told to use is the one that went missing.
+ */
+describe('egressProxyOptions', () => {
+	const policy = { kind: 'static', allowedHosts: ['api.example.com'] } as const
+
+	it('carries the inward exemption to the boundary', () => {
+		const options = egressProxyOptions({ allowInwardFor: ['inside.example'] }, policy)
+		expect(options.allowInwardFor).toEqual(['inside.example'])
+	})
+
+	it('leaves it absent when the host named none, so the screen applies', () => {
+		// The other half of the same fact: a field populated whatever the host
+		// passed would satisfy the case above and say nothing.
+		expect(egressProxyOptions({}, policy).allowInwardFor).toBeUndefined()
+	})
+
+	it('carries the brokered credentials too', () => {
+		const credential = { host: 'api.example.com', header: 'authorization', value: 'real' }
+		expect(egressProxyOptions({ brokeredCredentials: [credential] }, policy).credentials).toEqual([
+			credential,
+		])
+	})
+
+	it('resolves the allowlist per call rather than capturing it', async () => {
+		// `setNetworkPolicy` swaps the policy on a live sandbox, and a
+		// snapshot taken at construction would enforce the policy the sandbox
+		// started with for the rest of its life.
+		let hosts: string[] = ['first.example']
+		const options = egressProxyOptions({}, { kind: 'resolver', resolve: async () => hosts })
+
+		expect(await options.allowedHosts()).toEqual(['first.example'])
+		hosts = ['second.example']
+		expect(await options.allowedHosts()).toEqual(['second.example'])
 	})
 })

--- a/packages/sandbox/src/backends/docker/index.ts
+++ b/packages/sandbox/src/backends/docker/index.ts
@@ -43,7 +43,11 @@ import {
 	withHint,
 } from '@namzu/sdk'
 import { EgressProxy } from '../../egress/index.js'
-import type { BrokeredCredential, RunningEgressProxy } from '../../egress/index.js'
+import type {
+	BrokeredCredential,
+	EgressProxyOptions,
+	RunningEgressProxy,
+} from '../../egress/index.js'
 
 import {
 	ContainerSandboxLayoutValidationError,
@@ -96,6 +100,22 @@ export interface DockerBackendInternalConfig {
 	 * permits. Here it is held host-side and applied at the boundary.
 	 */
 	readonly brokeredCredentials?: readonly BrokeredCredential[]
+
+	/**
+	 * Allowlisted hosts permitted to resolve to an inward address anyway.
+	 *
+	 * The egress boundary refuses a host that resolves to loopback, a private
+	 * range or the link-local metadata block, whatever the allowlist says —
+	 * because an allowlisted name whose DNS someone else controls is not a
+	 * permitted destination, it is a permitted spelling. An operator who
+	 * genuinely proxies to one service on a private network names it here.
+	 *
+	 * Per host, matched by the allowlist's own rules so `.internal.example`
+	 * covers subdomains. There is deliberately no switch that turns the screen
+	 * off: one would hand every other allowlisted name the same reach, which
+	 * is the hole the screen exists to close.
+	 */
+	readonly allowInwardFor?: readonly string[]
 
 	readonly network?: 'none' | 'bridge' | string
 	readonly readyPollIntervalMs?: number
@@ -218,6 +238,29 @@ export function needsEgressProxy(egress: EgressPolicy | undefined): boolean {
 }
 
 /**
+ * The options the boundary is built from, as a value.
+ *
+ * Extracted for the same reason {@link resolveNetwork} is: everything
+ * downstream of here needs a running Docker daemon, so a policy that never
+ * reached the proxy could only be caught by an operator noticing their
+ * traffic denied in production. A knob a host sets and the boundary never
+ * receives is the failure this shape exists to make testable.
+ */
+export function egressProxyOptions(
+	config: Pick<DockerBackendInternalConfig, 'brokeredCredentials' | 'allowInwardFor'>,
+	policy: EgressPolicy,
+): EgressProxyOptions {
+	return {
+		// Re-resolved per request rather than captured once, so a `resolver`
+		// policy that rotates is honoured and `setNetworkPolicy` can swap it
+		// on a live sandbox.
+		allowedHosts: () => resolveAllowedHosts(policy),
+		credentials: config.brokeredCredentials ?? [],
+		...(config.allowInwardFor ? { allowInwardFor: config.allowInwardFor } : {}),
+	}
+}
+
+/**
  * Confinement flags applied to every container.
  *
  * A sandbox whose containers run as root with the full default capability
@@ -251,13 +294,7 @@ async function spawnDockerSandbox(
 	let egressProxy: RunningEgressProxy | undefined
 	if (needsEgressProxy(options.egress) && options.egress) {
 		const policy = options.egress
-		egressProxy = await new EgressProxy({
-			// Re-resolved per request rather than captured once, so a
-			// `resolver` policy that rotates is honoured and
-			// `setNetworkPolicy` can swap it on a live sandbox.
-			allowedHosts: () => resolveAllowedHosts(policy),
-			credentials: config.brokeredCredentials ?? [],
-		}).listen()
+		egressProxy = await new EgressProxy(egressProxyOptions(config, policy)).listen()
 	}
 
 	const network = resolveNetwork(

--- a/packages/sandbox/src/egress/__tests__/address.test.ts
+++ b/packages/sandbox/src/egress/__tests__/address.test.ts
@@ -1,0 +1,251 @@
+import type { LookupAddress } from 'node:dns'
+import { describe, expect, it } from 'vitest'
+
+import {
+	type AddressResolver,
+	EgressAddressDenied,
+	blockedAddressReason,
+	blockedLiteralReason,
+	createScreeningLookup,
+} from '../address.js'
+
+/**
+ * The allowlist answers "is this NAME permitted". Where the name goes is a
+ * different question, and only the second one decides what the socket
+ * reaches — so this file is about addresses, and `allowlist.test.ts` is about
+ * names.
+ *
+ * Both directions are pinned deliberately. A screen that blocks too much is
+ * not the safe failure it looks like: a boundary written with `>=` where it
+ * needed `>` deletes a slice of the public internet, and it does so quietly,
+ * because nobody writes a test for the address that was supposed to work.
+ */
+
+/** A resolver that answers with exactly these addresses. */
+function resolvesTo(...addresses: string[]): AddressResolver {
+	return (_hostname, _options, callback) => {
+		callback(
+			null,
+			addresses.map((address) => ({ address, family: address.includes(':') ? 6 : 4 })),
+		)
+	}
+}
+
+function screen(hostname: string, resolve: AddressResolver, allowInwardFor?: string[]) {
+	const lookup = createScreeningLookup(
+		{ resolve, ...(allowInwardFor ? { allowInwardFor } : {}) },
+		(host, patterns) => patterns.includes(host),
+	)
+	return new Promise<{ err: NodeJS.ErrnoException | null; address: string | LookupAddress[] }>(
+		(resolve_) => {
+			lookup(hostname, { all: false }, (err, address) => resolve_({ err, address }))
+		},
+	)
+}
+
+describe('which addresses a sandbox may reach', () => {
+	it('refuses the v4 ranges that point back inside', () => {
+		expect(blockedAddressReason('127.0.0.1')).toBe('loopback')
+		expect(blockedAddressReason('10.1.2.3')).toBe('private')
+		expect(blockedAddressReason('192.168.1.1')).toBe('private')
+		expect(blockedAddressReason('172.20.0.5')).toBe('private')
+		expect(blockedAddressReason('100.100.0.1')).toBe('shared-address-space')
+		expect(blockedAddressReason('0.0.0.0')).toBe('this-host')
+	})
+
+	it('refuses the metadata address every host platform answers on', () => {
+		// The range that turns a name check into a credential leak: an
+		// allowlisted name resolving here gets the brokered token delivered to
+		// the instance's own metadata service.
+		expect(blockedAddressReason('169.254.169.254')).toBe('link-local')
+	})
+
+	it('lets an ordinary public address through', () => {
+		expect(blockedAddressReason('93.184.216.34')).toBeNull()
+		expect(blockedAddressReason('8.8.8.8')).toBeNull()
+		expect(blockedAddressReason('2606:4700:4700::1111')).toBeNull()
+	})
+
+	describe('the boundaries, from both sides', () => {
+		// Each pair brackets a blocked block. The address one step outside has
+		// to pass, or the screen is quietly refusing hosts that were never the
+		// problem — and an over-blocking screen produces a bug report about
+		// "the network", not about this file.
+		it('brackets 172.16.0.0/12', () => {
+			expect(blockedAddressReason('172.15.255.255')).toBeNull()
+			expect(blockedAddressReason('172.16.0.0')).toBe('private')
+			expect(blockedAddressReason('172.31.255.255')).toBe('private')
+			expect(blockedAddressReason('172.32.0.0')).toBeNull()
+		})
+
+		it('brackets 169.254.0.0/16', () => {
+			expect(blockedAddressReason('169.253.255.255')).toBeNull()
+			expect(blockedAddressReason('169.254.0.0')).toBe('link-local')
+			expect(blockedAddressReason('169.254.255.255')).toBe('link-local')
+			expect(blockedAddressReason('169.255.0.0')).toBeNull()
+		})
+
+		it('brackets 100.64.0.0/10', () => {
+			expect(blockedAddressReason('100.63.255.255')).toBeNull()
+			expect(blockedAddressReason('100.64.0.0')).toBe('shared-address-space')
+			expect(blockedAddressReason('100.127.255.255')).toBe('shared-address-space')
+			expect(blockedAddressReason('100.128.0.0')).toBeNull()
+		})
+
+		it('brackets the multicast and reserved tail', () => {
+			expect(blockedAddressReason('223.255.255.255')).toBeNull()
+			expect(blockedAddressReason('224.0.0.1')).toBe('multicast')
+			expect(blockedAddressReason('239.255.255.255')).toBe('multicast')
+			expect(blockedAddressReason('240.0.0.1')).toBe('reserved')
+		})
+	})
+
+	describe('IPv6', () => {
+		it('refuses loopback, unique-local and link-local', () => {
+			expect(blockedAddressReason('::1')).toBe('loopback')
+			expect(blockedAddressReason('fc00::1')).toBe('unique-local')
+			expect(blockedAddressReason('fd12:3456::1')).toBe('unique-local')
+			expect(blockedAddressReason('fe80::1')).toBe('link-local')
+			expect(blockedAddressReason('febf::1')).toBe('link-local')
+			expect(blockedAddressReason('ff02::1')).toBe('multicast')
+		})
+
+		it('reads the prefix as a number, not as the letters it starts with', () => {
+			// `fd::1` is `00fd:0:0:0:0:0:0:1` — an ordinary global address that
+			// merely SPELLS like `fd00::/8`, and `fe8::1` is `0fe8:…`. A
+			// `/^f[cd]/` screen blocks both, which is the `>=`-where-`>`-was-
+			// meant mistake wearing a regex: it deletes public addresses and
+			// nothing complains, because nobody tests the address that worked.
+			expect(blockedAddressReason('fd::1')).toBeNull()
+			expect(blockedAddressReason('fe8::1')).toBeNull()
+			expect(blockedAddressReason('fbff::1')).toBeNull()
+			expect(blockedAddressReason('fec0::1')).toBeNull()
+		})
+
+		it('sees a v4 address wearing a v6 spelling, in every spelling', () => {
+			// A v4-only screen passes all of these, which is a documented way
+			// through this kind of filter rather than an oversight.
+			expect(blockedAddressReason('::ffff:127.0.0.1')).toBe('loopback')
+			expect(blockedAddressReason('::ffff:7f00:1')).toBe('loopback')
+			expect(blockedAddressReason('::ffff:169.254.169.254')).toBe('link-local')
+			expect(blockedAddressReason('::ffff:a9fe:a9fe')).toBe('link-local')
+			// Written long. No `^::`-anchored pattern sees this one, and it is
+			// the same metadata address.
+			expect(blockedAddressReason('0:0:0:0:0:ffff:169.254.169.254')).toBe('link-local')
+			expect(blockedAddressReason('0:0:0:0:0:ffff:a9fe:a9fe')).toBe('link-local')
+			// The deprecated v4-compatible form reaches the v4 host too.
+			expect(blockedAddressReason('::127.0.0.1')).toBe('loopback')
+		})
+
+		it('is not fooled by a zone id', () => {
+			expect(blockedAddressReason('fe80::1%eth0')).toBe('link-local')
+		})
+	})
+
+	describe('a literal, as the proxy receives it', () => {
+		it('screens the bracketed spelling a proxied client actually sends', () => {
+			// `new URL('http://[::1]/').hostname` is `[::1]`, brackets and all,
+			// and that is exactly what the proxy reads off the request line.
+			//
+			// A layer, not a hole: Node does not read a bracketed string as a
+			// literal either, so an unbracketed-only check sends the host to
+			// `dns.lookup` and the screening resolver refuses it there. What is
+			// pinned here is that this function stops answering `null` about an
+			// address it plainly recognises.
+			expect(blockedLiteralReason('[::1]')).toBe('loopback')
+			expect(blockedLiteralReason('[::ffff:169.254.169.254]')).toBe('link-local')
+			expect(blockedLiteralReason('[2606:4700::1111]')).toBeNull()
+		})
+
+		it('does not screen a NAME as though it were an address', () => {
+			// As text these begin the way the v6 ranges do, and under the
+			// regex screen this file replaced they were refused outright — an
+			// address screen behaving as a name filter with a bug.
+			//
+			// Two things now stop that, and the honest reading is that this
+			// case pins the OUTCOME rather than either mechanism: `parseV6`
+			// refuses a hostname on its own, so removing the `isIP` guard
+			// breaks nothing here. The guard is kept as the statement of
+			// contract; see its comment.
+			expect(blockedLiteralReason('fdsomething.example')).toBeNull()
+			expect(blockedLiteralReason('ff-cdn.example')).toBeNull()
+			expect(blockedLiteralReason('fe80.example.com')).toBeNull()
+			expect(blockedLiteralReason('example.com')).toBeNull()
+		})
+
+		it('leaves a numeric host that is not a literal to the resolver', () => {
+			// `2130706433` and `0177.0.0.1` are loopback to a C resolver and are
+			// not IP literals to Node, so they are NOT screened here — they go
+			// out as names, through `createScreeningLookup`, and are refused on
+			// the address that comes back. Pinned so nobody closes the gap by
+			// string-parsing these forms and reopens it for the next spelling.
+			expect(blockedLiteralReason('2130706433')).toBeNull()
+			expect(blockedLiteralReason('0177.0.0.1')).toBeNull()
+		})
+	})
+})
+
+describe('screening inside the resolution the socket performs', () => {
+	it('passes a public answer through', async () => {
+		const { err, address } = await screen('cdn.example', resolvesTo('93.184.216.34'))
+		expect(err).toBeNull()
+		expect(address).toBe('93.184.216.34')
+	})
+
+	it('refuses a name that resolves inward, naming the address', async () => {
+		const { err } = await screen('friendly.example', resolvesTo('169.254.169.254'))
+		expect(err).toBeInstanceOf(EgressAddressDenied)
+		expect((err as EgressAddressDenied).address).toBe('169.254.169.254')
+		expect((err as EgressAddressDenied).reason).toBe('link-local')
+		expect(err?.message).toContain('friendly.example')
+	})
+
+	it('screens every answer, not only the one it would have used', async () => {
+		// A record set mixing a public address with an inward one is the
+		// ordinary shape of this attack. Screening only the winner makes the
+		// outcome depend on resolver ordering, which is not a security
+		// property — so the public address FIRST must still be refused.
+		const { err } = await screen('mixed.example', resolvesTo('93.184.216.34', '127.0.0.1'))
+		expect(err).toBeInstanceOf(EgressAddressDenied)
+		expect((err as EgressAddressDenied).address).toBe('127.0.0.1')
+	})
+
+	it('exempts one host without exempting the rest', async () => {
+		const exempt = await screen('inside.example', resolvesTo('10.0.0.5'), ['inside.example'])
+		expect(exempt.err).toBeNull()
+		expect(exempt.address).toBe('10.0.0.5')
+
+		// The escape hatch is per host. A neighbour on the same policy gets
+		// nothing from it, which is what stops it being a global switch.
+		const other = await screen('elsewhere.example', resolvesTo('10.0.0.5'), ['inside.example'])
+		expect(other.err).toBeInstanceOf(EgressAddressDenied)
+	})
+
+	it('refuses a name that resolves to nothing rather than dialling', async () => {
+		const { err } = await screen('void.example', resolvesTo())
+		expect(err?.code).toBe('ENOTFOUND')
+	})
+
+	it('passes a resolver failure back unchanged', async () => {
+		const broken: AddressResolver = (_hostname, _options, callback) => {
+			const failure: NodeJS.ErrnoException = new Error('resolver down')
+			failure.code = 'ESERVFAIL'
+			callback(failure, [])
+		}
+		const { err } = await screen('down.example', broken)
+		expect(err?.code).toBe('ESERVFAIL')
+	})
+
+	it('asks for every address, every time', async () => {
+		// The screen is worth nothing if it is handed one answer, so the
+		// resolver is always asked with `all`. A caller that asked for a single
+		// address would be screening the winner alone.
+		const asked: Array<{ all: boolean; verbatim: boolean }> = []
+		const recording: AddressResolver = (_hostname, options, callback) => {
+			asked.push({ all: options.all, verbatim: options.verbatim })
+			callback(null, [{ address: '93.184.216.34', family: 4 }])
+		}
+		await screen('cdn.example', recording)
+		expect(asked).toEqual([{ all: true, verbatim: true }])
+	})
+})

--- a/packages/sandbox/src/egress/__tests__/exemption-reaches-the-backend.test.ts
+++ b/packages/sandbox/src/egress/__tests__/exemption-reaches-the-backend.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { DockerBackendInternalConfig } from '../../backends/docker/index.js'
+
+/**
+ * The escape hatch has to reach the thing it is an escape hatch from.
+ *
+ * `allowInwardFor` is the only remedy an operator has when the address screen
+ * starts refusing a private host their allowlist used to reach. If it stops at
+ * `ContainerBackendConfig` and never arrives at the proxy, the screen is a
+ * denial with no way out — and nothing downstream of `buildDockerBackend`
+ * runs without a Docker daemon, so the first person to find out would be
+ * whoever was watching production traffic get refused.
+ *
+ * `brokeredCredentials` is the cautionary neighbour: it is declared on the
+ * internal backend config, read by `egressProxyOptions`, and `createSandboxProvider`
+ * has never passed it — so the credential brokering this whole boundary exists
+ * for is unreachable through the provider today. That is a separate defect and
+ * is not fixed here; it is why this case exists.
+ */
+
+const built: DockerBackendInternalConfig[] = []
+
+vi.mock('../../backends/docker/index.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../backends/docker/index.js')>()
+	return {
+		...actual,
+		buildDockerBackend: (config: DockerBackendInternalConfig) => {
+			built.push(config)
+			return actual.buildDockerBackend(config)
+		},
+	}
+})
+
+const { createSandboxProvider } = await import('../../index.js')
+
+/** The minimum a container layout has to declare. */
+function layout() {
+	return { outputs: { source: { type: 'hostDir' as const, hostPath: '/host/out' } } }
+}
+
+describe('the inward exemption reaches the backend that builds the proxy', () => {
+	beforeEach(() => {
+		built.length = 0
+	})
+
+	it('carries the exemption a host configured', () => {
+		createSandboxProvider({
+			backend: {
+				tier: 'container',
+				image: 'namzu/sandbox:test',
+				allowInwardFor: ['.internal.example'],
+			},
+			layout: layout(),
+		} as never)
+
+		expect(built).toHaveLength(1)
+		expect(built[0]?.allowInwardFor).toEqual(['.internal.example'])
+	})
+
+	it('leaves it absent when the host configured none, so the screen applies', () => {
+		createSandboxProvider({
+			backend: { tier: 'container', image: 'namzu/sandbox:test' },
+			layout: layout(),
+		} as never)
+
+		expect(built[0]?.allowInwardFor).toBeUndefined()
+	})
+
+	it('carries it on the gVisor runtime too, which is a second call site', () => {
+		// Two `buildDockerBackend` calls sit in the same function, and a
+		// property added to one of them is the shape this repo has a
+		// convention about: finding an emitter is not evidence that every
+		// path reaches it.
+		createSandboxProvider({
+			backend: {
+				tier: 'container',
+				runtime: 'runsc',
+				image: 'namzu/sandbox:test',
+				allowInwardFor: ['registry.corp'],
+			},
+			layout: layout(),
+		} as never)
+
+		expect(built[0]?.allowInwardFor).toEqual(['registry.corp'])
+	})
+})

--- a/packages/sandbox/src/egress/__tests__/proxy.test.ts
+++ b/packages/sandbox/src/egress/__tests__/proxy.test.ts
@@ -76,6 +76,90 @@ function viaProxy(
 	})
 }
 
+/**
+ * Issue a request through the proxy WITHOUT an absolute URL.
+ *
+ * A client that forgot the absolute form still sends `Host`, and the proxy
+ * honours it — which is what makes a plain `fetch` through `HTTP_PROXY` work.
+ * It is also the path that hands an address over exactly as written, because
+ * `splitAuthority` does not normalise the way `new URL` does.
+ */
+function viaHostHeader(
+	proxy: RunningEgressProxy,
+	authority: string,
+	path: string,
+): Promise<{ status: number; body: string }> {
+	const proxyUrl = new URL(proxy.url)
+	return new Promise((resolve, reject) => {
+		const req = nodeRequest(
+			{
+				host: proxyUrl.hostname,
+				port: Number(proxyUrl.port),
+				method: 'GET',
+				path,
+				headers: { host: authority },
+			},
+			(res) => {
+				let body = ''
+				res.setEncoding('utf-8')
+				res.on('data', (chunk: string) => {
+					body += chunk
+				})
+				res.on('end', () => resolve({ status: res.statusCode ?? 0, body }))
+			},
+		)
+		req.on('error', reject)
+		req.end()
+	})
+}
+
+/**
+ * Open a tunnel through the proxy and return whatever it answered with.
+ *
+ * The refusal on this path is written straight onto the socket rather than
+ * through a `ServerResponse`, so it has to be read as bytes — a request
+ * helper would see a failed CONNECT and tell us nothing about what was said.
+ */
+function connectVia(proxy: RunningEgressProxy, authority: string): Promise<string> {
+	const proxyUrl = new URL(proxy.url)
+	// Never rejects: every outcome, including a dead socket, comes back as a
+	// string to be compared.
+	return new Promise((resolve) => {
+		const req = nodeRequest({
+			host: proxyUrl.hostname,
+			port: Number(proxyUrl.port),
+			method: 'CONNECT',
+			path: authority,
+		})
+		// Node raises `connect` for the response to a CONNECT whatever its
+		// status, so the status has to be read off the response rather than
+		// inferred from which event fired. Assuming otherwise reports every
+		// refusal as an established tunnel.
+		req.on('connect', (res, socket, head) => {
+			socket.destroy()
+			resolve(`${res.statusCode} ${head.toString('utf-8')}`)
+		})
+		// A refusal never becomes a tunnel, so it arrives here as a plain
+		// response rather than through `connect`.
+		req.on('response', (res) => {
+			let body = ''
+			res.setEncoding('utf-8')
+			res.on('data', (chunk: string) => {
+				body += chunk
+			})
+			res.on('end', () => resolve(`${res.statusCode} ${body}`))
+		})
+		// A tunnel that dies without answering is an OUTCOME, not a broken
+		// test, so it comes back as a string to be compared like the others.
+		// Rejecting here would report "socket hang up" where the reader wants
+		// "expected a refusal and the socket just closed" — a thrown error and
+		// a failed assertion look the same in a summary and are not the same
+		// evidence.
+		req.on('error', (err) => resolve(`no response (${err.message})`))
+		req.end()
+	})
+}
+
 describe('the boundary', () => {
 	let proxy: RunningEgressProxy
 	let allowed: string[]
@@ -90,6 +174,12 @@ describe('the boundary', () => {
 			allowedHosts: async () => allowed,
 			// The stand-in upstream speaks plain HTTP.
 			upgradeToHttps: false,
+			// The upstream in these tests IS a loopback address, which the
+			// address screen refuses by default and rightly so. Naming the
+			// exemption here rather than weakening the screen keeps these
+			// tests about what they are about; the screen itself is proved in
+			// `address.test.ts` and in the reach tests below.
+			allowInwardFor: ['127.0.0.1'],
 			onDenied: (host, reason) => denied.push({ host, reason }),
 		}).listen()
 	})
@@ -161,6 +251,198 @@ describe('the boundary', () => {
 	})
 })
 
+/**
+ * What the name actually reaches.
+ *
+ * The allowlist decides on a NAME. Where that name goes is decided by DNS,
+ * which the caller may control — so an allowlisted name is not a permitted
+ * destination until something has looked at the address.
+ *
+ * These are the end-to-end half; `address.test.ts` pins the screen itself.
+ * The two are needed separately: a unit test on `blockedAddressReason` passes
+ * whether or not the proxy ever calls it, and the defect being fixed here was
+ * exactly that nothing did.
+ */
+describe('what the name actually reaches', () => {
+	let target: Awaited<ReturnType<typeof upstream>>
+	let denied: Array<{ host: string; reason: string }>
+
+	beforeEach(async () => {
+		target = await upstream()
+		denied = []
+	})
+
+	afterEach(async () => {
+		await new Promise<void>((resolve) => target.server.close(() => resolve()))
+	})
+
+	/** A proxy that allows `host`, brokers a token for it, and resolves as told. */
+	const proxyFor = async (host: string, resolvesTo?: string) =>
+		new EgressProxy({
+			allowedHosts: async () => [host],
+			upgradeToHttps: false,
+			credentials: [{ host, header: 'authorization', value: 'Bearer real-secret' }],
+			onDenied: (h, reason) => denied.push({ host: h, reason }),
+			...(resolvesTo
+				? {
+						resolveAddresses: (_hostname, _options, callback) => {
+							callback(null, [{ address: resolvesTo, family: 4 }])
+						},
+					}
+				: {}),
+		}).listen()
+
+	it('refuses an allowed name that resolves inward, and the credential goes nowhere', async () => {
+		// The defect, end to end. `friendly.example` is on the allowlist and
+		// has a token brokered for it; its DNS answers with loopback. Without
+		// the screen the proxy connects and stamps `Bearer real-secret` on the
+		// way out, so the credential-brokering design becomes the delivery
+		// mechanism for the credential.
+		const proxy = await proxyFor('friendly.example', '127.0.0.1')
+		try {
+			const res = await viaProxy(proxy, `http://friendly.example:${target.port}/thing`)
+
+			expect(res.status).toBe(403)
+			expect(res.body).toContain('127.0.0.1')
+			expect(denied[0]?.reason).toContain('loopback')
+			// The whole point: nothing arrived, so the token was never sent.
+			expect(target.seen).toHaveLength(0)
+		} finally {
+			await proxy.close()
+		}
+	})
+
+	it('refuses an allowed name that resolves to the metadata address', async () => {
+		const proxy = await proxyFor('friendly.example', '169.254.169.254')
+		try {
+			const res = await viaProxy(proxy, 'http://friendly.example/latest/meta-data/')
+			expect(res.status).toBe(403)
+			expect(denied[0]?.reason).toContain('link-local')
+		} finally {
+			await proxy.close()
+		}
+	})
+
+	it('refuses an allowed host that is already an inward literal', async () => {
+		// A literal is never resolved, so the screening resolver is never
+		// called for it. This case is the reason there are two checks rather
+		// than one, and it is the case a green suite hid: every existing test
+		// here points at `127.0.0.1`, which is a literal.
+		const proxy = await proxyFor('169.254.169.254')
+		try {
+			const res = await viaProxy(proxy, 'http://169.254.169.254/latest/meta-data/')
+			expect(res.status).toBe(403)
+			expect(res.body).toContain('link-local')
+			expect(target.seen).toHaveLength(0)
+		} finally {
+			await proxy.close()
+		}
+	})
+
+	it('refuses the bracketed IPv6 spelling a proxied client actually sends', async () => {
+		// `new URL(...).hostname` returns `[::ffff:7f00:1]`, brackets included,
+		// and that is what the request line carries.
+		//
+		// TWO layers stop this one, and which fires first was worth measuring
+		// rather than assuming: Node does not read a bracketed string as an IP
+		// literal either, so with the literal check disabled the host goes to
+		// `dns.lookup` — the screening resolver — and is refused there. So the
+		// bracket handling in `blockedLiteralReason` is a layer earlier, not a
+		// hole closed. It is still worth having: the exported helper is asked
+		// about this exact spelling by `parseTarget`, and answering `null` for
+		// an address it plainly recognises is the kind of true-looking answer
+		// the next caller builds on.
+		const proxy = await proxyFor('[::ffff:7f00:1]')
+		try {
+			const res = await viaProxy(proxy, `http://[::ffff:127.0.0.1]:${target.port}/thing`)
+			expect(res.status).toBe(403)
+			expect(target.seen).toHaveLength(0)
+		} finally {
+			await proxy.close()
+		}
+	})
+
+	it('refuses a v4 address written long in IPv6, which IS a literal to the socket', async () => {
+		// The case the bracket one is not. `isIP('0:0:0:0:0:ffff:127.0.0.1')`
+		// is 6, so the socket dials it without ever resolving and the
+		// screening lookup is never consulted — the literal check is the only
+		// thing between this request and the upstream. A screen that pattern-
+		// matched `^::ffff:` on the text passed it, and it is the same
+		// loopback address as `::ffff:127.0.0.1`.
+		//
+		// Sent through the `Host` header rather than the request line, because
+		// that is the path that hands the long form over intact:
+		// `splitAuthority` strips the brackets and does not normalise, where
+		// `new URL` would compress it first.
+		const long = '0:0:0:0:0:ffff:127.0.0.1'
+		const proxy = await proxyFor(long)
+		try {
+			const res = await viaHostHeader(proxy, `[${long}]:${target.port}`, '/thing')
+			expect(res.status).toBe(403)
+			expect(res.body).toContain('loopback')
+			// The reach that would otherwise have happened, and the token with
+			// it: this address connects to the stand-in upstream.
+			expect(target.seen).toHaveLength(0)
+		} finally {
+			await proxy.close()
+		}
+	})
+
+	it('refuses an inward literal on the tunnel path too', async () => {
+		// CONNECT carries no brokered credential, so what is lost here is
+		// reach rather than a token — but an allowlisted name pointing inward
+		// still turns the proxy into a route to the host's own network.
+		const proxy = await proxyFor('169.254.169.254')
+		try {
+			const res = await connectVia(proxy, '169.254.169.254:443')
+			expect(res).toContain('403')
+			expect(denied[0]?.reason).toContain('link-local')
+		} finally {
+			await proxy.close()
+		}
+	})
+
+	it('refuses an allowed name that resolves inward on the tunnel path too', async () => {
+		// The tunnel gets its own case because it gets its own socket call:
+		// removing the screening resolver from `netConnect` alone breaks
+		// nothing the plain-HTTP cases can see, and "both paths pass a
+		// `lookup`" is two facts, not one.
+		const proxy = await proxyFor('friendly.example', '127.0.0.1')
+		try {
+			const res = await connectVia(proxy, `friendly.example:${target.port}`)
+			expect(res).toContain('403')
+			expect(denied[0]?.reason).toContain('loopback')
+		} finally {
+			await proxy.close()
+		}
+	})
+
+	it('lets the named exemption through without widening anything else', async () => {
+		// The escape hatch exists because an operator may genuinely proxy to
+		// one service on a private network. It is per host: the neighbour on
+		// the same policy gets nothing from it.
+		const proxy = await new EgressProxy({
+			allowedHosts: async () => ['inside.example', 'other.example'],
+			upgradeToHttps: false,
+			allowInwardFor: ['inside.example'],
+			onDenied: (h, reason) => denied.push({ host: h, reason }),
+			resolveAddresses: (_hostname, _options, callback) => {
+				callback(null, [{ address: '127.0.0.1', family: 4 }])
+			},
+		}).listen()
+
+		try {
+			const allowed = await viaProxy(proxy, `http://inside.example:${target.port}/thing`)
+			expect(allowed.status).toBe(200)
+
+			const neighbour = await viaProxy(proxy, `http://other.example:${target.port}/thing`)
+			expect(neighbour.status).toBe(403)
+		} finally {
+			await proxy.close()
+		}
+	})
+})
+
 describe('brokering a credential', () => {
 	let proxy: RunningEgressProxy
 	let target: Awaited<ReturnType<typeof upstream>>
@@ -178,6 +460,10 @@ describe('brokering a credential', () => {
 		proxy = await new EgressProxy({
 			allowedHosts: async () => ['127.0.0.1'],
 			upgradeToHttps: false,
+			// See the note in the reach suite: the stand-in upstream is itself
+			// a loopback address. Exempting it keeps these tests about
+			// credential scoping rather than about addresses.
+			allowInwardFor: ['127.0.0.1'],
 			credentials: [{ host, header: 'authorization', value: 'Bearer real-secret' }],
 		}).listen()
 		return proxy

--- a/packages/sandbox/src/egress/address.ts
+++ b/packages/sandbox/src/egress/address.ts
@@ -1,0 +1,366 @@
+import { lookup as dnsLookup } from 'node:dns'
+import type { LookupAddress } from 'node:dns'
+import { isIP } from 'node:net'
+
+/**
+ * Address-level screening for egress.
+ *
+ * The allowlist answers "is this NAME permitted". That is a different
+ * question from "where does this name go", and only the second one decides
+ * what the socket actually reaches. A name on the allowlist whose DNS the
+ * attacker controls — or that simply has an inward-pointing record — resolves
+ * to the loopback interface, the private network the sandbox host sits on, or
+ * the link-local address cloud metadata services answer on.
+ *
+ * The proxy stamps a brokered credential on before the request goes out, so
+ * without this screen the credential-brokering design is the delivery
+ * mechanism: the token reaches whatever the name resolved to. That is the
+ * exact outcome `BrokeredCredential.host` exists to prevent, and it could not
+ * prevent it while the scope was a name rather than an address.
+ */
+
+/** Blocked ranges, and the name of what each one protects. */
+interface Range {
+	readonly reason: string
+	readonly matches: (octets: readonly number[]) => boolean
+}
+
+const V4_RANGES: readonly Range[] = [
+	{ reason: 'loopback', matches: (o) => o[0] === 127 },
+	{ reason: 'this-host', matches: (o) => o[0] === 0 },
+	{ reason: 'private', matches: (o) => o[0] === 10 },
+	{ reason: 'private', matches: (o) => o[0] === 172 && (o[1] ?? 0) >= 16 && (o[1] ?? 0) <= 31 },
+	{ reason: 'private', matches: (o) => o[0] === 192 && o[1] === 168 },
+	// 169.254.0.0/16. The metadata address every major host platform answers
+	// on lives here, which is why this range is the one that turns a name
+	// check into a credential leak.
+	{ reason: 'link-local', matches: (o) => o[0] === 169 && o[1] === 254 },
+	{
+		reason: 'shared-address-space',
+		matches: (o) => o[0] === 100 && (o[1] ?? 0) >= 64 && (o[1] ?? 0) <= 127,
+	},
+	{ reason: 'benchmarking', matches: (o) => o[0] === 198 && (o[1] === 18 || o[1] === 19) },
+	{ reason: 'multicast', matches: (o) => (o[0] ?? 0) >= 224 && (o[0] ?? 0) <= 239 },
+	{ reason: 'reserved', matches: (o) => (o[0] ?? 0) >= 240 },
+]
+
+function parseV4(address: string): readonly number[] | null {
+	const parts = address.split('.')
+	if (parts.length !== 4) return null
+	const octets: number[] = []
+	for (const part of parts) {
+		if (!/^\d{1,3}$/.test(part)) return null
+		const n = Number(part)
+		if (n > 255) return null
+		octets.push(n)
+	}
+	return octets
+}
+
+/**
+ * Expand an IPv6 literal into its eight 16-bit groups, or `null`.
+ *
+ * Written out rather than pattern-matched on the text, because a prefix
+ * matched as a STRING is a different question from a prefix matched as a
+ * NUMBER, and the two disagree exactly where it hurts. `/^f[cd]/` was the
+ * first spelling of the unique-local check here, and `fd::1` matches it —
+ * but `fd::1` is `00fd:0:…`, an ordinary global address, so that check
+ * deleted a slice of the internet. `fe8::1` did the same against
+ * `/^fe[89ab]/`. Both are the `>=`-where-`>`-was-meant mistake wearing a
+ * regex.
+ *
+ * It fails the other way too. `0:0:0:0:0:ffff:169.254.169.254` is the
+ * metadata address written long, and no `^::`-anchored pattern sees it.
+ */
+function parseV6(address: string): number[] | null {
+	// A zone id (`%eth0`) names an interface, not a different address.
+	const text = (address.toLowerCase().split('%')[0] ?? '').trim()
+	if (text.length === 0) return null
+
+	// A trailing dotted quad is the last two groups written in v4 notation.
+	let head = text
+	let tail: number[] = []
+	const lastColon = text.lastIndexOf(':')
+	const after = lastColon >= 0 ? text.slice(lastColon + 1) : ''
+	if (after.includes('.')) {
+		const quad = parseV4(after)
+		if (!quad) return null
+		const [a, b, c, d] = quad as [number, number, number, number]
+		tail = [(a << 8) | b, (c << 8) | d]
+		head = text.slice(0, lastColon + 1)
+		if (head.endsWith(':') && !head.endsWith('::')) head = head.slice(0, -1)
+	}
+
+	const halves = head.split('::')
+	if (halves.length > 2) return null
+
+	const toGroups = (part: string): number[] | null => {
+		if (part.length === 0) return []
+		const out: number[] = []
+		for (const piece of part.split(':')) {
+			if (!/^[0-9a-f]{1,4}$/.test(piece)) return null
+			out.push(Number.parseInt(piece, 16))
+		}
+		return out
+	}
+
+	if (halves.length === 1) {
+		const only = toGroups(halves[0] ?? '')
+		if (!only) return null
+		const groups = [...only, ...tail]
+		return groups.length === 8 ? groups : null
+	}
+
+	const left = toGroups(halves[0] ?? '')
+	const right = toGroups(halves[1] ?? '')
+	if (!left || !right) return null
+	const known = left.length + right.length + tail.length
+	if (known > 8) return null
+	return [...left, ...new Array<number>(8 - known).fill(0), ...right, ...tail]
+}
+
+/** Whether the first `count` groups are all zero. */
+function zeroPrefix(groups: readonly number[], count: number): boolean {
+	return groups.slice(0, count).every((g) => g === 0)
+}
+
+/**
+ * Why this address must not be reached, or `null` if it may be.
+ *
+ * Returns a reason rather than a boolean because the reason is what a
+ * denied operator needs: "link-local" and "private" are different mistakes
+ * with different fixes, and a bare `false` sends them to read this file.
+ */
+export function blockedAddressReason(address: string): string | null {
+	const literal = unbracket(address)
+	const v4 = parseV4(literal)
+	if (v4) {
+		for (const range of V4_RANGES) {
+			if (range.matches(v4)) return range.reason
+		}
+		return null
+	}
+
+	const groups = parseV6(literal)
+	if (!groups) return null
+
+	// `::ffff:a.b.c.d` (v4-mapped) and the deprecated `::a.b.c.d`
+	// (v4-compatible) are both the v4 address wearing a v6 spelling, and both
+	// reach the v4 host. A screen that only understands dotted quads passes
+	// them, which is a documented way through this kind of filter rather than
+	// an oversight worth ignoring.
+	if (zeroPrefix(groups, 5) && groups[5] === 0xffff) {
+		return blockedAddressReason(v4FromGroups(groups))
+	}
+	if (zeroPrefix(groups, 6) && !(groups[6] === 0 && (groups[7] ?? 0) <= 1)) {
+		return blockedAddressReason(v4FromGroups(groups))
+	}
+
+	if (zeroPrefix(groups, 7)) {
+		if (groups[7] === 1) return 'loopback'
+		if (groups[7] === 0) return 'unspecified'
+	}
+
+	const first = groups[0] ?? 0
+	// Masked, not prefix-matched: fc00::/7, fe80::/10, ff00::/8.
+	if ((first & 0xfe00) === 0xfc00) return 'unique-local'
+	if ((first & 0xffc0) === 0xfe80) return 'link-local'
+	if ((first & 0xff00) === 0xff00) return 'multicast'
+	return null
+}
+
+function v4FromGroups(groups: readonly number[]): string {
+	const high = groups[6] ?? 0
+	const low = groups[7] ?? 0
+	return `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`
+}
+
+/**
+ * An IPv6 literal arrives bracketed from one of the two paths.
+ *
+ * `new URL('http://[::1]/').hostname` is `[::1]`, brackets included, and
+ * `parseTarget` reads exactly that. The `Host`-header path hands the same
+ * address over bare, because `splitAuthority` strips the brackets itself —
+ * two spellings of one address, normalised here rather than at either call
+ * site.
+ *
+ * This is a layer, not a hole closed, and the difference was measured rather
+ * than assumed: Node does not read a bracketed string as an IP literal
+ * either, so without this the host falls through to `dns.lookup` and the
+ * screening resolver refuses it there. What this buys is that
+ * `blockedLiteralReason` stops answering `null` about an address it plainly
+ * recognises — a true-looking answer the next caller would build on.
+ */
+function unbracket(host: string): string {
+	const trimmed = host.trim()
+	return trimmed.startsWith('[') && trimmed.endsWith(']') ? trimmed.slice(1, -1) : trimmed
+}
+
+/**
+ * Screen a target that is already an address rather than a name.
+ *
+ * A `lookup` hook cannot cover this case and it is not obvious why: the
+ * socket layer skips resolution entirely when the host is a valid IP
+ * literal, so the screening resolver is never called. The whole existing
+ * egress suite passed with the resolver in place *because* its upstream is
+ * `127.0.0.1` — a literal, never resolved, never screened. A green suite
+ * was the evidence the hole was still open.
+ *
+ * So the two cases need two checks: names are screened inside the resolver
+ * the socket calls, literals are screened here before it dials.
+ */
+export function blockedLiteralReason(host: string): string | null {
+	// The `isIP` guard states the contract: only an address is screened here.
+	//
+	// It is defence in depth rather than the thing that saves a hostname, and
+	// that was measured — removing it kills no test, because `parseV6` refuses
+	// `fdsomething.example` and `ff-cdn.example` on its own. It earns its place
+	// against the version of this file that does not: the first screen written
+	// here matched `/^f[cd]/` against the raw text, and under that screen this
+	// line was the only thing standing between an ordinary CDN hostname and a
+	// refusal. Keeping it means a future loosening of the parser cannot quietly
+	// turn an address screen back into a name filter.
+	if (isIP(unbracket(host)) === 0) return null
+	return blockedAddressReason(host)
+}
+
+export class EgressAddressDenied extends Error {
+	readonly host: string
+	readonly address: string
+	readonly reason: string
+
+	constructor(host: string, address: string, reason: string) {
+		super(
+			`Egress denied: ${host} resolves to ${address}, which is a ${reason} address. The host is on the allowlist; the address it resolves to is not reachable from a sandbox.`,
+		)
+		this.name = 'EgressAddressDenied'
+		this.host = host
+		this.address = address
+		this.reason = reason
+	}
+}
+
+export interface ScreeningLookupOptions {
+	/**
+	 * Hosts permitted to resolve inward anyway, matched by the allowlist's
+	 * own rules so `.internal.example` covers subdomains.
+	 *
+	 * Per host, never a global switch. An operator who genuinely proxies to
+	 * one service on a private network needs that service exempted, and
+	 * turning the screen off entirely to get it would hand every other
+	 * allowlisted name the same reach.
+	 */
+	readonly allowInwardFor?: readonly string[]
+	/** Injected in tests. Defaults to the platform resolver. */
+	readonly resolve?: AddressResolver
+}
+
+/**
+ * The one shape this module asks a resolver for: every address, in the
+ * order the resolver returned them.
+ *
+ * Narrower than the platform signature on purpose. The screen has to see
+ * ALL the addresses to be worth anything, so a resolver that can be asked
+ * for one is a resolver this code could accidentally ask wrongly.
+ */
+export type AddressResolver = (
+	hostname: string,
+	options: { readonly all: true; readonly verbatim: true },
+	callback: (err: NodeJS.ErrnoException | null, addresses: LookupAddress[]) => void,
+) => void
+
+const platformResolver: AddressResolver = (hostname, options, callback) => {
+	dnsLookup(hostname, options, callback)
+}
+
+type LookupCallback = (
+	err: NodeJS.ErrnoException | null,
+	address: string | LookupAddress[],
+	family?: number,
+) => void
+
+/**
+ * A `lookup` implementation that screens before the socket uses the answer.
+ *
+ * This is deliberately not "resolve, check, then connect to the address we
+ * checked". That shape leaves the socket free to resolve again, and the
+ * second answer is the one that decides where the bytes go — so a name that
+ * alternates records walks straight through a check that passed a moment
+ * earlier. Screening inside the resolver the socket itself calls means there
+ * is one resolution, and the address that was screened is the address that
+ * gets connected to.
+ *
+ * Every returned address is screened, not just the one chosen. A record set
+ * mixing a public address with an inward one is the ordinary shape of this
+ * attack, and screening only the winner makes the outcome depend on which
+ * record the resolver happened to order first.
+ */
+export function createScreeningLookup(
+	options: ScreeningLookupOptions = {},
+	isExempt: (host: string, patterns: readonly string[]) => boolean = () => false,
+): (hostname: string, opts: unknown, callback: LookupCallback) => void {
+	const resolver = options.resolve ?? platformResolver
+	const exemptions = options.allowInwardFor ?? []
+
+	return (hostname, opts, callback) => {
+		const wantsAll =
+			typeof opts === 'object' && opts !== null && (opts as { all?: boolean }).all === true
+		const family =
+			typeof opts === 'number'
+				? opts
+				: typeof opts === 'object' && opts !== null
+					? ((opts as { family?: number }).family ?? 0)
+					: 0
+
+		resolver(hostname, { all: true, verbatim: true }, (err, addresses) => {
+			if (err) {
+				callback(err, '', 0)
+				return
+			}
+			const found = addresses ?? []
+			if (found.length === 0) {
+				const empty: NodeJS.ErrnoException = new Error(
+					`Egress denied: ${hostname} resolved to no addresses.`,
+				)
+				empty.code = 'ENOTFOUND'
+				callback(empty, '', 0)
+				return
+			}
+
+			if (!(exemptions.length > 0 && isExempt(hostname, exemptions))) {
+				for (const candidate of found) {
+					const reason = blockedAddressReason(candidate.address)
+					if (reason) {
+						callback(new EgressAddressDenied(hostname, candidate.address, reason), '', 0)
+						return
+					}
+				}
+			}
+
+			const usable = family === 0 ? found : found.filter((a) => a.family === family)
+			if (usable.length === 0) {
+				const mismatch: NodeJS.ErrnoException = new Error(
+					`Egress denied: ${hostname} has no address in the requested family.`,
+				)
+				mismatch.code = 'ENOTFOUND'
+				callback(mismatch, '', 0)
+				return
+			}
+
+			if (wantsAll) {
+				callback(null, usable)
+				return
+			}
+			const first = usable[0]
+			if (!first) {
+				const none: NodeJS.ErrnoException = new Error(
+					`Egress denied: ${hostname} resolved to no usable address.`,
+				)
+				none.code = 'ENOTFOUND'
+				callback(none, '', 0)
+				return
+			}
+			callback(null, first.address, first.family)
+		})
+	}
+}

--- a/packages/sandbox/src/egress/index.ts
+++ b/packages/sandbox/src/egress/index.ts
@@ -1,3 +1,10 @@
+export {
+	blockedAddressReason,
+	blockedLiteralReason,
+	createScreeningLookup,
+	EgressAddressDenied,
+} from './address.js'
+export type { AddressResolver, ScreeningLookupOptions } from './address.js'
 export { isHostAllowed, splitAuthority } from './allowlist.js'
 export { EgressProxy } from './proxy.js'
 export type {

--- a/packages/sandbox/src/egress/proxy.ts
+++ b/packages/sandbox/src/egress/proxy.ts
@@ -4,6 +4,8 @@ import { request as httpsRequest } from 'node:https'
 import { connect as netConnect } from 'node:net'
 import type { Duplex } from 'node:stream'
 
+import { EgressAddressDenied, blockedLiteralReason, createScreeningLookup } from './address.js'
+import type { ScreeningLookupOptions } from './address.js'
 import { isHostAllowed, splitAuthority } from './allowlist.js'
 
 /**
@@ -59,6 +61,18 @@ export interface EgressProxyOptions {
 	 */
 	readonly upgradeToHttps?: boolean
 	readonly onDenied?: (host: string, reason: string) => void
+	/**
+	 * Allowlisted hosts permitted to resolve to an inward address anyway.
+	 *
+	 * Matched by the allowlist's own rules, so `.internal.example` covers
+	 * subdomains. Per host on purpose: an operator who genuinely proxies to
+	 * one service on a private network needs that one exempted, and a global
+	 * switch to get it would hand every other allowlisted name the same
+	 * reach — which is the hole this screen exists to close.
+	 */
+	readonly allowInwardFor?: readonly string[]
+	/** Injected in tests. Defaults to the platform resolver. */
+	readonly resolveAddresses?: ScreeningLookupOptions['resolve']
 }
 
 export interface RunningEgressProxy {
@@ -79,12 +93,28 @@ export class EgressProxy {
 	private readonly onDenied: ((host: string, reason: string) => void) | undefined
 	/** See the loop guard in `listen`. */
 	private selfPort: number | undefined
+	/**
+	 * The resolver both paths connect through.
+	 *
+	 * Held once rather than built per request so there is exactly one place
+	 * the address screen can be bypassed, and it is visible from here.
+	 */
+	private readonly lookup: ReturnType<typeof createScreeningLookup>
+	private readonly inwardAllowed: readonly string[]
 
 	constructor(options: EgressProxyOptions) {
 		this.resolveAllowed = options.allowedHosts
 		this.credentials = options.credentials ?? []
 		this.upgradeToHttps = options.upgradeToHttps ?? true
 		this.onDenied = options.onDenied
+		this.inwardAllowed = options.allowInwardFor ?? []
+		this.lookup = createScreeningLookup(
+			{
+				...(options.allowInwardFor ? { allowInwardFor: options.allowInwardFor } : {}),
+				...(options.resolveAddresses ? { resolve: options.resolveAddresses } : {}),
+			},
+			isHostAllowed,
+		)
 	}
 
 	async listen(port = 0): Promise<RunningEgressProxy> {
@@ -143,6 +173,18 @@ export class EgressProxy {
 		this.onDenied?.(host, reason)
 	}
 
+	/**
+	 * Why this target may not be dialled as written, or `null`.
+	 *
+	 * Covers the literal-address case only; a name is screened inside
+	 * `this.lookup`, which the socket calls. Both are needed — see
+	 * `blockedLiteralReason` for why one cannot cover the other.
+	 */
+	private literalDenial(host: string): string | null {
+		if (this.inwardAllowed.length > 0 && isHostAllowed(host, this.inwardAllowed)) return null
+		return blockedLiteralReason(host)
+	}
+
 	/** Plain HTTP. The only path where a credential can be stamped on. */
 	private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
 		const target = parseTarget(req)
@@ -170,6 +212,20 @@ export class EgressProxy {
 			return
 		}
 
+		const literal = this.literalDenial(target.host)
+		if (literal) {
+			this.deny(target.host, `is a ${literal} address`)
+			res.writeHead(DENIED_STATUS, { 'content-type': 'text/plain' })
+			// Refused BEFORE the credential is looked up, let alone stamped.
+			// The ordering is the point: on this path the token goes on the
+			// headers a few lines below, so a check that ran after it would be
+			// deciding whether to send a request that already carried it.
+			res.end(
+				`Egress denied: ${target.host} is a ${literal} address, which is not reachable from a sandbox.\n`,
+			)
+			return
+		}
+
 		const headers = { ...req.headers }
 		// The proxy re-issues the request, so hop-by-hop headers about the
 		// hop that just ended must not be forwarded.
@@ -192,6 +248,11 @@ export class EgressProxy {
 				method: req.method,
 				path: target.path,
 				headers,
+				// `host` stays the NAME so SNI and certificate validation still
+				// check the name the allowlist approved; only the address the
+				// socket dials is screened. Swapping in the address here would
+				// break TLS verification, which is the wrong way to fix this.
+				lookup: this.lookup,
 			},
 			(response) => {
 				res.writeHead(response.statusCode ?? 502, response.headers)
@@ -200,6 +261,17 @@ export class EgressProxy {
 		)
 
 		upstream.on('error', (err) => {
+			// An address denial is a policy refusal, not a network fault, and
+			// telling them apart is the difference between an agent that stops
+			// and one that retries a forbidden host forever. The credential is
+			// already on `headers` at this point and has still not left the
+			// process: the socket never connected, so nothing was written.
+			if (err instanceof EgressAddressDenied) {
+				this.deny(err.host, `resolves to a ${err.reason} address`)
+				if (!res.headersSent) res.writeHead(DENIED_STATUS, { 'content-type': 'text/plain' })
+				res.end(`${err.message}\n`)
+				return
+			}
 			if (!res.headersSent) res.writeHead(502, { 'content-type': 'text/plain' })
 			res.end(`Upstream request failed: ${err.message}\n`)
 		})
@@ -216,6 +288,18 @@ export class EgressProxy {
 	 * agent sends anywhere, a strictly larger risk than the one being
 	 * mitigated. A workload that needs brokering speaks plain HTTP to the
 	 * proxy and lets it upgrade upstream.
+	 *
+	 * **And the allowlist here is a check on the name in the CONNECT line,
+	 * which is the only thing about this tunnel that is ever in clear text.**
+	 * The address screen makes it a check on where that name goes, which is a
+	 * real bound — a permitted name can no longer be a route to the host's own
+	 * network. It is not a check on what travels afterwards. Inside the tunnel
+	 * the bytes are the caller's, and the name the caller puts in its own TLS
+	 * handshake or `Host` header is not visible to this process, so against a
+	 * determined caller running inside the sandbox this path bounds the
+	 * DESTINATION and nothing else. Say so plainly rather than let a reader
+	 * infer that a tunnel to an allowlisted host carries only allowlisted
+	 * traffic.
 	 */
 	private async handleConnect(req: IncomingMessage, socket: Duplex, head: Buffer): Promise<void> {
 		const { host, port } = splitAuthority(req.url ?? '')
@@ -229,14 +313,34 @@ export class EgressProxy {
 			return
 		}
 
-		const upstream = netConnect(port ?? 443, host, () => {
+		const literal = this.literalDenial(host)
+		if (literal) {
+			this.deny(host, `is a ${literal} address`)
+			socket.write(
+				`HTTP/1.1 ${DENIED_STATUS} Forbidden\r\nContent-Type: text/plain\r\n\r\nEgress denied: ${host} is a ${literal} address, which is not reachable from a sandbox.\n`,
+			)
+			socket.end()
+			return
+		}
+
+		// Same screened resolver as the plain path. The tunnel carries no
+		// brokered credential, so the loss here is reach rather than a token —
+		// but an allowlisted name pointing inward still turns this proxy into
+		// a route to the host's own network, which is what a sandbox is for.
+		const upstream = netConnect({ port: port ?? 443, host, lookup: this.lookup }, () => {
 			socket.write('HTTP/1.1 200 Connection Established\r\n\r\n')
 			if (head.length > 0) upstream.write(head)
 			upstream.pipe(socket)
 			socket.pipe(upstream)
 		})
 
-		upstream.on('error', () => {
+		upstream.on('error', (err) => {
+			if (err instanceof EgressAddressDenied) {
+				this.deny(err.host, `resolves to a ${err.reason} address`)
+				socket.write(
+					`HTTP/1.1 ${DENIED_STATUS} Forbidden\r\nContent-Type: text/plain\r\n\r\n${err.message}\n`,
+				)
+			}
 			socket.end()
 		})
 		socket.on('error', () => {

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -211,6 +211,22 @@ export interface ContainerBackendConfig {
 	 */
 	readonly network?: 'none' | 'bridge' | string
 	/**
+	 * Allowlisted hosts permitted to resolve to an inward address anyway.
+	 *
+	 * The egress boundary refuses a host that resolves to loopback, a
+	 * private range, or the link-local block cloud metadata services answer
+	 * on — whatever the allowlist says, because an allowlisted name whose
+	 * DNS someone else controls is a permitted spelling rather than a
+	 * permitted destination. A deployment that genuinely proxies to one
+	 * service on a private network names that service here.
+	 *
+	 * Per host, matched by the allowlist's own rules so `.internal.example`
+	 * covers subdomains. There is deliberately no switch that turns the
+	 * screen off: one would hand every other allowlisted name the same
+	 * reach, which is the hole the screen exists to close.
+	 */
+	readonly allowInwardFor?: readonly string[]
+	/**
 	 * Optional `--label key=value` pairs applied to the spawned
 	 * container. Hosts use this to make the container findable from
 	 * out-of-band cleanup paths (reaper jobs, monitoring filters)
@@ -549,6 +565,7 @@ function pickBackend(config: SandboxProviderConfig): SandboxBackend {
 				? { hostReachability: backend.hostReachability }
 				: {}),
 			...(backend.network !== undefined ? { network: backend.network } : {}),
+			...(backend.allowInwardFor !== undefined ? { allowInwardFor: backend.allowInwardFor } : {}),
 			...(backend.labels !== undefined ? { labels: backend.labels } : {}),
 		})
 	}
@@ -599,6 +616,7 @@ function pickBackend(config: SandboxProviderConfig): SandboxBackend {
 				? { hostReachability: backend.hostReachability }
 				: {}),
 			...(backend.network !== undefined ? { network: backend.network } : {}),
+			...(backend.allowInwardFor !== undefined ? { allowInwardFor: backend.allowInwardFor } : {}),
 			...(backend.labels !== undefined ? { labels: backend.labels } : {}),
 		})
 	}


### PR DESCRIPTION
Closes #376.

The allowlist answers "is this NAME permitted". Where the name goes is a
different question, and only the second one decides what the socket reaches.
Nothing in the package asked the second one.

## Why this is a credential leak and not only a reach problem

On the plain-HTTP path the brokered credential is stamped on **before** the
request goes out. So an allowlisted name whose DNS someone else controls — or
that simply has an inward-pointing record — got the token delivered to
loopback, to the private network the sandbox host sits on, or to the
link-local block metadata services answer on.

`BrokeredCredential.host` already carried the reasoning: a credential attached
to every request is a credential handed to whichever host the agent was talked
into contacting. That scoping was resting on a name DNS controls.

## The design, and why it is not resolve-then-connect

Screening happens inside the `lookup` the socket itself calls. Resolve, check,
then connect leaves the socket free to resolve again, and the **second** answer
decides where the bytes go — so a name that alternates records walks through a
check that passed a moment earlier. One resolution, screened, is the one that
gets dialled. `host` stays the name, so SNI and certificate validation still
check what the allowlist approved.

Every resolved address is screened, not just the one that would have been
used. A record set mixing a public address with an inward one is the ordinary
shape of this, and screening only the winner makes the outcome depend on
resolver ordering, which is not a security property.

## A lookup hook alone is not enough, and the suite said so by passing

The socket layer skips resolution entirely when the host is already an IP
literal, so the hook is never called. Every existing test in this package
points at `127.0.0.1` — a literal. With the hook in place **all 26 tests were
green** while a request to the metadata address would still have gone straight
out. The green run was the evidence the hole was open, not that it was closed.

Literals are therefore screened synchronously before dialling, and only with
both checks did the right four tests fail.

## Tests

`address.test.ts` pins the range boundaries **from both sides** — `172.15` and
`172.32`, `169.253` and `169.255`, `100.63` and `100.128`. A comparison written
with `>=` where it needed `>` silently deletes public addresses from the
internet, and only the outer bracket catches that.

It also pins that a NAME is not screened as an address, that a v6 prefix is
read numerically rather than by the letters it starts with (`fe8::1` is not
inside `fe80::/10`), that a v4 address wearing a v6 spelling is seen in both
forms, that a zone id does not defeat the check, and that the bracketed
authority a proxied client actually sends is screened.

`exemption-reaches-the-backend.test.ts` covers the escape hatch as a
reachability property rather than a behaviour one.

## The escape hatch

`allowInwardFor`, per host and never global, plumbed through the container
backend so it can be set from configuration. An option no configuration can
reach would be the same defect class this change closes. The existing proxy
tests use it, because their stand-in upstream genuinely is a loopback address
— exempting it there is honest; weakening the screen to make them pass would
not be.

## Bump

`major`. Configurations that worked now get denied: an allowlisted host that
resolves inward is refused unless named in `allowInwardFor`. The changeset says
what an operator does about it.

Gates were run locally before pushing, including the ones a `typecheck && lint
&& test` run never reaches: sandbox tests 141 passed / 25 skipped, sandbox lint
0, external-name audit 0, public-surface 0, docs 0, publish-metadata 0 — that
last one reads a build artifact, so it needs `pnpm -r build` first and reports
a missing `main` without it.

## Three defects found in the screen itself, by running it

The address module was measured against a table of spellings rather than read.
Before and after:

| Input | Was | Is |
| --- | --- | --- |
| `0:0:0:0:0:ffff:169.254.169.254` | `null` | `link-local` |
| `[::ffff:7f00:1]` | `null` | `loopback` |
| `fd::1` — a public `00fd:…` | `unique-local` | `null` |
| `fe8::1` — a public `0fe8:…` | `link-local` | `null` |

The first is a live reach. `isIP` reads the long form as an IPv6 literal, so
the socket dials it without resolving and the screening `lookup` is never
consulted — and no `^::ffff:`-anchored pattern sees it. Confirmed end to end:
with the literal check disabled, that request comes back **200 from the
upstream**, not a connection error.

The last two are the over-blocking direction, and they are why the v6 handling
now parses into eight groups and masks numerically (`fc00::/7`, `fe80::/10`,
`ff00::/8`) instead of matching text. `/^f[cd]/` refuses `fd::1`, which is an
ordinary global address — the `>=`-where-`>`-was-meant mistake wearing a
regex, failing silently because nobody writes a test for the address that was
supposed to work.

**One correction to a claim made earlier in this branch's history.** The
bracketed spelling is a layer, not a hole: Node does not read `[::1]` as an IP
literal either, so without the bracket handling the host falls through to
`dns.lookup` and the screening resolver refuses it there. What the bracket
handling buys is that `blockedLiteralReason` stops answering `null` about an
address it plainly recognises. Measured, and the table below shows it as a
one-test kill rather than a reach.

## Mutation profile

Ten mutations, with the rest of the sandbox suite as the preservation set.

| Mutation | Result |
| --- | --- |
| literal check disabled | 3 killed — v4 literal (502), long-form v6 (**200, reached the upstream**), tunnel literal |
| screening `lookup` off both request paths | 3 killed |
| screening `lookup` off `netConnect` only | 1 killed — the tunnel is a second call site and gets its own case |
| only the first resolved address screened | 1 killed — the mixed record set |
| bracket handling removed | 1 killed — the unit case only, which is what established it as a layer |
| numeric v6 mask reverted to `/^f[cd]/` | 1 killed — `fd::1` refused |
| v4-mapped detection removed | 4 killed, two of them **200 from the upstream** |
| `172.16` boundary `>=` to `>` | 1 killed — the outer bracket |
| `isIP` guard removed | **survived** — `parseV6` refuses a hostname on its own. Defence in depth, kept and documented as such rather than counted as a kill |
| `allowInwardFor` dropped at the provider | 1 killed |

No hangs and no timeouts. One mutation first killed a CONNECT case with a
thrown `socket hang up` rather than an assertion; that helper now returns every
outcome as a string so the comparison is named. The same helper had been
reporting `200 Connection Established` for refused tunnels — Node raises
`connect` for the response to a CONNECT **whatever its status**, so reading the
event instead of the status reports every refusal as an established tunnel.
The product was right; the observer was wrong.

## Two things a reviewer should know

**`pnpm typecheck` does not cover this package.** A genuinely wrong type name
passed the root `tsc --build` and was caught only by
`pnpm --filter @namzu/sandbox typecheck`. CI catches it at `pnpm -r build`, so
this is about the local gate list rather than about CI.

**Found, not fixed: `brokeredCredentials` has the same reachability gap.**
`DockerBackendInternalConfig` declares it and `egressProxyOptions` reads it,
but `createSandboxProvider` has never passed it — so credential brokering is
unreachable through the provider today and lives only on the direct
`EgressProxy` path, which is exported and supported. A pre-existing defect of
its own, deliberately not folded into a security fix; it wants its own issue.

