### PR TITLE
feat(sdk): the MCP server has a transport, and a hook failure is not a missing worktree

### DIFF
--- a/.changeset/namzu-can-be-driven-and-a-hook-is-not-a-failure.md
+++ b/.changeset/namzu-can-be-driven-and-a-hook-is-not-a-failure.md
@@ -1,0 +1,17 @@
+---
+'@namzu/sdk': minor
+---
+
+The MCP server has a transport, and a failing post-checkout hook no longer discards a good worktree
+
+Two independent gaps, both found by studying how a comparable product solves the same problems. Neither is a port: the code here is namzu's, and in both cases the missing piece was smaller than it looked because the machinery already existed.
+
+**`MCPServer` had no way to run.** It is a complete implementation — `initialize`, `tools/list`, `tools/call`, resource and prompt providers — and nothing anywhere constructed one, because every transport in `connector/mcp/` is the *client* side: they connect this process to somebody else's server. `ServerStdioTransport` is the other end, so somebody else's client can drive namzu.
+
+Stdio first, deliberately. The client spawns the server as a child process, so there is no port, no bind address, and no inbound authentication question to answer wrongly. Note that stdout belongs to the protocol on this transport — a stray write corrupts the stream. This repository's logger writes to stderr, which is what makes it safe.
+
+**`GitWorktreeDriver.create` trusted the exit code.** `git worktree add` runs the repository's post-checkout hook *after* the checkout completes, so a hook that fails or is killed by a timeout reports failure over a worktree that is finished and usable. Trusting the status threw that worktree away and leaked it — the path stays registered, so the next attempt fails differently, with "already exists".
+
+`create` now checks the repository when the command reports failure, and accepts only a worktree registered under this exact path carrying the branch this call asked for. A registered path alone proves nothing: it can be a half-finished checkout or one somebody else owns, and those two are indistinguishable from here. Any error while checking counts as a failure, because this runs on a path that has already gone wrong once.
+
+No behaviour changes for a `create` that succeeds — the check runs only on the failure path.

