### PR TITLE
fix(sandbox): the network has to be able to carry the policy

### DIFF
--- a/.changeset/the-network-has-to-carry-the-policy.md
+++ b/.changeset/the-network-has-to-carry-the-policy.md
@@ -1,0 +1,19 @@
+---
+'@namzu/sandbox': major
+---
+
+The docker backend's default configuration could not create a sandbox, and the test that would have caught it had never run
+
+`create()` failed on the documented defaults — `network: 'none'`, `hostReachability: 'host-port'` — with `index of untyped nil` thrown out of a `docker inspect` template, reported as "the container exited immediately". The container was alive and well. Docker binds a published port to the container's address by NAT, so a container with no route out has no address to bind to and nothing is published; measured against Docker 29.6, `--network none --publish 127.0.0.1::2024` is *accepted* and `NetworkSettings.Ports` comes back `{"2024/tcp":[]}`. An `--internal` network behaves the same way.
+
+`deny-all` had the same defect from the other side. It answered `--network none`, which reads as the strictest possible answer and removes the interface the worker is reached on — so it denied the way *in* along with the way out, in both reachability modes.
+
+**Why no one noticed.** `packages/sandbox/vitest.config.ts` excludes `**/*.smoke.test.ts` from every run it governs, including the `test:smoke` run that exists to run them; naming the files as CLI arguments does not re-include them, because positional arguments filter what discovery already found. With `--passWithNoTests`, `pnpm sandbox:smoke` printed `No test files found, exiting with code 0` and the workflow went green — after building a Debian image with a browser and an office suite in it to run nothing. The suite's own fail-fast guard for a misconfigured CI could not fire either: it lives inside a file that was never loaded.
+
+**What changes for you.**
+
+- The smoke suite has its own config and no `--passWithNoTests`, so an empty run is now a failure.
+- `create()` checks the container's network against the daemon before starting anything, and refuses with the reason. **The `network` default of `'none'` is one of the pairings it refuses** — name a bridge to reach the worker by host port, or set `hostReachability: 'container-network'`.
+- `deny-all` now keeps the configured network and **requires it to be one created with `docker network create --internal`**, verified rather than trusted. That is a real boundary: outbound gets `Network unreachable` from the kernel, not from an environment variable a workload may decline to read, while sibling containers still reach the worker by name.
+- Consequently **`deny-all` over a published host port is refused as impossible**, not unsupported: a published port needs a route out and `deny-all` needs none. Closing that means moving the worker's control channel off TCP, which is tracked separately.
+- `resolveNetwork` no longer returns `'none'` for `deny-all`. `assertNetworkCarriesThePolicy` and `isInternalNetwork` are exported alongside it.

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -64,11 +64,34 @@ throws instead of quietly ignoring it:
 
 | Backend | `deny-all` | `allow-all` | `static` | `resolver` |
 |---|---|---|---|---|
-| `container:docker` | enforced (`--network none`) | enforced | **throws** — no proxy to filter through | **throws** |
+| `container:docker` | enforced on an `--internal` network, and **throws** under `hostReachability: 'host-port'` | enforced | **throws** — no proxy to filter through | **throws** |
 | `container:standby-pool` | **throws** | **throws** | **throws** | **throws** |
 | `microvm:firecracker` | enforced (empty allowlist) | enforced (no allowlist) | enforced | enforced — `resolve()` is called and its result forwarded |
 
-Two rows carry the same lesson from opposite directions.
+### The network has to be able to carry the policy
+
+`network` and `hostReachability` are not independent of the egress policy,
+and pairing them wrongly used to produce a container nobody could reach:
+
+| You want | `network` | `hostReachability` |
+|---|---|---|
+| no egress, enforced | a network created `--internal` | `container-network` |
+| egress, restricted by allowlist | a bridge, plus an egress proxy | either |
+| egress, unrestricted | a bridge | either |
+
+Docker binds a published port to the container's address by NAT, so a
+container with no route out has no address to bind to and **nothing is
+published** — that holds for `--network none` and for an `--internal`
+network alike. `deny-all` needs exactly such a network. The two
+requirements are opposites, so *no egress plus a published host port* is
+impossible rather than unsupported; closing that means moving the worker's
+control channel off TCP.
+
+`create()` checks both against the daemon and refuses with the reason.
+Note that the `network` default of `'none'` is one of the pairings it
+refuses.
+
+Two rows of the table above carry the same lesson from opposite directions.
 
 The docker row used to accept a restrictive policy and silently grant the
 configured network, which is worse than not supporting the feature: the
