### PR TITLE
fix(sdk): a plan the model serialized is still a plan, not markup

### DIFF
--- a/.changeset/plan-steps-are-not-markup.md
+++ b/.changeset/plan-steps-are-not-markup.md
@@ -1,0 +1,27 @@
+---
+'@namzu/sdk': minor
+---
+
+`approve_plan` now advertises a closed model-facing input schema, and its
+string fallback stops turning markup into steps.
+
+A model that serialises `steps` instead of building it tends to reach for
+XML. The fallback split that string on newlines, so `<steps>`, `<step>` and
+`</step>` each became a step — and a host numbered them in its approval card
+and asked a person to approve `</steps>`. Observed on a real run.
+
+Two changes, in the order they matter:
+
+- `modelInputSchema` + `enforceModelInput`, the same instrument
+  `ask_user_question` already carries for the same failure. A capable
+  provider now constrains generation to the closed shape, so the array is
+  not serialised in the first place. The schema stays inside the strict
+  subset (`assertStrictSchema` is what would refuse it).
+- The fallback reads the `<description>` blocks the model named when there
+  are any, drops tag-only lines when there are not, and yields no steps at
+  all for a string carrying no words — rather than inventing one that reads
+  `<steps>`.
+
+Nothing to do on upgrade. A host that renders `plan.steps` verbatim gets
+sentences where it used to get fragments; a host that already worked around
+this can drop the workaround.

--- a/packages/sdk/src/tools/coordinator/__tests__/an-approver-is-never-asked-to-approve-markup.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/an-approver-is-never-asked-to-approve-markup.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+
+import type { TaskGateway } from '../../../types/agent/gateway.js'
+import { buildCoordinatorTools } from '../index.js'
+
+/**
+ * A model that serializes `steps` instead of building it tends to reach
+ * for markup. Split on newlines, that string became one "step" per LINE —
+ * so a host numbered `<step>`, `</step>` and `</steps>` in its approval
+ * card and asked a person to approve them. Reported from a real run.
+ *
+ * The parse is checked here through the tool's own input schema, which is
+ * where the preprocess actually runs.
+ */
+const SERIALIZED_AS_XML = `<steps>
+<step>
+<description>Write a test document covering the plan, the cases and the scenarios</description>
+</step>
+<step>
+<description>Convert it to Word and save it under outputs/</description>
+</step>
+<step>
+<description>Verify the file that was produced</description>
+</step>
+</steps>`
+
+function unusedGateway(): TaskGateway {
+	return {
+		async createTask() {
+			throw new Error('not used')
+		},
+		async waitForTask() {
+			throw new Error('not used')
+		},
+		async continueTask() {},
+		cancelTask() {},
+		getTask() {
+			return undefined
+		},
+		listTasks() {
+			return []
+		},
+		onTaskCompleted() {
+			return () => {}
+		},
+	}
+}
+
+function approvePlanTool() {
+	const tools = buildCoordinatorTools({
+		gateway: unusedGateway(),
+		workingDirectory: '/tmp/test',
+		allowedAgentIds: ['sales-strategy'],
+		getPlanManager: () => undefined,
+	})
+	const tool = tools.find((candidate) => candidate.name === 'approve_plan')
+	if (!tool) throw new Error('approve_plan tool missing from coordinator builder')
+	return tool
+}
+
+function parseSteps(steps: unknown): Array<{ description: string }> {
+	const parsed = approvePlanTool().inputSchema.parse({
+		title: 'Produce a test document',
+		summary: 'Draft it, convert it, verify it.',
+		steps,
+	}) as { steps: Array<{ description: string }> }
+	return parsed.steps
+}
+
+describe('an approver is never asked to approve markup', () => {
+	it('reads the descriptions out of a step list serialized as XML', () => {
+		expect(parseSteps(SERIALIZED_AS_XML).map((step) => step.description)).toEqual([
+			'Write a test document covering the plan, the cases and the scenarios',
+			'Convert it to Word and save it under outputs/',
+			'Verify the file that was produced',
+		])
+	})
+
+	it('drops the tag-only lines of a list it has to read line by line', () => {
+		expect(parseSteps('<step>\nDraft the brief\n</step>').map((step) => step.description)).toEqual([
+			'Draft the brief',
+		])
+	})
+
+	it('yields no steps at all for a string that carries no words', () => {
+		expect(parseSteps('<steps>\n</steps>')).toEqual([])
+	})
+
+	it('still reads a plain numbered list, and a JSON array', () => {
+		expect(parseSteps('1. Draft the brief\n2. Send it').map((step) => step.description)).toEqual([
+			'Draft the brief',
+			'Send it',
+		])
+		expect(parseSteps('[{"description":"Draft the brief"}]')).toEqual([
+			{ description: 'Draft the brief' },
+		])
+	})
+
+	it('leaves a step that merely mentions a tag alone', () => {
+		expect(parseSteps('Wrap the table in a <div> and re-render')).toEqual([
+			{ description: 'Wrap the table in a <div> and re-render' },
+		])
+	})
+
+	it('advertises the closed shape so a capable provider refuses the string outright', () => {
+		// Surviving the serialization is not the same as preventing it: the
+		// normalizer can only guess at a structure the model already threw
+		// away. `ask_user_question` carries the same instrument for the same
+		// failure.
+		const tool = approvePlanTool()
+		expect(tool.enforceModelInput).toBe(true)
+		const schema = tool.modelInputSchema as {
+			additionalProperties: boolean
+			properties: { steps: { type: string; items: { additionalProperties: boolean } } }
+		}
+		expect(schema.additionalProperties).toBe(false)
+		expect(schema.properties.steps.type).toBe('array')
+		expect(schema.properties.steps.items.additionalProperties).toBe(false)
+	})
+})