--- a/packages/sdk/src/connector/mcp/__tests__/a-server-can-be-driven-over-stdio.test.ts
+++ b/packages/sdk/src/connector/mcp/__tests__/a-server-can-be-driven-over-stdio.test.ts
@@ -1,0 +1,182 @@
+import { PassThrough } from 'node:stream'
+import { describe, expect, it } from 'vitest'
+
+import type { MCPJsonRpcMessage } from '../../../types/connector/mcp.js'
+import { ServerStdioTransport } from '../server-stdio.js'
+import { MCPServer } from '../server.js'
+
+/**
+ * `MCPServer` was a complete protocol implementation with no caller,
+ * because every transport in this directory is the client side. These
+ * tests drive the real server through the real transport, so what they
+ * establish is that the two halves fit — not that either half parses.
+ */
+
+/** Collects whatever the server writes, one parsed message per line. */
+function harness() {
+	const input = new PassThrough()
+	const output = new PassThrough()
+	const written: MCPJsonRpcMessage[] = []
+
+	let pending = ''
+	output.on('data', (chunk: Buffer) => {
+		pending += chunk.toString('utf8')
+		let nl = pending.indexOf('\n')
+		while (nl !== -1) {
+			const line = pending.slice(0, nl).trim()
+			pending = pending.slice(nl + 1)
+			if (line) written.push(JSON.parse(line) as MCPJsonRpcMessage)
+			nl = pending.indexOf('\n')
+		}
+	})
+
+	return { input, output, written }
+}
+
+function serverWith(tools: Array<{ name: string; description: string }>) {
+	return new MCPServer(
+		{ name: 'namzu', version: '1.0.0' },
+		{
+			listTools: () =>
+				tools.map((t) => ({
+					name: t.name,
+					description: t.description,
+					inputSchema: { type: 'object' as const, properties: {} },
+				})),
+			callTool: async (name: string) => ({
+				content: [{ type: 'text' as const, text: `ran ${name}` }],
+			}),
+		},
+	)
+}
+
+/** Give the event loop a turn so stream data is delivered and handled. */
+const settle = () => new Promise((resolve) => setImmediate(resolve))
+
+describe('a client driving namzu over stdio', () => {
+	it('gets the tool list it asked for', async () => {
+		const { input, output, written } = harness()
+		const server = serverWith([{ name: 'run_agent', description: 'Run an agent' }])
+		await server.start(new ServerStdioTransport({ input, output }))
+
+		input.write(`${JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' })}\n`)
+		await settle()
+
+		const reply = written.find((m) => (m as { id?: number }).id === 1)
+		expect(reply).toBeDefined()
+		const result = (reply as { result?: { tools?: Array<{ name: string }> } }).result
+		expect(result?.tools?.map((t) => t.name)).toEqual(['run_agent'])
+	})
+
+	it('reads two messages that arrived in one chunk', async () => {
+		// A read is whatever size the pipe hands over. Treating one read as
+		// one message is the framing bug this transport exists to not have,
+		// and it only shows up under load — which is where it is worst.
+		const { input, output, written } = harness()
+		const server = serverWith([{ name: 'a', description: 'a' }])
+		await server.start(new ServerStdioTransport({ input, output }))
+
+		input.write(
+			`${JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' })}\n${JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' })}\n`,
+		)
+		await settle()
+
+		expect(written.map((m) => (m as { id?: number }).id).filter(Boolean)).toEqual([1, 2])
+	})
+
+	it('reads one message that arrived split across two chunks', async () => {
+		// The other half of the same framing question, and the more common
+		// one: a long tool schema does not fit in one read.
+		const { input, output, written } = harness()
+		const server = serverWith([{ name: 'a', description: 'a' }])
+		await server.start(new ServerStdioTransport({ input, output }))
+
+		const message = JSON.stringify({ jsonrpc: '2.0', id: 7, method: 'tools/list' })
+		input.write(message.slice(0, 12))
+		await settle()
+		expect(written).toHaveLength(0)
+
+		input.write(`${message.slice(12)}\n`)
+		await settle()
+		expect((written[0] as { id?: number }).id).toBe(7)
+	})
+
+	it('survives a malformed line and still answers the next request', async () => {
+		// One bad line is not the end of a session. Tearing down the
+		// transport would take every other conversation on the pipe with it,
+		// and silence would look to the client exactly like a hung server.
+		const { input, output, written } = harness()
+		const server = serverWith([{ name: 'a', description: 'a' }])
+		const transport = new ServerStdioTransport({ input, output })
+		await server.start(transport)
+
+		input.write('this is not json\n')
+		await settle()
+		input.write(`${JSON.stringify({ jsonrpc: '2.0', id: 9, method: 'tools/list' })}\n`)
+		await settle()
+
+		// Asserted through the server rather than by watching the error slot:
+		// `start` registers its own handlers and the slots are last-wins, so a
+		// test that installed its own would be measuring a transport the
+		// server is no longer wired to.
+		expect((written[0] as { id?: number }).id).toBe(9)
+		expect(transport.isConnected()).toBe(true)
+	})
+
+	it('writes nothing to the stream until it is asked something', async () => {
+		// stdout IS the protocol here. A transport that greeted the client,
+		// or a logger that wrote a banner, would corrupt the first message.
+		const { input, output, written } = harness()
+		const server = serverWith([{ name: 'a', description: 'a' }])
+		await server.start(new ServerStdioTransport({ input, output }))
+		await settle()
+
+		expect(written).toHaveLength(0)
+		expect(input.listenerCount('data')).toBe(1)
+	})
+
+	it('reports the stream ending as a close rather than an error', async () => {
+		// Driven without a server. The handler slots are single-assignment
+		// and `start` claims them, so this property belongs to the transport
+		// on its own — asserting it through a server would only prove which
+		// of the two registered last.
+		const { input, output } = harness()
+		const transport = new ServerStdioTransport({ input, output })
+		let closed = false
+		let errored = false
+		transport.onClose(() => {
+			closed = true
+		})
+		transport.onError(() => {
+			errored = true
+		})
+		await transport.connect()
+
+		input.end()
+		await settle()
+
+		expect(closed).toBe(true)
+		expect(errored).toBe(false)
+		expect(transport.isConnected()).toBe(false)
+	})
+
+	it('reports a malformed line to the error slot without disconnecting', async () => {
+		// The transport-level half of the survival test above.
+		const { input, output } = harness()
+		const transport = new ServerStdioTransport({ input, output })
+		const errors: Error[] = []
+		const seen: MCPJsonRpcMessage[] = []
+		transport.onError((err) => errors.push(err))
+		transport.onMessage((msg) => seen.push(msg))
+		await transport.connect()
+
+		input.write('not json\n')
+		input.write(`${JSON.stringify({ jsonrpc: '2.0', id: 3, method: 'ping' })}\n`)
+		await settle()
+
+		expect(errors).toHaveLength(1)
+		expect(errors[0]?.message).toContain('could not parse')
+		expect(seen).toHaveLength(1)
+		expect(transport.isConnected()).toBe(true)
+	})
+})

