### PR TITLE
fix(cli)!: a config that cannot be read is not a config with nothing in it

### DIFF
--- a/.changeset/an-unreadable-config-is-not-an-empty-one.md
+++ b/.changeset/an-unreadable-config-is-not-an-empty-one.md
@@ -1,0 +1,29 @@
+---
+'@namzu/cli': major
+---
+
+A config file that cannot be read stops the run instead of being read as an empty one
+
+**What breaks.** `loadConfig` returned `{}` for a config file it failed to open
+or parse, which is the same answer it gives for a file that is not there. It now
+throws `ConfigLoadError`, and the binary exits `78` (sysexits `EX_CONFIG`) with a
+message naming the file. Three inputs that used to start a run now refuse:
+a file that exists and cannot be opened, a file whose contents do not parse, and
+a file whose top level is not a mapping of settings.
+
+**Why this is not a nicety.** `permissions` is read from these files. An empty
+config is an empty rule table, and a headless run resolves every call no rule
+covered to `auto` — so a `deny` an operator had written became approval of
+exactly those calls, with nothing printed to say the table had been dropped. The
+fail-open landed on the one path where nobody is watching, and a missing brace
+was enough to reach it.
+
+**What a caller does about it.** If the run should have no rules, delete the file
+or empty it — absent and empty both still mean "no settings", and neither throws.
+If the file is meant to be read, the message names the file and the reason; fix
+it. A host embedding the CLI that wants the old behaviour has to catch
+`ConfigLoadError` itself and decide, in the open, that starting unrestricted is
+what it wants.
+
+Also new: `EXIT_BAD_CONFIG` (78) is exported alongside the other exit codes, and
+`ConfigLoadError` is exported from the package root.

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -8,7 +8,7 @@ owner: bahadirarda
 status: current
 timestamp: 2026-08-09
 lastReviewed: 2026-08-09
-last_updated: 2026-08-09
+last_updated: 2026-08-11
 related_packages: ["@namzu/cli", "@namzu/sdk"]
 ---
 
@@ -52,6 +52,7 @@ never returned were reported identically, so the report could not distinguish
 | `2` | No checks were registered — namzu is not configured here, or a `--category` filter matched nothing. |
 | `69` | At least one check **could not answer**. Nothing was established to have failed, and nothing can be concluded from the rest of the report either. |
 | `70` | An internal CLI error (sysexits `EX_SOFTWARE`) — worth a bug report. |
