### PR TITLE
fix(sandbox): a public address is chosen, not defaulted

### DIFF
--- a/.changeset/a-public-address-is-chosen-not-defaulted.md
+++ b/.changeset/a-public-address-is-chosen-not-defaulted.md
@@ -1,0 +1,16 @@
+---
+'@namzu/sandbox': major
+---
+
+The standby-pool backend refuses to claim a container group on a public address
+
+Omitting `subnetId` meant the platform assigned a public address, and the backend claimed the group and dialled it without comment. The worker answering there has no authentication of any kind — `worker/server.js` states "Authn: none" in its own docblock — so an unauthenticated execute endpoint was reachable from the internet, chosen by a caller who had never heard of a field.
+
+The backend now refuses that combination. Two ways forward, and the error names both:
+
+- **`subnetId`** — inject the group into a private network. This is the production answer, and the file already recommended it.
+- **`allowPublicAddress: true`** — a new option, off by default, for a benchmark where you mean it.
+
+**This is `major` and it will stop a deployment that works today.** If you run this backend with no `subnetId`, the next claim throws instead of succeeding. That is deliberate: the alternative is a warning on a path that otherwise succeeds, which is read once and never again.
+
+The trust-model docblock used to end "Caller decides". Nothing asked them — omitting a field chose the public address silently, which is not a decision. That sentence has been corrected rather than deleted, so a reader who saw the old one learns what changed.

--- a/packages/sandbox/src/backends/aci-standby-pool/__tests__/a-public-address-is-chosen-not-defaulted.test.ts
+++ b/packages/sandbox/src/backends/aci-standby-pool/__tests__/a-public-address-is-chosen-not-defaulted.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+
+import { assertNotPubliclyAddressed } from '../index.js'
+
+/**
+ * With no subnet the platform assigns a public address, and the worker
+ * answering on it has no authentication of any kind — its own docblock
+ * says "Authn: none". Inside a private network that is the boundary doing
+ * the work; on a public address there is no boundary left.
+ *
+ * The defect was not that a public address is possible. It is that it was
+ * reachable by *omission* — a caller who had never heard of `subnetId` got
+ * one with no signal at all. These tests are about which way the default
+ * falls, not about whether the option exists.
+ */
+
+describe('claiming a container group with no subnet', () => {
+	it('refuses, rather than quietly taking a public address', () => {
+		expect(() => assertNotPubliclyAddressed({})).toThrow(/will not claim/i)
+	})
+
+	it('names both ways out, because a refusal a reader cannot act on is a dead end', () => {
+		// The operator who hits this has two legitimate destinations — a
+		// private network, or an explicit acceptance for a benchmark — and a
+		// message naming neither sends them to read the source.
+		expect(() => assertNotPubliclyAddressed({})).toThrow(/subnetId/)
+		expect(() => assertNotPubliclyAddressed({})).toThrow(/allowPublicAddress/)
+	})
+
+	it('says what is on the address, not just that it is public', () => {
+		// "Public address" alone reads as a networking preference. The reason
+		// it is refused is that the thing answering there is unauthenticated,
+		// and that is the sentence that changes an operator's mind.
+		expect(() => assertNotPubliclyAddressed({})).toThrow(/no authentication/i)
+	})
+})
+
+describe('the two ways to proceed', () => {
+	it('accepts a subnet, which is the production answer', () => {
+		expect(() =>
+			assertNotPubliclyAddressed({ subnetId: '/subscriptions/x/subnets/private' }),
+		).not.toThrow()
+	})
+
+	it('accepts an explicit acceptance of a public address', () => {
+		expect(() => assertNotPubliclyAddressed({ allowPublicAddress: true })).not.toThrow()
+	})
+
+	it('does not treat a falsy opt-in as an opt-in', () => {
+		// `allowPublicAddress: false` is a caller who considered it and said
+		// no. Reading it as "unset, therefore ask again" would be harmless;
+		// reading it as truthy would be the hole reopened, so pin it.
+		expect(() => assertNotPubliclyAddressed({ allowPublicAddress: false })).toThrow()
+	})
+
+	it('does not treat an empty subnet id as a subnet', () => {
+		// An empty string is what a missing environment variable interpolates
+		// to, and it is the shape most likely to arrive from a config file
+		// rather than from a person.
+		expect(() => assertNotPubliclyAddressed({ subnetId: '' })).toThrow()
+	})
+})