--- a/packages/sdk/src/tools/coordinator/__tests__/an-approver-is-never-asked-to-approve-markup.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/an-approver-is-never-asked-to-approve-markup.test.ts
@@ -102,6 +102,26 @@ describe('an approver is never asked to approve markup', () => {
 		])
 	})
 
+	it('drops a line whose tags only look like content after one pass', () => {
+		// Removing a tag can splice its neighbours into a new one:
+		// `<<step>step>` loses the inner `<step>` and closes back up into
+		// `<step>`. A single pass therefore reports "something is left" for a
+		// line that is nothing but markup, and the approver is shown it.
+		//
+		// Raised by the static analyser as incomplete multi-character
+		// sanitization, which is the same defect under a security name.
+		expect(parseSteps('<<step>step>')).toEqual([])
+		expect(parseSteps('<steps>\n<<step>step>\n</steps>')).toEqual([])
+	})
+
+	it('still keeps the content when the doubled tag has words around it', () => {
+		// The fixed point must not eat the sentence — the failure mode of
+		// over-correcting here is silently deleting a real step.
+		expect(parseSteps('<<div>div>Render the summary')).toEqual([
+			{ description: '<<div>div>Render the summary' },
+		])
+	})
+
 	it('advertises the closed shape so a capable provider refuses the string outright', () => {
 		// Surviving the serialization is not the same as preventing it: the
 		// normalizer can only guess at a structure the model already threw

--- a/packages/sdk/src/tools/coordinator/index.ts
+++ b/packages/sdk/src/tools/coordinator/index.ts
@@ -157,6 +157,46 @@ const askUserQuestionModelInputSchema: Record<string, unknown> = {
 	additionalProperties: false,
 }
 
+/** One well-formed tag token: `<step>`, `</step>`, `<a href="…">`, `<br/>`. */
+const TAG_TOKEN = /<\/?[A-Za-z][\w-]*(?:\s[^<>]*)?\/?>/g
+const DESCRIPTION_BLOCK = /<description>([\s\S]*?)<\/description>/gi
+
+/**
+ * Peel tag wrappers off the ENDS of one line, and nowhere else — a step
+ * that legitimately says "wrap it in a <div>" keeps its sentence.
+ */
+function unwrapStepLine(line: string): string {
+	let text = line.trim()
+	for (;;) {
+		const next = text
+			.replace(/^<[A-Za-z][\w-]*(?:\s[^<>]*)?>\s*/, '')
+			.replace(/\s*<\/[A-Za-z][\w-]*>$/, '')
+			.trim()
+		if (next === text) break
+		text = next
+	}
+	return text
+}
+
+/**
+ * A step list the model serialized instead of building.
+ *
+ * The line-splitting fallback below is the general case, and it had one
+ * shape badly wrong. A model that serializes this array tends to reach for
+ * MARKUP, not for prose:
+ *
+ *     <steps>
+ *     <step>
+ *     <description>Convert the document to Word</description>
+ *     </step>
+ *     </steps>
+ *
+ * Split on newlines, that is seven "steps", five of which are tags. A host
+ * then numbered them in an approval card and asked a person to approve
+ * `</steps>` — reported from a real run. The descriptions the model named
+ * are right there, so read them; fall back to lines only when there are
+ * none, and drop the lines that carry no words at all.
+ */
 function normalizeApprovePlanSteps(value: unknown): unknown {
 	if (typeof value !== 'string') return value
 
@@ -171,19 +211,84 @@ function normalizeApprovePlanSteps(value: unknown): unknown {
 		}
 	}
 
+	const described = [...trimmed.matchAll(DESCRIPTION_BLOCK)]
+		.map((match) => (match[1] ?? '').trim())
+		.filter(Boolean)
+	if (described.length > 0) {
+		return described.map((description) => ({ description }))
+	}
+
 	const lines = trimmed
 		.split(/\r?\n+/)
 		.map((line) =>
-			line
-				.trim()
-				.replace(/^(?:[-*•]|\d+[.)])\s*/, '')
-				.trim(),
+			unwrapStepLine(
+				line
+					.trim()
+					.replace(/^(?:[-*•]|\d+[.)])\s*/, '')
+					.trim(),
+			),
 		)
