### PR TITLE
fix(sdk): the tool-call id attribute is spelled with a dot, and something sets it

### DIFF
--- a/.changeset/tool-call-id-is-spelled-and-emitted.md
+++ b/.changeset/tool-call-id-is-spelled-and-emitted.md
@@ -1,0 +1,42 @@
+---
+'@namzu/sdk': major
+---
+
+The tool-call id attribute is spelled the way the convention spells it, and something now sets it
+
+`GENAI.TOOL_CALL_ID` was `'gen_ai.tool.call_id'` — one underscore where the
+GenAI attribute registry has a dot, and where the two constants beside it in the
+same object (`gen_ai.tool.name`, `gen_ai.tool.type`) already had one. Its value
+is now `'gen_ai.tool.call.id'`.
+
+**What breaks.** The exported constant is `as const`, so both its value and its
+literal type change. If you import it and stamp it on your own spans, those
+spans start carrying a different key, and a saved query, dashboard panel or
+alert that groups by `gen_ai.tool.call_id` will match nothing after the upgrade
+— it will read as "no tool calls", not as an error. Anything that pinned the
+old literal as a type (`typeof GENAI.TOOL_CALL_ID`, or a union built from it)
+fails to compile.
+
+**What to do.** Repoint anything keyed on `gen_ai.tool.call_id` at
+`gen_ai.tool.call.id`. If you referenced the constant rather than the string,
+there is nothing to change beyond taking the upgrade. Traces already in your
+backend keep the old key; a query that has to span the upgrade needs both for
+as long as the old retention window lasts.
+
+There is no deprecation window, and the reason is that no working code needs
+one: nothing in this SDK ever emitted the attribute, under either spelling. The
+constant was exported with no writer at all — `registry/tool/execute.ts` stamped
+the tool name and the tool type onto the span and stopped — so no namzu-produced
+trace has ever carried the old key, and there is nothing to migrate off it.
+
+**What is added.** The tool span now stamps the id of the call it is about,
+taken from `ToolContext.toolUseId`, which the run loop already sets per call.
+Before this, a trace showing four tool spans with the same name in one turn
+could not say which span answered which `tool_use` block. The attribute is
+omitted rather than set to `undefined` when there is no call to correlate to —
+a host invoking a tool directly, outside a run.
+
+Tool **arguments** and **results** are deliberately still not recorded. They are
+the thing an incident review wants first and they are also where a secret
+travels, so they want a redaction design and a test for it rather than a ride
+along with a spelling fix.

