### PR TITLE
fix(sandbox): the worker's comments say what its bind actually does

### DIFF
--- a/packages/sandbox/worker/Dockerfile
+++ b/packages/sandbox/worker/Dockerfile
@@ -23,8 +23,13 @@
 #
 # Trust model:
 #   - Container is the trust boundary; host treats process inside
-#     as untrusted code. Worker listens on 127.0.0.1 only; outbound
-#     network goes through the egress proxy (P3.2).
+#     as untrusted code. The worker listens on every interface and
+#     authenticates nobody, so that boundary is the network the
+#     container is attached to — not the bind address. This line used
+#     to claim "127.0.0.1 only", which was never true of the default.
+#   - Outbound goes through the egress proxy where one is configured.
+#     It allows by resolved address and brokers credentials outbound;
+#     it does not authenticate anything inbound.
 #   - Non-root user (`namzu:1001`) for the worker process. Host
 #     mounts `/workspace` writable to that uid.
 # =============================================================================

--- a/packages/sandbox/worker/__tests__/the-bind-default-is-load-bearing.test.js
+++ b/packages/sandbox/worker/__tests__/the-bind-default-is-load-bearing.test.js
@@ -1,0 +1,106 @@
+import { spawn } from 'node:child_process'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import net from 'node:net'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+/**
+ * This worker binds every interface by default, and that is deliberate.
+ *
+ * It reads as a mistake — an unauthenticated control API listening
+ * everywhere — and it has already been proposed as one. Measuring it
+ * settled the question: a published container port translates to the
+ * container's bridge address, so a worker bound to the container's own
+ * loopback is unreachable through that port. Both of the container
+ * backend's reachability modes need a non-loopback bind, so narrowing
+ * this default does not harden the container tier, it disables it.
+ *
+ * The boundary is the network the container is attached to. Where that
+ * boundary is absent — a group with a public address, say — the fix
+ * belongs there, and `assertNotPubliclyAddressed` in the standby-pool
+ * backend is that fix.
+ *
+ * So this test exists to fail on a well-meaning narrowing, and to make
+ * whoever proposes it read the reason first. It pins the default, not
+ * the ability to change it: `NAMZU_SANDBOX_BIND` still overrides.
+ */
+
+const workers = []
+
+afterEach(async () => {
+	while (workers.length > 0) {
+		const w = workers.pop()
+		w.child.kill('SIGKILL')
+		await rm(w.workspace, { recursive: true, force: true })
+	}
+})
+
+function getFreePort() {
+	return new Promise((resolve, reject) => {
+		const srv = net.createServer()
+		srv.once('error', reject)
+		srv.listen(0, '127.0.0.1', () => {
+			const { port } = srv.address()
+			srv.close(() => resolve(port))
+		})
+	})
+}
+
+/** Start the real file and return the line it logs when it binds. */
+async function startAndReadBindLine(env) {
+	const port = await getFreePort()
+	const workspace = await mkdtemp(path.join(os.tmpdir(), 'namzu-worker-bind-'))
+	const source = await readFile(path.join(import.meta.dirname, '..', 'server.js'), 'utf8')
+	const entry = path.join(workspace, 'server.cjs')
+	await writeFile(entry, source)
+
+	const child = spawn(process.execPath, [entry], {
+		env: {
+			...process.env,
+			NAMZU_SANDBOX_PORT: String(port),
+			NAMZU_SANDBOX_WORKSPACE: workspace,
+			NAMZU_SANDBOX_IDLE_TIMEOUT_MS: '0',
+			// Deliberately NOT setting NAMZU_SANDBOX_BIND unless a case asks
+			// for it — the unset case is the whole subject here. The sibling
+			// suite sets it, which is why it cannot observe this.
+			...env,
+		},
+		stdio: ['ignore', 'pipe', 'pipe'],
+	})
+	workers.push({ child, workspace })
+
+	return await new Promise((resolve, reject) => {
+		let out = ''
+		const timer = setTimeout(() => reject(new Error(`worker never logged a bind: ${out}`)), 15_000)
+		child.stdout.on('data', (chunk) => {
+			out += chunk.toString('utf8')
+			const line = out.split('\n').find((l) => l.includes('listening on'))
+			if (line) {
+				clearTimeout(timer)
+				resolve(line)
+			}
+		})
+		child.once('error', (err) => {
+			clearTimeout(timer)
+			reject(err)
+		})
+	})
+}
+
+describe('the worker bind address', () => {
+	it('binds every interface when nothing says otherwise', async () => {
+		const line = await startAndReadBindLine({})
+
+		// Asserted on the address the worker reports having bound, rather
+		// than on the source of the default. A test reading the constant
+		// passes if the constant is right and the `listen` call ignores it.
+		expect(line).toContain('listening on 0.0.0.0:')
+	})
+
+	it('still honours an explicit override, so the default is a default', async () => {
+		const line = await startAndReadBindLine({ NAMZU_SANDBOX_BIND: '127.0.0.1' })
+
+		expect(line).toContain('listening on 127.0.0.1:')
+	})
+})

