### PR TITLE
fix(sdk)!: a stdio server is handed what it was granted, not the whole environment

### DIFF
--- a/.changeset/a-stdio-server-gets-only-what-it-was-given.md
+++ b/.changeset/a-stdio-server-gets-only-what-it-was-given.md
@@ -1,0 +1,26 @@
+---
+'@namzu/sdk': major
+'@namzu/cli': major
+---
+
+A stdio server is handed what it was granted, not everything the host holds
+
+`StdioTransport` spawned its child with `{ ...process.env, ...config.env }`, so every connected server received every environment variable the host process had. Measured through the real transport: **119 variables on a developer machine, including a secret planted in the parent for the probe.** A server that needs one token was handed all of them, and nothing in its configuration said so — the grant was invisible because it was total.
+
+The child now receives process plumbing (`PATH`, `HOME`/`USERPROFILE`, `SystemRoot`, `ComSpec`, `TEMP`, locale, and the rest of that kind), plus whatever the configuration names.
+
+**What breaks.** A server that was reading a credential straight out of your environment stops finding it. That is the whole point of the change, and it will look like the server failing to authenticate rather than like a configuration change, so it is worth knowing before the upgrade rather than after.
+
+**What to do.** Name what the server may have:
+
+```toml
+[mcpServers.issues]
+command = "some-mcp-server"
+inheritEnv = ["GITHUB_TOKEN"]
+```
+
+`inheritEnv` names variables to pass through from your own environment. Prefer it over `env` for anything secret — `env` writes the literal value into the config file, and this leaves the value where it already lives. A named variable the parent does not hold is absent from the child rather than empty, so a server's own `if (!token)` still works; it does not fail the spawn.
+
+**Plugin-declared servers get no `inheritEnv`, deliberately.** A plugin that could name the host variables its server receives would be awarding itself a credential grant, which is not a plugin's to award. A plugin-declared server gets plumbing plus the literal `env` in its own manifest; if it needs a host credential, declare that server in `mcpServers` instead, where the operator is the one naming it.
+
+The tests assert on the environment the child actually receives, driving a real spawn — not on whether the configuration was accepted. A test of the second kind passes against the version this replaces.

--- a/docs/cli/tool-servers.md
+++ b/docs/cli/tool-servers.md
@@ -31,12 +31,34 @@ An entry names **either** a command **or** a URL, never both.
 | --- | --- | --- |
 | `command` | a local server | The executable to run. |
 | `args` | a local server | Its arguments. |
-| `env` | a local server | Extra environment variables for the child. |
+| `env` | a local server | Literal environment variables for the child. |
+| `inheritEnv` | a local server | Names of variables from **your** environment the child may have. |
 | `cwd` | a local server | Its working directory. Defaults to the agent's. |
 | `url` | a remote server | The endpoint to connect to. |
 | `headers` | a remote server | Extra headers, for authentication. |
 
 An entry naming both, or neither, is refused **by name** rather than skipped — picking one for you would run something you did not ask to run.
+
+### What a local server is handed
+
+A local server gets process plumbing — `PATH`, the home and temp directories, the locale, and the platform equivalents — plus exactly what you name in `env` and `inheritEnv`. It does **not** get the rest of your environment.
+
+That is a change. It used to receive every variable the namzu process held, so a server needing one token was handed every credential on the machine, and nothing in the config recorded it. If a server stops authenticating after an upgrade, this is why, and the fix is to say what it may have:
+
+```json
+{
+  "mcpServers": {
+    "issues": {
+      "command": "some-mcp-server",
+      "inheritEnv": ["GITHUB_TOKEN"]
+    }
+  }
+}
+```
+
+Use `inheritEnv` rather than `env` for anything secret: `env` puts the literal value in a config file you probably commit, while `inheritEnv` names a variable and leaves the value in your environment. A name you have not set is simply absent for the child — the server sees no variable rather than an empty one, and the spawn still succeeds.
+
+A server declared by a **plugin** cannot use `inheritEnv`. A plugin naming the host variables its server receives would be granting itself a credential, which is the operator's call — declare that server under `mcpServers` instead.
 
 ## When a server does not come up
 

