### PR TITLE
fix(sdk): sort the imports that turned main's lint red

### DIFF
--- a/packages/sdk/src/tools/coordinator/__tests__/both-delegation-tools-get-the-same-deadline.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/both-delegation-tools-get-the-same-deadline.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { DEFAULT_TOOL_TIMEOUT_MS } from '../../../runtime/query/executor.js'
 import { buildAgentTool } from '../agent.js'
-import { buildCoordinatorTools, DELEGATION_TIMEOUT_MS } from '../index.js'
+import { DELEGATION_TIMEOUT_MS, buildCoordinatorTools } from '../index.js'
 
 /**
  * Two tools delegate a whole agent run and block on it. One declared a


### PR DESCRIPTION
`main` has been failing `pnpm lint` since #403, through six subsequent merges. One import statement in a test I added there listed its named imports out of order.

One line. The interesting part is the two ways it stayed hidden, and both are mine.

## Why the local check missed it

I ran `pnpm lint`, grepped the output for my directory, got nothing, and read that as no finding.

Biome truncates its diagnostic list — the run printed **"Diagnostics not shown: 3"** — and my error was inside the truncated set. So I filtered an already-truncated output and treated the absence of a match as the absence of a finding.

That is `docs/conventions/never-filter-a-verification.md`, committed in the same session where I quoted that rule at three separate agents.

## Why the merge gate missed it, which is worse

Every merge today ran `gh pr checks --watch --fail-fast` immediately after opening the PR. At that instant only the fast checks are registered — Socket, Docs, the analyzers — and they were green, so `--watch` reported all checks complete and passing and exited 0. `Build & Test` had not started yet and was never observed.

Four of my merged PRs carry a `FAILURE` on `Build & Test` right now. The gate reported green for all of them.

This is the same shape as the release-run race fixed earlier today: **selecting by timing rather than by identity.** There the fix was to pick the run whose head SHA matches; here the equivalent is to require that the expected checks have actually registered and concluded, rather than trusting whatever the API returns at the moment of asking. Filed separately — the gate is a procedure, not code in this repo, and it needs its own change.

## Scope

Import order only. The 23 warnings this run also reports are pre-existing and do not fail the gate; folding unrelated cleanups in would bury the one-line cause.

Verified: workspace `pnpm lint` exits 0, the three tests from #403 still pass.