--- a/packages/sdk/src/connector/mcp/index.ts
+++ b/packages/sdk/src/connector/mcp/index.ts
@@ -1,6 +1,9 @@
 export { StdioTransport } from './stdio.js'
 export { HttpSseTransport } from './http-sse.js'
 export { StreamableHttpTransport } from './streamable-http.js'
+// The server half. The three above connect this process to somebody
+// else's MCP server; this one lets somebody else's client drive ours.
+export { ServerStdioTransport } from './server-stdio.js'
 
 export { MCPClient } from './client.js'
 

--- a/packages/sdk/src/connector/mcp/server-stdio.ts
+++ b/packages/sdk/src/connector/mcp/server-stdio.ts
@@ -1,0 +1,137 @@
+import type { Readable, Writable } from 'node:stream'
+
+import type { MCPJsonRpcMessage, MCPTransport } from '../../types/connector/mcp.js'
+import { type Logger, getRootLogger } from '../../utils/logger.js'
+
+/**
+ * The server half of stdio, so `MCPServer` has something to run on.
+ *
+ * `MCPServer` is a complete implementation — `initialize`, `tools/list`,
+ * `tools/call`, resource and prompt providers — and nothing anywhere
+ * constructed one, because every transport in this directory is the
+ * CLIENT side. `StdioTransport` spawns a child and talks to its streams;
+ * this reads the streams THIS process was given. Same interface, opposite
+ * end of the pipe.
+ *
+ * Stdio is the first transport rather than an afterthought: a client
+ * spawns the server as a child process, so there is no port, no bind
+ * address and no inbound authentication question to get wrong. The
+ * boundary is the process, and the process was started by the client.
+ *
+ * **stdout belongs to the protocol.** A single stray `console.log`
+ * anywhere in the process corrupts the message stream, and the symptom is
+ * a client that reports malformed JSON rather than anything naming the
+ * culprit. This repository's logger already writes to stderr, which is
+ * what makes this transport safe to add; keep it that way.
+ */
+export class ServerStdioTransport implements MCPTransport {
+	private readonly input: Readable
+	private readonly output: Writable
+	private buffer = ''
+	private connected = false
+	private readonly log: Logger
+
+	private messageHandler?: (message: MCPJsonRpcMessage) => void
+	private closeHandler?: () => void
+	private errorHandler?: (error: Error) => void
+
+	private readonly onData = (chunk: Buffer | string): void => this.consume(chunk)
+	private readonly onEnd = (): void => {
+		this.connected = false
+		this.closeHandler?.()
+	}
+	private readonly onStreamError = (err: Error): void => this.errorHandler?.(err)
+
+	/**
+	 * Streams are injected rather than read from `process` directly so a
+	 * test can drive this without owning the process's own stdio — a test
+	 * that replaced `process.stdin` would break every other test sharing
+	 * the runner.
+	 */
+	constructor(streams?: { input?: Readable; output?: Writable }) {
+		this.input = streams?.input ?? process.stdin
+		this.output = streams?.output ?? process.stdout
+		this.log = getRootLogger().child({ component: 'ServerStdioTransport' })
+	}
+
+	async connect(): Promise<void> {
+		if (this.connected) return
+		this.input.setEncoding?.('utf8')
+		this.input.on('data', this.onData)
+		this.input.on('end', this.onEnd)
+		this.input.on('error', this.onStreamError)
+		this.connected = true
+		this.log.info('MCP stdio server listening on this process')
+	}
+
+	async close(): Promise<void> {
+		if (!this.connected) return
+		this.input.off('data', this.onData)
+		this.input.off('end', this.onEnd)
+		this.input.off('error', this.onStreamError)
+		this.connected = false
+		this.closeHandler?.()
+	}
+
+	async send(message: MCPJsonRpcMessage): Promise<void> {
+		// Newline-delimited JSON, one message per line. A message carrying a
+		// literal newline would split into two unparseable halves, so it is
+		// stripped by `JSON.stringify` escaping rather than by trusting the
+		// payload.
+		this.output.write(`${JSON.stringify(message)}\n`)
+	}
+
+	onMessage(handler: (message: MCPJsonRpcMessage) => void): void {
+		this.messageHandler = handler
+	}
+
+	onClose(handler: () => void): void {
+		this.closeHandler = handler
+	}
+
+	onError(handler: (error: Error) => void): void {
+		this.errorHandler = handler
+	}
+
+	isConnected(): boolean {
+		return this.connected
+	}
+
+	/**
+	 * A chunk is not a message. Reads arrive at whatever size the pipe
+	 * hands over, so one read can carry half a message, several messages,
+	 * or the tail of one and the head of the next. Buffering until a
+	 * newline is the whole protocol framing.
+	 */
+	private consume(chunk: Buffer | string): void {
+		this.buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8')
+
+		let newline = this.buffer.indexOf('\n')
+		while (newline !== -1) {
+			const line = this.buffer.slice(0, newline).trim()
+			this.buffer = this.buffer.slice(newline + 1)
+			if (line) this.deliver(line)
+			newline = this.buffer.indexOf('\n')
+		}
+	}
+
+	private deliver(line: string): void {
+		let message: MCPJsonRpcMessage
+		try {
+			message = JSON.parse(line) as MCPJsonRpcMessage
+		} catch (err) {
+			// Reported, not thrown, and not fatal. A client that sends one bad
+			// line has not ended the session, and killing the transport over it
+			// would take down every other conversation on this pipe. The
+			// alternative — silence — is worse: a request that vanishes looks
+			// to the client exactly like a server that hung.
+			this.errorHandler?.(
+				new Error(
+					`MCP stdio server could not parse a message: ${err instanceof Error ? err.message : String(err)}`,
+				),
+			)
+			return
+		}
+		this.messageHandler?.(message)
+	}
+}