--- a/packages/cli/src/integrations/mcp/servers.ts
+++ b/packages/cli/src/integrations/mcp/servers.ts
@@ -65,6 +65,18 @@ export interface McpServerSpec {
 	readonly command?: string
 	readonly args?: readonly string[]
 	readonly env?: Readonly<Record<string, string>>
+	/**
+	 * Variables from the operator's own environment this server may have.
+	 *
+	 * The child used to receive the whole parent environment, so every server
+	 * held every credential on the machine. It now gets process plumbing plus
+	 * what is named — so a server that needs one token is granted that token,
+	 * and the config is where a reviewer can see it.
+	 *
+	 * Prefer this over `env` for anything secret: `env` writes the value into
+	 * the config file, and this leaves it in the environment.
+	 */
+	readonly inheritEnv?: readonly string[]
 	/** Working directory for the child. Defaults to the agent's. */
 	readonly cwd?: string
 	/** HTTP: the server's endpoint. */
@@ -120,6 +132,7 @@ export function transportFor(spec: McpServerSpec, defaultCwd: string): MCPTransp
 			command: spec.command as string,
 			...(spec.args ? { args: [...spec.args] } : {}),
 			...(spec.env ? { env: { ...spec.env } } : {}),
+			...(spec.inheritEnv ? { inheritEnv: [...spec.inheritEnv] } : {}),
 			cwd: spec.cwd ?? defaultCwd,
 		}
 	}

