### PR TITLE
feat(cli)!: commands run in a sandbox, and the operator configures it

### DIFF
--- a/.changeset/the-cli-attaches-a-sandbox.md
+++ b/.changeset/the-cli-attaches-a-sandbox.md
@@ -1,0 +1,23 @@
+---
+'@namzu/cli': major
+---
+
+The CLI runs commands in a sandbox, and you can configure it
+
+`sandboxProvider` appeared **zero times** in this package. `query()` attaches a sandbox only when one is supplied, so `context.sandbox` was always undefined and `BashTool` took its fallback branch — `execAsync` in the host process, with `{ ...process.env }`. Every credential your shell holds went to every command the model chose to run, on every path, interactive included. The isolation the documentation described held nowhere.
+
+**A sandbox is now attached by default.** Nothing to configure to get it.
+
+**And it is yours to control**, under a new `sandbox` block:
+
+```yaml
+sandbox:
+  enabled: true                            # default; false runs on the host
+  requireIsolation: [filesystem, network]  # refuse to start unless enforced
+```
+
+`requireIsolation` is empty by default, and that default is honest rather than safe: available isolation differs per platform, so requiring anything by default would refuse to run on machines where the CLI works today. Name a control and you get a refusal at startup instead of a surprise at runtime.
+
+**Every session reports what it got**, including when the answer is "nothing". A sandbox that confines nothing is not the same as no sandbox and is not protection, so the notice says which controls are enforced and which are not, and says outright when commands are unconfined.
+
+**Why `major`.** Commands now run inside a sandbox, so anything reaching a path outside the workspace, or the network where the platform confines it, behaves differently. Set `sandbox.enabled: false` to keep the old behaviour — a real choice with a real reason, announced on startup rather than assumed.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -144,6 +144,7 @@ export async function runCli(opts: RunCliOptions): Promise<number> {
 				skipPermissions,
 				rules: permissions.rules,
 				...(tuiCtx.config.mcpServers ? { mcpServers: tuiCtx.config.mcpServers } : {}),
+				...(tuiCtx.config.sandbox ? { sandbox: tuiCtx.config.sandbox } : {}),
 			})
 			const code = await Promise.resolve(0)
 			setExitCode(code)

