### PR TITLE
docs(sdk): the README no longer promises reranking the retriever does not have

### DIFF
--- a/.changeset/retriever-readme-drops-the-rerank-claim.md
+++ b/.changeset/retriever-readme-drops-the-rerank-claim.md
@@ -1,0 +1,23 @@
+---
+'@namzu/sdk': patch
+---
+
+The README no longer promises reranking the retriever does not implement
+
+`README.md` described `rag/retriever.ts` as "the retrieval query path with
+configurable top-k, threshold, and reranking". There is no rerank stage and
+never was: no field on `RetrievalConfig`, no member in
+`DEFAULT_RETRIEVAL_CONFIG`, no method on the `Retriever` interface, and no
+stage in `DefaultRetriever.retrieve`, which runs vector, keyword (BM25) or
+hybrid search and slices to `topK`. `rerank` appeared exactly once in the
+repository, in that sentence.
+
+Nothing errors when a reader configures for it, because there is no setting to
+set — you simply receive first-stage results and believe they were reranked.
+The line now describes what the file does and says outright that there is no
+rerank stage. This is a documentation fix; no behaviour changes.
+
+The capability is a reasonable thing to want and is deliberately not built
+here. Published results include cases where a reranker scores *below* the
+first stage, so it wants a retrieval eval beside it rather than an assumption
+that adding one is an improvement.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -239,7 +239,7 @@ RAG is a full kernel subsystem, not a bolt-on. The pipeline:
 - `rag/ingestion.ts` — end-to-end ingest: document → chunks → embeddings → vector store.
 - `rag/vector-store.ts` — the `VectorStore` interface, tenant-scoped via `TenantId`. Bring your own backend (pgvector, Pinecone, an in-memory impl for tests).
 - `rag/knowledge-base.ts` — a named collection of documents with metadata and config.
-- `rag/retriever.ts` — the retrieval query path with configurable top-k, threshold, and reranking.
+- `rag/retriever.ts` — the retrieval query path: vector, keyword (BM25) or hybrid, with configurable top-k and score threshold. Hybrid normalises both rankings before blending them by `hybridAlpha`. **There is no rerank stage.** This line used to promise one; there was no rerank stage behind it and no setting to turn it on, so a reader could configure for it and receive nothing.
 - `rag/context-assembler.ts` — turns retrieval hits into prompt-ready context windows.
 - `rag/rag-tool.ts` — a first-class tool your agent can invoke, not an external integration.
 


### PR DESCRIPTION
Closes #375.

`packages/sdk/README.md` described `rag/retriever.ts` as "the retrieval query path with configurable top-k, threshold, and reranking".

## The seam is absent, not built-and-unwired

Worth stating precisely, because the two findings call for different fixes. `rerank`, case-insensitive, matched **exactly one line** in the tracked tree — that sentence. No field on `RetrievalConfig`, no member in `DEFAULT_RETRIEVAL_CONFIG`, no method on the `Retriever` interface, no stage in `DefaultRetriever.retrieve`, which runs vector, keyword (BM25) or hybrid search, normalises the two rankings before blending them by `hybridAlpha`, and slices to `topK`.

So there is nothing half-wired to finish. A reader configures for behaviour that has no setting to set, receives first-stage results, and nothing errors.

## Replaced, not marked "not yet implemented"

Both were on the table. Every neighbouring bullet in that inventory is a plain statement of what a file does, so a roadmap annotation among them reads as the one item being finished rather than the one item missing — the reader's picture stays wrong, in a new way.

The line now says what the retriever does, and says outright that there is no rerank stage. That last clause is deliberate: it is what tells a reader who saw the old sentence that the capability did not move somewhere else.

## Not implementing the feature

Out of scope by the issue's own reasoning, and the doc correction should not wait on it. Reranking is a well-evidenced retrieval intervention, but published results include cases where a reranker scores *below* the first stage, so it wants a retrieval eval beside it rather than the assumption that adding one is an improvement.

Documentation only; no behaviour changes. Changeset is `patch` — the README ships in the published tarball.