--- a/packages/sdk/src/connector/mcp/__tests__/a-server-gets-only-what-it-was-given.test.ts
+++ b/packages/sdk/src/connector/mcp/__tests__/a-server-gets-only-what-it-was-given.test.ts
@@ -1,0 +1,137 @@
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { removeTempDirs } from '../../../__fixtures__/temp-dir.js'
+import { StdioTransport, buildChildEnv } from '../stdio.js'
+
+/**
+ * A stdio server used to be spawned with `{ ...process.env, ...config.env }`.
+ *
+ * Measured before the change, through this same transport: the child received
+ * 119 environment variables on a developer machine, including a secret planted
+ * in the parent for the probe. A server that needs one token was handed every
+ * credential the host held, and nothing in its config said so — the grant was
+ * invisible because it was total.
+ *
+ * These tests assert on the ENVIRONMENT THE CHILD RECEIVES. A test that only
+ * checked `inheritEnv` was accepted by the config would have passed against the
+ * version this replaces, which is the shape of check that let this ship.
+ */
+
+const SECRET = 'NAMZU_TEST_PARENT_SECRET'
+const TOKEN = 'NAMZU_TEST_GRANTED_TOKEN'
+
+function parentEnv(): NodeJS.ProcessEnv {
+	return {
+		PATH: '/usr/bin',
+		HOME: '/home/someone',
+		[SECRET]: 'sk-live-must-not-travel',
+		[TOKEN]: 'granted-value',
+	}
+}
+
+describe('the environment a stdio server is handed', () => {
+	it('carries the plumbing a process needs to run at all', () => {
+		const env = buildChildEnv({}, parentEnv())
+
+		// Not hardening, and dropping it would only break the spawn: a child
+		// with no PATH cannot resolve its own interpreter.
+		expect(env.PATH).toBe('/usr/bin')
+		expect(env.HOME).toBe('/home/someone')
+	})
+
+	it('does not carry a parent secret nobody named', () => {
+		const env = buildChildEnv({}, parentEnv())
+
+		expect(env).not.toHaveProperty(SECRET)
+	})
+
+	it('carries a variable the config names, and still not the one it does not', () => {
+		const env = buildChildEnv({ inheritEnv: [TOKEN] }, parentEnv())
+
+		expect(env[TOKEN]).toBe('granted-value')
+		// The half that makes the grant mean something. Naming one variable
+		// must not re-open the rest.
+		expect(env).not.toHaveProperty(SECRET)
+	})
+
+	it('leaves a named-but-unset variable absent rather than empty', () => {
+		const env = buildChildEnv({ inheritEnv: ['NAMZU_TEST_NOT_SET'] }, parentEnv())
+
+		// An empty string tells a server it HAS a credential. Absent is the
+		// truth, and it is what a server's own `if (!token)` is written for.
+		expect(env).not.toHaveProperty('NAMZU_TEST_NOT_SET')
+	})
+
+	it('lets a literal value win over both an inherited one and the base', () => {
+		const env = buildChildEnv(
+			{ inheritEnv: [TOKEN], env: { [TOKEN]: 'literal-wins', PATH: '/opt/bin' } },
+			parentEnv(),
+		)
+
+		expect(env[TOKEN]).toBe('literal-wins')
+		expect(env.PATH).toBe('/opt/bin')
+	})
+})
+
+describe('the transport actually spawns with that environment', () => {
+	let workdirs: string[] = []
+
+	afterEach(async () => {
+		await removeTempDirs(workdirs)
+		workdirs = []
+	})
+
+	/**
+	 * Reachability is its own property. Every case above proves the helper is
+	 * right and none of them proves `connect()` calls it — which is exactly the
+	 * gap that would leave the spawn passing the whole parent environment while
+	 * a green suite reported the filter working.
+	 */
+	it('gives a real child the plumbing and not the parent secret', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'namzu-stdio-env-'))
+		workdirs.push(dir)
+		const server = join(dir, 'report-env.mjs')
+		await writeFile(
+			server,
+			[
+				'const answer = {',
+				'  hasSecret: process.env.NAMZU_TEST_PARENT_SECRET !== undefined,',
+				'  hasToken: process.env.NAMZU_TEST_GRANTED_TOKEN !== undefined,',
+				'  hasPath: process.env.PATH !== undefined,',
+				'}',
+				'process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: 1, result: answer }) + "\\n")',
+			].join('\n'),
+			'utf-8',
+		)
+
+		process.env[SECRET] = 'sk-live-must-not-travel'
+		process.env[TOKEN] = 'granted-value'
+
+		const transport = new StdioTransport({
+			type: 'stdio',
+			command: process.execPath,
+			args: [server],
+			inheritEnv: [TOKEN],
+		})
+
+		const reported = new Promise<Record<string, boolean>>((resolve) => {
+			transport.onMessage((message) => {
+				const result = (message as { result?: Record<string, boolean> }).result
+				if (result) resolve(result)
+			})
+		})
+
+		await transport.connect()
+		const answer = await reported
+		await transport.close()
+		process.env[SECRET] = undefined
+		process.env[TOKEN] = undefined
+
+		expect(answer.hasPath).toBe(true)
+		expect(answer.hasToken).toBe(true)
+		expect(answer.hasSecret).toBe(false)
+	})
+})

--- a/packages/sdk/src/connector/mcp/stdio.ts
+++ b/packages/sdk/src/connector/mcp/stdio.ts
@@ -13,6 +13,111 @@ import { type Logger, getRootLogger } from '../../utils/logger.js'
  */
 const TERMINATE_GRACE_MS = 2_000
 