@@ -120,7 +143,8 @@ Every container is launched with:
   layout advisory rather than enforced.
 - `--security-opt=no-new-privileges` — without it a setuid binary in the
   image re-escalates after the drop.
-- `--network none` by default (see the egress table above).
+- the configured network, which defaults to `none` (see the egress table
+  above, and the network note below it).
 
 There is deliberately **no re-add list** for capabilities. A workload that
 genuinely needs one should say so somewhere a reviewer sees it, not inherit

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -49,7 +49,7 @@
     "lint:fix": "biome check --write src/",
     "format": "biome format --write src/",
     "test": "vitest run --passWithNoTests",
-    "test:smoke": "vitest run --passWithNoTests src/**/*.smoke.test.ts",
+    "test:smoke": "vitest run --config vitest.smoke.config.ts",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "pnpm lint && pnpm typecheck && pnpm build"
   },

--- a/packages/sandbox/src/backends/docker/__tests__/deny-all-must-be-a-boundary-not-a-name.test.ts
+++ b/packages/sandbox/src/backends/docker/__tests__/deny-all-must-be-a-boundary-not-a-name.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+
+import { assertNetworkCarriesThePolicy, isInternalNetwork } from '../index.js'
+
+/**
+ * The backend shipped a default configuration that could not create a
+ * sandbox, and the one test that would have caught it had never run.
+ *
+ * Two requirements meet on the container's network and neither was checked.
+ * A published host port needs a network with a route out, because docker
+ * binds the port by NAT to the container's address. `deny-all` needs a
+ * network with no route out, because it no longer answers `--network none`
+ * and a network's name says nothing about whether it has one.
+ *
+ * Measured against Docker 29.6 before this was written:
+ *
+ *  - `--network none --publish 127.0.0.1::2024` is accepted;
+ *    `NetworkSettings.Ports` comes back `{"2024/tcp":[]}` and `docker port`
+ *    prints nothing. An `--internal` network behaves identically.
+ *  - `--network bridge` publishes: `2024/tcp -> 127.0.0.1:62528`.
+ *  - `docker network inspect bridge --format '{{.Internal}}'` → `false`;
+ *    the same against an `--internal` network → `true`.
+ *  - From a container on an internal network a sibling is reachable by
+ *    name, and `wget http://1.1.1.1` fails with `Network unreachable` — the
+ *    kernel refusing, not a proxy environment variable a workload may
+ *    decline to read.
+ *
+ * Driving the real backend with the documented defaults produced
+ * `index of untyped nil` out of the port readback, reported as "the
+ * container exited immediately".
+ */
+
+const NONE = undefined
+const DENY_ALL = { kind: 'deny-all' } as const
+
+describe('isInternalNetwork', () => {
+	it('reads the daemon’s answer', () => {
+		expect(isInternalNetwork('true')).toBe(true)
+		expect(isInternalNetwork('false')).toBe(false)
+	})
+
+	it('tolerates the trailing newline the docker CLI actually prints', () => {
+		// A version that only matched an already-trimmed string would pass a
+		// unit test and reject every real network.
+		expect(isInternalNetwork('true\n')).toBe(true)
+	})
+
+	it('treats an unreadable answer as no boundary', () => {
+		// A missing network or a daemon that is down arrives as the empty
+		// string. Absence of evidence is not a boundary, and defaulting the
+		// other way turns every lookup failure into full egress under a
+		// policy that says none.
+		expect(isInternalNetwork('')).toBe(false)
+	})
+
+	it('refuses anything that merely contains the word', () => {
+		// Guards a substring match, the shape of bug that has already cost
+		// this repo a permission rule.
+		expect(isInternalNetwork('not true')).toBe(false)
+	})
+})
+
+describe('a published host port', () => {
+	it('is refused on `none`, which is the documented default', () => {
+		// The whole finding in one assertion: the default configuration threw
+		// from inside a docker inspect template.
+		expect(() => assertNetworkCarriesThePolicy('none', 'host-port', NONE, 'false')).toThrow(
+			/cannot publish the worker's port/,
+		)
+	})
+
+	it('is refused on an internal network, which publishes nothing either', () => {
+		expect(() => assertNetworkCarriesThePolicy('locked-down', 'host-port', NONE, 'true')).toThrow(
+			/cannot publish the worker's port/,
+		)
+	})
+
+	it('is allowed on a bridge, which is the only thing that works', () => {
+		expect(() => assertNetworkCarriesThePolicy('bridge', 'host-port', NONE, 'false')).not.toThrow()
+	})
+
+	it('names both ways forward, so the refusal is actionable', () => {
+		expect(() => assertNetworkCarriesThePolicy('none', 'host-port', NONE, 'false')).toThrow(
+			/container-network/,
+		)
+	})
+})
+
+describe('a deny-all policy', () => {
+	it('is satisfied by an internal network reached by container name', () => {
+		expect(() =>
+			assertNetworkCarriesThePolicy('locked-down', 'container-network', DENY_ALL, 'true'),
+		).not.toThrow()
+	})
+
+	it('is refused on a network that can still reach the world', () => {
+		expect(() =>
+			assertNetworkCarriesThePolicy('shared', 'container-network', DENY_ALL, 'false'),
+		).toThrow(/is not internal/)
+	})
+
+	it('names the network and the command that fixes it', () => {
+		// An operator reading this has to know which network was rejected;
+		// "a network is not internal" sends them to inspect all of them.
+		const refuse = () =>
+			assertNetworkCarriesThePolicy('shared-bridge', 'container-network', DENY_ALL, 'false')
+		expect(refuse).toThrow(/shared-bridge/)
+		expect(refuse).toThrow(/docker network create --internal/)
+	})
+
+	it('is impossible over a published host port, from the two rules alone', () => {
+		// The requirements are exact opposites — a published port needs a
+		// route out and deny-all needs none — so this is impossible rather
+		// than unsupported. Closing it means moving the control channel off
+		// TCP. Asserted for both answers the daemon can give, because the
+		// case must not become reachable by choosing a different network.
+		expect(() => assertNetworkCarriesThePolicy('bridge', 'host-port', DENY_ALL, 'false')).toThrow()
+		expect(() =>
+			assertNetworkCarriesThePolicy('locked-down', 'host-port', DENY_ALL, 'true'),
+		).toThrow()
+	})
+})

