### PR TITLE
feat(sdk): a long command says something while it runs

### DIFF
--- a/.changeset/a-long-command-says-something.md
+++ b/.changeset/a-long-command-says-something.md
@@ -1,0 +1,18 @@
+---
+'@namzu/sdk': minor
+'@namzu/sandbox': minor
+---
+
+A command running in a sandbox now reports progress while it runs
+
+Both halves of this existed and neither was connected to the other.
+
+Every container worker streams its output a chunk at a time — the wire has always carried `stdout_delta` and `stderr_delta` events — and every backend concatenated those chunks into a string and returned it when the process exited. Separately, `ToolContext.report` exists precisely to answer "is it still working?", is supplied per call by the executor, emits a `tool_progress` event, and is mapped onto the event stream for live consumers. It had **no caller anywhere in the tree**.
+
+So a command that ran for eight minutes said nothing for eight minutes, over a transport that had been reporting the whole time.
+
+**New:** `SandboxExecOptions.onOutput`, called as output arrives. Optional and additive — a backend that cannot stream never calls it, and `SandboxExecResult.stdout` still carries the complete output either way, so a caller that ignores it behaves exactly as before. Wired through the two container backends that carry the streaming worker protocol.
+
+**The `bash` builtin now uses it**, sending the last non-empty line of each chunk to `context.report`. A progress slot renders one line and replaces it, so sending a whole chunk would put a wall of text in a space that shows one line of it.
+
+Progress is ephemeral by design — `tool_progress` is excluded from the durable transcript so a tool reporting every file it compiles cannot write thousands of lines into the record. The model is still given `result.stdout`; this is a status signal, not a second copy of the output.

