### PR TITLE
fix(bedrock): the health check can pass, and says which failure it saw

### DIFF
--- a/.changeset/bedrock-health-check-can-pass.md
+++ b/.changeset/bedrock-health-check-can-pass.md
@@ -1,0 +1,52 @@
+---
+'@namzu/bedrock': minor
+---
+
+the bedrock health check can pass, and says which failure it saw
+
+`healthCheck()` hardcoded `anthropic.claude-haiku-4-20250514` — the exact
+unversioned form this driver's own `assertModelReachable` refuses. It built its
+command directly, so the predicate never ran locally: the service rejected the
+id, and `catch { return false }` reported that rejection as an outage. The check
+returned `false` with correct credentials, a correct region and a service that
+was entirely up, and nothing could tell that apart from a real failure.
+
+**What you do.** Pass the model you run:
+
+```ts
+const healthy = await provider.healthCheck('anthropic.claude-sonnet-4-20250514-v1:0')
+```
+
+`healthCheck()` still returns `Promise<boolean>` and still takes no required
+argument, so nothing stops compiling. Called with no model it now returns
+`false` without a network call, because this driver's config holds no model and
+there is nothing to probe — the same value it returned before, and it could not
+return any other one.
+
+When the answer matters, call `doctorCheck(model)`. It returns the same probe
+with its reasoning intact: `status` (`pass` / `fail` / `warn` / `inconclusive` /
+`skipped`) plus a machine-readable `reason` separating a rejected credential
+from a model this region does not serve, from a request the service refused,
+from a throttle, from a timeout that established nothing. The return type of
+`healthCheck` was deliberately NOT widened: every caller writing
+`if (await provider.healthCheck())` would keep compiling and start always
+passing against a truthy result object.
+
+The probe now sends `ConverseStream` — the operation `chatStream` sends — so it
+exercises `bedrock:InvokeModelWithResponseStream` rather than a permission your
+real calls never use, and it reads the failures Bedrock reports as stream events
+after a 200 rather than treating the handshake as the answer.
+
+**`listModels()` model ids changed.** It advertised
+`anthropic.claude-sonnet-4-20250514` and `anthropic.claude-haiku-4-20250514`;
+both are ids the request path rejects, so an operator who picked either off the
+menu got a throw before any call was made. They are now
+`anthropic.claude-sonnet-4-20250514-v1:0` and
+`anthropic.claude-haiku-4-5-20251001-v1:0`, which are the `bedrock-runtime`
+Model IDs on the vendor's own model cards. There was never a "Claude Haiku 4".
+If you copied an id out of this catalogue, it did not work; take the versioned
+one, or the inference-profile form (`us.`, `eu.`, `apac.`, `jp.`, `global.`) for
+a model served cross-region.
+
+`BedrockHealthReason` and `BedrockHealthReport` are exported from the package
+root.

--- a/.changeset/provider-health-probe-takes-a-model.md
+++ b/.changeset/provider-health-probe-takes-a-model.md
@@ -1,0 +1,28 @@
+---
+'@namzu/sdk': minor
+---
+
+a provider health probe can be told which model to check
+
+`LLMProvider.healthCheck` and `LLMProvider.doctorCheck` now take an optional
+`model`. Both were declared no-argument, and that made a model-aware probe
+unreachable: `ProviderRegistry.create()` hands back an `LLMProvider`, not the
+concrete driver, so a driver whose config carries no model had nowhere to get
+one and hardcoded an id instead — which is how one of them came to probe a model
+nobody ran and could not pass at all.
+
+**What you do: nothing.** The parameter is optional on an already-optional
+method, so an existing implementation that takes no argument still satisfies the
+interface and an existing call site still compiles. A driver is free to ignore
+the argument — one that probes an endpoint rather than a model has no use for
+it — and passing it is always safe.
+
+`doctorCheck` may now return a SUBTYPE of `DoctorCheckResult`, so a driver can
+carry its own machine-readable detail while `runDoctor()` keeps reading
+`status`.
+
+`withProviderRetry` and `withProviderFallback` forward the model to the wrapped
+driver. They rebuilt the provider as an object literal and spelled the forwarded
+methods `() => provider.healthCheck?.()`, which would have dropped the argument
+silently: the call still happens, the driver still answers, and the answer is
+"there was nothing to check" — an unusable probe produced by wrapping alone.