--- a/packages/sdk/src/session/workspace/__tests__/a-hook-failure-is-not-a-missing-worktree.test.ts
+++ b/packages/sdk/src/session/workspace/__tests__/a-hook-failure-is-not-a-missing-worktree.test.ts
@@ -1,0 +1,136 @@
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+
+import { WorkspaceBackendError } from '../../errors.js'
+import { GitWorktreeDriver } from '../git-worktree.js'
+
+/**
+ * `git worktree add` runs the repository's post-checkout hook AFTER the
+ * checkout completes. A hook that exits non-zero — or that a timeout kills
+ * — therefore reports failure over a worktree that is finished and usable.
+ *
+ * Trusting the exit code throws that worktree away AND leaks it: the path
+ * stays registered, so the next attempt fails differently, with "already
+ * exists". So the status is a hint and the repository is the evidence.
+ *
+ * The bar is deliberately narrow. A registered path alone proves nothing —
+ * it can be a half-finished checkout or one somebody else owns — so the
+ * branch this call asked for has to be on it.
+ */
+
+const REPO = '/repo'
+const WORKTREES = '/repo/.worktrees'
+/**
+ * The driver builds this with `path.join`, so it is backslash-separated on
+ * Windows. The porcelain fixture has to carry the same string the driver
+ * will look for, or the lookup misses for a reason that has nothing to do
+ * with what is being tested.
+ */
+const W1 = join(WORKTREES, 'w1')
+
+/** `git worktree list --porcelain` output for one registered worktree. */
+function porcelain(path: string, branch: string): string {
+	return ['', `worktree ${path}`, 'HEAD abc123', `branch ${branch}`, ''].join('\n')
+}
+
+function stubLogger(): never {
+	return {
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		child() {
+			return stubLogger()
+		},
+	} as never
+}
+
+function driverWith(exec: ReturnType<typeof vi.fn>) {
+	return new GitWorktreeDriver({
+		repoRoot: REPO,
+		worktreesDir: WORKTREES,
+		execFile: exec as never,
+		logger: stubLogger(),
+	})
+}
+
+describe('a worktree add that reports failure', () => {
+	it('succeeds when the worktree arrived with the branch this call asked for', async () => {
+		const exec = vi.fn(async (_bin: string, argv: string[]) => {
+			if (argv.includes('add')) throw new Error('post-checkout hook exited 1')
+			return { stdout: porcelain(W1, 'refs/heads/namzu/w1'), stderr: '' }
+		})
+
+		const ref = await driverWith(exec).create({ label: 'w1' })
+
+		expect(ref.meta.worktreePath).toBe(W1)
+		expect(ref.meta.branch).toBe('namzu/w1')
+	})
+
+	it('compares against the full ref the porcelain actually prints', async () => {
+		// The check is `refs/heads/<branch>` because that is what git writes.
+		// Comparing the short name would be a check that can never pass, and
+		// this whole recovery would be dead while looking alive.
+		const exec = vi.fn(async (_bin: string, argv: string[]) => {
+			if (argv.includes('add')) throw new Error('hook failed')
+			return { stdout: porcelain(W1, 'namzu/w1'), stderr: '' }
+		})
+
+		await expect(driverWith(exec).create({ label: 'w1' })).rejects.toBeInstanceOf(
+			WorkspaceBackendError,
+		)
+	})
+
+	it('still fails when the worktree is not there', async () => {
+		const exec = vi.fn(async (_bin: string, argv: string[]) => {
+			if (argv.includes('add')) throw new Error('fatal: invalid reference')
+			return { stdout: '', stderr: '' }
+		})
+
+		await expect(driverWith(exec).create({ label: 'w1' })).rejects.toBeInstanceOf(
+			WorkspaceBackendError,
+		)
+	})
+
+	it('refuses a path registered under a different branch', async () => {
+		// A leftover from a killed attempt and a checkout somebody else owns
+		// are indistinguishable from here. Claiming either would hand the
+		// caller a workspace whose contents nobody vouched for.
+		const exec = vi.fn(async (_bin: string, argv: string[]) => {
+			if (argv.includes('add')) throw new Error('hook failed')
+			return { stdout: porcelain(W1, 'refs/heads/someone-elses'), stderr: '' }
+		})
+
+		await expect(driverWith(exec).create({ label: 'w1' })).rejects.toBeInstanceOf(
+			WorkspaceBackendError,
+		)
+	})
+
+	it('treats a failure to check as a failure', async () => {
+		// This runs on a path that has already gone wrong once. Guessing
+		// optimistically here turns a bad situation into a wrong one.
+		const exec = vi.fn(async (_bin: string, argv: string[]) => {
+			if (argv.includes('add')) throw new Error('hook failed')
+			throw new Error('git list also failed')
+		})
+
+		await expect(driverWith(exec).create({ label: 'w1' })).rejects.toBeInstanceOf(
+			WorkspaceBackendError,
+		)
+	})
+
+	it('does not run the check at all when the add succeeded', async () => {
+		// The recovery is for a failure. Listing on every create would pay a
+		// subprocess on the happy path to learn something already known.
+		const seen: string[][] = []
+		const exec = vi.fn(async (_bin: string, argv: string[]) => {
+			seen.push(argv)
+			return { stdout: '', stderr: '' }
+		})
+
+		await driverWith(exec).create({ label: 'w1' })
+
+		expect(seen).toHaveLength(1)
+		expect(seen[0]).toContain('add')
+	})
+})

