### PR TITLE
docs: a check that was never asked, and why the capability drop is load-bearing

### DIFF
--- a/.changeset/the-capability-drop-is-load-bearing.md
+++ b/.changeset/the-capability-drop-is-load-bearing.md
@@ -1,0 +1,13 @@
+---
+'@namzu/sandbox': patch
+---
+
+Record why the capability drop is load-bearing for egress denial
+
+Comment only; no behaviour change.
+
+`deny-all` is now enforced by the container's network being `--internal`, and it was worth measuring what that is actually worth. A container on such a network has no default route — but `ip route add default via <sibling>` is refused with `Operation not permitted` under docker's **default** capability set, before `--cap-drop=ALL` is applied at all. `NET_ADMIN` is what would lift that.
+
+So the internal network removes the route and the capability drop removes the ability to put one back. Both are needed, and `HARDENING_ARGS` previously justified the drop only on unrelated grounds (`CAP_DAC_OVERRIDE` walking past read-only binds) — a rationale that would survive softening the flag, while this one would not.
+
+Also recorded: given `NET_ADMIN` and a manually installed route, a dual-homed sibling *does* forward the packet (`net.ipv4.ip_forward` is `1` inside a container). No connection establishes because nothing masquerades the internal subnet, but the docblock says plainly that this is not a security property — one-way egress is enough for exfiltration, and what was measured is a failed handshake, not a dropped packet.

--- a/docs/conventions/a-check-that-cannot-fail.md
+++ b/docs/conventions/a-check-that-cannot-fail.md
@@ -1,13 +1,13 @@
 ---
 uid: namzu.conventions.a-check-that-cannot-fail
 title: A check that cannot fail is worse than no check
-description: A guard placed where its condition can never be false protects nothing, and it teaches the next reader that the checks here are decoration — so the one that matters gets skimmed too. The same shape reaches assertions, where a matcher can accept the value it exists to reject.
+description: A guard whose condition can never be false protects nothing, and teaches the next reader that the checks here are decoration. The same shape reaches a matcher that accepts what it exists to reject, and a suite that never runs — whose absence the runner reports as success.
 type: Convention
 diataxis: explanation
 owner: cogitave/namzu
 status: active
 timestamp: 2026-08-04T00:00:00Z
-lastReviewed: 2026-08-09
+lastReviewed: 2026-08-13
 tags: [convention, verification, code-review]
 ---
 
@@ -89,11 +89,91 @@ The fix is always the same: assert the **whole** phrase, or anchor it. Prefer
 matching what a reader would see in full — the complete marker, the complete
 line — over the fragment that happens to be distinctive today.
 
