### PR TITLE
fix(sandbox)!: the worker handed its own configuration to every child

### DIFF
--- a/.changeset/the-worker-does-not-hand-over-its-own-config.md
+++ b/.changeset/the-worker-does-not-hand-over-its-own-config.md
@@ -1,0 +1,24 @@
+---
+'@namzu/sandbox': major
+---
+
+The sandbox worker no longer hands its own configuration to the code it contains
+
+Every command the agent runs was spawned with `{ ...process.env, ...body.env }` — the worker's **entire** environment, copied into every child by construction, on every call, and visible in a bare `env` in any shell transcript.
+
+That is a stronger exposure than "untrusted code could read `/proc/self/environ` if it thought to look". It is active propagation: the agent does not have to go looking.
+
+What rode along: `NAMZU_SANDBOX_WORKSPACE`, `NAMZU_SANDBOX_READ_ROOTS` and `NAMZU_SANDBOX_WRITE_ROOTS` — **the confinement layout itself, handed to the code being confined** — plus every other worker setting. The boundary announced its own shape to the thing it was drawn around.
+
+Variables prefixed `NAMZU_SANDBOX_` are now stripped from the inherited environment.
+
+**Stripping by prefix rather than by an allowlist of known-safe names is the load-bearing choice**, and it is the difference between this working and this quietly breaking egress:
+
+- `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` are set on the container **on purpose**, so tooling inside routes through the egress boundary. An allowlist assembled from first principles drops them, and every proxied workload silently stops being proxied — which looks exactly like the policy working.
+- A host's own `options.env` arrives on the same channel and is meant to reach commands. Once both are in `process.env` it is indistinguishable from the worker's config; the prefix is the only thing that tells them apart.
+
+`body.env` is applied **after** the strip and is not filtered. Inheritance is implicit and gets the default; an explicit per-call value is a caller deciding, including one that deliberately sets a prefixed name.
+
+**What changes for you.** A command that read `NAMZU_SANDBOX_WORKSPACE`, `NAMZU_SANDBOX_READ_ROOTS` or `NAMZU_SANDBOX_WRITE_ROOTS` out of its own environment no longer sees them. Pass the value explicitly — `exec`'s `env`, or the provider's `options.env` under a name of your own — if a workload genuinely needs it. The workspace root is also the command's `cwd`, which is how most callers were getting it already.
+
+`major` because the environment a spawned command observes is behaviour a consumer can depend on, even though nothing in the type surface changed.

--- a/packages/sandbox/worker/__tests__/the-worker-does-not-hand-over-its-own-config.test.js
+++ b/packages/sandbox/worker/__tests__/the-worker-does-not-hand-over-its-own-config.test.js
@@ -53,8 +53,17 @@ async function spawnWorker(env) {
 	}
 }
 
