### PR TITLE
fix(sdk): a stale failure is not steering, so it evicts first

### DIFF
--- a/.changeset/a-stale-failure-is-not-steering.md
+++ b/.changeset/a-stale-failure-is-not-steering.md
@@ -1,0 +1,15 @@
+---
+'@namzu/sdk': patch
+---
+
+Compaction's failure list now drops its oldest entry, not its middle one
+
+Every list in working state protects its earliest entries when it has to evict, and the reason is written down: early decisions are load-bearing, and the one that set a run's approach should outlive twenty-five incidental notes.
+
+For failures that reasoning is backwards. The earliest failure is the one the model has most likely already worked around; the recent one is what it reads to decide what to do differently. So the slot was permanently protecting the least useful entries and evicting the most useful.
+
+It is not neutral ballast either. Sinha et al., "The Illusion of Diminishing Returns" (arXiv:2509.09677), inject errors into a model's own history at controlled rates and measure accuracy far later in the run: conditioning a model on its own error-prone history raises the likelihood of further errors, and scaling does not rescue it. A permanently-protected stale failure is exactly that input.
+
+Nothing decided failures should keep their oldest entries — the behaviour was inherited from a helper written for a slot where it is correct. Only the failure slot changes; decisions, discoveries and environment keep their existing policy, and there are tests pinning that.
+
+This does not change the rule that error results survive compaction. That rule is about keeping the error that steers, and keeping the recent one honours it better than keeping the first.

--- a/packages/sdk/src/compaction/__tests__/a-stale-failure-is-not-steering.test.ts
+++ b/packages/sdk/src/compaction/__tests__/a-stale-failure-is-not-steering.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import { WorkingStateManager } from '../manager.js'
+
+/**
+ * Every list in working state keeps its earliest entries when it has to
+ * drop something, because early decisions are load-bearing — the one that
+ * set the run's approach outlives twenty-five incidental notes.
+ *
+ * For failures that reasoning is backwards. The earliest failure is the
+ * one the model has most likely already worked around; the recent one is
+ * what it reads to decide what to do differently. And a stale failure is
+ * not neutral ballast: conditioning a model on its own error-prone history
+ * raises the likelihood of further errors (arXiv:2509.09677), so the slot
+ * was permanently protecting exactly the entries that hurt.
+ */
+
+function managerWith(maxListSize: number, keepFirstEntries: number): WorkingStateManager {
+	return new WorkingStateManager({
+		maxListSize,
+		keepFirstEntries,
+		maxToolResults: 30,
+	} as never)
+}
+
+describe('the failures slot', () => {
+	it('drops the oldest failure, not the middle one', () => {
+		const m = managerWith(3, 2)
+		for (const f of ['first', 'second', 'third', 'fourth']) m.addFailure(f)
+
+		const { failures } = m.getState()
+
+		expect(failures).toEqual(['second', 'third', 'fourth'])
+		expect(failures).not.toContain('first')
+	})
+
+	it('keeps the most recent failure whatever the list size', () => {
+		// The one the comment in `tool-result-editing.ts` is about: the
+		// error that steers is the one just seen.
+		const m = managerWith(2, 3)
+		for (const f of ['a', 'b', 'c', 'd', 'e']) m.addFailure(f)
+
+		expect(m.getState().failures.at(-1)).toBe('e')
+	})
+
+	it('still counts what it dropped', () => {
+		// A slot that silently shrinks presents a gap as complete.
+		const m = managerWith(2, 0)
+		for (const f of ['a', 'b', 'c', 'd']) m.addFailure(f)
+
+		expect(m.getState().evicted.failures).toBe(2)
+	})
+})
+
+describe('every other slot', () => {
+	it('still protects its earliest decisions', () => {
+		// The change is to one slot, not to the policy. A decision that set
+		// the run's approach has to outlive later noise, and breaking that
+		// while fixing failures would trade one defect for another.
+		const m = managerWith(3, 2)
+		for (const d of ['first', 'second', 'third', 'fourth']) m.addDecision(d)
+
+		const { decisions } = m.getState()
+
+		expect(decisions[0]).toBe('first')
+		expect(decisions[1]).toBe('second')
+		expect(decisions).toContain('fourth')
+	})
+
+	it('still protects its earliest discoveries', () => {
+		const m = managerWith(3, 2)
+		for (const d of ['first', 'second', 'third', 'fourth']) m.addDiscovery(d)
+
+		expect(m.getState().discoveries[0]).toBe('first')
+	})
+})

--- a/packages/sdk/src/compaction/manager.ts
+++ b/packages/sdk/src/compaction/manager.ts
@@ -47,8 +47,30 @@ export class WorkingStateManager {
 		this.pushWithEviction('decisions', this.state.decisions, decision, this.config.maxListSize)
 	}
 