+## The check that was never asked
+
+Amended 2026-08-13.
+
+The three forms above are all *present and evaluated* — a guard whose condition
+cannot be false, a test on a path the defect is not on, a matcher that accepts
+what it exists to reject. There is a fourth, and it is the worst of the family
+because nothing about it is wrong except that it never happened:
+
+**the check is correct, would have caught the defect, and is never run — and
+the runner reports that as success.**
+
+### The incident
+
+`packages/sandbox` has a smoke suite that spawns a real container, completes
+the worker handshake and asserts the leaf-mount permission contract. It is
+careful work. Its docstring explains that on CI it *fails fast* rather than
+skipping, "so a CI misconfiguration cannot silently mask a regression". A
+dedicated workflow builds the reference image and runs it on every change to
+the package.
+
+It had never run. Not once.
+
+Three things had to line up, and each is individually reasonable:
+
+1. `vitest.config.ts` excludes `**/*.smoke.test.ts` so the default `pnpm test`
+   stays daemon-free. Correct, and it governs **every run that config is used
+   for** — including the `test:smoke` run that exists to run them.
+2. `test:smoke` tried to re-include them by naming them as CLI arguments.
+   Positional arguments are a **filter applied to what discovery already
+   found**, not an include. They cannot re-add an excluded file.
+3. `--passWithNoTests` turned the resulting empty run into exit `0`.
+
+So the job printed `No test files found, exiting with code 0` and went green,
+after building a Debian image with a browser and an office suite in it to run
+nothing at all. Six words in a log, in a workflow nobody had reason to read,
+because it was passing.
+
+The fail-fast guard from the docstring could not fire either. It lives inside
+a file that was never loaded. **A guard against misconfiguration cannot survive
+a misconfiguration that prevents it from being read** — which is the same
+lesson as the rest of this page, arriving one level up.
+
+What it was hiding: the backend could not create a sandbox on its own
+documented defaults. `create()` died inside a `docker inspect` template, and
+the error blamed a container that was alive and well.
+
+### The tell
+
+You have a suite with a *dedicated* runner — a separate script, config, or
+workflow, usually because it is slow, needs a daemon, or would flake beside the
+unit tests. That separation is the risk. A suite in the default run announces
+its own absence by changing the count; a suite with its own path announces
+nothing to anyone.
+
+Ask two questions of any such runner:
+
+- **What is the last non-zero test count it printed?** Not "does it pass" —
+  passing is what the failure looks like. Read the summary line and find the
+  number. If you cannot find one in the log, that is the answer.
+- **Does its exit code distinguish "everything passed" from "nothing ran"?**
+  `--passWithNoTests` and its equivalents collapse the two on purpose, which is
+  right for a package that genuinely has no tests and wrong for one whose whole
+  point is a suite. Do not set it on a runner named after the suite it runs.
+
+### The fix, both halves
+
+Give the separated suite a config that *includes* it rather than a filter that
+hopes to, and drop the pass-with-no-tests flag from that runner so an empty run
+is a failure. Then check the two configs against each other: the exclude in one
+and the include in the other are now a pair, and changing either alone makes
+the suite invisible to both.
+
 ## Related
 
+- [Never filter a verification](never-filter-a-verification.md) — the adjacent
+  failure, and the contrast worth holding: there the check *runs* and its answer
+  is discarded; here the check never runs and its absence is reported as a pass.
+  Both end at a green summary line that means something other than "this is
+  fine".
 - [Mutate every test](mutation-check-every-test.md) — how you establish that a
   check can fail, rather than arguing that it can. The loose matcher above is
   the case mutation cannot report, which is why it is written down here as a
-  shape to recognise before you run one.
+  shape to recognise before you run one. Note that mutation cannot reach the
+  fourth form either: a suite that never runs kills nothing, and reads
+  identically to a suite with no coverage of the mutated line.
 - [An optional dependency may degrade a feature, never a check](an-optional-dependency-may-not-degrade-a-check.md)
   — a guard that cannot fail because its precondition was defaulted away.

--- a/docs/conventions/index.md
+++ b/docs/conventions/index.md
@@ -78,6 +78,8 @@ probably belong under `docs/sdk/` instead.
 - [A check that cannot fail is worse than no check](a-check-that-cannot-fail.md)
   — it teaches the next reader that the checks here are decoration. Includes the
   loose matcher: `toContain(old)` cannot see a change that only adds around it.
+  And the check that was never asked: a suite excluded from its own runner,
+  reported as a pass. A separated suite announces its absence to nobody.
 
 ### Reading the evidence
 