-/** A worker spawn plus a child process does not fit in vitest's 5s default. */
-const NEEDS_TWO_PROCESSES = 30_000
+/**
+ * A worker spawn plus a child process does not fit in vitest's 5s default.
+ *
+ * Generous rather than tight on purpose. These wait on two real process
+ * starts, so the number bounds a machine under load rather than the work —
+ * a healthy run exits as soon as the assertion is made and pays nothing for
+ * the headroom, while a tight bound turns a busy CI runner into a red build
+ * that says nothing about the subject. One failure was observed here with a
+ * heavy repo-wide script running alongside.
+ */
+const NEEDS_TWO_PROCESSES = 60_000
 
 function waitForListening(child) {
 	return new Promise((resolve, reject) => {

--- a/packages/sandbox/worker/__tests__/the-worker-does-not-hand-over-its-own-config.test.js
+++ b/packages/sandbox/worker/__tests__/the-worker-does-not-hand-over-its-own-config.test.js
@@ -1,0 +1,197 @@
+import { spawn } from 'node:child_process'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import net from 'node:net'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+/**
+ * The worker used to spawn every command with `{ ...process.env, ...body.env }`,
+ * so its entire environment reached the code it exists to contain — including
+ * `NAMZU_SANDBOX_WORKSPACE`, `_READ_ROOTS` and `_WRITE_ROOTS`, which describe
+ * the confinement layout to the thing being confined.
+ *
+ * These drive the real worker as a subprocess and read the environment back
+ * out of an actually-spawned child, because that is the only place the answer
+ * is observable. Asserting on `childEnvironment` directly would prove the
+ * helper filters and say nothing about whether `/execute` calls it.
+ */
+
+async function spawnWorker(env) {
+	const port = await getFreePort()
+	const workspace = await mkdtemp(path.join(os.tmpdir(), 'namzu-sandbox-worker-env-'))
+	const source = await readFile(path.join(import.meta.dirname, '..', 'server.js'), 'utf8')
+	const entry = path.join(workspace, 'server.cjs')
+	await writeFile(entry, source)
+
+	const child = spawn(process.execPath, [entry], {
+		env: {
+			...process.env,
+			NAMZU_SANDBOX_PORT: String(port),
+			NAMZU_SANDBOX_BIND: '127.0.0.1',
+			NAMZU_SANDBOX_WORKSPACE: workspace,
+			NAMZU_SANDBOX_IDLE_TIMEOUT_MS: '0',
+			...env,
+		},
+		stdio: ['ignore', 'pipe', 'pipe'],
+	})
+
+	await waitForListening(child)
+
+	return {
+		baseUrl: `http://127.0.0.1:${port}`,
+		async stop() {
+			// Wait for the process to actually go before removing the
+			// directory its script is running from: on Windows the file stays
+			// locked until then and `rm` fails with EBUSY, turning teardown
+			// into a test failure that says nothing about the subject.
+			const exited = new Promise((resolve) => child.once('exit', resolve))
+			child.kill('SIGKILL')
+			await exited
+			await rm(workspace, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+		},
+	}
+}
+
+/** A worker spawn plus a child process does not fit in vitest's 5s default. */
+const NEEDS_TWO_PROCESSES = 30_000
+
+function waitForListening(child) {
+	return new Promise((resolve, reject) => {
+		let out = ''
+		const onData = (chunk) => {
+			out += chunk.toString('utf8')
+			if (out.includes('listening on')) {
+				cleanup()
+				resolve()
+			}
+		}
+		const onExit = (code) => {
+			cleanup()
+			reject(new Error(`worker exited early (${code}): ${out}`))
+		}
+		const cleanup = () => {
+			child.stdout.off('data', onData)
+			child.stderr.off('data', onData)
+			child.off('exit', onExit)
+		}
+		child.stdout.on('data', onData)
+		child.stderr.on('data', onData)
+		child.on('exit', onExit)
+	})
+}
+
+function getFreePort() {
+	return new Promise((resolve, reject) => {
+		const server = net.createServer()
+		server.on('error', reject)
+		server.listen(0, '127.0.0.1', () => {
+			const { port } = server.address()
+			server.close(() => resolve(port))
+		})
+	})
+}
+
+/** Run a command through the worker and return the environment it saw. */
+async function environmentSeenByChild(worker, requestedEnv) {
+	const res = await fetch(`${worker.baseUrl}/execute`, {
+		method: 'POST',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify({
+			command: process.execPath,
+			args: ['-e', 'process.stdout.write(JSON.stringify(process.env))'],
+			...(requestedEnv ? { env: requestedEnv } : {}),
+		}),
+	})
+
+	const stdout = (await res.text())
+		.split('\n')
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.map((line) => JSON.parse(line))
+		.filter((event) => event.type === 'stdout_delta')
+		.map((event) => event.data)
+		.join('')
+
+	return JSON.parse(stdout)
+}
+
+describe('the environment a sandboxed command runs in', () => {
+	let worker
+
+	afterEach(async () => {
+		if (worker) await worker.stop()
+		worker = undefined
+	}, NEEDS_TWO_PROCESSES)
+
+	it('does not describe the confinement layout to the confined code', async () => {
+		// The concrete case. A command could read the workspace root and both
+		// root lists straight out of its own environment.
+		worker = await spawnWorker()
+
+		const seen = await environmentSeenByChild(worker)
+
+		expect(seen.NAMZU_SANDBOX_WORKSPACE).toBeUndefined()
+		expect(seen.NAMZU_SANDBOX_READ_ROOTS).toBeUndefined()
+		expect(seen.NAMZU_SANDBOX_WRITE_ROOTS).toBeUndefined()
+	}, NEEDS_TWO_PROCESSES)
+
+	it('strips by prefix, so a setting added later is covered without being listed', async () => {
+		// A deny-list of known names would leak whatever is added next. The
+		// prefix is the boundary, which is why the constant carries a docblock
+		// saying so.
+		worker = await spawnWorker({ NAMZU_SANDBOX_SOME_FUTURE_SECRET: 'must-not-propagate' })
+
+		const seen = await environmentSeenByChild(worker)
+
+		expect(seen.NAMZU_SANDBOX_SOME_FUTURE_SECRET).toBeUndefined()
+		expect(Object.keys(seen).filter((k) => k.startsWith('NAMZU_SANDBOX_'))).toEqual([])
+	}, NEEDS_TWO_PROCESSES)
+
+	it('still passes the proxy variables, which are set on purpose', async () => {
+		// The half that makes an allowlist wrong. The egress boundary works by
+		// tooling inside honouring these; dropping them stops every workload
+		// being proxied, which looks exactly like the policy working.
+		worker = await spawnWorker({
+			HTTP_PROXY: 'http://namzu-egress:8080',
+			HTTPS_PROXY: 'http://namzu-egress:8080',
+			NO_PROXY: 'localhost,127.0.0.1',
+		})
+
+		const seen = await environmentSeenByChild(worker)
+
+		expect(seen.HTTP_PROXY).toBe('http://namzu-egress:8080')
+		expect(seen.HTTPS_PROXY).toBe('http://namzu-egress:8080')
+		expect(seen.NO_PROXY).toBe('localhost,127.0.0.1')
+	}, NEEDS_TWO_PROCESSES)
+
+	it('still passes the host’s own environment, which is meant to reach commands', async () => {
+		// A host's `options.env` arrives on the same channel as the worker's
+		// config and is indistinguishable from it once both are in
+		// `process.env`. Only the prefix tells them apart.
+		worker = await spawnWorker({ MY_APP_TOKEN: 'host-supplied' })
+
+		const seen = await environmentSeenByChild(worker)
+
+		expect(seen.MY_APP_TOKEN).toBe('host-supplied')
+	}, NEEDS_TWO_PROCESSES)
+
+	it('still passes PATH, or nothing would run at all', async () => {
+		worker = await spawnWorker()
+
+		const seen = await environmentSeenByChild(worker)
+
+		expect(seen.PATH ?? seen.Path).toBeTruthy()
+	}, NEEDS_TWO_PROCESSES)
+
+	it('lets an explicit per-call value through, including a prefixed one', async () => {
+		// Inheritance is implicit and gets the default; `body.env` is a caller
+		// deciding. Filtering that too would silently drop a value the caller
+		// asked for by name.
+		worker = await spawnWorker()
+
+		const seen = await environmentSeenByChild(worker, { NAMZU_SANDBOX_WORKSPACE: 'chosen' })
+
+		expect(seen.NAMZU_SANDBOX_WORKSPACE).toBe('chosen')
+	}, NEEDS_TWO_PROCESSES)
+})

--- a/packages/sandbox/worker/server.js
+++ b/packages/sandbox/worker/server.js
@@ -50,6 +50,16 @@ const { spawn } = require('node:child_process')
 const fs = require('node:fs/promises')
 const path = require('node:path')
 
+/**
+ * Prefix every variable this worker reads its own configuration from.
+ *
+ * Load-bearing: {@link childEnvironment} strips it, so the prefix is the
+ * boundary between "the worker's configuration" and "the environment the
+ * sandbox is supposed to run commands in". A new setting that does not use
+ * it is handed to untrusted code automatically.
+ */
+const WORKER_CONFIG_PREFIX = 'NAMZU_SANDBOX_'
+
 const PORT = Number(process.env.NAMZU_SANDBOX_PORT || 2024)
 const WORKSPACE_ROOT = process.env.NAMZU_SANDBOX_WORKSPACE || '/workspace'
 const READ_ROOTS = normalizeRoots(
@@ -227,6 +237,48 @@ function resolveTimeoutMs(rawTimeoutMs) {
 	return timeoutMs
 }
 
+/**
+ * The environment a spawned command runs in.
+ *
+ * This used to be `{ ...process.env, ...body.env }`, which handed the
+ * worker's ENTIRE environment to every command the agent runs — by
+ * construction, on every call, visible in a bare `env` in any shell
+ * transcript. That is a stronger exposure than "untrusted code could read
+ * `/proc/self/environ` if it thought to": it is active propagation, and the
+ * agent does not have to go looking.
+ *
+ * What rode along: `NAMZU_SANDBOX_WORKSPACE`, `_READ_ROOTS` and
+ * `_WRITE_ROOTS` — the confinement layout itself, handed to the code being
+ * confined — plus every other setting below. So the boundary announced its
+ * own shape to the thing it was drawn around.
+ *
+ * Stripping by prefix rather than by an allowlist of known-safe names is
+ * deliberate, and it is the difference between this working and this
+ * breaking egress:
+ *
+ *  - `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` are set on the container ON
+ *    PURPOSE, so that tooling inside routes through the egress boundary. An
+ *    allowlist assembled from first principles drops them and every
+ *    proxied workload silently stops being proxied — which would look
+ *    exactly like the policy working.
+ *  - A host's own `options.env` arrives on this same channel and is meant
+ *    to reach commands. It is indistinguishable from the worker's config
+ *    once both are in `process.env`; the prefix is the only thing that
+ *    tells them apart.
+ *
+ * `body.env` is applied AFTER the strip and is not filtered. Inheritance is
+ * implicit and gets the default; an explicit per-call value is a caller
+ * deciding, including a caller that deliberately sets a prefixed name.
+ */
+function childEnvironment(requested) {
+	const inherited = {}
+	for (const key of Object.keys(process.env)) {
+		if (key.startsWith(WORKER_CONFIG_PREFIX)) continue
+		inherited[key] = process.env[key]
+	}
+	return { ...inherited, ...(requested || {}) }
+}
+
 async function handleExecute(req, res) {
 	let body
 	try {
@@ -287,7 +339,7 @@ async function handleExecute(req, res) {
 	try {
 		child = spawn(body.command, Array.isArray(body.args) ? body.args : [], {
 			cwd,
-			env: { ...process.env, ...(body.env || {}) },
+			env: childEnvironment(body.env),
 			stdio: [body.stdin === undefined ? 'ignore' : 'pipe', 'pipe', 'pipe'],
 		})
 	} catch (err) {


### PR DESCRIPTION
`handleExecute` spawned every command with `{ ...process.env, ...body.env }` — the worker's **entire** environment, copied into every child by construction, on every call, and visible in a bare `env` in any shell transcript.

That is a stronger exposure than "untrusted code could read `/proc/self/environ` if it thought to look". It is active propagation: the agent does not have to go looking, and does not have to know the mechanism exists.

What rode along: `NAMZU_SANDBOX_WORKSPACE`, `NAMZU_SANDBOX_READ_ROOTS` and `NAMZU_SANDBOX_WRITE_ROOTS` — **the confinement layout itself, handed to the code being confined.** The boundary announced its own shape to the thing it was drawn around.

## The fix, and why it is a prefix rather than an allowlist

Variables prefixed `NAMZU_SANDBOX_` are stripped from the inherited environment. The prefix gets a named constant with a docblock saying it *is* the boundary, because a setting added later without it is handed to untrusted code automatically.

An allowlist of known-safe names was the obvious alternative and would have been wrong in a way that is hard to notice:

- `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` are set on the container **on purpose**, so tooling inside routes through the egress boundary. An allowlist assembled from first principles drops them — and every proxied workload silently stops being proxied, which looks exactly like the policy working.
- A host's own `options.env` arrives on the same channel and is meant to reach commands. Once both are in `process.env` it is indistinguishable from the worker's config. **The prefix is the only thing that tells them apart.**

`body.env` is applied **after** the strip and is not filtered. Inheritance is implicit and gets the default; an explicit per-call value is a caller deciding, including one that deliberately sets a prefixed name. There is a test for that.

## Tests

They drive the real worker as a subprocess and read the environment back out of an **actually-spawned child**, because that is the only place the answer is observable. Asserting on `childEnvironment` directly would prove the helper filters and say nothing about whether `/execute` calls it.

Both halves are pinned: the prefixed variables are gone, and `PATH`, the proxy variables and the host's own environment still arrive.

## Breaking

`major`. A command that read `NAMZU_SANDBOX_WORKSPACE`, `NAMZU_SANDBOX_READ_ROOTS` or `NAMZU_SANDBOX_WRITE_ROOTS` from its own environment no longer sees them. Pass the value explicitly via `exec`'s `env` or the provider's `options.env` under a name of your own. The workspace root is also the command's `cwd`, which is how most callers were already getting it.

Nothing in the type surface changed — but the environment a spawned command observes is behaviour a consumer can depend on, so it is a major by [SemVer rule 8](https://semver.org/) rather than by signature.

## Reported honestly

**One transient failure was observed locally**, on a full-suite run that had a heavy repo-wide script executing alongside it. The output was truncated before it named the failing test, so I cannot attribute it. Three subsequent runs — one full suite (168 passed / 25 skipped) and two worker-only (10 passed each) — were clean. The per-test timeout was raised from 30s to 60s in a follow-up commit for that reason: these wait on two real process starts, so the bound is about the machine rather than the work, and a healthy run pays nothing for the headroom.

**Separately noticed and not fixed here:** `packages/sandbox/biome.json` sets `files.include` to `src/**/*.ts`, and the package's lint script is `biome check src/`. **The `worker/` directory is linted by nothing** — including the file this PR changes, which is the most security-sensitive one in the package. Extending the scope would mean reformatting files this branch did not otherwise touch, so it is filed rather than bundled.

## Gates

sandbox build 0 · sandbox lint 0 · external-name audit 0 · sandbox suite 168 passed / 25 skipped.
