### PR TITLE
docs(sdk): the security policy covers the versions that actually ship

### DIFF
--- a/packages/sdk/SECURITY.md
+++ b/packages/sdk/SECURITY.md
@@ -12,9 +12,25 @@ You should receive a response within 48 hours. We will work with you to understa
 
 ## Supported Versions
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.x     | :white_check_mark: |
+**The latest published major of each package is supported. Older majors are not.**
+
+This is stated as a rule rather than a table on purpose. This section used to
+list `0.x` as the only supported version, and every package in this repository
+had long since left it — so the document told a reporter that nothing shipping
+was covered, which is the opposite of what it exists to do and the version of
+being out of date that costs a report rather than a correction.
+
+Packages are versioned independently and released through Changesets, so
+"latest major" is answered by the registry rather than by this file:
+
+```
+npm view @namzu/sdk version
+```
+
+Every package published from this repository is in scope — the runtime, the
+operator application, the capability and observability packages, the eval
+suites, and each service driver. If you are unsure whether something is in
+scope, report it and we will tell you.
 
 ## Disclosure Policy
 


### PR DESCRIPTION
From the owner's security audit, verified against source.

`packages/sdk/SECURITY.md` listed `0.x` as the only supported version. Every publishable package in this repository left that range long ago:

```
@namzu/sdk 26.0.0   @namzu/cli 9.0.0    @namzu/sandbox 3.0.0
@namzu/telemetry 2.0.1   @namzu/computer-use 1.0.2   @namzu/files 0.2.1   @namzu/evals 0.2.0
```

So the policy told a reporter that **nothing currently shipping was covered**.

## Why this is not the ordinary cost of a stale document

A supported-versions table is read by somebody deciding whether to report at all. One that excludes every live version does not merely inform badly — it discourages the report, and the failure is invisible because a report that never arrives leaves no trace.

## A rule instead of a snapshot

Replaced with: **the latest published major of each package is supported.**

Packages here are versioned independently and released through Changesets, so a table restates the registry and begins rotting the day it is written — this one had rotted through 26 majors. A rule stays true without maintenance. The file now points at the registry for the current answer and says outright that everything published from this repository is in scope, including the drivers.

## What the audit got wrong, recorded so nobody re-checks it

The audit placed two other claims in this file: that it asserts the sandbox worker is loopback-only, and that it describes a token-authenticated egress proxy. **Neither is in this file.** Both claims are real and both live elsewhere — the loopback one in the worker's own sources (#408) and the proxy one in the sandbox package description on the registry page (#404). Corrected there.

Documentation only. No changeset — nothing published changes.

Gates: external-name audit, docs gate — green.