### PR TITLE
fix(sdk): the Agent tool bounds a delegated run by the hour, like its twin

### DIFF
--- a/.changeset/agent-tool-gets-the-delegation-deadline.md
+++ b/.changeset/agent-tool-gets-the-delegation-deadline.md
@@ -1,0 +1,13 @@
+---
+'@namzu/sdk': patch
+---
+
+The `Agent` tool now bounds a delegated run by the hour, like its twin
+
+`buildAgentTool` declared no `timeoutMs`, and declaring nothing is not "no deadline" — it is the executor's `DEFAULT_TOOL_TIMEOUT_MS`, 120 seconds. That is a reasonable bound for a tool call and an absurd one for a call that runs an entire agent to completion and blocks on it.
+
+Its twin `create_task`, built by `buildCoordinatorTools` in the sibling module, has declared `DELEGATION_TIMEOUT_MS` (one hour) all along, and the measurement behind that number is recorded in its docblock: three delegated children took 4m21s, 5m58s and 8m04s, and all three parents gave up at 120 seconds. That fix reached one of the two delegation surfaces and never carried to the other.
+
+**What changes for you.** A delegated run through the `Agent` tool that takes longer than two minutes now completes instead of being abandoned. If you were relying on the 120-second bound to catch a wedged child, note that the run budget and the iteration ceiling both still apply above this, and a wedged child is still caught — an hour later rather than two minutes later.
+
+The two tools are now asserted to agree, so a future change to one deadline fails until it moves the other. That is the assertion, rather than each tool's number separately: drifting apart is the defect, and two independent assertions pass while it happens.

--- a/packages/sdk/src/tools/coordinator/__tests__/both-delegation-tools-get-the-same-deadline.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/both-delegation-tools-get-the-same-deadline.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_TOOL_TIMEOUT_MS } from '../../../runtime/query/executor.js'
+import { buildAgentTool } from '../agent.js'
+import { buildCoordinatorTools, DELEGATION_TIMEOUT_MS } from '../index.js'
+
+/**
+ * Two tools delegate a whole agent run and block on it. One declared a
+ * deadline and the other declared nothing, which is not "no deadline" — it
+ * is the executor's 120-second default, a sensible bound for a tool call
+ * and an absurd one for an agent.
+ *
+ * The measurement is in `DELEGATION_TIMEOUT_MS`'s own docblock: three
+ * delegated children took 4m21s, 5m58s and 8m04s, and all three parents
+ * gave up at 120s. That fix reached one of the two surfaces.
+ *
+ * These tests are about the pair, not about a number. A test asserting
+ * each tool's timeout separately passes while they drift apart, and
+ * drifting apart is the defect.
+ */
+
+function agentTool() {
+	return buildAgentTool({
+		allowedAgentIds: ['researcher'],
+		gateway: {} as never,
+		workingDirectory: '/tmp',
+	})
+}
+
+function createTaskTool() {
+	const tools = buildCoordinatorTools({
+		allowedAgentIds: ['researcher'],
+		gateway: {} as never,
+		workingDirectory: '/tmp',
+	})
+	const found = tools.find((t) => t.name === 'create_task')
+	if (!found) throw new Error('create_task not built; this test is aimed at the wrong tool')
+	return found
+}
+
+describe('the two delegation tools', () => {
+	it('agree on how long a delegated run may take', () => {
+		// The pair is the assertion. Whichever way a future change moves one
+		// deadline, this fails unless it moves the other — which is exactly
+		// what did not happen the first time.
+		expect(agentTool().timeoutMs).toBe(createTaskTool().timeoutMs)
+	})
+
+	it('bound a delegated run by the hour rather than by the tool-call default', () => {
+		// Asserted against the executor default rather than against
+		// `DELEGATION_TIMEOUT_MS` alone: a test that only compares the tool to
+		// the constant it was built from still passes if the tool declares
+		// nothing and something else supplies the same number.
+		expect(agentTool().timeoutMs).toBe(DELEGATION_TIMEOUT_MS)
+		expect(agentTool().timeoutMs).toBeGreaterThan(DEFAULT_TOOL_TIMEOUT_MS)
+	})
+
+	it('declares a deadline at all, which is the thing that was missing', () => {
+		// `undefined` here is the original bug, and it is invisible in any
+		// assertion phrased as "is not too small" — undefined is not a number
+		// and does not fail a comparison, it fails the comparison's premise.
+		expect(agentTool().timeoutMs).toBeTypeOf('number')
+	})
+})