--- a/packages/cli/src/config/load.ts
+++ b/packages/cli/src/config/load.ts
@@ -194,6 +194,27 @@ const CONFIG_READERS: ConfigReaders = {
 	// operator can see into a server that silently was never there.
 	mcpServers: (v) =>
 		typeof v === 'object' && v !== null && !Array.isArray(v) ? (v as McpServersConfig) : undefined,
+	// Read field by field rather than shape-only, unlike the two above.
+	// Those hand their entries to a compiler that reports a bad one by name;
+	// this one is consumed directly, and a misspelled `require_isolation` or
+	// a string where a list belongs would otherwise become "no requirement"
+	// — a security control silently downgraded by a typo, which is the
+	// failure this whole change exists to remove.
+	sandbox: (v) => {
+		if (typeof v !== 'object' || v === null || Array.isArray(v)) return undefined
+		const raw = v as { enabled?: unknown; requireIsolation?: unknown }
+		const enabled = typeof raw.enabled === 'boolean' ? raw.enabled : undefined
+		const requireIsolation = Array.isArray(raw.requireIsolation)
+			? raw.requireIsolation.filter(
+					(c): c is 'filesystem' | 'network' | 'process' =>
+						c === 'filesystem' || c === 'network' || c === 'process',
+				)
+			: undefined
+		return {
+			...(enabled !== undefined ? { enabled } : {}),
+			...(requireIsolation !== undefined ? { requireIsolation } : {}),
+		}
+	},
 }
 
 function readEnv(env: NodeJS.ProcessEnv): MutableConfig {

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -32,6 +32,44 @@ export interface NamzuCliConfig {
 	 * means no external servers, which is what it meant before this existed.
 	 */
 	readonly mcpServers?: McpServersConfig
+	/**
+	 * Isolation for the commands this CLI runs.
+	 *
+	 * Absent means ON. That is a change from every version before this one,
+	 * where `sandboxProvider` appeared nowhere in this package and every
+	 * tool call ran in the host process with the host environment — the
+	 * isolation the documentation described held on no path at all.
+	 *
+	 * Named `sandbox` rather than `isolation` because the thing being
+	 * configured is the sandbox; what it enforces is `requireIsolation`
+	 * inside it, and collapsing the two would make "turn isolation off"
+	 * ambiguous between "no sandbox" and "a sandbox that requires nothing".
+	 */
+	readonly sandbox?: SandboxConfig
+}
+
+export interface SandboxConfig {
+	/**
+	 * Run commands inside a sandbox. Default `true`.
+	 *
+	 * Setting it to `false` is a real choice with a real reason — a host
+	 * that provides its own isolation, or a platform where the sandbox
+	 * cannot start — and it is announced on startup rather than assumed.
+	 * It is not a way to make a failing sandbox quiet.
+	 */
+	readonly enabled?: boolean
+	/**
+	 * Controls this machine must actually enforce, or the CLI refuses to
+	 * start.
+	 *
+	 * Empty by default, and the default is honest rather than safe: the
+	 * available isolation differs per platform, so requiring anything by
+	 * default would refuse to run on machines where the CLI works today.
+	 * What the sandbox does and does not confine is reported on startup
+	 * either way — an operator who needs a guarantee names it here and gets
+	 * a refusal instead of a surprise.
+	 */
+	readonly requireIsolation?: readonly ('filesystem' | 'network' | 'process')[]
 }
 
 export const DEFAULT_CONFIG: NamzuCliConfig = Object.freeze({

--- a/packages/cli/src/context/__tests__/a-sandbox-is-on-unless-it-is-turned-off.test.ts
+++ b/packages/cli/src/context/__tests__/a-sandbox-is-on-unless-it-is-turned-off.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { resolveSandbox } from '../sandbox.js'
+
+/**
+ * `sandboxProvider` appeared zero times in this package, so
+ * `context.sandbox` was always undefined and every command ran in the host
+ * process with the host environment. The docs described isolation that
+ * held on no path.
+ *
+ * These tests are about which way the default falls and whether an
+ * operator can find out what they actually got — not about what any one
+ * platform enforces, which is a property of the machine running them.
+ */
+
+function stubLogger(): never {
+	return {
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		child() {
+			return stubLogger()
+		},
+	} as never
+}
+
+describe('the sandbox for a run', () => {
+	it('is on when nothing is configured', () => {
+		// The whole point. Absent used to mean off, and not by decision.
+		const resolved = resolveSandbox(stubLogger(), undefined)
+
+		expect(resolved.provider).toBeDefined()
+	})
+
+	it('is on when the config names only an isolation requirement', () => {
+		const resolved = resolveSandbox(stubLogger(), { requireIsolation: [] })
+
+		expect(resolved.provider).toBeDefined()
+	})
+
+	it('is off only when the operator says so, and says why it is off', () => {
+		const resolved = resolveSandbox(stubLogger(), { enabled: false })
+
+		expect(resolved.provider).toBeUndefined()
+		expect(resolved.unconfined).toBe(true)
+		// A refusal a reader cannot act on is a dead end. The notice names
+		// the setting to change.
+		expect(resolved.notice).toContain('sandbox.enabled')
+	})
+
+	it('always produces a notice, including when it is on', () => {
+		// Silence on the happy path is how "isolated" becomes an assumption
+		// rather than something the operator was told.
+		const on = resolveSandbox(stubLogger(), undefined)
+		const off = resolveSandbox(stubLogger(), { enabled: false })
+
+		expect(on.notice.length).toBeGreaterThan(0)
+		expect(off.notice.length).toBeGreaterThan(0)
+	})
+
+	it('reports unconfined honestly when the platform enforces nothing', () => {
+		// A sandbox that confines nothing is not the same as no sandbox, and
+		// is emphatically not protection. Whichever this machine is, the two
+		// fields have to agree — a notice saying "not confined" beside
+		// `unconfined: false` would be the surface lying about its own state.
+		const resolved = resolveSandbox(stubLogger(), undefined)
+
+		if (resolved.unconfined) {
+			expect(resolved.notice).toMatch(/not confined/i)
+		} else {
+			expect(resolved.notice).toMatch(/enforcing/i)
+		}
+	})
+
+	it('refuses to start when a required control cannot be enforced here', () => {
+		// The one case that throws. An operator who names a control is
+		// asking a question, and starting anyway would answer it with
+		// something other than the truth.
+		//
+		// Skipped rather than asserted when this machine happens to enforce
+		// everything: a test that passes because the platform is generous
+		// proves nothing about the refusal.
+		const probe = resolveSandbox(stubLogger(), undefined)
+		if (!probe.unconfined && !probe.notice.includes('NOT enforcing')) return
+
+		expect(() =>
+			resolveSandbox(stubLogger(), { requireIsolation: ['filesystem', 'network', 'process'] }),
+		).toThrow()
+	})
+})

--- a/packages/cli/src/context/sandbox.ts
+++ b/packages/cli/src/context/sandbox.ts
@@ -1,0 +1,90 @@
+import {
+	LocalSandboxProvider,
+	type Logger,
+	SANDBOX_ISOLATION_CONTROLS,
+	type SandboxIsolationControl,
+	type SandboxProvider,
+	isolationOf,
+} from '@namzu/sdk'
+
+import type { SandboxConfig } from '../config/schema.js'
+
+/**
+ * The sandbox a CLI run executes its commands in.
+ *
+ * There was none. `sandboxProvider` appeared zero times in this package,
+ * so `context.sandbox` was always undefined and `BashTool` took its
+ * fallback branch — `execAsync` in the host process, with the host
+ * environment, meaning every credential the operator's shell holds went
+ * to every command the model chose to run. The isolation the docs
+ * described held on no path.
+ *
+ * On by default now. What it enforces is a property of the machine, and
+ * this module's other job is to make sure nobody has to guess which.
+ */
+
+export interface ResolvedSandbox {
+	/** Absent when the operator turned it off. */
+	readonly provider?: SandboxProvider
+	/** One line for the operator, always — including when it is off. */
+	readonly notice: string
+	/**
+	 * True when commands run on the host with no confinement.
+	 *
+	 * Either because the sandbox is off, or because this platform's
+	 * environment enforces nothing. A caller that wants to warn louder in
+	 * that case does not have to re-derive it from the notice text.
+	 */
+	readonly unconfined: boolean
+}
+
+/**
+ * Build the sandbox for a run, or explain why there is none.
+ *
+ * Never throws for an ordinary platform shortfall — a machine that cannot
+ * confine the network still runs the CLI, and says so. It DOES throw when
+ * the operator named a control under `requireIsolation` that this machine
+ * cannot enforce, because that request is the one case where continuing
+ * quietly would be answering a question they asked with a different
+ * answer than the true one.
+ */
+export function resolveSandbox(log: Logger, config: SandboxConfig | undefined): ResolvedSandbox {
+	if (config?.enabled === false) {
+		return {
+			notice:
+				"Sandbox off by configuration: commands run in this process, with this shell's environment. Remove `sandbox.enabled: false` to turn it back on.",
+			unconfined: true,
+		}
+	}
+
+	const required = (config?.requireIsolation ?? []) as readonly SandboxIsolationControl[]
+	// Constructing with the requirement is what makes `requireIsolation`
+	// mean something: the provider refuses rather than downgrading, and the
+	// refusal names the control. Catching it here would turn a stated
+	// requirement back into a preference.
+	const provider = new LocalSandboxProvider(log, { requireIsolation: required })
+
+	const report = isolationOf(provider.environment)
+	const enforced = SANDBOX_ISOLATION_CONTROLS.filter((c) => report[c])
+	const missing = SANDBOX_ISOLATION_CONTROLS.filter((c) => !report[c])
+
+	if (enforced.length === 0) {
+		// The honest case, and the one most likely to be misread. The
+		// sandbox is attached and confines nothing, which is not the same as
+		// no sandbox and is emphatically not protection.
+		return {
+			provider,
+			notice: `Sandbox on (${provider.environment}), but this platform enforces none of ${SANDBOX_ISOLATION_CONTROLS.join(', ')} — commands are not confined. Name what you need under \`sandbox.requireIsolation\` to be refused instead of surprised.`,
+			unconfined: true,
+		}
+	}
+
+	return {
+		provider,
+		notice:
+			missing.length === 0
+				? `Sandbox on (${provider.environment}): enforcing ${enforced.join(', ')}.`
+				: `Sandbox on (${provider.environment}): enforcing ${enforced.join(', ')}; NOT enforcing ${missing.join(', ')}.`,
+		unconfined: false,
+	}
+}

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -371,6 +371,7 @@ export function App({ ctx }: AppProps) {
 				cwd: ctx.cwd,
 				rules: ctx.rules,
 				...(ctx.mcpServers ? { mcpServers: ctx.mcpServers } : {}),
+				...(ctx.sandbox ? { sandbox: ctx.sandbox } : {}),
 			})
 			// Re-hydration (a provider switch via /model) builds a second session;
 			// without this the first one's tool-server child processes stay alive

--- a/packages/cli/src/tui/agent.ts
+++ b/packages/cli/src/tui/agent.ts
@@ -40,6 +40,7 @@ import {
 	type ReviewAnswer,
 	type RunEvent,
 	type RunId,
+	type SandboxProvider,
 	SearchToolsTool,
 	type SessionId,
 	type StopReason,
@@ -53,13 +54,16 @@ import {
 	buildMemoryTools,
 	createMemoryPromoter,
 	getBuiltinTools,
+	getRootLogger,
 	query,
 	resumeRun,
 } from '@namzu/sdk'
 
 import { join } from 'node:path'
+import type { SandboxConfig } from '../config/schema.js'
 import { composeEnvironmentPrompt, readEnvironmentFacts } from '../context/environment.js'
 import { loadProjectInstructions } from '../context/project.js'
+import { resolveSandbox } from '../context/sandbox.js'
 import {
 	type ConnectedMcpServer,
 	type FailedMcpServer,
@@ -593,6 +597,16 @@ export interface AgentSessionOptions {
 	 * `answer_rejected`. Absent uses the kernel's default.
 	 */
 	readonly maxAnswerReviews?: number
+	/**
+	 * Isolation for the commands this session runs. Absent means ON with
+	 * the platform's defaults.
+	 *
+	 * Absent used to mean the opposite, and not by decision: nothing in
+	 * this package ever built a provider, so `context.sandbox` was always
+	 * undefined and every command ran in this process with this
+	 * environment.
+	 */
+	readonly sandbox?: SandboxConfig
 }
 
 export async function createAgentSession(
@@ -709,6 +723,11 @@ export async function createAgentSession(
 	// turn would make the line a surface prints at connect time a claim about
 	// the past. An edited file takes effect on the next session.
 	const projectInstructions = loadProjectInstructions(cwd)
+	// Before the registry, because a `requireIsolation` this machine cannot
+	// meet throws here — and failing before the session is built is the
+	// difference between "namzu refused to start" and a half-constructed
+	// session reporting a tool error on the first command.
+	const sandbox = resolveSandbox(getRootLogger(), options.sandbox)
 	const { registry, memoryStore } = buildToolRegistry(cwd)
 	// External tool servers, before the roster is counted, so `toolNames` and
 	// the `/tools` list a user reads include what they configured. Connecting
@@ -904,6 +923,7 @@ export async function createAgentSession(
 				opts,
 				taskGateway: subagentGateway,
 				childSteps,
+				...(sandbox.provider ? { sandboxProvider: sandbox.provider } : {}),
 			})
 		},
 		resumeDurable: async ({ entry, checkpointStore, claimFence, signal }) => {
@@ -1348,6 +1368,11 @@ interface RunTurnParams {
 	readonly opts: SendOptions | undefined
 	readonly taskGateway: TaskGateway | undefined
 	readonly childSteps: string[]
+	/**
+	 * Where this turn's commands run. Absent means the host process, which
+	 * is what every turn did before the CLI built one.
+	 */
+	readonly sandboxProvider?: SandboxProvider
 }
 
 async function* runTurn({
@@ -1369,6 +1394,7 @@ async function* runTurn({
 	opts,
 	taskGateway,
 	childSteps,
+	sandboxProvider,
 }: RunTurnParams): AsyncIterable<AgentEvent> {
 	const signal = opts?.signal
 	try {
@@ -1385,6 +1411,7 @@ async function* runTurn({
 			// empty array, so passing it here discarded the operator's rules on the
 			// path that runs every top-level turn. The sub-agent path called
 			// `gateFor` and this one did not.
+			...(sandboxProvider ? { sandboxProvider } : {}),
 			verificationGate: gateFor(rules),
 			compactionConfig: COMPACTION_CONFIG,
 			// The CLI owns its process end to end, so it can safely hand the

--- a/packages/cli/src/tui/types.ts
+++ b/packages/cli/src/tui/types.ts
@@ -6,6 +6,7 @@
 
 import type { VerificationRule } from '@namzu/sdk'
 
+import type { SandboxConfig } from '../config/schema.js'
 import type { McpServersConfig } from '../integrations/mcp/servers.js'
 
 export type MessageRole = 'user' | 'assistant' | 'system' | 'tool'
@@ -70,4 +71,10 @@ export interface TuiContext {
 	 * they declared has to be there whichever way they started namzu.
 	 */
 	readonly mcpServers?: McpServersConfig
+	/**
+	 * Isolation config, by the same reasoning as the two above: it belongs
+	 * to the user, not to a command, so it has to reach the session
+	 * whichever way namzu was started.
+	 */
+	readonly sandbox?: SandboxConfig
 }


### PR DESCRIPTION
Closes #401. The owner's decision: on by default, and fully configurable.

## What was there

`sandboxProvider` appeared **zero times** in `packages/cli`. `query()` attaches a sandbox only under `if (params.sandboxProvider)`, so `context.sandbox` was always undefined and `BashTool` took its fallback branch:

```ts
await execAsync(input.command, { env: { ...process.env, ...context.env } })
```

Host process, host working directory, **the full host environment** — on every path, interactive included, not only headless as it was first reported. The isolation the documentation described held nowhere.

## What it does now

A sandbox is attached by default. Nothing to configure to get it.

```yaml
sandbox:
  enabled: true                            # default; false runs on the host
  requireIsolation: [filesystem, network]  # refuse to start unless enforced
```

**`requireIsolation` is empty by default, and that default is honest rather than safe.** Available isolation differs per platform, so requiring anything by default would refuse to run on machines where the CLI works today. Name a control and the provider refuses at construction — the refusal is the feature, and catching it would turn a stated requirement back into a preference.

## Every session says what it got, including when the answer is nothing

**A sandbox that confines nothing is not the same as no sandbox, and is emphatically not protection.** So the notice names the controls enforced, the controls not enforced, and says outright when commands are unconfined — including the case where the sandbox is attached and this platform enforces none of it.

Silence on the happy path is how "isolated" becomes an assumption rather than something the operator was told. That is the same failure as `doctor` reporting healthy isolation for a provider the run never built.

## Two decisions worth reviewing

**The config reader validates field by field**, unlike `permissions` and `mcpServers` which are shape-only. Those hand their entries to a compiler that reports a bad one by name. This one is consumed directly, so a misspelled `require_isolation` or a string where a list belongs would silently become "no requirement" — a security control downgraded by a typo, which is the exact failure this change exists to remove.

**Resolved before the tool registry is built.** A `requireIsolation` this machine cannot meet throws there, so it fails as "namzu refused to start" rather than as a half-constructed session erroring on the first command.

## Tests

About which way the default falls and whether an operator can find out what they got — not about what any one platform enforces, which is a property of the machine running them.

One asserts that `notice` and `unconfined` agree whichever machine it runs on: a notice saying "not confined" beside `unconfined: false` would be the surface lying about its own state. The refusal test skips rather than asserting when the platform happens to enforce everything — a test that passes because the machine was generous proves nothing about the refusal.

## Bump: `major`

Commands now run inside a sandbox, so anything reaching outside the workspace — or the network, where the platform confines it — behaves differently. `sandbox.enabled: false` keeps the old behaviour, and is announced on startup rather than assumed.

## Not in this change

`doctor` still reports on a provider it constructs for the check rather than the one the run builds. It is now wrong in a smaller way — a provider does get built — but it is still not reporting the run's. Separate, and noted on #401.

Gates: `pnpm -r build` 0, workspace lint 0, CLI suite 941 passed / 4 skipped, external-name audit 0, public-surface intact.