-		.filter(Boolean)
+		.filter((line) => line.length > 0 && line.replace(TAG_TOKEN, '').trim().length > 0)
 
-	return (lines.length ? lines : [trimmed]).map((description) => ({
-		description,
-	}))
+	// Every line was markup: there is no plan in this string, and inventing
+	// one step reading `<steps>` is worse than saying so.
+	if (lines.length === 0) {
+		return unwrapStepLine(trimmed).replace(TAG_TOKEN, '').trim()
+			? [{ description: unwrapStepLine(trimmed) }]
+			: []
+	}
+
+	return lines.map((description) => ({ description }))
+}
+
+/**
+ * The single closed shape a capable provider constrains this call to —
+ * the same instrument `ask_user_question` carries, for the same failure.
+ *
+ * `steps` arriving as a STRING is what everything above exists to survive,
+ * and surviving it is not the same as preventing it: the normalizer can
+ * only guess at a structure the model already threw away. Advertising the
+ * closed shape turns the guess into a refusal at generation time.
+ */
+const approvePlanModelInputSchema: Record<string, unknown> = {
+	type: 'object',
+	properties: {
+		title: {
+			type: 'string',
+			description: 'Short title for the plan (e.g. "TypeScript Security & Performance Review").',
+		},
+		summary: {
+			type: 'string',
+			description: '1-3 sentence summary of what you plan to do.',
+		},
+		steps: {
+			type: 'array',
+			description:
+				'A JSON array of ordered step objects. Never a string, and never markup — no <step> or <description> tags.',
+			items: {
+				type: 'object',
+				properties: {
+					description: {
+						type: 'string',
+						description: 'What this step does, as one plain sentence a person can read.',
+					},
+					agent_id: {
+						type: 'string',
+						description: 'Which agent handles this; omit for steps you carry out yourself.',
+					},
+					depends_on: {
+						type: 'array',
+						items: { type: 'string' },
+						description: 'Descriptions of the steps that must finish before this one.',
+					},
+				},
+				required: ['description'],
+				additionalProperties: false,
+			},
+		},
+	},
+	required: ['title', 'summary', 'steps'],
+	additionalProperties: false,
 }
 
 /**
@@ -1013,6 +1118,10 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 					.preprocess(normalizeApprovePlanSteps, z.array(approvePlanStepSchema))
 					.describe('Ordered list of planned steps'),
 			}),
+			modelInputSchema: structuredClone(approvePlanModelInputSchema),
+			enforceModelInput: true,
+			validationErrorHint:
+				'Required shape: {"title":"…","summary":"…","steps":[{"description":"One plain sentence"}]}. "steps" must be a JSON array of objects — never a string, and never markup such as <step> or <description>.',
 			category: 'custom',
 			permissions: [],
 			readOnly: true,

--- a/packages/sdk/src/tools/coordinator/index.ts
+++ b/packages/sdk/src/tools/coordinator/index.ts
@@ -162,6 +162,33 @@ const TAG_TOKEN = /<\/?[A-Za-z][\w-]*(?:\s[^<>]*)?\/?>/g
 const DESCRIPTION_BLOCK = /<description>([\s\S]*?)<\/description>/gi
 
 /**
+ * Remove every tag token, including the ones removing a tag creates.
+ *
+ * One pass is not enough and the reason is not obvious: deleting an inner
+ * tag can splice its neighbours into a new one. `<<step>step>` loses the
+ * inner `<step>` and the halves close up into `<step>` again, so a line
+ * that is nothing but markup comes back non-empty and is offered to a
+ * human as a step to approve — which is the exact outcome this whole path
+ * exists to prevent.
+ *
+ * Repeating to a fixed point terminates: every pass that changes the
+ * string removes at least one token and so strictly shortens it.
+ *
+ * Only ever used to ANSWER "is there anything here besides markup". The
+ * result is never shown to anyone, so this is a test rather than a
+ * sanitiser, and it does not have to defend against every way a tag can
+ * be spelled.
+ */
+function withoutTags(text: string): string {
+	let current = text
+	for (;;) {
+		const next = current.replace(TAG_TOKEN, '')
+		if (next === current) return current
+		current = next
+	}
+}
+
+/**
  * Peel tag wrappers off the ENDS of one line, and nowhere else — a step
  * that legitimately says "wrap it in a <div>" keeps its sentence.
  */