--- a/packages/sdk/src/session/workspace/git-worktree.ts
+++ b/packages/sdk/src/session/workspace/git-worktree.ts
@@ -89,7 +89,26 @@ export class GitWorktreeDriver implements WorkspaceBackendDriver {
 		try {
 			await this.exec('git', argv)
 		} catch (cause) {
-			throw new WorkspaceBackendError({ op: 'create', kind: this.kind, cause })
+			// A non-zero exit here does not mean the worktree was not created.
+			// `git worktree add` runs the repository's post-checkout hook AFTER
+			// the checkout has completed, so a hook that fails — or that a
+			// timeout kills — reports failure over a worktree that is finished
+			// and usable. Treating the status as the answer throws away a good
+			// checkout AND leaks it: the path stays registered, and the next
+			// attempt fails differently, with "already exists".
+			//
+			// So the exit code is a hint and the repository is the evidence.
+			// The bar is deliberately high: registered under this exact path
+			// AND carrying the branch this call asked for. A registered path
+			// alone can be a half-finished checkout, or somebody else's.
+			if (!(await this.createdDespite(worktreePath, branch))) {
+				throw new WorkspaceBackendError({ op: 'create', kind: this.kind, cause })
+			}
+			this.log.warn('git-worktree add reported failure but the worktree is present', {
+				branch,
+				worktreePath,
+				cause: cause instanceof Error ? cause.message : String(cause),
+			})
 		}
 
 		const meta: GitWorktreeBackendMeta = {
@@ -139,6 +158,41 @@ export class GitWorktreeDriver implements WorkspaceBackendDriver {
 				return
 			}
 			throw new WorkspaceBackendError({ op: 'dispose', kind: this.kind, cause })
+		}
+	}
+
+	/**
+	 * Did the worktree arrive despite the command reporting failure?
+	 *
+	 * Answers only for the branch this call created. A path registered
+	 * without that branch is not this call's worktree — it is a leftover
+	 * from a killed attempt, or a checkout somebody else owns, and the two
+	 * are indistinguishable from here. Claiming either would mean handing
+	 * a caller a workspace whose contents nobody vouched for, so both are
+	 * left to surface as the failure they are.
+	 *
+	 * Any error while checking is itself a "no". This runs on a path that
+	 * has already gone wrong once, and guessing optimistically there is how
+	 * a recovery turns a bad situation into a wrong one.
+	 */
+	private async createdDespite(worktreePath: string, branch: string): Promise<boolean> {
+		try {
+			const { stdout } = await this.exec('git', [
+				'-C',
+				this.repoRoot,
+				'worktree',
+				'list',
+				'--porcelain',
+			])
+			const entry = parseWorktreeList(stdout, worktreePath)
+			// `--porcelain` writes the branch as a full ref (`refs/heads/x`),
+			// and `branch` here is the short name this call passed to `-b`.
+			// Comparing them directly is a check that can never pass, which
+			// would make this whole recovery path silently dead — the exact
+			// shape it exists to catch.
+			return entry?.branch === `refs/heads/${branch}`
+		} catch {
+			return false
 		}
 	}
 


