### PR TITLE
fix(bedrock): prompt caching is requested, not only documented

### DIFF
--- a/.changeset/caching-is-requested-not-only-documented.md
+++ b/.changeset/caching-is-requested-not-only-documented.md
@@ -1,0 +1,15 @@
+---
+'@namzu/bedrock': major
+---
+
+Prompt caching is now requested, not only documented
+
+The provider page said caching was requested when the caller set `cacheControl`, with breakpoints after the tool schemas, after the static system text, and after the last message. None of it was true. This wire enables caching with an explicit `cachePoint` block inside the request, and the driver emitted none — while mapping `cacheReadInputTokenCount` and `cacheWriteInputTokenCount` correctly, so the usage came back a truthful zero and a caller could not tell "caching does not help this workload" from "caching was never asked for". Prompt caching is the largest single cost lever on a long run, and this one was off with the switch documented as on.
+
+The driver now emits the three cache points the page describes: after the last tool schema, after the last system message tagged `cacheHint: 'cache'`, and after the last content block of the last message. The system point is placed after the *static* block rather than at the end of the array — a marker after the per-run dynamic text would cache a prefix that changes every run, so every read would miss and every write would be billed.
+
+**Why this is major even though no exported type changed.** Your requests change shape without you changing a line. The runtime sets `cacheControl` on every iteration, so any caller on a model Anthropic serves through Converse starts sending cache points as soon as they take this version. Expect cache-write tokens on the first turn of a stable prefix — they are priced above ordinary input — and cache reads, priced below it, on the turns after. The steady state is cheaper; the first turn is not. There is no per-driver switch to decline: a request without `cacheControl` is uncached, and the runtime supplies it, so declining means not taking this version.
+
+**Only for the models Anthropic serves on this wire.** Converse carries several vendors and prompt caching is a property of the models on it, not of the wire, so a cache point sent to a model that does not accept one is rejected outright — the whole request, not the caching. The gate reuses `isAnthropicServedModel`, which this driver already uses to pick a tool-schema dialect for the same reason. A model outside the gate sends exactly the bytes it sends today and `cacheControl` has no effect on it; the provider page now says so.
+
+Two documentation claims on the same page were also false and are corrected: the capability snapshot reported `supportsVision: true` where the package exports `false`, and the paragraph beside it described images travelling as raw bytes. This driver maps no image content at all — a user attachment does not reach the model, and an image in a tool result becomes a named placeholder.

--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -1,7 +1,7 @@
 ---
 title: Bedrock Provider
 description: Configure @namzu/bedrock for AWS Bedrock Converse API usage with Namzu.
-last_updated: 2026-08-03
+last_updated: 2026-08-11
 status: current
 related_packages: ["@namzu/sdk", "@namzu/bedrock"]
 ---
@@ -111,14 +111,28 @@ The package exports `BEDROCK_CAPABILITIES`:
   supportsTools: true,
   supportsStreaming: true,
   supportsFunctionCalling: true,