--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -48,7 +48,7 @@ const { provider, capabilities } = ProviderRegistry.create({
 
 ```ts
 const response = await provider.chat({
-  model: 'anthropic.claude-sonnet-4-20250514',
+  model: 'anthropic.claude-sonnet-4-20250514-v1:0',
   messages: [{ role: 'user', content: 'Say hello in one sentence.' }],
 })
 
@@ -82,7 +82,7 @@ const result = await agent.run(
   {
     provider,
     tools: new ToolRegistry(),
-    model: 'anthropic.claude-sonnet-4-20250514',
+    model: 'anthropic.claude-sonnet-4-20250514-v1:0',
     tokenBudget: 8_192,
     timeoutMs: 60_000,
     projectId: generateProjectId(),
@@ -134,14 +134,62 @@ The model condition is not a formality. Converse is a multi-vendor wire, and pro
 
 Cache hits and writes are reported separately from ordinary input, as `cachedTokens` and `cacheWriteTokens` on the usage of every turn. Those counters were always mapped correctly — for a period the driver reported them while requesting no caching at all, so they read a truthful zero, and a caller could not distinguish "caching does not help this workload" from "caching was never asked for". A run with caching on and a stable prefix should show `cachedTokens` rising after the first turn; if it stays at zero, the prefix is changing rather than the caching being off.
 
-## 9. Operational Notes
+## 9. Checking Health
+
+`healthCheck(model)` and `doctorCheck(model)` both take the model you intend to
+run. This driver's config carries no model, so a probe without one has no
+subject — it reports that, rather than reporting an outage:
+
+```ts
+const healthy = await provider.healthCheck('anthropic.claude-sonnet-4-20250514-v1:0')
+```
+
+The boolean is a summary. When the answer matters, ask for the reason:
+
+```ts
+const health = await provider.doctorCheck('anthropic.claude-sonnet-4-20250514-v1:0')
+
+if (health.status !== 'pass') {
+  console.error(health.reason, health.message, health.remediation)
+}
+```
+
+| `reason` | `status` | What happened |
+| --- | --- | --- |
+| `ok` | `pass` | The model answered. |
+| `no-model` | `skipped` | Nothing was probed, because no model id was given. |
+| `unreachable-model` | `fail` | This driver's own rule refuses the id. Nothing was sent. |
+| `no-credentials` | `fail` | No AWS credentials or region resolved here. The request never left the machine. |
+| `credentials` | `fail` | AWS answered and rejected the credential or its permissions. |
+| `unknown-model` | `fail` | The id is well-formed and this region serves no such model. |
+| `refused` | `fail` | The service looked at the request and would not take it. |
+| `throttled` | `warn` | Reached, authenticated, rate limited. The probe did not complete. |
+| `service` | `fail` | The service answered and could not serve the request. |
+| `unreachable-service` | `inconclusive` | Nothing was learned. Do not read this as an outage. |
+
+`healthCheck` is `true` only for `pass`, so a `warn` reads as not-healthy: the
+service is up, but the probe did not run to completion and traffic sent on the
+strength of it would be sent on no evidence.
+
+The probe sends one `ConverseStream` request capped at one output token — the
+same operation `chatStream` sends, so it exercises
+`bedrock:InvokeModelWithResponseStream` rather than a permission your real calls
+never use. It costs that one token.
+
+This check previously hardcoded `anthropic.claude-haiku-4-20250514` and reported
+every failure as a bare `false`. That id is one the driver itself classifies as
+unreachable, so the check could not pass at any credential, region or service
+state, and an operator could not tell a wrong key from an outage.
+
+## 10. Operational Notes
 
 - If you do not pass explicit credentials, the AWS SDK default credential chain is used.
 - Model access in Bedrock is region-specific, so enable the models you need in the target AWS region before testing.
-- The provider also implements `listModels()` and `healthCheck()`.
+- The provider also implements `listModels()`, `healthCheck(model)` and `doctorCheck(model)`; see the section above.
+- `listModels()` offers the `bedrock-runtime` Model IDs from the vendor's model cards. Every id it advertises is one this driver will actually send — it previously listed two the request path rejected before building a request.
 - Bedrock model identifiers differ from direct vendor identifiers, so keep your runtime model config Bedrock-specific.
 
-## 10. Common Errors
+## 11. Common Errors
 
 | Error | Meaning | Fix |
 | --- | --- | --- |

--- a/packages/providers/bedrock/src/__tests__/health-check.test.ts
+++ b/packages/providers/bedrock/src/__tests__/health-check.test.ts
@@ -1,0 +1,479 @@
+/**
+ * The health check can pass, and says which failure it saw.
+ *
+ * The defect it is written against is not "the check returns false". It is that
+ * the check could return NOTHING ELSE: it built its command directly around a
+ * hardcoded `anthropic.claude-haiku-4-20250514`, the exact unversioned form
+ * this driver's own `assertModelReachable` refuses, so the service rejected the
+ * id and `catch { return false }` reported the rejection as an outage. Correct
+ * credentials, correct region, service entirely up, answer `false`.
+ *
+ * A test asserting `healthCheck()` is `false` therefore passes against the
+ * broken driver, which is why the first case here is that a HEALTHY fake makes
+ * it `true`. The rest assert that the failures arrive apart from one another,
+ * and that the probe is the request the driver actually makes.
+ *
+ * The harness is the one `cache-points.test.ts` uses: swap `provider.client`
+ * and read what the AWS client was HANDED. Nothing here rests on a return value
+ * alone, because the previous check's return value was honest about a request
+ * nobody would have wanted made.
+ */
+
+import {
+	AccessDeniedException,
+	ResourceNotFoundException,
+	ServiceUnavailableException,
+	ThrottlingException,
+	ValidationException,
+} from '@aws-sdk/client-bedrock-runtime'
+import type { ConverseStreamOutput } from '@aws-sdk/client-bedrock-runtime'
+import { describe, expect, it } from 'vitest'
+
+import { BedrockProvider } from '../client.js'
+import type { BedrockHealthReason } from '../health.js'
+import { assertModelReachable } from '../model-reachability.js'
+
+/** An id this wire serves: ARN-versioned, behind an inference profile. */
+const REACHABLE = 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
+
+/** The exact id the broken check hardcoded. */
+const HARDCODED = 'anthropic.claude-haiku-4-20250514'
+
+interface Sent {
+	readonly commandName: string
+	readonly input: Record<string, unknown>
+}
+
+/**
+ * A provider whose AWS client is replaced, plus the log of what it was handed.
+ *
+ * `sent` is the point of the harness. A green boolean cannot say which model
+ * was probed or which operation carried the probe, and both were wrong.
+ */
+function providerWith(send: (command: unknown) => Promise<unknown>): {
+	provider: BedrockProvider
+	sent: Sent[]
+} {
+	const provider = new BedrockProvider({ region: 'us-east-1' })
+	const sent: Sent[] = []
+	;(provider as unknown as { client: unknown }).client = {
+		send: (command: { constructor: { name: string }; input: Record<string, unknown> }) => {
+			sent.push({ commandName: command.constructor.name, input: command.input })
+			return send(command)
+		},
+	}
+	return { provider, sent }
+}
+
+/** A service that answers: 200, then a one-token stream that ends cleanly. */
+function healthyProvider() {
+	return providerWith(async () => ({
+		$metadata: { httpStatusCode: 200, requestId: 'health-test' },
+		stream: (async function* () {
+			yield { contentBlockDelta: { delta: { text: 'h' }, contentBlockIndex: 0 } }
+			yield { messageStop: { stopReason: 'max_tokens' } }
+		})(),
+	}))
+}
+
+/** A service that rejects the request with a real AWS exception class. */
+function rejectingProvider(err: unknown) {
+	return providerWith(() => Promise.reject(err))
+}
+
+/**
+ * A service that hands back a 200 and then reports the failure as a member of
+ * the output union — which is how Bedrock reports several of them.
+ */
+function midStreamFailureProvider(...events: ConverseStreamOutput[]) {
+	return providerWith(async () => ({
+		$metadata: { httpStatusCode: 200, requestId: 'health-test' },
+		stream: (async function* () {
+			yield* events
+		})(),
+	}))
+}
+
+describe('the check can pass', () => {
+	it('returns true against a service that answers', async () => {
+		const { provider } = healthyProvider()
+
+		// The assertion the broken driver could not satisfy at any credential,
+		// region or service state.
+		expect(await provider.healthCheck(REACHABLE)).toBe(true)
+	})
+
+	it('reports pass with the reason and the model it probed', async () => {
+		const { provider } = healthyProvider()
+
+		const health = await provider.doctorCheck(REACHABLE)
+
+		expect(health.status).toBe('pass')
+		expect(health.reason).toBe('ok')
+		expect(health.model).toBe(REACHABLE)
+	})
+
+	it('times the probe', async () => {
+		const { provider } = healthyProvider()
+
+		const health = await provider.doctorCheck(REACHABLE)
+
+		expect(typeof health.durationMs).toBe('number')
+	})
+})
+
+describe('the check probes what the caller asked for', () => {
+	it('sends the model it was given, not a hardcoded one', async () => {
+		const { provider, sent } = healthyProvider()
+
+		await provider.healthCheck(REACHABLE)
+
+		expect(sent).toHaveLength(1)
+		expect(sent[0]?.input.modelId).toBe(REACHABLE)
+		// Named rather than left to the equality above: the point is this id,
+		// which the driver's own rule refuses and which shipped for months.
+		expect(sent[0]?.input.modelId).not.toBe(HARDCODED)
+	})
+
+	it('probes with the operation the request path uses', async () => {
+		const { provider, sent } = healthyProvider()
+
+		await provider.healthCheck(REACHABLE)
+
+		// `Converse` and `ConverseStream` are separate IAM actions. A probe on
+		// the one `chatStream` does not send can pass under a policy that fails
+		// every real call, which is a green check about a request nobody makes.
+		expect(sent[0]?.commandName).toBe('ConverseStreamCommand')
+	})
+
+	it('asks for one token, so the probe is not a completion', async () => {
+		const { provider, sent } = healthyProvider()
+
+		await provider.healthCheck(REACHABLE)
+
+		expect(sent[0]?.input.inferenceConfig).toMatchObject({ maxTokens: 1 })
+	})
+})
+
+describe('the check refuses to invent a subject', () => {
+	it('reports skipped, not unhealthy, when given no model', async () => {
+		const { provider, sent } = healthyProvider()
+
+		const health = await provider.doctorCheck()
+
+		// `fail` here would be the original defect in a new spelling: a report
+		// of an outage produced by the driver having nothing to ask about.
+		expect(health.status).toBe('skipped')
+		expect(health.reason).toBe('no-model')
+		expect(sent).toHaveLength(0)
+	})
+
+	it('treats a blank model id the same as none', async () => {
+		const { provider, sent } = healthyProvider()
+
+		const health = await provider.doctorCheck('   ')
+
+		expect(health.reason).toBe('no-model')
+		expect(sent).toHaveLength(0)
+	})
+
+	it('returns false from healthCheck with no model, without calling AWS', async () => {
+		const { provider, sent } = healthyProvider()
+
+		expect(await provider.healthCheck()).toBe(false)
+		expect(sent).toHaveLength(0)
+	})
+})
+
+describe('an id this wire cannot serve is named as that, before any request', () => {
+	it('fails on the unversioned form with the reachability reason', async () => {
+		const { provider, sent } = healthyProvider()
+
+		const health = await provider.doctorCheck('anthropic.claude-opus-5')
+
+		expect(health.status).toBe('fail')
+		expect(health.reason).toBe('unreachable-model')
+		expect(sent).toHaveLength(0)
+	})
+
+	it('fails on the very id the broken check hardcoded', async () => {
+		const { provider, sent } = healthyProvider()
+
+		// The whole defect in one place: the driver classifies this id as
+		// unreachable, and the old check sent it anyway — here, against a fake
+		// that would have answered.
+		expect(() => assertModelReachable(HARDCODED)).toThrow()
+
+		const health = await provider.doctorCheck(HARDCODED)
+
+		expect(health.reason).toBe('unreachable-model')
+		expect(sent).toHaveLength(0)
+	})
+
+	it("carries the predicate's own explanation, not a summary of it", async () => {
+		const { provider } = healthyProvider()
+
+		const health = await provider.doctorCheck('anthropic.claude-opus-5')
+
+		expect(health.message).toMatch(/cannot reach/)
+		expect(health.message).toMatch(/Converse API/)
+	})
+})
+
+describe('the failures arrive apart from one another', () => {
+	const cases: ReadonlyArray<{
+		readonly label: string
+		readonly error: unknown
+		readonly reason: BedrockHealthReason
+		readonly status: string
+	}> = [
+		{
+			label: 'a rejected credential',
+			error: new AccessDeniedException({
+				message: 'User is not authorized to perform bedrock:InvokeModelWithResponseStream',
+				$metadata: { httpStatusCode: 403 },
+			}),
+			reason: 'credentials',
+			status: 'fail',
+		},
+		{
+			label: 'a model this region does not serve',
+			error: new ResourceNotFoundException({
+				message: 'Could not resolve the foundation model from the provided model identifier.',
+				$metadata: { httpStatusCode: 404 },
+			}),
+			reason: 'unknown-model',
+			status: 'fail',
+		},
+		{
+			label: 'a request the service looked at and refused',
+			error: new ValidationException({
+				message: "Invocation of model ID with on-demand throughput isn't supported.",
+				$metadata: { httpStatusCode: 400 },
+			}),
+			reason: 'refused',
+			status: 'fail',
+		},
+		{
+			label: 'a rate limit',
+			error: new ThrottlingException({
+				message: 'Too many requests, please wait before trying again.',
+				$metadata: { httpStatusCode: 429 },
+			}),
+			reason: 'throttled',
+			status: 'warn',
+		},
+		{
+			label: 'a service that answered and could not serve',
+			error: new ServiceUnavailableException({
+				message: 'The service is unavailable. Please retry.',
+				$metadata: { httpStatusCode: 503 },
+			}),
+			reason: 'service',
+			status: 'fail',
+		},
+		{
+			label: 'a machine with no resolvable credentials',
+			error: Object.assign(new Error('Could not load credentials from any providers'), {
+				name: 'CredentialsProviderError',
+			}),
+			reason: 'no-credentials',
+			status: 'fail',
+		},
+		{
+			label: 'a request that never got an answer',
+			error: Object.assign(new Error('connect ECONNREFUSED'), { name: 'TimeoutError' }),
+			reason: 'unreachable-service',
+			status: 'inconclusive',
+		},
+	]
+
+	for (const { label, error, reason, status } of cases) {
+		it(`reports ${label} as ${reason}/${status}`, async () => {
+			const { provider } = rejectingProvider(error)
+
+			const health = await provider.doctorCheck(REACHABLE)
+
+			expect(health.reason).toBe(reason)
+			expect(health.status).toBe(status)
+		})
+	}
+
+	it('gives every one of them a distinct reason', async () => {
+		const reasons = new Set<string>()
+		for (const { error } of cases) {
+			const { provider } = rejectingProvider(error)
+			reasons.add((await provider.doctorCheck(REACHABLE)).reason)
+		}
+
+		// The assertion `catch { return false }` fails: seven inputs an operator
+		// acts on differently, seven answers. A mapping that collapsed any two
+		// would still satisfy every per-case test above, because each of those
+		// only names its own expectation.
+		expect(reasons.size).toBe(cases.length)
+	})
+
+	it('tells the operator what to do about the ones they can act on', async () => {
+		const actionable: readonly BedrockHealthReason[] = [
+			'credentials',
+			'unknown-model',
+			'no-credentials',
+		]
+		for (const { error, reason } of cases) {
+			if (!actionable.includes(reason)) continue
+			const { provider } = rejectingProvider(error)
+			const health = await provider.doctorCheck(REACHABLE)
+			expect(health.remediation, `${reason} has no remediation`).toBeTruthy()
+		}
+	})
+
+	it('keeps "nothing was learned" apart from "the service is down"', async () => {
+		const { provider: unreachable } = rejectingProvider(
+			Object.assign(new Error('socket hang up'), { name: 'TimeoutError' }),
+		)
+		const { provider: down } = rejectingProvider(
+			new ServiceUnavailableException({
+				message: 'unavailable',
+				$metadata: { httpStatusCode: 503 },
+			}),
+		)
+
+		// Reporting a timeout as `fail` would send an operator on broken wifi to
+		// rotate a credential that is fine.
+		expect((await unreachable.doctorCheck(REACHABLE)).status).toBe('inconclusive')
+		expect((await down.doctorCheck(REACHABLE)).status).toBe('fail')
+	})
+
+	it('reports every failure as not-healthy through the boolean', async () => {
+		for (const { error, reason } of cases) {
+			const { provider } = rejectingProvider(error)
+			expect(await provider.healthCheck(REACHABLE), reason).toBe(false)
+		}
+	})
+})
+
+describe('a 200 handshake is not a pass on its own', () => {
+	it('reads a mid-stream refusal that arrived after the 200', async () => {
+		const { provider } = midStreamFailureProvider({
+			validationException: new ValidationException({
+				message: 'The provided model identifier is invalid.',
+				$metadata: { httpStatusCode: 400 },
+			}),
+		} as unknown as ConverseStreamOutput)
+
+		const health = await provider.doctorCheck(REACHABLE)
+
+		// Bedrock reports several failures as members of the output union, after
+		// a 200. A check that read only `$metadata.httpStatusCode` would call
+		// this healthy.
+		expect(health.status).toBe('fail')
+		expect(health.reason).toBe('refused')
+	})
+
+	it('reads a mid-stream throttle the same way', async () => {
+		const { provider } = midStreamFailureProvider({
+			throttlingException: new ThrottlingException({
+				message: 'slow down',
+				$metadata: { httpStatusCode: 429 },
+			}),
+		} as unknown as ConverseStreamOutput)
+
+		expect((await provider.doctorCheck(REACHABLE)).reason).toBe('throttled')
+		expect(await provider.healthCheck(REACHABLE)).toBe(false)
+	})
+
+	it('fails a handshake that carried no stream body', async () => {
+		const { provider } = providerWith(async () => ({
+			$metadata: { httpStatusCode: 200, requestId: 'health-test' },
+		}))
+
+		const health = await provider.doctorCheck(REACHABLE)
+
+		expect(health.status).toBe('fail')
+		expect(health.reason).toBe('service')
+	})
+})
+
+describe('the catalogue offers only ids this driver will send', () => {
+	it("every advertised id survives the driver's own reachability rule", async () => {
+		const provider = new BedrockProvider({ region: 'us-east-1' })
+
+		const models = await provider.listModels()
+
+		expect(models.length).toBeGreaterThan(0)
+		for (const model of models) {
+			// Two entries used to fail this: an operator picking either off the
+			// menu got a throw before any request was built.
+			expect(() => assertModelReachable(model.id), model.id).not.toThrow()
+		}
+	})
+
+	it('advertises neither of the two ids that shipped and could not be invoked', async () => {
+		const provider = new BedrockProvider({ region: 'us-east-1' })
+
+		const ids = (await provider.listModels()).map((m) => m.id)
+
+		expect(ids).not.toContain('anthropic.claude-sonnet-4-20250514')
+		expect(ids).not.toContain(HARDCODED)
+	})
+
+	it('lets a menu entry be probed without changing it', async () => {
+		const { provider, sent } = healthyProvider()
+		const [first] = await provider.listModels()
+
+		expect(await provider.healthCheck(first?.id)).toBe(true)
+		expect(sent[0]?.input.modelId).toBe(first?.id)
+	})
+})
+
+describe('a failure report says what it was about', () => {
+	it('names the model it probed, on the failure paths too', async () => {
+		const { provider } = rejectingProvider(
+			new AccessDeniedException({ message: 'denied', $metadata: { httpStatusCode: 403 } }),
+		)
+
+		const health = await provider.doctorCheck(REACHABLE)
+
+		// A report that names a failure and not its subject sends an operator
+		// looking through every model they run.
+		expect(health.model).toBe(REACHABLE)
+	})
+
+	it('reports the classified message rather than the raw AWS one', async () => {
+		const { provider } = rejectingProvider(
+			new AccessDeniedException({
+				message: 'User AKIAIOSFODNN7EXAMPLE is not authorized to perform this action',
+				$metadata: { httpStatusCode: 403 },
+			}),
+		)
+
+		const health = await provider.doctorCheck(REACHABLE)
+
+		// AWS builds its exception message from the response body, so a
+		// credential the service echoed back is inside `err.message` before
+		// this driver sees it. The message therefore comes from the SDK's
+		// classifier, which is the one place that strips it — and a report is
+		// exactly the value someone pastes into an issue.
+		expect(health.message).not.toContain('AKIAIOSFODNN7EXAMPLE')
+		expect(health.message).toContain('bedrock')
+	})
+})
+
+describe('a machine that was never configured is not a service that is down', () => {
+	it('reads a missing region as a local failure, not as an unreachable service', async () => {
+		// The AWS SDK reports this as a plain `Error` with no exception class to
+		// match on, so it is the one reason that has to come off the message.
+		// Neither mutation round reached this branch; it is here because a table
+		// where everything dies is a map of the lines the tests execute, and this
+		// line was not on it.
+		const { provider, sent } = rejectingProvider(new Error('Region is missing'))
+
+		const health = await provider.doctorCheck(REACHABLE)
+
+		expect(health.reason).toBe('no-credentials')
+		expect(health.status).toBe('fail')
+		// It did leave the driver — the request was built and handed over — which
+		// is what separates this from the reachability refusal above.
+		expect(sent).toHaveLength(1)
+	})
+})

--- a/packages/providers/bedrock/src/client.ts
+++ b/packages/providers/bedrock/src/client.ts
@@ -1,8 +1,4 @@
-import {
-	BedrockRuntimeClient,
-	ConverseCommand,
-	ConverseStreamCommand,
-} from '@aws-sdk/client-bedrock-runtime'
+import { BedrockRuntimeClient, ConverseStreamCommand } from '@aws-sdk/client-bedrock-runtime'
 import type {
 	Message as BedrockMessage,
 	CachePointBlock,
@@ -33,6 +29,8 @@ import {
 	isProviderRequestError,
 	providerVendorError,
 } from '@namzu/sdk'
+import type { BedrockHealthReport } from './health.js'
+import { report, reportForError } from './health.js'
 import { assertModelReachable, isAnthropicServedModel } from './model-reachability.js'
 import type { BedrockConfig } from './types.js'
 
@@ -276,6 +274,25 @@ function formatToolChoice(tc?: ToolChoice) {
 	return { auto: {} }
 }
 
+/**
+ * The failure Bedrock reported as a stream EVENT rather than as a throw.
+ *
+ * Several post-handshake failures arrive as members of the output union, after
+ * a 200. Ignoring them makes a throttled or failed stream look like a clean
+ * EOF — which is why this is read on the request path, and why the health probe
+ * reads it through the same function rather than through a second copy that
+ * could drift from this one.
+ */
+export function streamFailureIn(event: ConverseStreamOutput): unknown {
+	return (
+		('internalServerException' in event ? event.internalServerException : undefined) ??
+		('modelStreamErrorException' in event ? event.modelStreamErrorException : undefined) ??
+		('validationException' in event ? event.validationException : undefined) ??
+		('throttlingException' in event ? event.throttlingException : undefined) ??
+		('serviceUnavailableException' in event ? event.serviceUnavailableException : undefined)
+	)
+}
+
 interface RawBedrockUsage {
 	inputTokens?: number
 	outputTokens?: number
@@ -446,12 +463,7 @@ export class BedrockProvider implements LLMProvider {
 				// Bedrock reports several post-handshake failures as UNION
 				// EVENTS, not thrown exceptions. Ignoring these members makes a
 				// throttled or failed stream look like a clean EOF.
-				const streamFailure =
-					('internalServerException' in event ? event.internalServerException : undefined) ??
-					('modelStreamErrorException' in event ? event.modelStreamErrorException : undefined) ??
-					('validationException' in event ? event.validationException : undefined) ??
-					('throttlingException' in event ? event.throttlingException : undefined) ??
-					('serviceUnavailableException' in event ? event.serviceUnavailableException : undefined)
+				const streamFailure = streamFailureIn(event)
 				if (streamFailure) {
 					throw providerVendorError({
 						providerId: 'bedrock',
@@ -550,10 +562,40 @@ export class BedrockProvider implements LLMProvider {
 		}
 	}
 
+	/**
+	 * The menu this driver offers.
+	 *
+	 * Every Claude id here is the `bedrock-runtime` Model ID from the vendor's
+	 * own model card, and that is a correction rather than a preference: the
+	 * two entries this list used to carry — `anthropic.claude-sonnet-4-20250514`
+	 * and `anthropic.claude-haiku-4-20250514` — are ids `assertModelReachable`
+	 * refuses, so an operator picking either off the menu got a throw before any
+	 * request was built. A catalogue its own request path rejects is worse than
+	 * a short one.
+	 *
+	 * The card for Claude Haiku 4.5 is what settles that the predicate is right
+	 * rather than too strict. It lists the SAME model under two ids on two
+	 * endpoints: `anthropic.claude-haiku-4-5-20251001-v1:0` on
+	 * `bedrock-runtime`, and the unversioned `anthropic.claude-haiku-4-5` on
+	 * `bedrock-mantle`, at a different URL. The bare form is a real id for the
+	 * endpoint this driver does not speak — which is exactly the claim
+	 * `model-reachability.ts` makes, stated by the vendor in one table.
+	 *
+	 * "Claude Haiku 4" was never a model. The Haiku line goes 3.5 to 4.5, and
+	 * the id that shipped here carried Sonnet 4's launch date.
+	 *
+	 * `inputPrice`/`outputPrice` are per million tokens and are DISPLAY data:
+	 * `resolveModelPricing` in `@namzu/sdk` has no `bedrock` vendor, so no run
+	 * is costed from them. The Haiku 4.5 rates are the reviewed ones from that
+	 * package's own `rates.source.json`. AWS publishes Bedrock's on-demand rates
+	 * on a page that renders them client-side, so they could not be read here,
+	 * and if Bedrock diverges from the vendor's list price this row is wrong in
+	 * that direction only.
+	 */
 	async listModels(): Promise<ModelInfo[]> {
 		return [
 			{
-				id: 'anthropic.claude-sonnet-4-20250514',
+				id: 'anthropic.claude-sonnet-4-20250514-v1:0',
 				name: 'Claude Sonnet 4 (Bedrock)',
 				contextWindow: 200_000,
 				maxOutputTokens: 64_000,
@@ -563,12 +605,12 @@ export class BedrockProvider implements LLMProvider {
 				supportsStreaming: true,
 			},
 			{
-				id: 'anthropic.claude-haiku-4-20250514',
-				name: 'Claude Haiku 4 (Bedrock)',
+				id: 'anthropic.claude-haiku-4-5-20251001-v1:0',
+				name: 'Claude Haiku 4.5 (Bedrock)',
 				contextWindow: 200_000,
 				maxOutputTokens: 64_000,
-				inputPrice: 0.8,
-				outputPrice: 4.0,
+				inputPrice: 1.0,
+				outputPrice: 5.0,
 				supportsToolUse: true,
 				supportsStreaming: true,
 			},
@@ -585,19 +627,92 @@ export class BedrockProvider implements LLMProvider {
 		]
 	}
 
-	async healthCheck(): Promise<boolean> {
+	/**
+	 * Can this driver serve `model` right now?
+	 *
+	 * One bit, and deliberately still one bit. Widening the return type would
+	 * break every caller that writes `if (await provider.healthCheck())`
+	 * SILENTLY — the code keeps compiling and starts always passing, because a
+	 * result object is truthy. {@link doctorCheck} is the same probe with its
+	 * reasoning intact, and is what to call when the answer matters.
+	 *
+	 * `model` is required in practice though the type says optional: this
+	 * driver's config holds no model, so with nothing passed there is nothing to
+	 * probe, and the answer is `false` for the stated reason `no-model` rather
+	 * than for a guessed one. It used to probe a hardcoded id instead, which is
+	 * how it came to send an id its own reachability rule rejects and report the
+	 * refusal as an outage.
+	 */
+	async healthCheck(model?: string): Promise<boolean> {
+		return (await this.doctorCheck(model)).status === 'pass'
+	}
+
+	/**
+	 * The health probe, with the reason it reached its verdict.
+	 *
+	 * Probes with `ConverseStream` rather than `Converse` because that is the
+	 * command {@link chatStream} sends. They are separate IAM actions —
+	 * `bedrock:InvokeModelWithResponseStream` and `bedrock:InvokeModel` — so a
+	 * probe on the other one can pass under a policy every real call fails
+	 * under, which is a green check about a request nobody makes.
+	 *
+	 * It costs one inference of one token. Nothing cheaper on the runtime client
+	 * establishes credentials, region and model reachability together, and the
+	 * alternatives establish them for a permission the request path does not
+	 * use.
+	 */
+	async doctorCheck(model?: string): Promise<BedrockHealthReport> {
+		if (model === undefined || model.trim() === '') {
+			return report(
+				'no-model',
+				'No model id was given and this driver holds none in its config, so nothing was probed. This is not a report that Bedrock is unhealthy.',
+			)
+		}
+
+		const startedAt = Date.now()
+		const elapsed = () => Date.now() - startedAt
+
+		// The same rule the request path applies, applied here. Skipping it is
+		// how the previous check came to send an id this driver classifies as
+		// uninvokable and then read the service's refusal as an outage.
 		try {
-			const command = new ConverseCommand({
-				modelId: 'anthropic.claude-haiku-4-20250514',
+			assertModelReachable(model)
+		} catch (err) {
+			return report('unreachable-model', err instanceof Error ? err.message : String(err), {
+				model,
+				durationMs: elapsed(),
+			})
+		}
+
+		try {
+			const command = new ConverseStreamCommand({
+				modelId: model,
 				messages: [{ role: 'user', content: [{ text: 'hi' }] }],
 				inferenceConfig: { maxTokens: 1 },
 			})
-			const response = await this.client.send(command, {
-				requestTimeout: 5000,
-			})
-			return response.$metadata.httpStatusCode === 200
-		} catch {
-			return false
+			const response = await this.client.send(command, { requestTimeout: 5000 })
+
+			// No branch on the status code: this SDK throws for a non-2xx, so a
+			// handshake that returns at all returned success. A branch production
+			// cannot enter is one only a fixture unlike production could test.
+			if (!response.stream) {
+				return report('service', 'bedrock accepted the request and returned no stream body', {
+					model,
+					durationMs: elapsed(),
+				})
+			}
+
+			// The handshake is a 200 even when the model then refuses, because
+			// Bedrock reports those failures as members of the output union.
+			// Reading only the status would call that a pass.
+			for await (const event of response.stream as AsyncIterable<ConverseStreamOutput>) {
+				const failure = streamFailureIn(event)
+				if (failure) return reportForError(failure, model, elapsed())
+			}
+
+			return report('ok', `bedrock served ${model}`, { model, durationMs: elapsed() })
+		} catch (err) {
+			return reportForError(err, model, elapsed())
 		}
 	}
 }

--- a/packages/providers/bedrock/src/health.ts
+++ b/packages/providers/bedrock/src/health.ts
@@ -1,0 +1,194 @@
+/**
+ * What a health probe against this wire concluded, and why.
+ *
+ * `healthCheck` used to answer with one bit produced by `catch { return false }`.
+ * The three failures a caller actually needs apart — the credential is wrong,
+ * the service is down, that model is not invokable here — all arrived as
+ * `false`, and so did success, because the id it probed was one the driver's
+ * own `assertModelReachable` classifies as unreachable. A check that cannot
+ * pass is the same defect class as a check that cannot fail: neither carries
+ * information, and this one carried none in a shape that looked like an outage.
+ *
+ * So the reason is a value rather than a sentence. `status` is the
+ * `DoctorCheckResult` field `runDoctor()` reads; `reason` is what a caller
+ * switches on.
+ */
+
+import type { DoctorCheckResult } from '@namzu/sdk'
+import { providerVendorError } from '@namzu/sdk'
+
+/**
+ * Why the probe reached the verdict it did.
+ *
+ * Named for what an operator would do next, which is why `credentials` and
+ * `unreachable-model` are separate from `refused`: the first is a key to
+ * rotate, the second an id to change, the third a request the service looked
+ * at and would not take.
+ */
+export type BedrockHealthReason =
+	/** The model answered. */
+	| 'ok'
+	/** Nothing was probed: no model id was given and this driver holds none. */
+	| 'no-model'
+	/** The driver's own reachability rule refuses this id; nothing was sent. */
+	| 'unreachable-model'
+	/** No AWS credentials could be resolved on this machine. Never left it. */
+	| 'no-credentials'
+	/** AWS answered and rejected the credential or its permissions. */
+	| 'credentials'
+	/** The id is well-formed but this region serves no such model. */
+	| 'unknown-model'
+	/** The service looked at the request and refused it. */
+	| 'refused'
+	/** Reached, authenticated, and rate limited. The probe did not complete. */
+	| 'throttled'
+	/** The service answered and could not serve the request. */
+	| 'service'
+	/** Nothing was learned: the request did not get an answer. */
+	| 'unreachable-service'
+
+/**
+ * A `DoctorCheckResult` with the reason kept.
+ *
+ * Extends rather than replaces so it satisfies `LLMProvider.doctorCheck`
+ * unchanged: `runDoctor()` reads `status` and never sees the extra field, and a
+ * caller holding the concrete driver reads `reason` without a cast.
+ */
+export interface BedrockHealthReport extends DoctorCheckResult {
+	readonly reason: BedrockHealthReason
+	/** The id that was probed. Absent only when nothing was probed. */
+	readonly model?: string
+}
+
+/**
+ * AWS models its failures as distinct exception CLASSES rather than as status
+ * codes, and the class is the only thing that separates the cases an operator
+ * acts on differently.
+ *
+ * The SDK's `providerVendorError` deliberately flattens these into six kinds
+ * for the request path, where the question is "retry, compact, or give up".
+ * That is the right shape there and the wrong one here: it merges
+ * `ResourceNotFoundException` ("no such model in this region") with
+ * `ValidationException` ("the request was invalid") into `bad_request`, and
+ * those are the two answers a health check exists to tell apart. So the class
+ * is read here, where the raw error is still in hand.
+ *
+ * Matched on `name` rather than with `instanceof`: the exception classes are
+ * re-exported by every minor of the AWS SDK, and a caller running two copies of
+ * `@aws-sdk/client-bedrock-runtime` in one tree would fail every `instanceof`
+ * against errors that are otherwise correct.
+ */
+const REASON_BY_EXCEPTION: ReadonlyArray<readonly [RegExp, BedrockHealthReason]> = [
+	// Client-side, before a packet leaves: the credential chain found nothing.
+	// This is a definite answer about the machine, not a failure to reach AWS,
+	// and filing it as unreachable would tell someone with no credentials at
+	// all to go and check their network.
+	[/CredentialsProviderError|CredentialsError/i, 'no-credentials'],
+	[/AccessDenied|UnrecognizedClient|InvalidSignature|Unauthorized|Forbidden/i, 'credentials'],
+	[/ResourceNotFound/i, 'unknown-model'],
+	[/ThrottlingException|TooManyRequests|ServiceQuotaExceeded/i, 'throttled'],
+	[
+		/ServiceUnavailable|InternalServer|ModelNotReady|ModelTimeout|ModelStreamError|ModelError/i,
+		'service',
+	],
+	[/Validation/i, 'refused'],
+]
+
+const STATUS_BY_REASON: Readonly<Record<BedrockHealthReason, DoctorCheckResult['status']>> = {
+	ok: 'pass',
+	'no-model': 'skipped',
+	'unreachable-model': 'fail',
+	'no-credentials': 'fail',
+	credentials: 'fail',
+	'unknown-model': 'fail',
+	refused: 'fail',
+	// Reached, authenticated, throttled. The service is up, so this is not a
+	// failure of the integration — but the probe did not complete, so it is
+	// not a pass either, and reporting it as one would let a caller start
+	// sending traffic on the strength of a request that never ran.
+	throttled: 'warn',
+	service: 'fail',
+	// The check did not answer. Distinct from `fail` because nothing is known:
+	// telling an operator on broken wifi that Bedrock is down sends them to
+	// the wrong place.
+	'unreachable-service': 'inconclusive',
+}
+
+const REMEDIATION_BY_REASON: Readonly<Partial<Record<BedrockHealthReason, string>>> = {
+	'no-credentials':
+		'Pass accessKeyId/secretAccessKey to the driver, or make the AWS default credential chain resolve here (env, shared config, SSO, or an instance role).',
+	credentials:
+		'Check the credential is current and that its IAM policy allows bedrock:InvokeModelWithResponseStream on this model in this region.',
+	'unknown-model':
+		'This region serves no model by that id. Enable model access in the target region, or use the inference-profile form (us./eu./apac./jp./global.) for a model served cross-region.',
+	refused:
+		'The service rejected the request itself. A model served only through an inference profile refuses the bare id — try the profile-prefixed form.',
+	throttled: 'Retry. The service is reachable and the credential authenticated.',
+	service: 'Nothing to do here; the service could not serve the request. Retry later.',
+	'unreachable-service':
+		'Nothing was learned about the service. Check network reachability of the Bedrock endpoint for this region before changing any credential.',
+}
+
+/** The reason an AWS failure implies; "nothing was learned" when unrecognised. */
+export function reasonForError(err: unknown): BedrockHealthReason {
+	// Read off the object rather than gated on an instanceof check. Bedrock
+	// reports several failures as members of the stream's output union, and a
+	// deserialiser that hands one back as a plain shape would otherwise fall all
+	// the way through to "nothing was learned" while naming its own class.
+	const raw = (err as { name?: unknown } | null)?.name
+	const name = typeof raw === 'string' ? raw : ''
+	for (const [pattern, reason] of REASON_BY_EXCEPTION) {
+		if (pattern.test(name)) return reason
+	}
+
+	// A region that was never configured also never leaves the machine, and the
+	// AWS SDK reports it as a plain `Error`, so there is no class to match.
+	const message = err instanceof Error ? err.message : String(err)
+	if (/region is missing|missing region/i.test(message)) return 'no-credentials'
+
+	return 'unreachable-service'
+}
+
+/**
+ * Build the report for a failure.
+ *
+ * The vendor error's message is taken from `providerVendorError` rather than
+ * from `err.message`, and that is not stylistic. AWS builds an exception
+ * message from the response body, so a credential the service echoed back is
+ * already inside `err.message` before this code sees it; `providerVendorError`
+ * is the one place in this estate that strips it. The class name is read off
+ * the raw error first — a name is not a body — and then the raw error is
+ * dropped.
+ */
+export function reportForError(
+	err: unknown,
+	model: string,
+	durationMs: number,
+): BedrockHealthReport {
+	const reason = reasonForError(err)
+	const safe = providerVendorError({ providerId: 'bedrock', error: err })
+	return {
+		status: STATUS_BY_REASON[reason],
+		reason,
+		model,
+		message: safe.message,
+		...(REMEDIATION_BY_REASON[reason] ? { remediation: REMEDIATION_BY_REASON[reason] } : {}),
+		durationMs,
+	}
+}
+
+/** The report for a reason that needs no vendor error to describe it. */
+export function report(
+	reason: BedrockHealthReason,
+	message: string,
+	extra: { readonly model?: string; readonly durationMs?: number } = {},
+): BedrockHealthReport {
+	return {
+		status: STATUS_BY_REASON[reason],
+		reason,
+		message,
+		...(extra.model !== undefined ? { model: extra.model } : {}),
+		...(REMEDIATION_BY_REASON[reason] ? { remediation: REMEDIATION_BY_REASON[reason] } : {}),
+		...(extra.durationMs !== undefined ? { durationMs: extra.durationMs } : {}),
+	}
+}

--- a/packages/providers/bedrock/src/index.ts
+++ b/packages/providers/bedrock/src/index.ts
@@ -23,4 +23,5 @@ export function registerBedrock(options?: RegisterOptions): void {
 }
 
 export { BEDROCK_CAPABILITIES, BedrockProvider } from './client.js'
+export type { BedrockHealthReason, BedrockHealthReport } from './health.js'
 export type { BedrockConfig, BedrockProviderConfig } from './types.js'

--- a/packages/sdk/src/provider/__tests__/health-model-forwarding.test.ts
+++ b/packages/sdk/src/provider/__tests__/health-model-forwarding.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The model reaches the wrapped driver's health probe.
+ *
+ * `healthCheck` and `doctorCheck` carry the model the caller intends to run,
+ * because at least one driver's config does not hold one and so cannot probe
+ * without it. Both decorators rebuild the provider object as a literal, and a
+ * literal that spells the forwarded method `() => provider.healthCheck?.()`
+ * drops the argument silently: the call still happens, the wrapped driver still
+ * answers, and the answer is "there was nothing to check" — an unusable probe
+ * produced by wrapping alone, with no type error anywhere.
+ *
+ * So the wrappers are driven rather than read. Counting call sites in the
+ * source would not have caught it either way.
+ *
+ * The fallback cases use a TWO-member chain deliberately. A one-member chain is
+ * the identity — `withProviderFallback` returns the provider itself — so the
+ * first draft of these tests passed against a wrapper that dropped the model,
+ * because it never reached a wrapper at all. Mutation is what said so.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import type { ChatCompletionParams, LLMProvider, StreamChunk } from '../../types/provider/index.js'
+import { withProviderFallback } from '../fallback.js'
+import { withProviderRetry } from '../retry.js'
+
+/** A driver that answers only when it is told which model to probe. */
+function modelAwareProvider(): { provider: LLMProvider; asked: Array<string | undefined> } {
+	const asked: Array<string | undefined> = []
+	const provider: LLMProvider = {
+		id: 'probe',
+		name: 'Probe',
+		// biome-ignore lint/correctness/useYield: the stream is never iterated here
+		async *chatStream(_params: ChatCompletionParams): AsyncIterable<StreamChunk> {
+			throw new Error('chatStream is not the subject of these tests')
+		},
+		async healthCheck(model?: string) {
+			asked.push(model)
+			return model !== undefined
+		},
+		async doctorCheck(model?: string) {
+			asked.push(model)
+			return { status: model === undefined ? ('skipped' as const) : ('pass' as const) }
+		},
+	}
+	return { provider, asked }
+}
+
+/** A second chain member, so the decorator is a wrapper rather than identity. */
+function spareMember(): LLMProvider {
+	return {
+		id: 'spare',
+		name: 'Spare',
+		// biome-ignore lint/correctness/useYield: never reached
+		async *chatStream(_params: ChatCompletionParams): AsyncIterable<StreamChunk> {
+			throw new Error('the spare member is never asked anything')
+		},
+	}
+}
+
+describe('the retry decorator forwards the model', () => {
+	it('hands healthCheck the model it was called with', async () => {
+		const { provider, asked } = modelAwareProvider()
+
+		const wrapped = withProviderRetry(provider)
+
+		expect(await wrapped.healthCheck?.('us.anthropic.claude-sonnet-4-5-20250929-v1:0')).toBe(true)
+		expect(asked).toEqual(['us.anthropic.claude-sonnet-4-5-20250929-v1:0'])
+	})
+
+	it('hands doctorCheck the model it was called with', async () => {
+		const { provider, asked } = modelAwareProvider()
+
+		const wrapped = withProviderRetry(provider)
+		const result = await wrapped.doctorCheck?.('amazon.nova-pro-v1:0')
+
+		expect(result?.status).toBe('pass')
+		expect(asked).toEqual(['amazon.nova-pro-v1:0'])
+	})
+
+	it('still passes nothing through when the caller passed nothing', async () => {
+		const { provider, asked } = modelAwareProvider()
+
+		const wrapped = withProviderRetry(provider)
+
+		// The preservation half: a wrapper that invented a model would be as
+		// wrong as one that dropped it.
+		expect(await wrapped.healthCheck?.()).toBe(false)
+		expect(asked).toEqual([undefined])
+	})
+})
+
+describe('the fallback decorator forwards the model', () => {
+	it('hands healthCheck the model it was called with', async () => {
+		const { provider, asked } = modelAwareProvider()
+
+		const wrapped = withProviderFallback([
+			{ provider, model: 'primary' },
+			{ provider: spareMember(), model: 'spare' },
+		])
+
+		expect(await wrapped.healthCheck?.('amazon.nova-pro-v1:0')).toBe(true)
+		expect(asked).toEqual(['amazon.nova-pro-v1:0'])
+	})
+
+	it('hands doctorCheck the model it was called with', async () => {
+		const { provider, asked } = modelAwareProvider()
+
+		const wrapped = withProviderFallback([
+			{ provider, model: 'primary' },
+			{ provider: spareMember(), model: 'spare' },
+		])
+		const result = await wrapped.doctorCheck?.('us.anthropic.claude-haiku-4-5-20251001-v1:0')
+
+		expect(result?.status).toBe('pass')
+		expect(asked).toEqual(['us.anthropic.claude-haiku-4-5-20251001-v1:0'])
+	})
+
+	it('probes the chain HEAD, which is the member a request would reach first', async () => {
+		const { provider, asked } = modelAwareProvider()
+
+		const wrapped = withProviderFallback([
+			{ provider, model: 'primary' },
+			{ provider: spareMember(), model: 'spare' },
+		])
+		await wrapped.healthCheck?.('amazon.nova-pro-v1:0')
+
+		// One member asked, not two: the probe is not a survey of the chain.
+		expect(asked).toHaveLength(1)
+	})
+})

--- a/packages/sdk/src/provider/fallback.ts
+++ b/packages/sdk/src/provider/fallback.ts
@@ -382,7 +382,13 @@ export function withProviderFallback(
 		},
 		chatStream,
 		...(first.provider.listModels ? { listModels: () => first.provider.listModels?.() } : {}),
-		...(first.provider.healthCheck ? { healthCheck: () => first.provider.healthCheck?.() } : {}),
-		...(first.provider.doctorCheck ? { doctorCheck: () => first.provider.doctorCheck?.() } : {}),
+		// Forwarded for the reason `retry.ts` forwards it: a wrapper that drops
+		// the model turns a probe the caller could answer into one it cannot.
+		...(first.provider.healthCheck
+			? { healthCheck: (model?: string) => first.provider.healthCheck?.(model) }
+			: {}),
+		...(first.provider.doctorCheck
+			? { doctorCheck: (model?: string) => first.provider.doctorCheck?.(model) }
+			: {}),
 	} as LLMProvider
 }

--- a/packages/sdk/src/provider/retry.ts
+++ b/packages/sdk/src/provider/retry.ts
@@ -231,7 +231,15 @@ export function withProviderRetry(
 		},
 		chatStream,
 		...(provider.listModels ? { listModels: () => provider.listModels?.() } : {}),
-		...(provider.healthCheck ? { healthCheck: () => provider.healthCheck?.() } : {}),
-		...(provider.doctorCheck ? { doctorCheck: () => provider.doctorCheck?.() } : {}),
+		// The model is forwarded, not dropped. A wrapper that swallowed it would
+		// leave the wrapped driver probing whatever it probes with no argument
+		// — which for at least one driver is "nothing", so the check would come
+		// back unanswerable purely because it was wrapped.
+		...(provider.healthCheck
+			? { healthCheck: (model?: string) => provider.healthCheck?.(model) }
+			: {}),
+		...(provider.doctorCheck
+			? { doctorCheck: (model?: string) => provider.doctorCheck?.(model) }
+			: {}),
 	} as LLMProvider
 }

--- a/packages/sdk/src/types/provider/interface.ts
+++ b/packages/sdk/src/types/provider/interface.ts
@@ -73,7 +73,23 @@ export interface LLMProvider {
 	 */
 	probeCredential?(): Promise<void>
 
-	healthCheck?(): Promise<boolean>
+	/**
+	 * Is this driver able to serve traffic? A summary bit; `doctorCheck` is
+	 * the same probe with its reasoning intact.
+	 *
+	 * `model` is the model the CALLER intends to run, and it is a parameter
+	 * rather than something the driver reads off its own config because at
+	 * least one driver's config does not carry a model at all. That driver
+	 * hardcoded an id instead, which is how its check came to probe a model
+	 * nobody used — and, once the id went stale, could not pass at any
+	 * credential, region or service state. A health check against a model the
+	 * operator does not run tests the wrong thing even while the id is valid.
+	 *
+	 * Optional, and a driver may ignore it: one that probes an endpoint rather
+	 * than a model has nothing to do with the argument. Passing it is always
+	 * safe.
+	 */
+	healthCheck?(model?: string): Promise<boolean>
 
 	/**
 	 * Optional structured health probe used by `runDoctor()`.
@@ -82,8 +98,13 @@ export interface LLMProvider {
 	 * (latency, model availability, auth status, …). Providers that
 	 * cannot be cheaply probed should return `{ status: 'inconclusive' }`
 	 * so the doctor doesn't mark them as failing — see ses_007 Q6.4.
+	 *
+	 * Takes `model` for the reason `healthCheck` does, and a driver is free to
+	 * return a SUBTYPE of `DoctorCheckResult` carrying its own machine-readable
+	 * detail. `status` is what `runDoctor()` reads; a caller holding the
+	 * concrete driver can read more.
 	 */
-	doctorCheck?(): Promise<DoctorCheckResult>
+	doctorCheck?(model?: string): Promise<DoctorCheckResult>
 
 	/**
 	 * Which {@link ChatCompletionParams.effort} levels this model accepts,


### PR DESCRIPTION
Closes #392.

## The defect

`healthCheck()` hardcoded `anthropic.claude-haiku-4-20250514` — the exact unversioned form this driver's own `assertModelReachable` refuses. It built its `ConverseCommand` directly, so the predicate never ran locally: the service rejected the id, and `catch { return false }` reported that rejection as an outage.

So the check returned `false` with correct credentials, a correct region and a service that was entirely up, and nothing could tell that apart from a real failure. **A check that cannot pass carries no more information than one that cannot fail** — and this one carried none in the shape of an outage.

## What the check now distinguishes

`healthCheck(model)` keeps `Promise<boolean>`. Widening the return type would break every caller writing `if (await provider.healthCheck())` **silently**: the code keeps compiling and starts always passing, because a result object is truthy. The distinction goes on `doctorCheck(model)`, which the provider interface already declares for exactly this, returning a `DoctorCheckResult` subtype with a machine-readable `reason`:

| `reason` | `status` | What happened |
| --- | --- | --- |
| `ok` | `pass` | The model answered. |
| `no-model` | `skipped` | Nothing was probed — no model id was given. |
| `unreachable-model` | `fail` | This driver's own rule refuses the id. Nothing was sent. |
| `no-credentials` | `fail` | No credentials or region resolved. Never left the machine. |
| `credentials` | `fail` | AWS answered and rejected the credential or its permissions. |
| `unknown-model` | `fail` | Well-formed id, and this region serves no such model. |
| `refused` | `fail` | The service looked at the request and would not take it. |
| `throttled` | `warn` | Reached, authenticated, rate limited. The probe did not complete. |
| `service` | `fail` | The service answered and could not serve the request. |
| `unreachable-service` | `inconclusive` | Nothing was learned. Not an outage report. |

`inconclusive` is separate from `fail` on purpose: reporting a timeout as a failure tells an operator on broken wifi to rotate a credential that is fine.

## Two things a review should look at

**The model had to become a parameter on the shared interface.** `LLMProvider.healthCheck` and `doctorCheck` were declared no-argument, `ProviderRegistry.create()` hands back an `LLMProvider` rather than the concrete driver, and this driver's config carries no model. A `modelId` added only to `BedrockProvider` would have been a parameter nothing could pass — `declared-but-undriven` with extra steps. Both methods are widened (optional param on an already-optional method: no implementor and no call site changes), and `withProviderRetry` / `withProviderFallback` forward it.

**The probe uses `ConverseStream`, not `Converse`.** That is the command `chatStream` sends, and they are separate IAM actions (`bedrock:InvokeModelWithResponseStream` vs `bedrock:InvokeModel`). A probe on the other one can pass under a policy every real call fails under. It also reads the failures Bedrock reports as stream *events* after a 200, through the same helper the request path uses, so a handshake is not mistaken for an answer.

## The catalogue question is settled, from the vendor rather than from memory

The issue left open whether the ids are wrong or the predicate is too strict. **The predicate is right.**

- [Claude Haiku 4.5's model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-haiku-4-5.html) lists the **same model under two ids on two endpoints**: `anthropic.claude-haiku-4-5-20251001-v1:0` on `bedrock-runtime`, and the unversioned `anthropic.claude-haiku-4-5` on `bedrock-mantle`, at `https://bedrock-mantle.{region}.api.aws/anthropic/v1/messages`. The bare form is a real id *for the endpoint this driver does not speak* — which is precisely the claim `model-reachability.ts` makes, stated by the vendor in one table.
- [Claude Sonnet 4's card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4.html) gives the `bedrock-runtime` Model ID as `anthropic.claude-sonnet-4-20250514-v1:0`. The catalogue's `anthropic.claude-sonnet-4-20250514` is not a Bedrock id in any form.
- **There was never a "Claude Haiku 4."** The Haiku line goes 3.5 → 4.5 (launched 2025-10-16). The id that shipped here carried Sonnet 4's launch date on a model that never existed.

So `listModels()` now advertises the published `bedrock-runtime` ids, and `docs/providers/bedrock.md` uses one in its samples. A test asserts every advertised id survives `assertModelReachable`, which is the invariant that was broken.

Prices in that catalogue are display data — `resolveModelPricing` has no `bedrock` vendor, so no run is costed from them. The Haiku 4.5 rates are the reviewed ones from the SDK's own `rates.source.json`; AWS renders Bedrock's on-demand table client-side and it could not be read here, which the code comment says rather than implies.

## Tests

31 new bedrock tests and 6 in the SDK. The first one is `healthCheck` returning **`true`** against a healthy fake — an assertion the broken driver could not satisfy at any credential, region or service state, and the reason a test asserting `false` would have passed against it. The harness is the existing capture pattern from `cache-points.test.ts`: swap `provider.client`, assert what the AWS client was handed.

Mutation-checked in two rounds, profile in the session log. Round one: **10 of 11 killed**. The survivor is the finding — `withProviderFallback` returns the provider *itself* for a one-member chain, so both fallback tests were driving the raw provider and never reached a wrapper; they would have passed against a wrapper that dropped the model entirely. Rewritten with a two-member chain. Round two, written *against* round one and aimed at branches it never touched: **10 of 10 killed**, and four of the tests that kill them exist because that round was written to find gaps rather than to confirm the first.

The one branch neither round reached — the missing-region path, the only reason that comes off a message rather than an exception class — was then covered and mutated on its own.

## Gates

Every CI gate run separately and unpiped, reading each command's own exit code: `lint`, `typecheck`, `-r build`, `-r test`, `sdk test:proc`, `audit-external-names`, `generate-model-prices --check`, `check-publish-metadata`, `verify-public-surface` (560/1286 unchanged), `check-sdk-test-presence`, `sdk test:coverage` + module coverage, `check-docs` — all `0`.

`verify-consumer-install.sh` exits `1` on this Windows machine for an environmental reason and not a defect in this branch: it resolves `require("$WORKSPACE_ROOT/packages/sdk/package.json")` where `$WORKSPACE_ROOT` is an MSYS `/c/...` path Windows node cannot resolve. Proven by running the same `require` with the drive-letter path, which returns `25.0.0`. It fails in the `@namzu/telemetry` fixture, **after** every consumer-install assertion has passed including `@namzu/bedrock + @namzu/sdk` (`✅ Consumer install verified for all 9 SDK-dependent packages`). It will exercise properly on the Linux runner.

## Bump intent

`@namzu/bedrock` **minor**, `@namzu/sdk` **minor**. Nothing stops compiling: the added parameters are optional on already-optional methods, and `healthCheck`'s return type is unchanged. No working configuration changes behaviour, because there was no working configuration — the probe could not return `true`. Callers who copied a model id out of `listModels()` are given the ids that work, in the changeset.