@@ -228,12 +255,12 @@ function normalizeApprovePlanSteps(value: unknown): unknown {
 					.trim(),
 			),
 		)
-		.filter((line) => line.length > 0 && line.replace(TAG_TOKEN, '').trim().length > 0)
+		.filter((line) => line.length > 0 && withoutTags(line).trim().length > 0)
 
 	// Every line was markup: there is no plan in this string, and inventing
 	// one step reading `<steps>` is worse than saying so.
 	if (lines.length === 0) {
-		return unwrapStepLine(trimmed).replace(TAG_TOKEN, '').trim()
+		return withoutTags(unwrapStepLine(trimmed)).trim()
 			? [{ description: unwrapStepLine(trimmed) }]
 			: []
 	}


### PR DESCRIPTION
Reported from a real run: an approval card numbered ten steps, five of which read `<step>`, `</step>`, `<steps>`, `</steps>`. The person was being asked to approve a closing tag.

`normalizeApprovePlanSteps` only runs when `steps` arrives as a **string** — the model serializing the array instead of building it — and its fallback split that string on newlines. A model that serializes tends to reach for XML, so every tag got its own line and every line became a step.

## What changed

**The fallback** reads the `<description>` blocks the model named when there are any, drops lines carrying no words when there are not, and yields no steps at all for a string with nothing in it. Peeling happens at the ends of a line only, so `wrap it in a <div>` keeps its sentence.

**The fix**, which is the other half: `approve_plan` now advertises a closed model-facing schema and asks capable providers to constrain generation to it — `modelInputSchema` + `enforceModelInput`, the same instrument `ask_user_question` has carried for its own `options`-as-a-string report. The array stops being serializable at generation time; the normalizer goes back to being a backstop rather than the mechanism.

The schema stays inside the strict subset deliberately — `assertStrictSchema` runs at registration and again where the driver vouches for it, and a keyword outside the subset does not degrade: the vendor rejects the entire request and takes every other tool down with it.

## Verified

- New spec `an-approver-is-never-asked-to-approve-markup.test.ts` drives the real tool's input schema: the reported XML payload, a tag-only string, a plain numbered list, a JSON array, and a step that merely mentions a tag.
- `vitest run src/tools/coordinator` — 145 passing, 16 files.
- `tsc --noEmit` clean, `biome check src/` clean.
- Downstream: a host's own provider-wire contract test independently confirms the widened strict surface reaches the wire and that the new schema is one the provider accepts.