--- a/packages/sandbox/src/backends/docker/index.ts
+++ b/packages/sandbox/src/backends/docker/index.ts
@@ -341,6 +341,30 @@ export function egressProxyOptions(
  * `--cap-drop=ALL` is deliberately not softened by a re-add list: a
  * workload that genuinely needs a capability should say so through
  * `extraRunArgs` and be visible in review.
+ *
+ * **It carries a second, independent load, and this is the one that would
+ * survive being forgotten.** An egress policy of `deny-all` is enforced by
+ * the container's network being `--internal`, which gives it no route out.
+ * Measured against Docker 29.6: a container on such a network has only its
+ * own subnet in `ip route` and no default, and `ip route add default via
+ * <a sibling>` answers `RTNETLINK answers: Operation not permitted` —
+ * already, with docker's DEFAULT capability set, before this flag is
+ * applied. `NET_ADMIN` is what would lift that, and dropping every
+ * capability is what guarantees the workload does not have it.
+ *
+ * So the internal network removes the route and this flag removes the
+ * ability to put one back. Both are needed. Measured on a container given
+ * `--cap-add=NET_ADMIN`, adding the route and reaching a sibling attached
+ * to an external bridge produces `download timed out` rather than
+ * `Network unreachable` — the route existed, the packet left, and the
+ * dual-homed sibling forwarded it (`net.ipv4.ip_forward` is `1` inside a
+ * container). Nothing masquerades the internal subnet so no reply finds its
+ * way back and no connection establishes, **but that is not a security
+ * property**: one-way egress is sufficient for exfiltration, and what was
+ * measured is that the handshake fails, not that the packet was dropped.
+ *
+ * Recorded here because the first justification above would survive
+ * softening this flag and the second would not.
  */
 const HARDENING_ARGS: readonly string[] = ['--cap-drop=ALL', '--security-opt=no-new-privileges']
 


### PR DESCRIPTION
Two things measured this week, recorded where the next reader will hit them rather than left in a PR body.

## The fourth form of a check that is not one

`a-check-that-cannot-fail.md` already covers a guard whose condition can never be false, a test on a path the defect is not on, and a matcher that accepts what it exists to reject. All three are **present and evaluated**. The fourth is the correct check that never runs — and the runner reports that as success.

The incident, from #425: the sandbox smoke suite spawns a real container, completes the worker handshake and asserts the leaf-mount contract. Careful work. Its docstring explains that on CI it *fails fast* rather than skipping, "so a CI misconfiguration cannot silently mask a regression".

It had never run. Not once.

Three reasonable things lined up — the default config excludes `*.smoke.test.ts` from every run it governs *including the one that exists to run them*; naming files as CLI arguments filters what discovery already found rather than re-including them; and `--passWithNoTests` turned the empty result into exit 0. The job printed `No test files found, exiting with code 0` and went green, after building a Debian image with a browser and an office suite in it to run nothing.

The fail-fast guard could not fire either. **A guard against misconfiguration cannot survive a misconfiguration that prevents it from being read** — the same lesson as the rest of the page, one level up.

The tell is written down with it: a suite in the default run announces its own absence by changing the count; a suite with a dedicated runner announces nothing to anyone. So ask what the last non-zero test count that runner printed was, and whether its exit code distinguishes "everything passed" from "nothing ran".

Cross-linked with `never-filter-a-verification`, which is the adjacent failure and worth the contrast: there the check *runs* and its answer is discarded; here it never runs and its absence reads as a pass. Both end at a green summary line meaning something other than "this is fine".

## The capability drop carries a second load

`deny-all` is now enforced by the container's network being `--internal` (#425), so it was worth measuring what that is worth on its own.

A container on such a network has no default route — and `ip route add default via <sibling>` is refused with `Operation not permitted` under docker's **default** capability set, before `--cap-drop=ALL` applies at all. `NET_ADMIN` is what would lift it.

So the internal network removes the route and the flag removes the ability to put one back. `HARDENING_ARGS` previously justified the drop only on unrelated grounds (`CAP_DAC_OVERRIDE` walking past read-only binds) — **a rationale that would survive softening the flag, while this one would not.** That is precisely why it belongs in that docblock.

One more sentence recorded because it is the one someone would otherwise get wrong: given `NET_ADMIN` and a manual route, the dual-homed sibling **does** forward the packet (`net.ipv4.ip_forward` is `1` inside a container). No connection establishes because nothing masquerades the internal subnet — **but that is not a security property.** One-way egress is sufficient for exfiltration, and what was measured is a failed handshake, not a dropped packet.

## Scope

Comment and documentation only; no behaviour change. `patch` changeset for `@namzu/sandbox` because the PR touches a publishable package.

Gates: docs gate 0 · sandbox build 0 · sandbox lint 0 · external-name audit 0.