+/**
+ * The variables a child needs in order to be a working process at all.
+ *
+ * This spawn used to pass `{ ...process.env, ...config.env }`, so a connected
+ * server received every credential the host happened to hold — measured at 119
+ * variables on a developer machine, including a planted secret the server had
+ * no reason to see. A server that needs one token was handed all of them, and
+ * nothing in the config said so.
+ *
+ * The list below is process plumbing, not secrets: where to find executables,
+ * where the home and temp directories are, what the locale is. Dropping any of
+ * it does not harden anything and does break servers — a child with no `PATH`
+ * cannot resolve its own interpreter.
+ *
+ * Anything else a server needs is now named: `env` gives it a literal value,
+ * and `inheritEnv` names a parent variable to pass through. Naming is the
+ * point — a grant that has to be written down is a grant somebody can review.
+ *
+ * Windows spellings are matched case-insensitively, because its environment is
+ * case-insensitive and a lookup for `Path` against a key stored as `PATH` would
+ * silently drop it — which would present as "the server does not start on
+ * Windows" rather than as anything to do with this list.
+ */
+const BASE_ENV_KEYS: readonly string[] = [
+	// Everywhere.
+	'PATH',
+	'LANG',
+	'LC_ALL',
+	'LC_CTYPE',
+	'TZ',
+	// POSIX.
+	'HOME',
+	'SHELL',
+	'TMPDIR',
+	'USER',
+	'LOGNAME',
+	// Windows. `SystemRoot` and `ComSpec` are load-bearing: without them a
+	// child cannot resolve system DLLs or the command interpreter.
+	'PATHEXT',
+	'SystemRoot',
+	'SystemDrive',
+	'ComSpec',
+	'WINDIR',
+	'TEMP',
+	'TMP',
+	'USERPROFILE',
+	'HOMEDRIVE',
+	'HOMEPATH',
+	'APPDATA',
+	'LOCALAPPDATA',
+	'PROGRAMDATA',
+	'PROGRAMFILES',
+	'NUMBER_OF_PROCESSORS',
+	'PROCESSOR_ARCHITECTURE',
+]
+
+/**
+ * Read one variable from the parent, honouring the platform's own casing rules.
+ *
+ * Node exposes `process.env` on Windows through a case-insensitive proxy, so a
+ * direct lookup already works there — but the KEY this returns has to be the
+ * one the parent actually uses, or a child comparing key names sees a spelling
+ * the host never set.
+ */
+function readParentVar(source: NodeJS.ProcessEnv, name: string): [string, string] | undefined {
+	const direct = source[name]
+	if (direct !== undefined) return [name, direct]
+	if (process.platform !== 'win32') return undefined
+	const lowered = name.toLowerCase()
+	for (const [key, value] of Object.entries(source)) {
+		if (key.toLowerCase() === lowered && value !== undefined) return [key, value]
+	}
+	return undefined
+}
+
+/**
+ * What the child is handed: plumbing, then the named inheritances, then the
+ * literal values.
+ *
+ * Later wins, and the order is the precedence an operator would guess: a
+ * literal `env` entry overrides an inherited one, and both override the base.
+ * Exported for the tests, which assert on the ENV rather than on the spawn —
+ * a test that only checked the config was accepted would have passed against
+ * the version this replaces.
+ */
+export function buildChildEnv(
+	config: Pick<MCPStdioTransportConfig, 'env' | 'inheritEnv'>,
+	source: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+	const env: Record<string, string> = {}
+	for (const name of BASE_ENV_KEYS) {
+		const found = readParentVar(source, name)
+		if (found) env[found[0]] = found[1]
+	}
+	for (const name of config.inheritEnv ?? []) {
+		const found = readParentVar(source, name)
+		// A named variable the parent does not hold is simply absent. Refusing
+		// the spawn would turn an optional credential into a startup failure,
+		// and inventing an empty string would tell the server it has one.
+		if (found) env[found[0]] = found[1]
+	}
+	for (const [name, value] of Object.entries(config.env ?? {})) env[name] = value
+	return env
+}
+
 export class StdioTransport implements MCPTransport {
 	private process: ChildProcess | null = null
 	private messageHandlers: Array<(message: MCPJsonRpcMessage) => void> = []
@@ -32,7 +137,7 @@ export class StdioTransport implements MCPTransport {
 		if (this.connected) return
 
 		this.process = spawn(this.config.command, this.config.args ?? [], {
-			env: { ...process.env, ...this.config.env },
+			env: buildChildEnv(this.config),
 			cwd: this.config.cwd,
 			stdio: ['pipe', 'pipe', 'pipe'],
 		})

--- a/packages/sdk/src/types/connector/mcp.ts
+++ b/packages/sdk/src/types/connector/mcp.ts
@@ -18,7 +18,24 @@ export interface MCPStdioTransportConfig extends MCPTransportConfigBase {
 	type: 'stdio'
 	command: string
 	args?: string[]
+	/** Literal values for the child. Highest precedence. */
 	env?: Record<string, string>
+	/**
+	 * Parent variables the child may have, named one at a time.
+	 *
+	 * The spawn used to pass the whole parent environment, so a server that
+	 * needed one token received every credential the host held. It now gets
+	 * process plumbing plus what is named here and in `env`, which is what
+	 * makes the grant reviewable: the config says which secrets cross the
+	 * boundary instead of the answer being "all of them".
+	 *
+	 * Use this rather than `env` for a credential — `env` puts the value in the
+	 * config file, and this keeps it in the environment where it already lives.
+	 *
+	 * A name the parent does not hold is absent from the child rather than
+	 * empty, and does not fail the spawn.
+	 */
+	inheritEnv?: readonly string[]
 	cwd?: string
 }
 


### PR DESCRIPTION
One of three claims a survey made without verified paths. Established by running it, not by reading the line.

## What was measured

`StdioTransport.connect()` spawned with `{ ...process.env, ...config.env }`. I planted a fake secret in the parent, spawned a child through the real transport, and had the child report what it received:

```
child sees 119 env vars; NAMZU_PROBE_FAKE_SECRET=sk-live-0000-not-a-real-key
```

Nothing between the config and the spawn filters anything. Two construction sites reach it and neither filters either: `cli/src/integrations/mcp/servers.ts` (the operator's `mcpServers` config) and `sdk/src/plugin/lifecycle.ts` (a plugin-declared server).

A server that needs one token was handed every credential the host held, and nothing in its configuration recorded that — the grant was invisible because it was total.

## What now happens

The child gets process plumbing — `PATH`, home and temp, `SystemRoot`/`ComSpec` on Windows, locale — plus whatever the configuration names:

```json
{
  "mcpServers": {
    "issues": { "command": "some-mcp-server", "inheritEnv": ["GITHUB_TOKEN"] }
  }
}
```

`inheritEnv` names a variable to pass through from the parent. That is the right shape for a credential: `env` would write the literal value into a config file, and this leaves it where it already lives. A named variable the parent does not hold is **absent** rather than empty, so a server's own `if (!token)` still works and the spawn still succeeds.

The field is threaded to the operator's `mcpServers` entry, because a grant an operator cannot express is the declared-and-undriven shape rather than a fix.

**It is deliberately absent from the plugin manifest.** A plugin naming the host variables its server receives would be awarding itself a credential grant, which is the operator's to award. A plugin-declared server gets plumbing plus its own literal `env`; if it needs a host credential, the operator declares that server under `mcpServers`.

## Verification

Six tests, and the split between them is the point. Five drive `buildChildEnv` directly. The sixth writes a small server to a temp dir, spawns it through the real `StdioTransport`, and asserts on what the child reports it received.

Reverting the spawn line to the old `{ ...process.env, ...config.env }` leaves **all five unit tests green** and fails only the end-to-end one. A suite without that sixth test would report a filter that the spawn ignores — which is the exact shape of the defect being fixed, one level up.

## Bump intent: `major` on `@namzu/sdk` and `@namzu/cli`

A server that was reading a credential straight out of the environment stops finding it. That is the point of the change, and it will present as the server failing to authenticate rather than as a configuration change, so the changeset says it plainly and names the remedy.

Gates: `typecheck`, `lint` (exit 0), `test`, `-r build`, `audit-external-names`, `verify-public-surface`, `check-publish-metadata`, `check-docs`, `@namzu/sandbox lint` — all green. `docs/cli/tool-servers.md` updated: the field table, what a local server is handed, and why a server may stop authenticating after the upgrade.