### PR DESCRIPTION
From studying how a comparable product solves the same problems. **Nothing is ported** — that product is source-available under a licence incompatible with this repository's, so reading it for reference is permitted and copying it is not. What crossed over is knowledge, and in both cases it landed on machinery namzu already had.

## `MCPServer` had no way to run

It is a complete implementation — `initialize`, `tools/list`, `tools/call`, resource and prompt providers — and **nothing anywhere constructed one**. The reason is easy to miss: every transport in `connector/mcp/` is the *client* side. `StdioTransport` spawns a child and talks to its streams; `StreamableHttpTransport` and `HttpSseTransport` dial somebody else's server. There was no other end of the pipe.

`ServerStdioTransport` is that end. It reads the streams this process was given, and lets somebody else's client drive namzu.

**Stdio first, deliberately.** The client spawns the server as a child process, so there is no port, no bind address and no inbound authentication question to answer wrongly. The boundary is the process, and the client started it. After a week of findings about a worker binding every interface with no authentication, that ordering is not an accident.

**stdout belongs to the protocol on this transport.** A single stray write corrupts the message stream, and the symptom is a client reporting malformed JSON rather than anything naming the culprit. This repository's logger already writes to stderr, which is what makes this safe to add — and worth keeping that way.

### What the tests pin