--- a/packages/sdk/src/tools/coordinator/agent.ts
+++ b/packages/sdk/src/tools/coordinator/agent.ts
@@ -7,6 +7,7 @@ import { defineTool } from '../defineTool.js'
 import { wrapUntrusted } from '../untrusted-envelope.js'
 import { failureLabel, taskSucceeded } from './outcome.js'
 
+import { DELEGATION_TIMEOUT_MS } from './index.js'
 import type { TaskLaunchedCallback } from './index.js'
 
 /**
@@ -107,6 +108,17 @@ export function buildAgentTool(opts: AgentToolOptions): ToolDefinition {
 		readOnly: false,
 		destructive: false,
 		concurrencySafe: true,
+		// Declaring nothing here does not mean "no deadline"; it means the
+		// executor's 120-second default, which is a bound for a tool call and
+		// absurd for a whole agent run. `create_task` in the sibling module
+		// carries the same reasoning and the same hour, and the measurement
+		// behind that number is in its docblock: three delegated children took
+		// 4m21s, 5m58s and 8m04s, and all three parents gave up at 120s.
+		//
+		// This surface did not get that fix when its twin did, and the file's
+		// own note above records the pair doing exactly this before. The two
+		// tools are twins; a bound applied to one of them is not applied.
+		timeoutMs: DELEGATION_TIMEOUT_MS,
 		...(opts.terminal !== undefined ? { terminal: opts.terminal } : {}),
 		async execute({ description, prompt, subagent_type }, context) {
 			// With a single registered subagent the type is optional — default to


### PR DESCRIPTION
A live bug on the exported surface, found while establishing something else.

`buildAgentTool` declared no `timeoutMs`. Declaring nothing is not "no deadline" — `runtime/query/executor.ts` resolves the tool's own value, then the run-level default, then `DEFAULT_TOOL_TIMEOUT_MS`, which is **120 seconds**. That is a sensible bound for a tool call and an absurd one for a call that runs an entire agent to completion and blocks on it.

## The twin already had the fix

`create_task`, built by `buildCoordinatorTools` in the sibling module, has declared `DELEGATION_TIMEOUT_MS` — one hour — all along. The measurement behind that number is in the constant's own docblock: three delegated children took **4m21s, 5m58s and 8m04s, and all three parents gave up at 120 seconds**.

So this is not a missing bound that nobody had thought about. It is a bound that was designed, measured, argued and shipped — to one of two surfaces that do the same thing.

`agent.ts` already records this pair doing exactly that once before, in the docblock about the roster fallback: *"shipping the closed reading in one delegation surface while leaving it open in the exported one is exactly that oversight."* Same pair, same shape, second occurrence. `docs/conventions/one-site-is-not-every-site.md` is the ratified rule.

## The test asserts the pair, not the number

This is the part worth reviewing. Two assertions that each tool declares an hour **both pass while the two drift apart**, and drifting apart is the defect. So the first test asserts the two tools agree with each other — whichever way a future change moves one deadline, it fails until the other moves too.

The other two cover traps that a single equality would leave open:

- **Asserted against the executor default, not only against `DELEGATION_TIMEOUT_MS`.** A test comparing the tool to the constant it was built from still passes if the tool declares nothing and something else happens to supply the same number.
- **Asserted that the field is a number at all.** `undefined` is the original bug and it is invisible to any assertion phrased as "is not too small" — `undefined` does not fail a `toBeGreaterThan`, it fails that comparison's premise.

## Verification

Mutation: removing the declaration fails all three tests. Coordinator suite 142 passed. Typecheck, external-name audit, public-surface (1286/1286 declared, 560/560 runtime), docs gate, test-presence gate all green.

Lint reports pre-existing findings in `packages/sdk` files this branch does not touch — checked against `git diff --name-only origin/main...HEAD`, none are in the two files changed here. That check is now written into `AGENTS.md`.

## Bump

`patch`. No exported type changes and no signature changes; a delegated run that used to be abandoned at two minutes now completes. If you were relying on the 120-second bound to catch a wedged child, it is still caught — an hour later — and the run budget and iteration ceiling both still apply above it.

## Not in this change

`buildAgentTool` is exported, undocumented, and shares the tool name `Agent` with a differently-shaped tool the CLI builds for itself. Both are real and both are separate: the first is a docs gap, the second a design hazard for a model that learned one and meets the other. Neither belongs in a one-line deadline fix.