--- a/packages/sandbox/src/backends/docker/__tests__/hardening.test.ts
+++ b/packages/sandbox/src/backends/docker/__tests__/hardening.test.ts
@@ -14,10 +14,13 @@ describe('resolveNetwork', () => {
 		expect(resolveNetwork('bridge', undefined)).toBe('bridge')
 	})
 
-	it('enforces deny-all natively', () => {
-		// Docker can actually do this one, so there is no excuse for
-		// accepting the policy and ignoring it.
-		expect(resolveNetwork('bridge', { kind: 'deny-all' })).toBe('none')
+	it('keeps the network for deny-all, because the container is reached THROUGH it', () => {
+		// This used to answer `'none'`, which reads as the strictest possible
+		// answer and was in fact unusable: `--network none` removes the
+		// interface the worker is reached on, not just the route out. What
+		// makes the kept network a boundary is `assertNetworkCarriesThePolicy`,
+		// which has its own file.
+		expect(resolveNetwork('locked-down', { kind: 'deny-all' })).toBe('locked-down')
 	})
 
 	it('allow-all keeps the configured network', () => {

--- a/packages/sandbox/src/backends/docker/__tests__/leaf-permissions.smoke.test.ts
+++ b/packages/sandbox/src/backends/docker/__tests__/leaf-permissions.smoke.test.ts
@@ -49,6 +49,16 @@ import { createSandboxProvider } from '../../../index.js'
 const IMAGE = process.env.NAMZU_SANDBOX_SMOKE_IMAGE ?? 'namzu-sandbox-worker:smoke'
 const IS_CI = process.env.CI === 'true'
 
+/**
+ * These cases reach the worker over a published host port, which docker
+ * binds to the container's address — so the network has to be one that
+ * gives it an address. The `network` default of `'none'` does not, and this
+ * file used to rely on it: every case here would have failed at `create()`
+ * with `index of untyped nil` out of a `docker inspect` template, had the
+ * suite ever been discovered.
+ */
+const SMOKE_NETWORK = 'bridge'
+
 function dockerAvailable(): boolean {
 	const probe = spawnSync('docker', ['version', '--format', '{{.Server.Version}}'], {
 		stdio: 'ignore',
@@ -93,7 +103,7 @@ describe.skipIf(skipReason !== null)('docker smoke — leaf permissions', () => 
 
 	it('uid 1001 can write to the outputs bind, and the host sees the file', async () => {
 		const provider = createSandboxProvider({
-			backend: { tier: 'container', image: IMAGE },
+			backend: { tier: 'container', image: IMAGE, network: SMOKE_NETWORK },
 			layout: {
 				outputs: { source: { type: 'hostDir', hostPath: outputsHost } },
 			},
@@ -116,7 +126,7 @@ describe.skipIf(skipReason !== null)('docker smoke — leaf permissions', () => 
 
 	it('unbound leaves do not exist — uploads/transcripts/tool_results are ENOENT, not empty', async () => {
 		const provider = createSandboxProvider({
-			backend: { tier: 'container', image: IMAGE },
+			backend: { tier: 'container', image: IMAGE, network: SMOKE_NETWORK },
 			layout: {
 				outputs: { source: { type: 'hostDir', hostPath: outputsHost } },
 				// Intentionally leave uploads / toolResults / transcripts
@@ -146,7 +156,7 @@ describe.skipIf(skipReason !== null)('docker smoke — leaf permissions', () => 
 
 	it('uid 1001 cannot mkdir into the root-owned 0555 parent /mnt/user-data', async () => {
 		const provider = createSandboxProvider({
-			backend: { tier: 'container', image: IMAGE },
+			backend: { tier: 'container', image: IMAGE, network: SMOKE_NETWORK },
 			layout: {
 				outputs: { source: { type: 'hostDir', hostPath: outputsHost } },
 			},

--- a/packages/sandbox/src/backends/docker/index.ts
+++ b/packages/sandbox/src/backends/docker/index.ts
@@ -186,10 +186,17 @@ export function buildDockerBackend(config: DockerBackendInternalConfig): Sandbox
  *
  * The policy used to be accepted and silently ignored, which is worse than
  * not supporting it: a host that set `deny-all` believed the container had
- * no network and it had the configured one. Docker can enforce `deny-all`
- * natively (`--network none`); it cannot enforce a host allowlist without
- * a proxy this backend does not have, so those policies are REFUSED rather
- * than quietly downgraded to "allow everything".
+ * no network and it had the configured one. It cannot enforce a host
+ * allowlist without a proxy this backend does not have, so those policies
+ * are REFUSED rather than quietly downgraded to "allow everything".
+ *
+ * `deny-all` used to answer `'none'`, which reads as the strictest possible
+ * answer and produced a sandbox nobody could reach. `--network none`
+ * removes every interface, and this backend's control channel is inbound
+ * TCP to the worker — so removing the interfaces removes the way IN, not
+ * just the way out. It now keeps the configured network, and
+ * {@link assertNetworkCarriesThePolicy} is what makes that network a
+ * boundary.
  */
 export function resolveNetwork(
 	configured: string,
@@ -200,7 +207,6 @@ export function resolveNetwork(
 
 	switch (egress.kind) {
 		case 'deny-all':
-			return 'none'
 		case 'allow-all':
 			return configured
 		default:
@@ -235,6 +241,68 @@ export async function resolveAllowedHosts(egress: EgressPolicy): Promise<readonl
 /** Whether a policy needs a boundary before it can be enforced at all. */
 export function needsEgressProxy(egress: EgressPolicy | undefined): boolean {
 	return egress?.kind === 'static' || egress?.kind === 'resolver'
+}
+
+/**
+ * Whether the daemon says a network has no route out.
+ *
+ * Takes the raw `docker network inspect --format '{{.Internal}}'` output
+ * rather than reading it, so every decision below is testable without a
+ * daemon and the daemon call stays one line. Anything other than a literal
+ * `true` counts as "not internal": an unreadable answer is not evidence of
+ * a boundary.
+ */
+export function isInternalNetwork(inspectedInternalFlag: string): boolean {
+	return inspectedInternalFlag.trim() === 'true'
+}
+
+/**
+ * Refuse a container whose network cannot do what was asked of it.
+ *
+ * Two requirements meet on the same object here, and both were previously
+ * unstated — which is how the backend came to ship a default configuration
+ * that could not create a sandbox at all:
+ *
+ *  - **A published host port needs a route out.** Docker binds the port by
+ *    NAT to the container's address, so a container with no address gets no
+ *    binding. Measured against Docker 29.6: `--network none --publish
+ *    127.0.0.1::2024` is *accepted*, `NetworkSettings.Ports` comes back
+ *    `{"2024/tcp":[]}`, and `docker port` prints nothing. An `--internal`
+ *    network behaves the same way. The port readback then failed with
+ *    `index of untyped nil` and reported it as "the container exited
+ *    immediately" — blaming a container that was alive and well.
+ *  - **`deny-all` needs a network with no route out.** Since it no longer
+ *    answers `--network none`, the configured name is all that stands
+ *    between the policy and ordinary outbound networking, and a name says
+ *    nothing. `deny-all` pointed at the default bridge would be full egress
+ *    under a policy object claiming none — the "accepted and silently
+ *    ignored" failure the rest of this file exists to refuse.
+ *
+ * They are exact opposites, so `deny-all` over a published host port is
+ * impossible rather than merely unsupported: no arrangement of docker
+ * networking both denies all egress and lets the host reach the worker over
+ * TCP. Closing that needs the control channel moved off TCP — see #398 —
+ * and is not a flag this function could accept.
+ */
+export function assertNetworkCarriesThePolicy(
+	network: string,
+	reachability: 'host-port' | 'container-network',
+	egress: EgressPolicy | undefined,
+	inspectedInternalFlag: string,
+): void {
+	const internal = isInternalNetwork(inspectedInternalFlag)
+
+	if (reachability === 'host-port' && (network === 'none' || internal)) {
+		throw new Error(
+			`The docker sandbox backend cannot publish the worker's port on network '${network}': docker binds a published port to the container's address, and a container with no route out has no address to bind to, so nothing is published and the sandbox is unreachable. Either give config.network a bridge that has one, or set hostReachability: 'container-network' and reach the worker by container name. Refusing rather than starting a container nobody can reach.`,
+		)
+	}
+
+	if (egress?.kind === 'deny-all' && !internal) {
+		throw new Error(
+			`The docker sandbox backend was asked for an egress policy of 'deny-all' on network '${network}', but that network is not internal, so the container can still reach the world. Create it with 'docker network create --internal ${network}' — an internal bridge denies egress in the kernel, rather than through an environment variable a workload may decline to read, while sibling containers still reach the worker by name. Refusing rather than reporting a boundary that is not there.`,
+		)
+	}
 }
 
 /**
@@ -297,13 +365,33 @@ async function spawnDockerSandbox(
 		egressProxy = await new EgressProxy(egressProxyOptions(config, policy)).listen()
 	}
 
+	const hostReachability = config.hostReachability ?? 'host-port'
 	const network = resolveNetwork(
 		config.network ?? 'none',
 		options.egress,
 		egressProxy !== undefined,
 	)
+	// Whether this network can carry the reachability mode and the policy is
+	// a fact about the network, so it is checked against the daemon rather
+	// than inferred from its name. Before the container starts on purpose: a
+	// refusal here is a wiring mistake and must not arrive dressed as a
+	// container that failed to come up, which is exactly how it used to
+	// arrive.
+	try {
+		assertNetworkCarriesThePolicy(
+			network,
+			hostReachability,
+			options.egress,
+			await inspectNetworkInternalFlag(docker, network),
+		)
+	} catch (err) {
+		// The allowlist kinds start a proxy above, and this is outside the
+		// try/catch that owns teardown — so without this the refusal would
+		// leave a listening server on loopback stamping real credentials.
+		await egressProxy?.close().catch(() => undefined)
+		throw err
+	}
 	const runtime = config.runtime
-	const hostReachability = config.hostReachability ?? 'host-port'
 	const containerName = `namzu-sandbox-${id}`
 
 	// All bind sources come from the consumer-supplied layout. The
@@ -804,6 +892,23 @@ function runOnce(binary: string, args: string[]): Promise<string> {
 			else reject(new Error(`${binary} ${args.join(' ')} exited ${code}: ${stderr.trim()}`))
 		})
 	})
+}
+
+/**
+ * Read a network's `Internal` flag from the daemon.
+ *
+ * A network that does not exist, or a daemon that is down, comes back as the
+ * empty string rather than throwing, so {@link assertNetworkCarriesThePolicy}
+ * refuses it for the reason the caller actually cares about — "this is not
+ * a boundary" — instead of surfacing a docker CLI error that says nothing
+ * about the egress policy that prompted the lookup.
+ */
+async function inspectNetworkInternalFlag(docker: string, network: string): Promise<string> {
+	try {
+		return await runOnce(docker, ['network', 'inspect', '--format', '{{.Internal}}', network])
+	} catch {
+		return ''
+	}
 }
 
 function runOnceQuiet(binary: string, args: string[]): Promise<void> {

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -203,11 +203,19 @@ export interface ContainerBackendConfig {
 	readonly hostReachability?: 'host-port' | 'container-network'
 	/**
 	 * Docker network the spawned container attaches to. Default
-	 * `'none'` (no inbound or outbound network). Set to a docker
-	 * bridge name when `hostReachability='container-network'` so the
-	 * SDK consumer (also on that bridge) can reach the worker by
-	 * container DNS name. Egress from the sandbox is governed
-	 * separately by `EgressPolicy`.
+	 * `'none'` (no inbound or outbound network).
+	 *
+	 * **The default does not work with the default `hostReachability`,
+	 * and `create()` refuses rather than starting a container nobody can
+	 * reach.** Docker binds a published port to the container's address,
+	 * so a container with no route out has no address to bind to and
+	 * nothing is published. Name a bridge here to reach the worker by host
+	 * port, or set `hostReachability: 'container-network'` and reach it by
+	 * container name — that mode works on an `--internal` network, which
+	 * is also the only way to get `deny-all` enforced.
+	 *
+	 * Egress from the sandbox is governed separately by `EgressPolicy`,
+	 * which is checked against this network rather than trusted.
 	 */
 	readonly network?: 'none' | 'bridge' | string
 	/**

--- a/packages/sandbox/vitest.config.ts
+++ b/packages/sandbox/vitest.config.ts
@@ -18,6 +18,13 @@ import { defineConfig } from 'vitest/config'
  * same command. When `process.env.CI === 'true'` and docker / the
  * image are absent, the smoke tests fail fast (rather than silently
  * skip) so a CI misconfiguration cannot mask a regression.
+ *
+ * The `exclude` below governs every run this config is used for, so
+ * `test:smoke` cannot re-include the files by naming them — positional
+ * arguments filter what discovery already found. It has its own config
+ * (`vitest.smoke.config.ts`) for exactly that reason; changing the pattern
+ * here means changing the `include` there too, or the suite silently stops
+ * being discovered by either.
  */
 export default defineConfig({
 	test: {

--- a/packages/sandbox/vitest.smoke.config.ts
+++ b/packages/sandbox/vitest.smoke.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from 'vitest/config'
+
+/**
+ * The docker-touching smoke suite, which the default config excludes.
+ *
+ * It needs its own config because `vitest.config.ts` excludes
+ * `**\/*.smoke.test.ts` from every run it governs — including the one
+ * `test:smoke` was meant to be. Naming the files as CLI arguments does not
+ * override that: positional arguments are a filter applied to the files
+ * discovery already found. So `pnpm sandbox:smoke` reported
+ * "No test files found, exiting with code 0" and the workflow went green,
+ * after building a Debian image with a browser and an office suite in it to
+ * run nothing at all.
+ *
+ * `--passWithNoTests` is deliberately NOT set here. An empty smoke run is
+ * the failure this file exists to make loud: the suite's own fail-fast
+ * guard (`process.env.CI === 'true'` with docker or the image missing) can
+ * only fire once a file is loaded, so a discovery bug disables the guard
+ * that was supposed to catch a misconfiguration.
+ */
+export default defineConfig({
+	test: {
+		include: ['src/**/*.smoke.test.ts'],
+		exclude: ['**/node_modules/**', '**/dist/**'],
+		// A container spawn, a worker handshake and a teardown do not fit in
+		// vitest's 5s default, and a timeout here reads as a product failure.
+		testTimeout: 120_000,
+		hookTimeout: 120_000,
+	},
+})


### PR DESCRIPTION
The docker backend could not create a sandbox on its own documented defaults, and the one test that would have caught it had never run.

## The failure

`network: 'none'` + `hostReachability: 'host-port'` — both defaults — died inside a `docker inspect` template with `index of untyped nil`. The hint reported it as *"the container exited immediately — check its logs"*. The container was alive and well; an operator following that hint would have found a happy worker and learned nothing.

Docker binds a published port to the container's address by NAT, so a container with no route out has no address to bind to. Measured against Docker 29.6:

| command | result |
|---|---|
| `--network none --publish 127.0.0.1::2024` | accepted; `NetworkSettings.Ports` → `{"2024/tcp":[]}`; `docker port` prints nothing |
| `--network bridge --publish 127.0.0.1::2024` | `2024/tcp -> 127.0.0.1:62528` |
| an `--internal` network | same as `none` — nothing published |

Driving the real backend with the documented defaults reproduced it exactly.

`deny-all` had the same defect from the other side. It answered `--network none`, which reads as the strictest possible answer and removes the interface the worker is reached **on** — denying the way in along with the way out, in both reachability modes.

## Why nobody noticed

`vitest.config.ts` excludes `*.smoke.test.ts` from every run it governs, **including the `test:smoke` run that exists to run them**. Naming the files as CLI arguments does not re-include them: positional arguments filter what discovery already found. With `--passWithNoTests`, the job printed

```
No test files found, exiting with code 0
```

and went green — after building a Debian image with a browser and an office suite in it to run nothing at all.

The suite's own fail-fast guard is the part worth pausing on. It was written so *"a CI misconfiguration cannot silently mask a regression"* — and it could not fire, because it lives inside a file that was never loaded. A green check meaning "never asked", again.

## The fix, both halves

- The smoke suite gets its own config and loses `--passWithNoTests`, so an empty run fails.
- `create()` checks the network against the daemon before starting anything. A published host port requires a network with a route out; `deny-all` requires one without. Both are facts about the network, so both are read from `docker network inspect` rather than inferred from a name.

`deny-all` now keeps the configured network and requires it to have been created `--internal`. Measured: outbound from such a network fails with `Network unreachable` from the kernel — not from an environment variable a workload may decline to read — while sibling containers still reach the worker by name. That is the enforcement mechanism #398 asks for, delivered for the reachability mode that can have it.

The two requirements are exact opposites, so **`deny-all` over a published host port is refused as impossible**, not unsupported. Closing that means moving the worker's control channel off TCP; that stays filed on #398.

## Breaking

`major` for `@namzu/sandbox`. The `network` default of `'none'` is now one of the pairings `create()` refuses, and `deny-all` requires an `--internal` network. Both configurations previously failed anyway — the change is that they now say why, before starting a container.

## Gates

`pnpm -r build` 0 · `pnpm typecheck` 0 · `pnpm lint` 0 · external-name audit 0 · public surface intact · sandbox 162 passed / 25 skipped.

The smoke workflow triggers on this PR, so its first real execution is here.