--- a/packages/sdk/src/constants/telemetry/index.ts
+++ b/packages/sdk/src/constants/telemetry/index.ts
@@ -23,7 +23,22 @@ export const GENAI = {
 
 	TOOL_NAME: 'gen_ai.tool.name',
 	TOOL_TYPE: 'gen_ai.tool.type',
-	TOOL_CALL_ID: 'gen_ai.tool.call_id',
+
+	/**
+	 * The id of the tool call this span is about.
+	 *
+	 * Spelled `call.id`, matching the registry and matching the two
+	 * neighbours above — this read `gen_ai.tool.call_id`, one underscore
+	 * where the convention has a dot, so a consumer grouping by the
+	 * conventional name found nothing under it. Nothing errored, because a
+	 * span attribute is a free-form key and a wrong one is simply a key
+	 * nobody asked for.
+	 *
+	 * Pinned by `telemetry/__tests__/tool-call-id-attribute.test.ts`, which
+	 * also drives the emitter: the spelling was only half the defect, and
+	 * the constant had no writer at all.
+	 */
+	TOOL_CALL_ID: 'gen_ai.tool.call.id',
 
 	AGENT_NAME: 'gen_ai.agent.name',
 	AGENT_ID: 'gen_ai.agent.id',

--- a/packages/sdk/src/registry/tool/execute.ts
+++ b/packages/sdk/src/registry/tool/execute.ts
@@ -415,9 +415,21 @@ Executable tool names, descriptions, and JSON input schemas are attached through
 
 		return tracer.startActiveSpan(toolSpanName(toolName), {}, parentCtx, async (span) => {
 			try {
+				// The call id joins this span to the assistant block that asked
+				// for it. Without it a trace shows that `Bash` ran four times
+				// this turn and cannot say which span answers which
+				// `tool_use` — and the id was already in hand here, threaded
+				// through `ToolContext` for the tools that reply
+				// asynchronously.
+				//
+				// Conditional because `toolUseId` is optional: a host calling
+				// a tool directly, outside a run, has no call to correlate to,
+				// and an attribute set to `undefined` is worse than an absent
+				// one — it reaches the exporter as a key with no value.
 				span.setAttributes({
 					[GENAI.TOOL_NAME]: toolName,
 					[GENAI.TOOL_TYPE]: 'function',
+					...(context.toolUseId !== undefined ? { [GENAI.TOOL_CALL_ID]: context.toolUseId } : {}),
 				})
 
 				const tool = this.getOrThrow(toolName)

--- a/packages/sdk/src/telemetry/__tests__/tool-call-id-attribute.test.ts
+++ b/packages/sdk/src/telemetry/__tests__/tool-call-id-attribute.test.ts
@@ -1,0 +1,182 @@
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+
+import { removeTempDirs } from '../../__fixtures__/temp-dir.js'
+import { GENAI } from '../../constants/telemetry/index.js'
+import { MockLLMProvider } from '../../provider/mock.js'
+import { ToolRegistry } from '../../registry/tool/execute.js'
+import { drainQuery } from '../../runtime/query/index.js'
+import type { RunId } from '../../types/ids/index.js'
+import { createUserMessage } from '../../types/message/index.js'
+import type { ToolContext } from '../../types/tool/index.js'
+
+/**
+ * Two halves of one defect, both of which read as working code.
+ *
+ * The constant was spelled `gen_ai.tool.call_id` while the registry and its
+ * two neighbours in the same object use `gen_ai.tool.name` / `.type` — one
+ * underscore where a dot belongs. A span attribute is a free-form key, so
+ * the wrong one raises nothing anywhere; it just means a consumer grouping
+ * by the conventional name finds an empty result and reads it as "no tool
+ * calls" rather than "wrong key".
+ *
+ * The half that a spelling fix alone would have left in place: nothing set
+ * the attribute. The constant was exported through the SDK root barrel and
+ * through `@namzu/telemetry/attributes` with zero writers, so no namzu span
+ * carried the correlation under EITHER spelling, and renaming it on its own
+ * would have changed a string no trace contained.
+ */
+
+interface Recorded {
+	name: string
+	attributes: Record<string, unknown>
+}
+
+const spans: Recorded[] = []
+
+// A function declaration, not a const: `vi.mock` is hoisted above the
+// imports, so anything the factory closes over has to be hoisted too.
+function record(name: string) {
+	const rec: Recorded = { name, attributes: {} }
+	spans.push(rec)
+	return {
+		setAttributes: (a: Record<string, unknown>) => Object.assign(rec.attributes, a),
+		setAttribute: (k: string, v: unknown) => {
+			rec.attributes[k] = v
+		},
+		setStatus: () => undefined,
+		recordException: () => undefined,
+		addEvent: () => undefined,
+		end: () => undefined,
+		spanContext: () => ({ traceId: 't', spanId: 's', traceFlags: 1 }),
+		isRecording: () => true,
+		updateName: () => undefined,
+	}
+}
+
+vi.mock('../runtime-accessors.js', () => ({
+	getTracer: () => ({
+		startSpan: (name: string) => record(name),
+		startActiveSpan: (name: string, _o: unknown, _c: unknown, fn: (s: unknown) => unknown) =>
+			fn(record(name)),
+	}),
+	getMeter: () => ({
+		createCounter: () => ({ add: () => undefined }),
+		createHistogram: () => ({ record: () => undefined }),
+	}),
+}))
+
+let workdirs: string[] = []
+
+beforeEach(() => {
+	spans.length = 0
+})
+
+afterEach(async () => {
+	await removeTempDirs(workdirs)
+	workdirs = []
+})
+
+const toolSpans = () => spans.filter((s) => s.name.startsWith('namzu.tool.execute '))
+
+function registerPing(): ToolRegistry {
+	const tools = new ToolRegistry()
+	tools.register({
+		name: 'ping',
+		description: 'answers',
+		inputSchema: z.object({}),
+		execute: async () => ({ success: true, output: 'pong' }),
+	})
+	return tools
+}
+
+function context(overrides: Partial<ToolContext> = {}): ToolContext {
+	return {
+		runId: 'run_call_id' as RunId,
+		workingDirectory: tmpdir(),
+		abortSignal: new AbortController().signal,
+		env: {},
+		log: () => {},
+		...overrides,
+	}
+}
+
+describe('the tool-call id attribute is spelled the way the registry spells it', () => {
+	it('uses a dot, matching its two neighbours', () => {
+		// The literal, deliberately. Asserting `attrs[GENAI.TOOL_CALL_ID]`
+		// below and nothing else would pass against any spelling at all,
+		// including the one this fixes — the emitter and the reader would
+		// simply agree on the wrong string.
+		expect(GENAI.TOOL_CALL_ID).toBe('gen_ai.tool.call.id')
+		expect(GENAI.TOOL_NAME).toBe('gen_ai.tool.name')
+		expect(GENAI.TOOL_TYPE).toBe('gen_ai.tool.type')
+	})
+})
+
+describe('the tool span carries the id of the call it is about', () => {
+	it('stamps it when the executor supplies one', async () => {
+		await registerPing().execute('ping', {}, context({ toolUseId: 'toolu_direct' }))
+
+		expect(toolSpans()).toHaveLength(1)
+		expect(toolSpans()[0]?.attributes['gen_ai.tool.call.id']).toBe('toolu_direct')
+	})
+
+	it('omits the key entirely when there is no call to correlate to', async () => {
+		// `toolUseId` is optional — a host may call a tool directly, outside
+		// a run. Setting the attribute to `undefined` would reach the
+		// exporter as a present key with no value, which is worse than an
+		// absent one: a query for "spans missing the id" would not find it.
+		await registerPing().execute('ping', {}, context())
+
+		expect(toolSpans()).toHaveLength(1)
+		expect(toolSpans()[0]?.attributes).not.toHaveProperty('gen_ai.tool.call.id')
+	})
+
+	it('carries the id a real run produced, not only one a test handed in', async () => {
+		// Reachability is its own property. The two cases above prove the
+		// emit site reads `ToolContext.toolUseId`; neither proves the run
+		// loop puts anything there, and the field's own docstring says not
+		// every executor path provides it. This drives the whole query path
+		// so the id on the span is one the provider actually emitted.
+		const dir = await mkdtemp(join(tmpdir(), 'namzu-callid-'))
+		workdirs.push(dir)
+
+		await drainQuery({
+			provider: new MockLLMProvider({
+				// The second turn settles the run. Without it the mock replays
+				// its LAST turn for every iteration past the end of the script,
+				// so the tool is called once per iteration and the span count
+				// below measures `maxIterations` rather than the script — a
+				// fixture bug that reads as a duplicate span, which is the
+				// reading that got a sibling assertion relaxed once already.
+				turns: [
+					{ toolCalls: [{ id: 'toolu_from_the_wire', name: 'ping', args: {} }] },
+					{ text: 'done' },
+				],
+			} as never),
+			tools: registerPing(),
+			runConfig: {
+				model: 'mock-model',
+				timeoutMs: 30_000,
+				tokenBudget: 100_000,
+				maxIterations: 2,
+				maxResponseTokens: 256,
+			},
+			agentId: 'agent_callid',
+			agentName: 'Call Id Agent',
+			workingDirectory: dir,
+			sessionId: 'ses_callid',
+			threadId: 'thd_callid',
+			projectId: 'prj_callid',
+			tenantId: 'tnt_callid',
+			messages: [createUserMessage('go')],
+		} as never)
+
+		expect(toolSpans()).toHaveLength(1)
+		expect(toolSpans()[0]?.attributes['gen_ai.tool.call.id']).toBe('toolu_from_the_wire')
+		expect(toolSpans()[0]?.attributes['gen_ai.tool.name']).toBe('ping')
+	})
+})


### PR DESCRIPTION
Closes #374.

`GENAI.TOOL_CALL_ID` read `gen_ai.tool.call_id`, one underscore where the GenAI registry has a dot and where its two neighbours in the same object — `gen_ai.tool.name`, `gen_ai.tool.type` — already had one. A span attribute is a free-form key, so the wrong spelling raises nothing anywhere: a consumer grouping by the conventional name gets an empty result, which reads as "no tool calls" rather than as a wrong key.

## The half a spelling fix would have left in place

Nothing set the attribute. The constant was exported through the SDK root barrel and through `@namzu/telemetry/attributes` with **zero writers** — `registry/tool/execute.ts` stamped the tool name and the tool type onto the span and stopped. So no namzu-produced trace has ever carried the correlation under *either* spelling, and correcting the string on its own would have changed a value no trace contained.

That is the shape `docs/conventions/declared-but-undriven.md` rules on: shipped, exported, read by nothing — drive it or remove it, and say which in the changeset. The id was already in hand at the emit site (`ToolContext.toolUseId`, set per call by the run loop for the tools that reply asynchronously), so driving it is three lines rather than a project.

The tool span now carries it. Omitted rather than set to `undefined` when there is no call to correlate to — a host invoking a tool directly, outside a run — because a key with no value reaches an exporter as a present key, and a query for "spans missing the id" would then not find it.

## Readers of the old spelling, in this repo

None. `gen_ai.tool.call_id` occurred exactly once in the tree: its own definition. No test asserting the string, no eval, no dashboard fixture. The rename moves nothing.

## Deliberately not included

`gen_ai.tool.call.arguments` and `gen_ai.tool.call.result`. They are what an incident review wants first, and they are also where a secret travels — a span is the worst place to discover that a tool's arguments carried one. They want an explicit, tested redaction design, not a ride along with a spelling fix.

## Bump intent: `major`

The constant is `as const`, so both its value and its literal type change. A consumer that stamps it on its own spans emits a different key after the upgrade, and a dashboard grouping by the old one silently matches nothing; `typeof GENAI.TOOL_CALL_ID` stops compiling. No deprecation window, because nothing ever emitted the old key and there is no working code to migrate — the changeset says so rather than implying it.

## Verification

New suite `packages/sdk/src/telemetry/__tests__/tool-call-id-attribute.test.ts`, 4 tests, asserting the **literal** key rather than the constant (a test written against `GENAI.TOOL_CALL_ID` alone passes with emitter and reader agreeing on the wrong string). One of the four drives the whole query path, because the two direct-execute tests prove the emit site reads `toolUseId` and neither proves the run loop puts anything there.

Three mutations, each killed by the assertion that should own it: reverting the value fails 3 of 4; removing the attribute fails the two emit tests; making the spread unconditional fails only the omission test.

Gates: `typecheck`, `lint` (exit 0), `test`, `-r build`, `audit-external-names`, `verify-public-surface` (560/560 runtime, 1286/1286 declared), `check-publish-metadata` (14 packages), `check-docs`, `@namzu/sandbox lint` — all green.