+| `78` | A config file is there and could not be read, so **no check ran**. Distinct from `2`: `2` says namzu is not configured here, `78` says its configuration cannot be established, and those are fixed by opposite actions. See [A config namzu cannot read stops the run](./headless.md#a-config-namzu-cannot-read-stops-the-run). |
 
 `69` outranks `0` and is outranked by `1`. A definite failure is the actionable
 fact and `1` claims no health, so reporting it loses nothing; conversely a run

--- a/docs/cli/headless.md
+++ b/docs/cli/headless.md
@@ -1,7 +1,7 @@
 ---
 title: Headless runs
 description: namzu run and namzu run-stream — one prompt, no terminal. Shared options, the working directory, exit codes, and the NDJSON event stream.
-last_updated: 2026-08-09
+last_updated: 2026-08-11
 status: current
 related_packages: ["@namzu/cli"]
 ---
@@ -275,6 +275,7 @@ later `history` look broken with nothing to connect it to.
 | `2` | No prompt was supplied. |
 | `64` | An argument is wrong (unknown option, bad `--cwd`), or a slash command was named and could not run — see [Your own slash commands](./tui.md#they-work-in-scripts-too). |
 | `77` | The folder has not been trusted, and **nothing ran**. Fixed by a decision, not by a different invocation — see [The folder has to be trusted](#the-folder-has-to-be-trusted). |
+| `78` | A config file is there and could not be read, and **nothing ran** — see [A config namzu cannot read stops the run](#a-config-namzu-cannot-read-stops-the-run). |
 
 A stopped run exits 1 even though it produced text, so
 `namzu run … > out.txt && deploy` cannot proceed on a partial or refused answer.
@@ -283,6 +284,32 @@ A stopped run exits 1 even though it produced text, so
 one a human decision about a folder can fix, and a caller that cannot tell them
 apart ends up matching on the message text — after which the message can never
 be reworded.
+
+## A config namzu cannot read stops the run
+
+`namzu.config.json` and `~/.namzu/config.yaml` are read before anything else
+happens. A file that is **not there** contributes nothing — that is the ordinary
+case and it stays the ordinary case. A file that **is** there and cannot be read
+— malformed, unopenable, or holding something that is not a mapping of settings
+— now ends the run with exit `78` and a message naming the file:
+
+```console
+$ namzu run "ship it"
+/srv/app/namzu.config.json is not valid JSON: Expected ',' or '}' after property value at position 34
+namzu will not start with a config it cannot read. Fix the file or remove it.
+$ echo $?
+78
+```
+
+This used to start anyway. An unreadable file was read as an empty one, and an
+empty one means no settings — including no `permissions`. A headless run sends
+every call no rule covered to `auto`, so a `deny` an operator had written became
+approval of exactly those calls, with nothing on stdout or stderr to say the
+table had been dropped. A missing brace was enough.
+
+The two situations no longer share a branch. For a run with no rules, remove the
+file or empty it; both still mean "no settings". What no longer means it is a
+file that says something namzu cannot read.
 
 ### `run-stream`
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -27,8 +27,8 @@ import {
 import { runCommand } from './commands/run.js'
 import { stubCommands } from './commands/stubs.js'
 import type { CommandContext } from './commands/types.js'
-import { loadConfig } from './config/load.js'
-import { EXIT_INTERNAL_ERROR } from './exit-codes.js'
+import { ConfigLoadError, loadConfig } from './config/load.js'
+import { EXIT_BAD_CONFIG, EXIT_INTERNAL_ERROR } from './exit-codes.js'
 import { type FormatName, createFormatter, isFormatName } from './output/index.js'
 import { compilePermissions } from './permissions/rules.js'
 
@@ -160,6 +160,15 @@ export async function runCli(opts: RunCliOptions): Promise<number> {
 	} catch (err) {
 		if (err instanceof CommanderError) {
 			return mapCommanderError(err)
+		}
+		// A config file the operator can fix. The message names the file and
+		// what is wrong with it; a stack trace would only point at the reader
+		// that noticed, which is not where the problem is.
+		if (err instanceof ConfigLoadError) {
+			process.stderr.write(
+				`${err.message}\nnamzu will not start with a config it cannot read. Fix the file or remove it.\n`,
+			)
+			return EXIT_BAD_CONFIG
 		}
 		process.stderr.write(
 			`Fatal: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,

--- a/packages/cli/src/config/load.test.ts
+++ b/packages/cli/src/config/load.test.ts
@@ -3,7 +3,14 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-import { loadConfig } from './load.js'
+import { ConfigLoadError, loadConfig } from './load.js'
+
+function userConfig(contents: string): string {
+	const home = mkdtempSync(join(tmpdir(), 'namzu-home-'))
+	mkdirSync(join(home, '.namzu'), { recursive: true })
+	writeFileSync(join(home, '.namzu', 'config.yaml'), contents)
+	return home
+}
 
 describe('loadConfig cascade', () => {
 	it('returns defaults when nothing is configured', () => {
@@ -15,18 +22,14 @@ describe('loadConfig cascade', () => {
 	})
 
 	it('reads user config from ~/.namzu/config.yaml', () => {
-		const home = mkdtempSync(join(tmpdir(), 'namzu-home-'))
-		mkdirSync(join(home, '.namzu'), { recursive: true })
-		writeFileSync(join(home, '.namzu', 'config.yaml'), 'format: yaml\nquiet: true\n')
+		const home = userConfig('format: yaml\nquiet: true\n')
 		const cfg = loadConfig({ home, cwd: tmpdir(), env: {} })
 		expect(cfg.format).toBe('yaml')
 		expect(cfg.quiet).toBe(true)
 	})
 
 	it('project config overrides user config', () => {
-		const home = mkdtempSync(join(tmpdir(), 'namzu-home-'))
-		mkdirSync(join(home, '.namzu'), { recursive: true })
-		writeFileSync(join(home, '.namzu', 'config.yaml'), 'format: yaml\n')
+		const home = userConfig('format: yaml\n')
 		const cwd = mkdtempSync(join(tmpdir(), 'namzu-cwd-'))
 		writeFileSync(join(cwd, 'namzu.config.json'), JSON.stringify({ format: 'json' }))
 		const cfg = loadConfig({ home, cwd, env: {} })
@@ -34,9 +37,7 @@ describe('loadConfig cascade', () => {
 	})
 
 	it('env vars override file config', () => {
-		const home = mkdtempSync(join(tmpdir(), 'namzu-home-'))
-		mkdirSync(join(home, '.namzu'), { recursive: true })
-		writeFileSync(join(home, '.namzu', 'config.yaml'), 'format: yaml\n')
+		const home = userConfig('format: yaml\n')
 		const cfg = loadConfig({
 			home,
 			cwd: tmpdir(),
@@ -46,18 +47,98 @@ describe('loadConfig cascade', () => {
 	})
 
 	it('ignores invalid format values silently', () => {
+		const home = userConfig('format: xml\n')
+		const cfg = loadConfig({ home, cwd: tmpdir(), env: {} })
+		expect(cfg.format).toBe('text')
+	})
+})
+
+/**
+ * A file that is not there is a default; a file that is there and cannot be
+ * read is a refusal.
+ *
+ * These are the same branch until you separate them, and the shared answer was
+ * `{}`. `permissions` is read from these files, so `{}` is an empty rule table,
+ * and a headless run sends everything no rule covered to `auto` — an operator's
+ * deny list becomes approval of the same calls, silently, on the path with
+ * nobody watching. See `docs/conventions/refuse-do-not-degrade.md`.
+ */
+describe('a config that cannot be read', () => {
+	it('refuses malformed yaml instead of reading it as no settings', () => {
+		const home = userConfig(': : : not yaml\n')
+		expect(() => loadConfig({ home, cwd: tmpdir(), env: {} })).toThrow(ConfigLoadError)
+	})
+
+	it('refuses malformed json instead of reading it as no settings', () => {
+		const cwd = mkdtempSync(join(tmpdir(), 'namzu-cwd-'))
+		writeFileSync(join(cwd, 'namzu.config.json'), '{ "format": ')
+		expect(() => loadConfig({ home: tmpdir(), cwd, env: {} })).toThrow(ConfigLoadError)
+	})
+
+	it('names the file it could not read', () => {
+		const home = userConfig(': : : not yaml\n')
+		const path = join(home, '.namzu', 'config.yaml')
+		try {
+			loadConfig({ home, cwd: tmpdir(), env: {} })
+			expect.unreachable('a malformed config must not load')
+		} catch (err) {
+			expect(err).toBeInstanceOf(ConfigLoadError)
+			expect((err as ConfigLoadError).path).toBe(path)
+			// The operator has to be able to find the file from the message
+			// alone — this is printed without a stack trace.
+			expect((err as ConfigLoadError).message).toContain(path)
+		}
+	})
+
+	it('refuses a file whose top level is not a mapping', () => {
+		const home = userConfig('just a string\n')
+		expect(() => loadConfig({ home, cwd: tmpdir(), env: {} })).toThrow(ConfigLoadError)
+	})
+
+	it('refuses a file that exists but is not a readable file', () => {
+		// A directory where the config belongs. Portable stand-in for the
+		// permission error the check is really about: both mean the path is
+		// occupied and its contents cannot be established, and neither is
+		// ENOENT. Mode bits are not a usable test fixture on every platform
+		// this runs on; this is.
 		const home = mkdtempSync(join(tmpdir(), 'namzu-home-'))
-		mkdirSync(join(home, '.namzu'), { recursive: true })
-		writeFileSync(join(home, '.namzu', 'config.yaml'), 'format: xml\n')
+		mkdirSync(join(home, '.namzu', 'config.yaml'), { recursive: true })
+		expect(() => loadConfig({ home, cwd: tmpdir(), env: {} })).toThrow(ConfigLoadError)
+	})
+
+	it('does not drop a permission table it failed to parse', () => {
+		// The finding, stated as the caller sees it. Before: this returned a
+		// config with no `permissions` key and the run continued unrestricted.
+		const home = userConfig('permissions:\n  bash: "deny"\n   badly: indented\n')
+		expect(() => loadConfig({ home, cwd: tmpdir(), env: {} })).toThrow(ConfigLoadError)
+	})
+})
+
+describe('a config that is legitimately absent or empty', () => {
+	it('treats a missing file as no settings', () => {
+		const home = mkdtempSync(join(tmpdir(), 'namzu-home-'))
+		expect(() => loadConfig({ home, cwd: tmpdir(), env: {} })).not.toThrow()
+	})
+
+	it('treats an empty file as no settings', () => {
+		// Emptied on purpose says nothing, which is what it looks like. Only
+		// content namzu cannot read is a refusal.
+		const home = userConfig('')
 		const cfg = loadConfig({ home, cwd: tmpdir(), env: {} })
 		expect(cfg.format).toBe('text')
 	})
 
-	it('ignores malformed yaml gracefully', () => {
-		const home = mkdtempSync(join(tmpdir(), 'namzu-home-'))
-		mkdirSync(join(home, '.namzu'), { recursive: true })
-		writeFileSync(join(home, '.namzu', 'config.yaml'), ': : : not yaml\n')
+	it('treats a comments-only file as no settings', () => {
+		const home = userConfig('# nothing configured yet\n')
 		const cfg = loadConfig({ home, cwd: tmpdir(), env: {} })
 		expect(cfg.format).toBe('text')
+	})
+
+	it('treats a missing parent directory as no settings', () => {
+		// ENOTDIR rather than ENOENT: nothing was ever written at that path
+		// either way.
+		const home = mkdtempSync(join(tmpdir(), 'namzu-home-'))
+		writeFileSync(join(home, '.namzu'), 'not a directory')
+		expect(() => loadConfig({ home, cwd: tmpdir(), env: {} })).not.toThrow()
 	})
 })

--- a/packages/cli/src/config/load.ts
+++ b/packages/cli/src/config/load.ts
@@ -11,6 +11,11 @@
  *
  * In M0 we wire steps 2, 3, 4, 5. CLI-flag merging happens in `bin.ts`
  * where Commander knows what was explicitly set vs defaulted.
+ *
+ * A file that is not there contributes nothing, and that is a default. A file
+ * that IS there and cannot be read throws {@link ConfigLoadError} — this loader
+ * has no way to say "some of your settings", and will not pretend the ones it
+ * failed to read were never written.
  */
 
 import { readFileSync } from 'node:fs'
@@ -48,24 +53,105 @@ export function loadConfig(opts: LoadConfigOptions = {}): NamzuCliConfig {
 	return mergeConfigs(DEFAULT_CONFIG, userCfg, projectCfg, envCfg)
 }
 
-function readYamlIfExists(path: string): MutableConfig {
-	const raw = safeRead(path)
-	if (raw === null) return {}
-	try {
-		return sanitize(yamlParse(raw))
-	} catch {
-		return {}
+/**
+ * A config file namzu could not read.
+ *
+ * Its own class rather than a bare `Error` so `cli.ts` can print the message on
+ * its own and exit `EXIT_BAD_CONFIG`, instead of the stack trace an internal
+ * error deserves and an operator's typo does not.
+ */
+export class ConfigLoadError extends Error {
+	/** The file whose contents could not be established. */
+	readonly path: string
+
+	constructor(path: string, message: string, options?: { cause?: unknown }) {
+		super(message, options)
+		this.name = 'ConfigLoadError'
+		this.path = path
 	}
 }
 
-function readJsonIfExists(path: string): MutableConfig {
-	const raw = safeRead(path)
+function readYamlIfExists(path: string): MutableConfig {
+	const raw = readIfPresent(path)
 	if (raw === null) return {}
+	let parsed: unknown
 	try {
-		return sanitize(JSON.parse(raw))
-	} catch {
-		return {}
+		parsed = yamlParse(raw)
+	} catch (cause) {
+		throw new ConfigLoadError(path, `${path} is not valid YAML: ${reasonOf(cause)}`, { cause })
 	}
+	return asConfigObject(path, parsed)
+}
+
+function readJsonIfExists(path: string): MutableConfig {
+	const raw = readIfPresent(path)
+	if (raw === null) return {}
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(raw)
+	} catch (cause) {
+		throw new ConfigLoadError(path, `${path} is not valid JSON: ${reasonOf(cause)}`, { cause })
+	}
+	return asConfigObject(path, parsed)
+}
+
+/**
+ * The file's text, or `null` when the file is genuinely not there.
+ *
+ * Absent and unreadable used to share one `catch`, and the shared answer was
+ * `{}` — "no settings". For a file nobody wrote that is the right default. For
+ * one that exists and could not be opened it is the wrong one, and wrong in the
+ * direction that never announces itself: `permissions` is read from these files,
+ * so an unreadable config becomes an empty rule table, and a headless run
+ * resolves every call no rule covered to `auto`. The operator's deny list
+ * becomes approval of the same calls, on the one path where nobody is watching.
+ *
+ * So only "the file is not there" reads as no settings. `ENOENT` is the file
+ * itself missing; `ENOTDIR` is a parent that is not a directory, which means the
+ * same thing — nothing was ever written at that path. A permission error, a
+ * directory where a file belongs, or an I/O failure all mean the file exists and
+ * its contents could not be established, and that is a refusal.
+ *
+ * See `docs/conventions/an-optional-dependency-may-not-degrade-a-check.md`: the
+ * degradation that matters is the one turning "I cannot establish this" into
+ * "this is satisfied".
+ */
+function readIfPresent(path: string): string | null {
+	try {
+		return readFileSync(path, 'utf8')
+	} catch (cause) {
+		const code = (cause as NodeJS.ErrnoException | null)?.code
+		if (code === 'ENOENT' || code === 'ENOTDIR') return null
+		throw new ConfigLoadError(path, `${path} could not be read: ${reasonOf(cause)}`, { cause })
+	}
+}
+
+/**
+ * The parsed document as a config object, refusing anything that is not one.
+ *
+ * An empty file parses to `null`, and that is a genuine "no settings" — a file
+ * someone emptied says nothing, which is what it looks like. A scalar or a list
+ * is different: it is content namzu cannot read as settings, and admitting it as
+ * `{}` is the same fail-open as the unreadable file one function up, reached by
+ * a different route.
+ */
+function asConfigObject(path: string, parsed: unknown): MutableConfig {
+	if (parsed === null || parsed === undefined) return {}
+	if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+		throw new ConfigLoadError(
+			path,
+			`${path} must contain a mapping of settings, but its top level is ${describe(parsed)}`,
+		)
+	}
+	return sanitize(parsed)
+}
+
+function describe(value: unknown): string {
+	return Array.isArray(value) ? 'a list' : `a ${typeof value}`
+}
+
+function reasonOf(cause: unknown): string {
+	return cause instanceof Error ? cause.message : String(cause)
 }
 
 /**
@@ -122,8 +208,7 @@ function readEnv(env: NodeJS.ProcessEnv): MutableConfig {
 	return out
 }
 
-function sanitize(value: unknown): MutableConfig {
-	if (typeof value !== 'object' || value === null) return {}
+function sanitize(value: object): MutableConfig {
 	const v = value as Record<string, unknown>
 	const out: MutableConfig = {}
 	for (const key of Object.keys(CONFIG_READERS) as (keyof NamzuCliConfig)[]) {
@@ -143,12 +228,4 @@ function mergeConfigs(...sources: readonly MutableConfig[]): NamzuCliConfig {
 	const out: MutableConfig = {}
 	for (const src of sources) Object.assign(out, src)
 	return out
-}
-
-function safeRead(path: string): string | null {
-	try {
-		return readFileSync(path, 'utf8')
-	} catch {
-		return null
-	}
 }

--- a/packages/cli/src/exit-codes.ts
+++ b/packages/cli/src/exit-codes.ts
@@ -37,6 +37,18 @@
  *                             nothing else is. A caller who cannot tell them
  *                             apart matches on the message string, and then
  *                             the message can never be reworded.
+ *   78  EXIT_BAD_CONFIG     — sysexits EX_CONFIG; a config file is present and
+ *                             its contents could not be established, so the
+ *                             run refused to start rather than continue with
+ *                             settings it failed to read. Distinct from 2 for
+ *                             the reason 2 is distinct from 0: "namzu is not
+ *                             configured here" and "your configuration is
+ *                             unreadable" are fixed by opposite actions, and a
+ *                             caller that cannot tell them apart treats a
+ *                             broken file as an absent one — which is the
+ *                             fail-open this code exists to make visible.
+ *                             Distinct from 70 on the same grounds as 64: 70
+ *                             says this CLI is broken, 78 says the file is.
  */
 export const EXIT_OK = 0
 export const EXIT_FAIL = 1
@@ -45,6 +57,7 @@ export const EXIT_USAGE = 64
 export const EXIT_UNAVAILABLE = 69
 export const EXIT_INTERNAL_ERROR = 70
 export const EXIT_UNTRUSTED = 77
+export const EXIT_BAD_CONFIG = 78
 
 export type CliExitCode =
 	| typeof EXIT_OK
@@ -54,3 +67,4 @@ export type CliExitCode =
 	| typeof EXIT_UNAVAILABLE
 	| typeof EXIT_INTERNAL_ERROR
 	| typeof EXIT_UNTRUSTED
+	| typeof EXIT_BAD_CONFIG

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -48,5 +48,5 @@ export {
 	type FormatterOptions,
 	isFormatName,
 } from './output/index.js'
-export { loadConfig, type LoadConfigOptions } from './config/load.js'
+export { ConfigLoadError, loadConfig, type LoadConfigOptions } from './config/load.js'
 export { DEFAULT_CONFIG, type NamzuCliConfig } from './config/schema.js'


### PR DESCRIPTION
From the owner's security audit.

`loadYamlConfig` and `loadJsonConfig` both ended `catch { return {} }`. A file that exists and cannot be parsed became "no settings" — and in headless mode the settings that vanish include the permission rules.

So a typo in a config file silently removed the restrictions it was written to impose, failing in the permissive direction, on the path where nobody is watching.

## Two situations were sharing one branch

- **The file is not there.** Contributes nothing. That is a legitimate default and stays one.
- **The file is there and cannot be read.** Now throws. This loader has no way to say *"some of your settings"*, and will not pretend the ones it failed to read were never written.

Separating them is most of the fix. The old branch treated an operator's typo and an operator's deliberate absence as the same event, and only one of them is a decision.

`ConfigLoadError` carries the path, so `cli.ts` prints the message alone and exits `EXIT_BAD_CONFIG`. An operator's typo deserves a sentence; a stack trace is what an internal error deserves and reads as a crash.

## The rule this already had a page for

`docs/conventions/an-optional-dependency-may-not-degrade-a-check.md` is this defect almost verbatim — a fallback turning *"I cannot establish this"* into *"this is satisfied"*. The page exists because it happened before, in a different file.

## Provenance, because the history is odd and a reviewer will notice

The work here was written by one agent and committed by a second agent sharing the same worktree, under a commit message describing **entirely different changes** — the message was about worktree etiquette and the diff was this config fix. That is the precise failure the discarded message was warning about: an agent staging everything in a directory it shared and sweeping up somebody else's files.

The files are taken from that commit and verified here. The message is not carried over, because a commit message describing other work is worse than no message at all.

The etiquette rules that message was meant to add to `AGENTS.md` are **not** in that commit and are not in this one either. They are lost and will be rewritten separately.

## Bump: `major`

A run that used to start with a broken config file and silently reduced permissions now refuses to start. That is the point, and the changeset names what an operator does about it.

Gates: CLI suite 935 passed / 4 skipped, config suite 15, typecheck, CLI lint (2 pre-existing warnings), external-name audit, docs gate, public-surface 1286/1286 — all green.