--- a/packages/sandbox/src/backends/aci-standby-pool/index.ts
+++ b/packages/sandbox/src/backends/aci-standby-pool/index.ts
@@ -636,10 +636,10 @@ async function execViaWorker(
 						| { type: 'error'; error: string }
 					if (event.type === 'stdout_delta') {
 						stdout += event.data
-						options.onOutput?.({ stream: 'stdout', data: event.data })
+						opts?.onOutput?.({ stream: 'stdout', data: event.data })
 					} else if (event.type === 'stderr_delta') {
 						stderr += event.data
-						options.onOutput?.({ stream: 'stderr', data: event.data })
+						opts?.onOutput?.({ stream: 'stderr', data: event.data })
 					} else if (event.type === 'result') {
 						exitCode = event.exitCode
 						timedOut = event.timedOut

--- a/packages/sandbox/src/backends/aci-standby-pool/index.ts
+++ b/packages/sandbox/src/backends/aci-standby-pool/index.ts
@@ -634,9 +634,13 @@ async function execViaWorker(
 						| { type: 'stderr_delta'; data: string }
 						| { type: 'result'; exitCode: number; timedOut: boolean }
 						| { type: 'error'; error: string }
-					if (event.type === 'stdout_delta') stdout += event.data
-					else if (event.type === 'stderr_delta') stderr += event.data
-					else if (event.type === 'result') {
+					if (event.type === 'stdout_delta') {
+						stdout += event.data
+						options.onOutput?.({ stream: 'stdout', data: event.data })
+					} else if (event.type === 'stderr_delta') {
+						stderr += event.data
+						options.onOutput?.({ stream: 'stderr', data: event.data })
+					} else if (event.type === 'result') {
 						exitCode = event.exitCode
 						timedOut = event.timedOut
 					} else if (event.type === 'error') {

--- a/packages/sandbox/src/backends/docker/index.ts
+++ b/packages/sandbox/src/backends/docker/index.ts
@@ -673,10 +673,10 @@ async function execViaWorker(
 						| { type: 'error'; error: string }
 					if (event.type === 'stdout_delta') {
 						stdout += event.data
-						options.onOutput?.({ stream: 'stdout', data: event.data })
+						opts?.onOutput?.({ stream: 'stdout', data: event.data })
 					} else if (event.type === 'stderr_delta') {
 						stderr += event.data
-						options.onOutput?.({ stream: 'stderr', data: event.data })
+						opts?.onOutput?.({ stream: 'stderr', data: event.data })
 					} else if (event.type === 'result') {
 						exitCode = event.exitCode
 						timedOut = event.timedOut

--- a/packages/sandbox/src/backends/docker/index.ts
+++ b/packages/sandbox/src/backends/docker/index.ts
@@ -671,9 +671,13 @@ async function execViaWorker(
 								durationMs: number
 						  }
 						| { type: 'error'; error: string }
-					if (event.type === 'stdout_delta') stdout += event.data
-					else if (event.type === 'stderr_delta') stderr += event.data
-					else if (event.type === 'result') {
+					if (event.type === 'stdout_delta') {
+						stdout += event.data
+						options.onOutput?.({ stream: 'stdout', data: event.data })
+					} else if (event.type === 'stderr_delta') {
+						stderr += event.data
+						options.onOutput?.({ stream: 'stderr', data: event.data })
+					} else if (event.type === 'result') {
 						exitCode = event.exitCode
 						timedOut = event.timedOut
 					} else if (event.type === 'error') {

--- a/packages/sdk/src/tools/builtins/__tests__/a-long-command-says-something.test.ts
+++ b/packages/sdk/src/tools/builtins/__tests__/a-long-command-says-something.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { Sandbox, SandboxExecOptions } from '../../../types/sandbox/index.js'
+import type { ToolContext } from '../../../types/tool/index.js'
+import { BashTool } from '../bash.js'
+
+/**
+ * Every container worker streams its output a chunk at a time, and every
+ * backend concatenated those chunks and returned the string when the
+ * process exited. `ToolContext.report` — the channel that exists precisely
+ * to answer "is it still working?" — had no caller anywhere in the tree.
+ *
+ * So a command that ran for eight minutes said nothing for eight minutes,
+ * over a transport that had been reporting the whole time.
+ *
+ * These tests are about the wire between those two halves. They assert
+ * that output reaches `report` BEFORE the command settles, because
+ * reporting it afterwards is indistinguishable from not reporting it.
+ */
+
+/** A sandbox that emits the given chunks, then finishes. */
+function streamingSandbox(chunks: Array<{ stream: 'stdout' | 'stderr'; data: string }>): {
+	sandbox: Sandbox
+	settle: () => void
+} {
+	let release: (() => void) | undefined
+	const gate = new Promise<void>((resolve) => {
+		release = resolve
+	})
+
+	const sandbox = {
+		async exec(_cmd: string, _args: string[], options?: SandboxExecOptions) {
+			for (const chunk of chunks) options?.onOutput?.(chunk)
+			// Nothing has settled yet: anything asserted after this await
+			// would prove only that the output arrived eventually.
+			await gate
+			return {
+				stdout: chunks
+					.filter((c) => c.stream === 'stdout')
+					.map((c) => c.data)
+					.join(''),
+				stderr: '',
+				exitCode: 0,
+				timedOut: false,
+				durationMs: 1,
+			}
+		},
+	} as unknown as Sandbox
+
+	return { sandbox, settle: () => release?.() }
+}
+
+function contextWith(sandbox: Sandbox, report?: ToolContext['report']): ToolContext {
+	return {
+		runId: 'run_1',
+		workingDirectory: '/workspace',
+		abortSignal: new AbortController().signal,
+		env: {},
+		log: () => {},
+		sandbox,
+		...(report ? { report } : {}),
+	} as unknown as ToolContext
+}
+
+describe('a command running in a sandbox', () => {
+	it('reports output while it is still running, not after it ends', async () => {
+		const report = vi.fn()
+		const { sandbox, settle } = streamingSandbox([
+			{ stream: 'stdout', data: 'compiling module one\n' },
+			{ stream: 'stdout', data: 'compiling module two\n' },
+		])
+
+		const pending = BashTool.execute(
+			{ command: 'build', timeout: 1000 },
+			contextWith(sandbox, report),
+		)
+		await Promise.resolve()
+
+		// The assertion that matters. The command has NOT finished here.
+		expect(report).toHaveBeenCalledWith('compiling module one')
+		expect(report).toHaveBeenCalledWith('compiling module two')
+
+		settle()
+		await pending
+	})
+
+	it('sends one line rather than the whole chunk', async () => {
+		// A progress slot renders one line and replaces it. Sending a chunk
+		// sends a wall of text into a space that shows the first line of it.
+		const report = vi.fn()
+		const { sandbox, settle } = streamingSandbox([
+			{ stream: 'stdout', data: 'first\nsecond\nthird\n' },
+		])
+
+		const pending = BashTool.execute(
+			{ command: 'build', timeout: 1000 },
+			contextWith(sandbox, report),
+		)
+		await Promise.resolve()
+
+		expect(report).toHaveBeenCalledTimes(1)
+		expect(report).toHaveBeenCalledWith('third')
+
+		settle()
+		await pending
+	})
+
+	it('says nothing for a chunk that is only whitespace', async () => {
+		// Progress that says nothing still repaints the slot, so a build
+		// emitting blank lines would flicker while conveying nothing.
+		const report = vi.fn()
+		const { sandbox, settle } = streamingSandbox([{ stream: 'stdout', data: '\n\n   \n' }])
+
+		const pending = BashTool.execute(
+			{ command: 'build', timeout: 1000 },
+			contextWith(sandbox, report),
+		)
+		await Promise.resolve()
+
+		expect(report).not.toHaveBeenCalled()
+
+		settle()
+		await pending
+	})
+
+	it('still returns the complete output, which is what the model is given', async () => {
+		// Progress is ephemeral and excluded from the durable transcript.
+		// If it ever became the tool's answer, the model would be handed a
+		// status line instead of the command's output.
+		const { sandbox, settle } = streamingSandbox([
+			{ stream: 'stdout', data: 'first\n' },
+			{ stream: 'stdout', data: 'second\n' },
+		])
+
+		const pending = BashTool.execute(
+			{ command: 'build', timeout: 1000 },
+			contextWith(sandbox, vi.fn()),
+		)
+		settle()
+		const result = await pending
+
+		expect(result.output).toContain('first')
+		expect(result.output).toContain('second')
+	})
+
+	it('runs unchanged when the host supplies no progress channel', async () => {
+		// `report` is optional on `ToolContext`. A host that never wired it
+		// must not get a crash out of a tool trying to use it.
+		const { sandbox, settle } = streamingSandbox([{ stream: 'stdout', data: 'output\n' }])
+
+		const pending = BashTool.execute({ command: 'build', timeout: 1000 }, contextWith(sandbox))
+		settle()
+		const result = await pending
+
+		expect(result.success).toBe(true)
+		expect(result.output).toContain('output')
+	})
+})

--- a/packages/sdk/src/tools/builtins/bash.ts
+++ b/packages/sdk/src/tools/builtins/bash.ts
@@ -60,6 +60,27 @@ const inputSchema = z.object({
 
 type BashInput = z.infer<typeof inputSchema>
 
+/**
+ * The last line worth showing from one chunk of streamed output.
+ *
+ * A progress line is a status, not a log: the host renders one line and
+ * replaces it as the next arrives, so sending a whole chunk sends a wall
+ * of text into a slot that shows one line of it. A chunk usually ends
+ * mid-line and usually ends with a newline, so the last NON-EMPTY line is
+ * the most recent complete thing the command actually said.
+ *
+ * Progress is capped rather than truncated with an ellipsis: this is
+ * glanced at, and a marker in a line nobody reads to the end is noise.
+ */
+function lastNonEmptyLine(chunk: string): string | undefined {
+	const lines = chunk.split('\n')
+	for (let i = lines.length - 1; i >= 0; i--) {
+		const line = lines[i]?.trim()
+		if (line) return line.length > 160 ? line.slice(0, 160) : line
+	}
+	return undefined
+}
+
 function isDangerousCommand(command: string): boolean {
 	return DANGEROUS_PATTERNS.some((pattern) => pattern.test(command))
 }
@@ -114,6 +135,19 @@ export const BashTool = defineTool({
 				// Same reason as the host path below: a Stop must reach the
 				// process, not just the promise waiting on it.
 				signal: context.abortSignal,
+				// The worker has always streamed its output; nothing asked for
+				// it, so a command that ran for minutes said nothing until it
+				// exited. `report` is ephemeral by design — it answers "is it
+				// still working?" for a live view and is excluded from the
+				// durable transcript — so this is a progress signal, not a
+				// second copy of the output. `result.stdout` remains the
+				// answer the model is given.
+				onOutput: context.report
+					? ({ data }) => {
+							const line = lastNonEmptyLine(data)
+							if (line) context.report?.(line)
+						}
+					: undefined,
 			})
 
 			if (result.timedOut) {

--- a/packages/sdk/src/types/sandbox/index.ts
+++ b/packages/sdk/src/types/sandbox/index.ts
@@ -104,6 +104,29 @@ export interface SandboxExecOptions {
 	readonly env?: Record<string, string>
 	readonly cwd?: string
 	/**
+	 * Called as output arrives, before the command has finished.
+	 *
+	 * Every container-tier worker already streams its output a chunk at a
+	 * time — the wire carries `stdout_delta` and `stderr_delta` events —
+	 * and every backend concatenated them into a string and returned that
+	 * when the process exited. So a command that takes eight minutes said
+	 * nothing for eight minutes, on a transport that had been reporting
+	 * the whole time.
+	 *
+	 * Additive and optional: a backend that cannot stream simply never
+	 * calls it, and `SandboxExecResult.stdout` still carries the complete
+	 * output either way. A caller that wants only the result ignores this
+	 * and behaves exactly as before.
+	 *
+	 * The callback must not throw and must not be awaited — it is on the
+	 * read path of a running process, so a slow or failing consumer would
+	 * otherwise become a slow or failing command.
+	 */
+	readonly onOutput?: (chunk: {
+		readonly stream: 'stdout' | 'stderr'
+		readonly data: string
+	}) => void
+	/**
 	 * Cancellation for the command. A backend that honours it kills the
 	 * process; one that does not simply ignores it, so this is additive.
 	 *


### PR DESCRIPTION
Answering a direct question — are intermediate outputs complete? — the answer was no, and the reason is the shape this repository has been closing all week.

## Two halves, both built, not connected

**The worker streams.** Every container-tier worker emits `stdout_delta` / `stderr_delta` per chunk. That has always been true.

**Every backend threw it away.** `stdout += event.data`, returned when the process exits.

**The progress channel exists.** `ToolContext.report(message, fraction?)` is declared on the public type, supplied per call by the executor, emits a `tool_progress` event, is mapped by the SSE bridge, and is handled by the reporter. Its docblock even explains the design: ephemeral, excluded from the durable transcript, because *"a tool reporting every file it compiles must not be able to write thousands of lines into the durable record."*

**Nothing called it.** Zero callers in the SDK or the CLI.

So a command that ran for eight minutes said nothing for eight minutes, over a transport that had been reporting the whole time — and the channel to surface it was sitting there, wired end to end, with no producer.

## The change

`SandboxExecOptions.onOutput`, optional and additive. A backend that cannot stream never calls it; `SandboxExecResult.stdout` still carries the complete output; a caller that ignores it behaves exactly as before. Threaded through the two backends that speak the streaming worker protocol.

`bash` sends the **last non-empty line** of each chunk to `report`. A progress slot renders one line and replaces it as the next arrives, so forwarding a whole chunk puts a wall of text into a space that shows one line of it — and a whitespace-only chunk repaints the slot while conveying nothing, so it is skipped.

The model is still given `result.stdout`. This is a status signal, not a second copy of the output.

## The tests, and the trap they avoid

They assert output reaches `report` **before the command settles**. The sandbox stub holds its result behind a gate the test releases only after asserting.

That ordering is the whole point: reporting after the command ends is indistinguishable from not reporting at all, and a test that awaited the call first would pass against the unfixed code.

Mutation: removing the wiring fails exactly the two tests that assert a call, and leaves the three about complete output, whitespace, and the absent-channel case passing. Two dying and three living is the discrimination wanted — five dying together would mean the tests were all asserting one fact.

## Not in this change

`ExecAccumulator` in the microVM protocol accumulates the same way and has no caller outside its own module, so wiring it would add a callback nothing invokes. Left alone rather than changed for symmetry.

The host (non-sandbox) path still buffers — `execAsync` returns on exit. Streaming it is a different change with a different failure mode, and #405 records that no CLI path attaches a sandbox at all, which decides which of the two matters first.

## Bump

`minor` on both packages: a new optional field, no behaviour change for anyone not passing it.

Gates: workspace lint 0, typecheck 0, external-name audit 0, public-surface intact (560/560 runtime, 1286/1286 declared), sdk builtins 102 passed, sandbox 150 passed / 25 skipped.