+	/**
+	 * Failures evict OLDEST-first, unlike every other slot here.
+	 *
+	 * `keepFirstEntries` exists because early decisions are load-bearing —
+	 * the one that set the run's approach outlives twenty-five incidental
+	 * notes. That reasoning is right for decisions and backwards for
+	 * failures: the earliest failure is the one the model has most likely
+	 * already worked around, and the recent one is the thing it reads to
+	 * decide what to do differently.
+	 *
+	 * It also matters more than a preference. Sinha et al.,
+	 * "The Illusion of Diminishing Returns" (arXiv:2509.09677), inject
+	 * errors into a model's own history at controlled rates and measure
+	 * accuracy far later in the run: conditioning a model on its own
+	 * error-prone history raises the likelihood of further errors, and
+	 * scaling does not rescue it. So a permanently-protected early failure
+	 * is not neutral ballast — it is the input that paper measures.
+	 *
+	 * Nothing here decided failures should keep their oldest entries; the
+	 * behaviour was inherited from a shared helper written for a slot where
+	 * it is correct.
+	 */
 	addFailure(failure: string): void {
-		this.pushWithEviction('failures', this.state.failures, failure, this.config.maxListSize)
+		this.pushWithEviction('failures', this.state.failures, failure, this.config.maxListSize, 0)
 	}
 
 	addDiscovery(discovery: string): void {
@@ -141,9 +163,23 @@ export class WorkingStateManager {
 	 * condenser uses. The eviction is counted so the serializer can say
 	 * something was dropped rather than presenting a gap as complete.
 	 */
-	private pushWithEviction(slot: string, list: string[], item: string, max: number): void {
+	private pushWithEviction(
+		slot: string,
+		list: string[],
+		item: string,
+		max: number,
+		/**
+		 * Entries to protect at the front. Defaults to the configured
+		 * `keepFirstEntries`; pass 0 for a slot where the early entries are
+		 * the ones to lose. See {@link addFailure}.
+		 */
+		keepFirstOverride?: number,
+	): void {
 		list.push(item)
-		const keepFirst = Math.min(this.config.keepFirstEntries, Math.max(0, max - 1))
+		const keepFirst = Math.min(
+			keepFirstOverride ?? this.config.keepFirstEntries,
+			Math.max(0, max - 1),
+		)
 		while (list.length > max) {
 			list.splice(keepFirst, 1)
 			this.state.evicted[slot] = (this.state.evicted[slot] ?? 0) + 1


### PR DESCRIPTION
The third finding from commissioned research, and it turned out **not** to require overturning the decision it appeared to contradict.

## What the research said

Sinha et al., **"The Illusion of Diminishing Returns" (arXiv:2509.09677)**, isolate *execution* from planning and knowledge, then inject errors into a model's own history at controlled rates and measure accuracy far later in the run. Conditioning a model on its own error-prone history raises the likelihood of further errors. Scaling does not rescue it — a 670B model degrades with the small ones.

That reads as a challenge to a decision written and reasoned in this repository, at `compaction/tool-result-editing.ts`:

> *An error result is small and it STEERS — it is the thing the model reads to decide what to do differently.*

## What was actually wrong, which is narrower and clearer

That comment is right, and it is about **keeping errors**. The defect is in **which** errors survive when the list must evict.

`pushWithEviction` protects the earliest entries, and `keepFirstEntries` explains why:

> *Eviction used to drop the OLDEST entry, so a long run silently deleted the decision that set its approach while keeping the last twenty-five incidental notes. The early entries are the load-bearing ones.*

Correct for decisions. **Backwards for failures.** The earliest failure is the one the model has most likely already worked around; the recent one is the thing it reads to decide what to do differently. So the slot was permanently protecting its least useful entries and evicting its most useful — and per the paper, a protected stale failure is not neutral ballast but precisely the input that raises the next error's probability.

**Nobody decided this.** The behaviour was inherited from a shared helper written for a slot where it is right. So this is not a reversal of a reasoned choice; it is bounding one that was never applied to this case deliberately.

It also *strengthens* the comment it appeared to contradict: the error that steers is the recent one, so keeping recent failures honours "it STEERS" better than keeping the first.

## Scope

One slot. `decisions`, `discoveries` and `environment` keep their existing policy, and there are tests pinning that — fixing one slot by breaking the others would trade one defect for another.

Mutation: reverting the override fails the eviction-order test and leaves the other four passing. One dying and four living is the discrimination wanted.

## Not in this change

Dropping a failure once a later call to the same tool on the same target succeeded — the resolution rule the research also suggested. `addFailure` records `"${toolName}: ${truncated}"` with no target key, so "same target" is not expressible without adding structure to the slot. Worth doing, and a different change.

Bump `patch`: no API change, no behaviour change for a run whose failure list never fills.

Gates: `pnpm -r build` 0, workspace lint 0, external-name audit 0, public-surface intact, SDK 3327 passed / 7 skipped, CLI 941 passed / 4 skipped.