Two of them are the framing, which is the whole job of a stdio transport:

- **A read is not a message.** One read can carry two messages; one message can arrive in two reads. Treating a read as a message is a bug that only appears under load, which is where it is worst.
- **One bad line does not end a session.** Tearing down the transport takes every other conversation on the pipe with it; staying silent looks to the client exactly like a hung server. So it reports and continues.

And one that came out of writing them: `MCPTransport`'s handler slots are **single-assignment**, and `start()` claims them. A test that registers its own `onError` is measuring a transport the server is no longer wired to — so the error and close behaviour is asserted at the transport level, and the protocol behaviour through the server.

## `GitWorktreeDriver.create` trusted the exit code

`git worktree add` runs the repository's post-checkout hook **after** the checkout completes. A hook that exits non-zero, or that a timeout kills, therefore reports failure over a worktree that is finished and usable.

Trusting the status threw that worktree away **and leaked it**: the path stays registered, so the next attempt fails differently, with "already exists".

`create` now consults the repository when the command reports failure. The bar is narrow on purpose — registered under this exact path **and** carrying the branch this call asked for. A registered path alone proves nothing: a leftover from a killed attempt and a checkout somebody else owns are indistinguishable from here, and claiming either hands a caller a workspace whose contents nobody vouched for. Any error while checking counts as a failure, because this runs on a path where something has already gone wrong once.

This is `docs/conventions/verify-claims-including-your-own.md` applied to a subprocess: the exit code is a hint, the repository is the evidence.

### The detail that would have made it dead

`git worktree list --porcelain` prints the branch as a **full ref** (`refs/heads/namzu/x`), and the value being compared is the short name passed to `-b`. Comparing them directly is a check that can never pass — the whole recovery would have been dead while looking alive, which is the shape it exists to catch. Verified against real `git` output, and there is a test for that specific comparison.

## Scope

`create` on the happy path is unchanged and pays nothing: the check runs only on the failure branch, and a test pins that it makes exactly one subprocess call when the add succeeds.

Not here: a CLI command to serve, and cleanup of worktrees the driver creates. Both are real and both are separate.

Bump `minor` — new export, new optional recovery, no behaviour change to anything that worked.

Gates: `pnpm -r build` 0, workspace lint 0, external-name audit 0, public-surface intact (1286/1286 declared), affected suites 172 passed.
