### PR TITLE
fix(sandbox): the package description no longer claims an authentication the proxy lacks

### DIFF
--- a/.changeset/the-package-description-is-true.md
+++ b/.changeset/the-package-description-is-true.md
@@ -1,0 +1,13 @@
+---
+'@namzu/sandbox': patch
+---
+
+The package description no longer claims an authentication this proxy does not have
+
+`package.json#description` described the container tier as an "HTTP worker + JWT-authenticated egress proxy". The egress proxy has no inbound authentication of any kind — no token, no JWT, no check. The only occurrence of `proxy-authorization` in `src/egress/proxy.ts` is in the list of hop-by-hop headers it deletes, so the header a client would authenticate with is explicitly stripped.
+
+This mattered more than an ordinary comment would, because a package description is the text on the registry page — where somebody decides whether this package is safe to depend on, before they have any source to read.
+
+The description now says what the proxy actually is: loopback-bound, deciding by resolved address rather than by hostname, and brokering outbound credentials so a token never enters the sandbox. Those are the controls it has, and they are the ones worth knowing about.
+
+No behaviour changes.

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@namzu/sandbox",
   "version": "3.0.0",
-  "description": "Pluggable sandbox provider for @namzu/sdk. Process-level isolation (bubblewrap on Linux, Seatbelt on macOS, via @anthropic-ai/sandbox-runtime) for developer dev loops; container-level isolation (HTTP worker + JWT-authenticated egress proxy) for multi-tenant production. Backend selected at construction time; the SDK consumes both through the same SandboxProvider interface.",
+  "description": "Pluggable sandbox provider for @namzu/sdk. Process-level isolation (bubblewrap on Linux, Seatbelt on macOS, via @anthropic-ai/sandbox-runtime) for developer dev loops; container-level isolation (HTTP worker + a loopback-bound egress proxy that allows by resolved address and brokers outbound credentials so they never enter the sandbox) for multi-tenant production. Backend selected at construction time; the SDK consumes both through the same SandboxProvider interface.",
   "license": "FSL-1.1-MIT",
   "type": "module",
   "homepage": "https://github.com/cogitave/namzu#readme",


### PR DESCRIPTION
`package.json#description` advertised the container tier as an "HTTP worker + JWT-authenticated egress proxy".

The proxy has no inbound authentication of any kind. The only occurrence of `proxy-authorization` in `src/egress/proxy.ts" is in the list of hop-by-hop headers it deletes — so the header a client would authenticate with is not merely unchecked, it is explicitly stripped.

## Why this one is worse than an ordinary false comment

A package description is the text on the registry page. It is read by somebody deciding whether this package is safe to depend on, **before they have any source in front of them to check it against**. Every other false claim we have corrected this week sat next to the code that contradicted it; this one sits where nobody can.

## What it says now

The controls the proxy actually has, which are worth knowing: loopback-bound, deciding by **resolved address** rather than by hostname, and brokering outbound credentials so a token never enters the sandbox.

Deleting the clause and saying nothing was the other option and is worse — a reader who saw the old text needs to know the control is absent, not be left with no statement either way.

No behaviour changes. Bump `patch`.

Gates: external-name audit, publish-metadata (14 packages, after `pnpm --filter @namzu/sandbox build` — it reads a build artifact), public-surface, typecheck. Found while reviewing an audit finding that placed this claim in `SECURITY.md`; it is not there, it is here.