-  supportsVision: true,
+  supportsVision: false,
   supportsDocuments: false,
 }
 ```
 
-An image travels as raw bytes beside the text, whether it came from a user attachment or from inside a tool result. A media type the service does not accept is named in the text instead, because sending it would fail the whole request.
+Images do not travel on this driver. A user attachment is not mapped into an image content block, and an image inside a tool result is replaced by a named placeholder saying what was there and how large it was — which is why `supportsVision` is `false` rather than a promise the message translation does not keep. This paragraph previously described images travelling as raw bytes, and the snapshot above previously reported `supportsVision: true`; neither was true of the package.
 
-Prompt caching is requested when the caller sets `cacheControl`, with breakpoints after the tool schemas, after the static system text, and after the last message.
+### Prompt caching
+
+Caching is requested when the caller sets `cacheControl` **and** the model is one Anthropic serves through Converse. The driver then emits three cache points:
+
+| Cache point | Placement | Omitted when |
+| --- | --- | --- |
+| tool schemas | after the last `toolSpec` in `toolConfig.tools` | the caller passes no tools |
+| static system text | after the last system message tagged `cacheHint: 'cache'` | no system message is tagged static |
+| conversation prefix | after the last content block of the last non-empty message | never, when caching is on |
+
+The prompt is assembled tools → system → messages, so each later point also covers every section before it.
+
+The model condition is not a formality. Converse is a multi-vendor wire, and prompt caching is a property of the models on it rather than of the wire, so a request carrying a cache point to a model that does not accept one is rejected outright. A model outside the gate therefore sends exactly the bytes it sends today, uncached, and `cacheControl` has no effect on it.
+
+Cache hits and writes are reported separately from ordinary input, as `cachedTokens` and `cacheWriteTokens` on the usage of every turn. Those counters were always mapped correctly — for a period the driver reported them while requesting no caching at all, so they read a truthful zero, and a caller could not distinguish "caching does not help this workload" from "caching was never asked for". A run with caching on and a stable prefix should show `cachedTokens` rising after the first turn; if it stays at zero, the prefix is changing rather than the caching being off.
 
 ## 9. Operational Notes
 

--- a/packages/providers/bedrock/src/__tests__/cache-points.test.ts
+++ b/packages/providers/bedrock/src/__tests__/cache-points.test.ts
@@ -1,0 +1,204 @@
+import type { ChatCompletionParams } from '@namzu/sdk'
+import { describe, expect, it } from 'vitest'
+
+import { BedrockProvider } from '../client.js'
+
+/**
+ * Caching was documented and never requested.
+ *
+ * The driver read `cacheReadInputTokenCount` and `cacheWriteInputTokenCount`
+ * correctly and emitted no cache point, so the counters reported zero
+ * honestly and a caller who had read the provider page was paying full
+ * input price on every turn with nothing to tell them apart from a workload
+ * caching cannot help.
+ *
+ * These tests assert the marker reaches the REQUEST. A green usage
+ * assertion cannot do that job — the counters were always parsed correctly,
+ * so they were green throughout the period when nothing was cached.
+ */
+
+const CACHED_MODEL = 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
+const OTHER_VENDOR_MODEL = 'amazon.nova-pro-v1:0'
+
+/** Every `cachePoint` anywhere in the request, however deeply nested. */
+function countCachePoints(value: unknown): number {
+	if (Array.isArray(value)) return value.reduce<number>((n, v) => n + countCachePoints(v), 0)
+	if (value === null || typeof value !== 'object') return 0
+
+	const entries = Object.entries(value as Record<string, unknown>)
+	return entries.reduce((n, [key, v]) => n + (key === 'cachePoint' ? 1 : countCachePoints(v)), 0)
+}
+
+/** Drive one request and hand back what the AWS client was actually given. */
+async function capture(
+	params: Partial<ChatCompletionParams> = {},
+): Promise<Record<string, unknown>> {
+	const provider = new BedrockProvider({ region: 'us-east-1' })
+	let commandInput: Record<string, unknown> | undefined
+	;(provider as unknown as { client: unknown }).client = {
+		send: async (command: { input: Record<string, unknown> }) => {
+			commandInput = command.input
+			return { $metadata: { requestId: 'request-test' }, stream: (async function* () {})() }
+		},
+	}
+
+	const request = {
+		model: CACHED_MODEL,
+		messages: [{ role: 'user', content: 'go' }],
+		...params,
+	} as ChatCompletionParams
+
+	for await (const _chunk of provider.chatStream(request)) {
+		// Drain the empty test stream.
+	}
+
+	if (!commandInput) throw new Error('the provider never called the client')
+	return commandInput
+}
+
+const TOOLS: ChatCompletionParams['tools'] = [
+	{
+		type: 'function',
+		function: { name: 'edit', description: 'Edit', parameters: { type: 'object' } },
+	},
+]
+
+const SYSTEM_STATIC_THEN_DYNAMIC: ChatCompletionParams['messages'] = [
+	{ role: 'system', content: 'static instructions', cacheHint: 'cache' },
+	{ role: 'system', content: 'per-run state', cacheHint: 'ephemeral' },
+	{ role: 'user', content: 'go' },
+]
+
+const CACHE_POINT = { cachePoint: { type: 'default' } }
+
+describe('a cache point reaches the request when caching is requested', () => {
+	it('marks the tail of the tool schemas', async () => {
+		const input = await capture({
+			cacheControl: { type: 'auto' },
+			tools: TOOLS,
+		})
+
+		const tools = (input.toolConfig as { tools: unknown[] }).tools
+		expect(tools).toHaveLength(2)
+		expect(tools[1]).toEqual(CACHE_POINT)
+		// The schema itself is untouched — the marker is appended beside it,
+		// not folded into it.
+		expect(tools[0]).toMatchObject({ toolSpec: { name: 'edit' } })
+	})
+
+	it('marks the tail of the STATIC system text, not the end of the array', async () => {
+		const input = await capture({
+			cacheControl: { type: 'auto' },
+			messages: SYSTEM_STATIC_THEN_DYNAMIC,
+		})
+
+		// Position, not presence. A marker after `per-run state` would put
+		// text that changes every run inside the cached prefix: every read
+		// would miss and every write would be paid for, which looks from
+		// outside like a cache that never warms up.
+		expect(input.system).toEqual([
+			{ text: 'static instructions' },
+			CACHE_POINT,
+			{ text: 'per-run state' },
+		])
+	})
+
+	it('marks the last content block of the last message', async () => {
+		const input = await capture({
+			cacheControl: { type: 'auto' },
+			messages: [
+				{ role: 'user', content: 'first' },
+				{ role: 'assistant', content: 'second' },
+				{ role: 'user', content: 'third' },
+			],
+		})
+
+		const messages = input.messages as { content: unknown[] }[]
+		expect(messages).toHaveLength(3)
+		expect(messages[2]?.content).toEqual([{ text: 'third' }, CACHE_POINT])
+		// Only the last one. Every earlier message is already inside that
+		// prefix, and the wire allows a small fixed number of these.
+		expect(countCachePoints(messages[0])).toBe(0)
+		expect(countCachePoints(messages[1])).toBe(0)
+	})
+
+	it('spends exactly three, which is what the provider page promises', async () => {
+		const input = await capture({
+			cacheControl: { type: 'auto' },
+			tools: TOOLS,
+			messages: SYSTEM_STATIC_THEN_DYNAMIC,
+		})
+
+		expect(countCachePoints(input)).toBe(3)
+	})
+
+	it('omits the system point when there is no static text to anchor it to', async () => {
+		const input = await capture({
+			cacheControl: { type: 'auto' },
+			tools: TOOLS,
+			messages: [
+				{ role: 'system', content: 'per-run state', cacheHint: 'ephemeral' },
+				{ role: 'user', content: 'go' },
+			],
+		})
+
+		expect(countCachePoints(input.system)).toBe(0)
+		// …while the other two still land, so an absent anchor costs one
+		// breakpoint rather than all of them.
+		expect(countCachePoints(input)).toBe(2)
+	})
+})
+
+describe('a cache point is absent when caching is not requested', () => {
+	it('sends nothing at all when the caller set no cacheControl', async () => {
+		const input = await capture({ tools: TOOLS, messages: SYSTEM_STATIC_THEN_DYNAMIC })
+
+		expect(countCachePoints(input)).toBe(0)
+	})
+
+	it('leaves a model outside the gate byte-for-byte as it was', async () => {
+		// Prompt caching is a property of the models on this wire, not of the
+		// wire, so the gate follows the model. The assertion is equality with
+		// the uncached request rather than "no cache point": a gate that
+		// suppressed the marker while perturbing anything else would be a
+		// silent change to a request that works today.
+		const withCaching = await capture({
+			model: OTHER_VENDOR_MODEL,
+			cacheControl: { type: 'auto' },
+			tools: TOOLS,
+			messages: SYSTEM_STATIC_THEN_DYNAMIC,
+		})
+		const without = await capture({
+			model: OTHER_VENDOR_MODEL,
+			tools: TOOLS,
+			messages: SYSTEM_STATIC_THEN_DYNAMIC,
+		})
+
+		expect(withCaching).toEqual(without)
+		expect(countCachePoints(withCaching)).toBe(0)
+	})
+
+	it('does not mark the placeholder tools minted from history', async () => {
+		// These are specs reconstructed to keep the wire happy when history
+		// references a tool the caller no longer passes — their description
+		// is the literal `(completed)`. Caching them would pin a prefix that
+		// is not the caller's tool set.
+		const input = await capture({
+			cacheControl: { type: 'auto' },
+			messages: [
+				{
+					role: 'assistant',
+					content: '',
+					toolCalls: [
+						{ id: 'call_1', type: 'function', function: { name: 'edit', arguments: '{}' } },
+					],
+				},
+				{ role: 'tool', toolCallId: 'call_1', content: 'done' },
+			],
+		})
+
+		const tools = (input.toolConfig as { tools: unknown[] }).tools
+		expect(tools).toHaveLength(1)
+		expect(countCachePoints(input.toolConfig)).toBe(0)
+	})
+})

--- a/packages/providers/bedrock/src/client.ts
+++ b/packages/providers/bedrock/src/client.ts
@@ -5,6 +5,7 @@ import {
 } from '@aws-sdk/client-bedrock-runtime'
 import type {
 	Message as BedrockMessage,
+	CachePointBlock,
 	ContentBlock,
 	ConversationRole,
 	ConverseStreamCommandOutput,
@@ -35,10 +36,70 @@ import {
 import { assertModelReachable, isAnthropicServedModel } from './model-reachability.js'
 import type { BedrockConfig } from './types.js'
 
-function extractSystemBlocks(messages: ChatCompletionParams['messages']): SystemContentBlock[] {
-	return messages
-		.filter((m) => m.role === 'system')
-		.map((m) => ({ text: typeof m.content === 'string' ? m.content : '' }))
+/**
+ * The marker that asks this wire to cache everything before it.
+ *
+ * Caching is not a flag on the request here — it is a block spliced into
+ * the content, and a request without one is uncached however the caller
+ * configured it. That is why nothing was cached before: the driver read
+ * the cache counters faithfully and never emitted a marker, so the
+ * counters were honestly zero and a caller could not tell "caching does
+ * not help this workload" from "caching was never asked for".
+ *
+ * `default` is the only member of the wire's cache-point enum. `ttl` is
+ * deliberately not set: omitting it takes the service's own default,
+ * and an extended TTL is priced differently, so choosing one is a cost
+ * decision rather than a translation.
+ */
+const CACHE_POINT: { cachePoint: CachePointBlock } = { cachePoint: { type: 'default' } }
+
+/**
+ * System text, with a cache point after the last STATIC block.
+ *
+ * Position is the whole point, not presence. The runtime tags its static
+ * segment `'cache'` and its per-run dynamic segment `'ephemeral'`, and a
+ * marker appended at the end of the array would put the dynamic text
+ * inside the cached prefix — which changes every run, so every read would
+ * miss and every write would be paid for. A caller would see cache writes
+ * and no reads, which looks like a cold cache forever.
+ *
+ * No static block means no system breakpoint, rather than a breakpoint in
+ * an arbitrary place.
+ */
+function extractSystemBlocks(
+	messages: ChatCompletionParams['messages'],
+	cachingEnabled = false,
+): SystemContentBlock[] {
+	const blocks: SystemContentBlock[] = []
+	let lastStatic = -1
+
+	for (const m of messages) {
+		if (m.role !== 'system') continue
+		blocks.push({ text: typeof m.content === 'string' ? m.content : '' })
+		if (m.cacheHint === 'cache') lastStatic = blocks.length - 1
+	}
+
+	if (cachingEnabled && lastStatic >= 0) blocks.splice(lastStatic + 1, 0, CACHE_POINT)
+
+	return blocks
+}
+
+/**
+ * The final cache point: after the last content block of the last
+ * non-empty message.
+ *
+ * An iteration only appends messages, so caching the whole conversation
+ * prefix here is what makes the NEXT turn read its history at cache rates
+ * — which on a long run is the largest single cost lever available.
+ */
+function applyMessageCachePoint(messages: BedrockMessage[]): void {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const content = messages[i]?.content
+		if (content && content.length > 0) {
+			content.push(CACHE_POINT)
+			return
+		}
+	}
 }
 
 function toBedrockRole(role: string): ConversationRole {
@@ -138,7 +199,10 @@ function extractToolNamesFromHistory(messages: ChatCompletionParams['messages'])
 	return Array.from(names)
 }
 
-export function toBedrockToolConfig(params: ChatCompletionParams): ToolConfiguration | undefined {
+export function toBedrockToolConfig(
+	params: ChatCompletionParams,
+	cachingEnabled = false,
+): ToolConfiguration | undefined {
 	// 'none' means the model must not call a tool. This used to map to the
 	// wire's 'auto', which means it MAY — the opposite, and silent. No wire
 	// format lets a model call a tool it was never given, so send none.
@@ -167,6 +231,16 @@ export function toBedrockToolConfig(params: ChatCompletionParams): ToolConfigura
 					},
 				}) as Tool,
 		)
+
+		// After the schemas, so the tool block — the largest fixed prefix on
+		// a tool-using run, and the one that changes least — is cached.
+		//
+		// The reconstruction path below deliberately does not get one. Those
+		// are placeholder specs minted to keep the wire happy when history
+		// references a tool the caller no longer passes; their descriptions
+		// are the literal string `(completed)`, so caching them would pin a
+		// prefix that is not the caller's tool set.
+		if (cachingEnabled) tools.push(CACHE_POINT)
 
 		const toolChoice = formatToolChoice(params.toolChoice)
 		return { tools, toolChoice }
@@ -298,9 +372,26 @@ export class BedrockProvider implements LLMProvider {
 		// reason and the fix, rather than as an opaque validation error from
 		// a service that was asked for something this wire does not carry.
 		assertModelReachable(params.model)
-		const system = extractSystemBlocks(params.messages)
+
+		// The runtime asks for caching on every iteration by setting
+		// `cacheControl`. Honouring it costs three cache points — tools tail,
+		// static-system tail, last message — and the prompt is assembled
+		// tools → system → messages, so each later point also covers every
+		// section before it.
+		//
+		// Gated on the model family for the reason `isAnthropicServedModel`
+		// already exists: Converse is a multi-vendor wire, and prompt caching
+		// is a property of the models on it rather than of the wire. The gate
+		// fails toward today's behaviour — a model outside it sends exactly
+		// the bytes it sends now, uncached — because the alternative failure
+		// is a rejected request, which costs a caller a working integration
+		// rather than a discount they never had.
+		const cachingEnabled = params.cacheControl !== undefined && isAnthropicServedModel(params.model)
+
+		const system = extractSystemBlocks(params.messages, cachingEnabled)
 		const messages = toBedrockMessages(params.messages)
-		const toolConfig = toBedrockToolConfig(params)
+		if (cachingEnabled) applyMessageCachePoint(messages)
+		const toolConfig = toBedrockToolConfig(params, cachingEnabled)
 
 		const inferenceConfig: Record<string, unknown> = {}
 		if (params.maxTokens !== undefined) inferenceConfig.maxTokens = params.maxTokens


### PR DESCRIPTION
Closes #387.

Resolution (1) of the two the issue offers: make the sentence true. The page already specified where the breakpoints go, the sibling driver in this repo implements exactly that shape, and this is the largest single cost lever on a long run.

## What was wrong, and why nothing caught it

This wire enables caching with an explicit marker **block inside the request**, not a flag on it. The driver emitted none, so a caller who set `cacheControl` — which the runtime does on every iteration — paid full input price on every turn.

The read side was correct the entire time. `parseBedrockUsage` mapped `cacheReadInputTokenCount` and `cacheWriteInputTokenCount` faithfully, so the usage came back an honest zero, and from outside "caching does not help this workload" and "caching was never requested" are the same observation. Only the first has an obvious next step.

## What now happens

Three cache points, matching the page:

| Cache point | Placement | Omitted when |
| --- | --- | --- |
| tool schemas | after the last `toolSpec` in `toolConfig.tools` | the caller passes no tools |
| static system text | after the last system message tagged `cacheHint: 'cache'` | no system message is tagged static |
| conversation prefix | after the last content block of the last non-empty message | never, when caching is on |

The system point is **anchored, not appended**. A marker at the end of the system array would put the runtime's per-run dynamic segment inside the cached prefix; that prefix changes every run, so every read would miss and every write would be billed — which looks from outside like a cache that never warms up. This is the single most important line in the change and it has the test that fails alone when it moves.

## The judgement call, stated rather than buried

`cachingEnabled = params.cacheControl !== undefined && isAnthropicServedModel(params.model)`

Converse is a multi-vendor wire, and whether a cache point is accepted is a property of the **model** rather than of the wire. A cache point sent to a model that does not take one is rejected outright — the whole request, not just the caching. So the gate follows the model, reusing the seam this driver already has for exactly this reason (`isAnthropicServedModel` picks the tool-schema dialect, and its docstring makes the same argument).

The gate deliberately fails toward today's behaviour: a model outside it sends byte-for-byte the request it sends now. The opposite default would trade a discount nobody currently has for a working integration somebody does have. **If you want the gate wider, this is the line to widen** — I did not want to broaden it on a claim I could not establish from source.

## Bump intent: `major`

No exported type changed, and it is still major, because your requests change shape without you changing a line: the runtime sets `cacheControl` on every iteration, so any caller on a served model starts sending cache points on upgrade. Cache writes are priced above ordinary input and land on the first turn of a stable prefix; reads are priced below it and land after. Steady state is cheaper, the first turn is not, and there is no per-driver switch to decline — a request without `cacheControl` is uncached and the runtime supplies it. The changeset says all of this in the words a consumer needs.

## Verification

New suite `packages/providers/bedrock/src/__tests__/cache-points.test.ts`, 8 tests, asserting what the AWS client was **handed** — the capture pattern `bedrock.test.ts` already uses. A usage assertion could not do this job: those counters were green throughout the period when nothing was cached.

Seven mutations, seven killed, and the useful part is the distribution: moving the system point kills only the position test; removing the model gate kills only the byte-for-byte equality test; removing the `cacheControl` check kills only the "sends nothing" test; marking the reconstruction path kills only the placeholder test. The suite discriminates four independent decisions rather than asserting one fact four ways.

Gates: `typecheck`, `lint` (exit 0), `test` (every package green), `-r build`, `audit-external-names`, `verify-public-surface` (560/560 runtime, 1286/1286 declared), `check-publish-metadata` (14 packages), `check-docs` — all green.

## Also on this page, and a third thing that is not in this PR

Two adjacent claims on `docs/providers/bedrock.md` were false and are corrected here, since leaving them would mean shipping a PR that fixes one untrue sentence on a page and steps over another: the capability snapshot printed `supportsVision: true` where the package exports `false`, and the paragraph beside it described images travelling as raw bytes, which this driver never maps.

**Not fixed, and it needs an owner's decision.** `listModels()` advertises `anthropic.claude-sonnet-4-20250514` and `anthropic.claude-haiku-4-20250514`, and the page uses the first in all three of its code samples — and `assertModelReachable` refuses both. Verified by executing the predicate:

```
anthropic.claude-sonnet-4-20250514             REFUSED
anthropic.claude-haiku-4-20250514              REFUSED
amazon.nova-pro-v1:0                           reachable
us.anthropic.claude-sonnet-4-5-20250929-v1:0   reachable
```

So the documented quickstart throws, and the driver's own catalogue lists models its own request path rejects. Whether the ids in `listModels` are wrong or the reachability check is too strict is not something I can settle from source, and guessing would ship a second bug wearing the first one's justification. Worth its own issue.