--- a/packages/sandbox/worker/server.js
+++ b/packages/sandbox/worker/server.js
@@ -30,10 +30,19 @@
  *                         body: { path, content, encoding? }
  *                         response: { ok, bytesWritten }
  *
- * Authn: none. The container only listens on loopback inside its
- * own network namespace; the only thing that can talk to it is
- * the host adapter via Docker's port-forward. JWT-style auth is
- * the egress proxy's job (separate concern, P3.2).
+ * Authn: none, and nothing here checks a caller. What keeps that safe
+ * is the network the container is attached to, NOT the bind address —
+ * this listens on every interface by default and has to, for the
+ * reasons recorded at the `BIND` constant below. So the boundary is the
+ * network namespace, and wherever that boundary is absent this endpoint
+ * is reachable by whoever can route to it.
+ *
+ * This paragraph used to say the worker "only listens on loopback".
+ * It does not, ten lines from a comment that says so correctly, and a
+ * reader who found the true half stopped looking. The claim also
+ * promised authentication from the egress proxy, which has none of any
+ * kind — that proxy stamps credentials outbound and checks nothing
+ * inbound.
  */
 
 const http = require('node:http')


### PR DESCRIPTION
Two files claimed the worker listens on loopback only. It listens on every interface by default.

## The sharp part: one file said both

`worker/server.js` carried the false claim in its header —

> *"Authn: none. The container only listens on loopback inside its own network namespace…"*

— and a correct, well-argued note about the same line at the `BIND` constant, explaining exactly why the default is `0.0.0.0` and what the real boundary is.

**A file asserting both is worse than one asserting neither.** A reader who finds the true half stops looking, and a reader who finds the false half has it confirmed by the file's own authority. `worker/Dockerfile` carried the same false claim, so the true version was outnumbered two to one.

The header also promised authentication from the egress proxy. That proxy has no inbound authentication of any kind — it stamps credentials outbound and checks nothing coming in. (Corrected separately on the registry page in #404, where the same claim was doing the most damage.)

## What the header says now

What actually keeps an unauthenticated endpoint safe: the network the container is attached to, not the bind address. And the consequence, stated plainly — wherever that boundary is absent, this endpoint is reachable by whoever can route to it.

## The bind default is deliberately NOT narrowed

This is the part worth reviewing, because narrowing it looks like the fix and is a regression.

Measured, not reasoned about: a published container port translates to the container's bridge address, so a worker bound to the container's own loopback is unreachable through that port. Both of the container backend's reachability modes need a non-loopback bind. Narrowing this default does not harden the container tier — it disables it, while leaving untouched the exposure that prompted the question.

That exposure is where the network boundary is absent, and it is fixed there: #407, `assertNotPubliclyAddressed` in the standby-pool backend.

So the default stays, the reason is now written next to it, and **a test pins it** — this proposal will come round again, and the test is what makes the next person read the reason first. `NAMZU_SANDBOX_BIND` still overrides, so the default is a default rather than a rule.

## The test

Asserts the address the worker **reports having bound**, not the constant it was read from. A test reading the constant passes if the constant is right and the `listen` call ignores it.

It also cannot live in the existing worker suite: that suite sets `NAMZU_SANDBOX_BIND` on every spawn, so it is structurally unable to observe the default. This one deliberately leaves it unset, which is the whole subject.

Mutation: narrowing the default fails the default test and leaves the override test passing — the discrimination wanted, not two tests dying together.

## No changeset

Comments and a test. No behaviour changes, nothing published differs.

Gates: sandbox suite 150 passed / 25 skipped, sandbox lint, external-name audit — green.