--- a/packages/sandbox/src/backends/aci-standby-pool/index.ts
+++ b/packages/sandbox/src/backends/aci-standby-pool/index.ts
@@ -29,8 +29,12 @@
  *  - ACI runs the container in a Microsoft-owned isolation host;
  *    inside, the worker is a non-root user (image's `USER namzu`).
  *  - The container group can be subnet-injected (no public IP) when
- *    `subnetId` is supplied. Without it the IP is public — fine for
- *    benchmarking, NOT acceptable for production. Caller decides.
+ *    `subnetId` is supplied. Without it the address is public — fine for
+ *    benchmarking, NOT acceptable for production. The caller decides,
+ *    but has to say so: with neither `subnetId` nor `allowPublicAddress`
+ *    the backend refuses to claim. This line used to end "Caller
+ *    decides", and nothing asked them — omitting a field they had never
+ *    heard of chose the public address silently.
  *  - The Confidential variant of Standby Pools (AMD SEV-SNP TEE) is
  *    a pool-side knob, not a backend knob — the backend never
  *    chooses; it just PUTs against whichever pool the caller named.
@@ -88,11 +92,28 @@ export interface ACIStandbyPoolBackendInternalConfig {
 	 */
 	readonly getArmToken: ArmTokenProvider
 	/**
-	 * Optional subnet to inject the container group into (no public IP).
-	 * Strongly recommended for production. When omitted, ACI assigns a
-	 * public IP — fine for benchmarks, attack-surface for prod.
+	 * Subnet to inject the container group into, so it has no public
+	 * address. Omitting it means the platform assigns a public one, which
+	 * the backend now refuses unless {@link allowPublicAddress} says
+	 * otherwise — so this is optional in the type and required in practice
+	 * for anything but a benchmark.
 	 */
 	readonly subnetId?: string
+	/**
+	 * Claim a container group on a public address anyway, with no subnet.
+	 *
+	 * Off by default, and the default is the whole point. The worker this
+	 * backend dials has no authentication of any kind — its own docblock
+	 * says so — so a public address puts an unauthenticated control API on
+	 * the internet. That is a fine trade for a benchmark and never for
+	 * production, and the difference between the two is a decision an
+	 * operator makes rather than one a missing field makes for them.
+	 *
+	 * Named for what it grants rather than what it disables: an operator
+	 * reading `allowPublicAddress: true` in a config review knows what they
+	 * are looking at.
+	 */
+	readonly allowPublicAddress?: boolean
 	readonly readyPollIntervalMs?: number
 	readonly readyTimeoutMs?: number
 	/**
@@ -335,11 +356,41 @@ export function assertEnforceable(options: SandboxBackendOptions): void {
 	)
 }
 
+/**
+ * Refuse to claim a container group that will answer on a public address.
+ *
+ * The sibling above refuses controls this backend cannot enforce. This
+ * refuses one it *can* enforce and would otherwise skip by omission —
+ * which is the more dangerous shape, because nothing is being dropped and
+ * so nothing looks wrong. A caller who never heard of `subnetId` gets a
+ * working sandbox on the internet and no signal at all.
+ *
+ * What is on that address matters: `worker/server.js` states "Authn: none"
+ * in its own docblock and binds every interface. Inside a private network
+ * that is the boundary doing the work. With a public address there is no
+ * boundary left, and the worker's `/execute` is reachable by anyone.
+ *
+ * Defaulting to refusal rather than to a warning, because a warning on a
+ * path that otherwise succeeds is read once and never again.
+ */
+export function assertNotPubliclyAddressed(config: {
+	subnetId?: string
+	allowPublicAddress?: boolean
+}): void {
+	if (config.subnetId) return
+	if (config.allowPublicAddress) return
+
+	throw new Error(
+		'The standby-pool sandbox backend will not claim a container group without `subnetId`: with no subnet the platform assigns a public address, and the worker on it has no authentication of any kind, so its execute endpoint would be reachable from the internet. Supply `subnetId` to inject the group into a private network, or set `allowPublicAddress: true` if this is a benchmark and you mean it.',
+	)
+}
+
 async function spawnAciSandbox(
 	config: ACIStandbyPoolBackendInternalConfig,
 	options: SandboxBackendOptions,
 ): Promise<Sandbox> {
 	assertEnforceable(options)
+	assertNotPubliclyAddressed(config)
 	const id = generateSandboxId()
 	const prefix = config.containerNamePrefix ?? DEFAULT_CONTAINER_NAME_PREFIX
 	const cgName = `${prefix}-${id


### PR DESCRIPTION
From the owner's security audit. Verified end to end before writing, and the remedy is not the one first proposed — see below.

## The exposure

Omitting `subnetId` means the platform assigns a public address. The backend then claimed the group and dialled `properties.ipAddress.ip` without comment.

What is on that address matters: `packages/sandbox/worker/server.js` states **"Authn: none"** in its own docblock and binds every interface. Inside a private network that binding is fine, because the network is the boundary. With a public address there is no boundary left, and the worker's execute endpoint is reachable by anyone.

The file's own trust model already said: *"Without it the IP is public — fine for benchmarking, NOT acceptable for production. Caller decides."* Nothing asked them. **Omitting a field you have never heard of is not a decision**, and that is the whole defect.

## Why not "default the worker to loopback", which was the first proposal

Measured rather than reasoned about — two containers running the real `worker/server.js`, same published port, differing only in the bind address:

```
worker bound 127.0.0.1 -> host port: UNREACHABLE (curl exit 52)
worker bound 0.0.0.0   -> host port: {"ok":true}
```

A published port translates to the container's bridge address, so a worker on the container's own loopback is unreachable through it. Both of the container backend's reachability modes need a non-loopback bind.

Narrowing that default would have **disabled the default backend while leaving this exposure untouched** — a change that looks like hardening, ships as a regression, and closes the issue so nobody looks again. The boundary on that tier is the network namespace. This exposure is specific to the path where that boundary is absent, and that is where the fix goes.

## The fix

A sibling of the guard already in this file. `assertEnforceable` refuses controls the backend *cannot* enforce; this refuses one it **can** and would otherwise skip by omission — the more dangerous shape, because nothing is being dropped and so nothing looks wrong.

Refusal rather than a warning: a warning on a path that otherwise succeeds is read once and never again.

## Tests

About which way the default falls, not about whether the option exists.

The refusal has to name **both** ways out — a refusal a reader cannot act on is a dead end wearing one — and it has to say what is *on* the address, because "public address" alone reads as a networking preference while "unauthenticated worker" is the sentence that changes an operator's mind.

An empty `subnetId` and `allowPublicAddress: false` are both pinned. An empty string is what an unset environment variable interpolates to, which is the shape that arrives from a config file rather than from a person.

Mutation: bypassing the guard fails five of the six.

## Bump: `major`, and it will stop a deployment that works today

If you run this backend with no `subnetId`, the next claim throws. Deliberate — the changeset names both ways forward.

Gates: sandbox suite 148 passed / 25 skipped, typecheck, sandbox lint, external-name audit, publish-metadata (14 packages), public-surface — all green.

Related: #405, the CLI attaching no sandbox on any path.
