### PR TITLE
docs(agents): the worktree workflow is written down where the next agent stands

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -94,7 +94,46 @@ Cuts new versions of publishable packages via [Changesets](https://github.com/ch
    - Runs the pre-publish consumer-install check (`.github/scripts/verify-consumer-install.sh`) against the packed tarballs.
    - Invokes `pnpm changeset publish` — publishes every bumped package to npm with provenance, creates Git tags (`@namzu/<pkg>@<version>`), and GitHub Releases.
 
-6. Monitor `https://github.com/cogitave/namzu/actions` for the release run. **Confirm each published package appears on npm under its expected dist-tag by asking npm, not by reading the workflow's exit status** — `npm view <pkg> version` against the version in `package.json` on `main`. A release run can succeed without publishing: if it re-versions instead, it exits green and opens a PR. Green means the run did what it decided to do, not that a package shipped.
+6. **Watch the right run.** Pick it by head SHA, never by recency:
+
+   ```bash
+   git fetch origin main && git rev-parse origin/main
+   gh run list --workflow=release.yml --limit 5 \
+     --json headSha,databaseId,status,conclusion,url
+   ```
+
+   `gh run list --limit 1` immediately after a merge returns the **previous**
+   push's run — the run for your merge commit has not been created yet. That
+   older run then completes green, because it was always going to, and says
+   nothing about the merge you just made. Take the entry whose `headSha` equals
+   `origin/main`; if no entry carries it, the run does not exist yet. Wait for
+   it rather than reading the top row.
+
+7. **Confirm the publish against the registry, not against the run.** A release
+   run can succeed without publishing: if it re-versions instead, it exits green
+   and opens a PR. Green means the run did what it decided to do.
+
+   Ask the registry itself rather than a package manager holding a local
+   metadata cache — a cached answer after a real publish still names the old
+   version, which reads exactly like a failed release:
+
+   ```bash
+   curl -sS https://registry.npmjs.org/@namzu/sdk/latest \
+     | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.parse(s).version))"
+   ```
+
+   Compare against the version in `package.json` on `main`, per package.
+
+8. **Confirm the fix is inside the tarball, not just in the version number.** A
+   version can be published from a build that does not contain the change; the
+   number agreeing proves a publish happened, not what it shipped. Fetch what
+   the registry actually holds and look:
+
+   ```bash
+   npm pack @namzu/sdk@<version> --pack-destination .
+   tar -tzf namzu-sdk-<version>.tgz | head
+   tar -xzOf namzu-sdk-<version>.tgz package/dist/<file> | grep <the change>
+   ```
 </procedure_phase_2>
 
 ## Hard rules
@@ -105,6 +144,7 @@ Cuts new versions of publishable packages via [Changesets](https://github.com/ch
 - Never skip hooks (`--no-verify`, `--no-gpg-sign`) during a release commit.
 - Never merge a "Version Packages" PR if CI is red on it — the red gate is catching a real publish-time regression.
 - Never merge a "Version Packages" PR that does not consume every changeset on `main` (Phase 2, step 4). Its existence is not evidence of its currency.
+- Never report a release as shipped on the strength of a green run. A run selected by recency is usually the previous push's, and a green one may have re-versioned rather than published (Phase 2, steps 6-7).
 - Peer range widening / narrowing happens via Changesets config (`___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange`). Do not hand-edit peer ranges in `package.json` files unless the change is a policy decision being ratified in a session (e.g., the original `>=0.1.6 <1.0.0` policy set in ses_012).
 - NPM Trusted Publisher is configured via OIDC (provenance). Do not add an `NPM_TOKEN` secret unless switching to classic auth.
 </hard_rules>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,35 @@ pnpm build        # Build all packages
 
 Use `pnpm --filter <pkg>` to scope commands to a single package.
 
+<ci_gates>
+Those four are a **subset**. The `Build & Test` job in `.github/workflows/ci.yml` runs sixteen steps, in this order, and the branch is not green until every one passes.
+
+| CI step | Run it locally |
+|---|---|
+| Lint | `pnpm lint` |
+| Type check | `pnpm typecheck` |
+| Build | `pnpm -r build` |
+| Test | `pnpm -r test` |
+| Process-level regression tests | `pnpm --filter @namzu/sdk test:proc` |
+| External-name audit | `node scripts/audit-external-names.mjs` |
+| Model price catalogue matches its source | `node scripts/generate-model-prices.mjs --check` |
+| Installer parses as POSIX sh | `sh -n install.sh && dash -n install.sh` |
+| Evals | `node packages/cli/dist/bin.js eval --dir packages/evals --out eval-report.json` |
+| SDK coverage (produce summary) | `pnpm --filter @namzu/sdk test:coverage` |
+| SDK coverage floor gate | `node .github/scripts/check-sdk-module-coverage.mjs` |
+| SDK test-presence gate | `node .github/scripts/check-sdk-test-presence.mjs` |
+| Publish-metadata gate | `node .github/scripts/check-publish-metadata.mjs` |
+| Pre-publish consumer install check | `bash .github/scripts/verify-consumer-install.sh` |
+| Public-surface regression check | `node .github/scripts/verify-public-surface.mjs` |
+| publint (package.json shape) | `npx -y publint@latest packages/<pkg>` |
+
+Eight of those carry `if: matrix.gates` and so run on one matrix leg only. Locally there is no leg, so run all sixteen.
+
+A **second job**, `Docs`, runs `node tools/check-docs.mjs` (= `pnpm docs:check`) on a full-history checkout. Its drift check compares a document's last commit against its `resource:`'s, which `git log` cannot answer on a shallow clone, so the gate refuses one rather than passing.
+
+**Why the short list is not enough.** A job stops at its first failing step, and every step after it is reported `skipped`, not `failure`. A red run therefore shows one red entry and a column of grey — and grey is not "these passed", it is "these were never asked". The four commands at the top of this section are the first four rows of that table: green on them establishes four of the sixteen steps and nothing whatsoever about the other twelve.
+</ci_gates>
+
 ## Where to find things
 
 This file is a **router**, not a rulebook. Detail lives in the folders below; read their `README.md` before drilling deeper.
@@ -76,6 +105,18 @@ This file is a **router**, not a rulebook. Detail lives in the folders below; re
   <runtime_state path=".namzu/">
     The repo's own dogfooding runtime state (threads, sessions, runs). Do not edit by hand.
   </runtime_state>
+
+  <worktrees path="(agent checkouts — the worktrees directory under the harness config)">
+    Path: `.claude/worktrees/<name>`, written here in a code span because the audit forbids that directory's name in bare prose. Most work in this repo now happens in one, and the directory is **gitignored** — a nested checkout committed as a gitlink is not clonable. So a worktree is a whole second copy of the tree carrying its own untracked state, and three things follow that have each cost a diagnosis.
+
+    **`.work/` is per-worktree. It is not shared and it does not travel with the branch.** Being gitignored is exactly why: a freshly added worktree has no `.work/` at all, and each existing one lists a different set of sessions in its own `.work/sessions/README.md`. The `pre-commit` hook resolves that index relative to the current working directory, so it gates on the sessions listed in **this** worktree — a session opened here is invisible to the shared checkout and to every sibling. Open your session where you are working; do not go looking for it elsewhere.
+
+    **A fresh worktree is not a working checkout until `pnpm install && pnpm -r build` has run in it.** Several gates read build output rather than source, and they name the source when they fail. Run `node .github/scripts/check-publish-metadata.mjs` in an unbuilt worktree and it reports, for thirteen of the fourteen publishable packages, that the package "would publish without its `main` (dist/index.js)". That is not a manifest defect: the script packs each package and asserts the declared entry point is in the tarball, and there is no `dist/` yet. The `Evals` gate fails the same way, because it invokes `packages/cli/dist/bin.js`.
+
+    **A lint finding is not evidence your branch caused it.** `pnpm lint` is `pnpm -r lint`, and each package's script is `biome check src/` — the package's whole source tree, never your diff. A worktree branched from an older `origin/main` therefore reports whatever was there at that commit. Check `git diff --name-only origin/main...HEAD` before you accept a hit as yours, and never reformat a file your branch did not change in order to make a gate pass.
+
+    `scripts/audit-external-names.mjs` skips this directory by path, so running it from the shared checkout never audits a worktree; run it from inside your worktree to audit the tree you are actually changing.
+  </worktrees>
 </routing>
 
 ## Documentation standard
@@ -97,7 +138,7 @@ The gate is authoritative only inside the directories listed in its `CONFORMING`
 2. Before a non-trivial change → read the relevant conventions.
 3. After drafting a plan → run an adversarial second-opinion check (see `codex-check` skill).
 4. **Every commit while an in-progress session exists** → `progress.md` entry is written **synchronously with the commit**, not as a follow-up. `.work/` is gitignored, so the entry does not enter the commit itself — it lives on local disk, and the discipline is that the working-tree update happens before `git commit` runs. This is non-negotiable — the log is what makes a fresh agent able to pick up after `/clear`, and a six-commit gap has happened before. An entry is one line minimum: `- <hash> <subject> — what/why` (hash filled post-commit); add a `**Deviation:**` line if the commit diverges from the ratified plan. See skill: `commit`.
-5. After implementation → `pnpm typecheck && pnpm lint && pnpm test` must all pass.
+5. After implementation → `pnpm typecheck && pnpm lint && pnpm test` must all pass. That trio is three of the sixteen steps CI runs, not the gate — before pushing, work the `<ci_gates>` table under **Build & Test**.
 6. Commit touches public surface (exported types, wire schema, CLI flags, API routes)? → **queue a `**Docs debt:**` line in the touching commit's `progress.md` entry**; the debt is cleared by running the `update-docs` skill before `freeze-session`. Queuing is mandatory per commit; actually writing `docs/` pages can batch at freeze time.
 7. Decisions turning final → freeze the session; extract stable rules into `docs/conventions/`, written to the documentation standard above.
 </flow>
@@ -124,6 +165,10 @@ Releases are driven by [Changesets](https://github.com/changesets/changesets). E
 - **Changing a default** ⇒ `major`, and the changeset names the value that changed and what a caller does to keep the old behaviour.
 
 A changeset body is read by a stranger deciding whether to take the upgrade. Name what breaks and what to do about it, not what the work was.
+
+**A version PR is a snapshot, and merging a stale one spends a version number on nothing.** Before merging `chore(release): version packages`, every changeset file present on `main` must appear in that PR's deleted files. One missing means the PR was computed before that changeset landed; merge it and the publish step sees pending changesets, opens a fresh version PR instead of publishing, and the bump it already wrote to the CHANGELOG reaches no registry. Its existence is not evidence of its currency — check what it consumes.
+
+**A green release run is not a publish, and a version number is not the fix.** Confirming a release means asking the registry, and picking the right run to watch in the first place. Both procedures, with the commands, are in skill: `release` (Phase 2, steps 4 and 6).
 </releases>
 
 <workflow_safety>


### PR DESCRIPTION
`AGENTS.md` is the router every agent reads before it reads anything else, and it said nothing about git worktrees — even though nearly all work in this repo now happens in one, and there are dozens of them. Six things learned the hard way, each costing real time every time it is rediscovered, now have a written home.

Each item is placed where the person who needs it will actually be standing, which splits them across two files.

## `AGENTS.md` — `<worktrees>` block in `<routing>`

1. **`.work/` is per-worktree, not shared.** Being gitignored is exactly why it does not travel with the branch: a freshly added worktree has none at all, and each existing one lists a different set of sessions in its own `.work/sessions/README.md`. The `pre-commit` hook resolves that index relative to the working directory, so it gates on the sessions listed in *this* worktree. Verified by comparing the shared checkout against two agent worktrees — three disjoint session sets.

2. **A fresh worktree is not a working checkout until `pnpm install && pnpm -r build` has run in it.** Symptom and cause stated together, because the error names the manifest and the cause is the build: `node .github/scripts/check-publish-metadata.mjs` in an unbuilt worktree reports that thirteen of the fourteen publishable packages "would publish without its `main` (dist/index.js)". Measured, not recalled — the script packs each package and asserts the declared entry point is in the tarball, and there is no `dist/` yet. `Evals` fails the same way on `packages/cli/dist/bin.js`.

3. **A lint finding is not evidence your branch caused it.** `pnpm lint` is `pnpm -r lint`, and each package's script is `biome check src/` over the package's whole source tree, never your diff. Check `git diff --name-only origin/main...HEAD` before accepting a hit, and never reformat a file your branch did not change to make a gate pass.

## `AGENTS.md` — `<ci_gates>` under Build & Test

4. **The full gate list.** That section listed four commands and nothing else. CI's `Build & Test` job runs **sixteen** steps, plus a separate `Docs` job on a full-history checkout. The table gives each step with the local command, enumerated from `.github/workflows/ci.yml`. Eight of the sixteen carry `if: matrix.gates` and run on one matrix leg only; locally there is no leg, so all sixteen apply.

   Why the short list is not enough: a job stops at its first failing step and reports every later step `skipped`, not `failure`. A red run therefore shows one red entry and a column of grey — and grey is not "these passed", it is "these were never asked".

## `.claude/skills/release/SKILL.md`

5. **Release-PR staleness — already present, left alone.** Phase 2 step 4 and a matching hard rule already state the mechanical form ("every changeset on `main` must appear in the PR's diff"), with the burned `4.4.0` as the worked example. Nothing to add there, so `AGENTS.md` `<releases>` gets a short pointer instead of a restatement.

6. **Verifying a publish — new steps 6-8.** The old step 6 said "ask npm, not the exit status" and the two traps were hit anyway, so they are now explicit:
   - Pick the run whose `headSha` equals `origin/main`. Right after a merge, the newest run is the *previous* push's; it completes green and reports nothing about your merge.
   - Ask the registry rather than a package manager holding a local metadata cache, which after a real publish can still name the old version — indistinguishable from a failed release.
   - Then open the tarball. A version number agreeing proves a publish happened, not what it shipped.

   Both commands were run against the live registry before being written down.

## Deviation from the brief

Item 3 was briefed as: Biome is a caret range, so worktrees installed at different times resolve different versions and report different findings. Measured rather than repeated, and **not established**:

- Root `package.json` does carry `"@biomejs/biome": "^1.9.0"`.
- `pnpm-lock.yaml` resolves `@biomejs/biome@1.9.4`, and `pnpm install` honours the lockfile.
- All 22 installed checkouts on this machine — the shared checkout plus 21 worktrees — report 1.9.4. Zero divergence.

So the version-drift mechanism is dropped. The practical rule the brief wanted survives on a mechanism that does hold: lint is workspace-wide, so a finding was never scoped to your diff in the first place.

## Notes

- **No changeset.** `AGENTS.md` and a skill file only; neither is a publishable package and Changesets versions nothing outside `packages/`.
- **Not `CLAUDE.md`.** None of this is specific to one agent, and that file holds only agent-specific guidance on top of its import of `AGENTS.md`.
- `node scripts/audit-external-names.mjs` — pass. It initially flagged the new block's `path=` attribute, since the agent-worktrees directory is named after a product on the forbidden list; the path now sits in a code span, which is the form the audit sanctions, and the block says why.
- `node tools/check-docs.mjs` — pass (0 problems across 16 files). Neither touched file is inside the gate's `CONFORMING` directories, so no frontmatter applies.
