### PR TITLE
chore(sandbox): bring the worker and guest agent under the linter

### DIFF
--- a/.changeset/the-worker-directory-is-linted-by-nothing.md
+++ b/.changeset/the-worker-directory-is-linted-by-nothing.md
@@ -1,0 +1,18 @@
+---
+'@namzu/sandbox': patch
+---
+
+Bring the worker and guest agent under the linter, and document what they already do
+
+`biome.json` restricted `files.include` to `src/**/*.ts` and the lint script ran `biome check src/`. Two independent exclusions of the same directories, so `worker/server.js` and `agent/agent.cjs` were checked by nothing — including the worker, which is the HTTP surface that executes commands inside the container and has no type checking either, being plain CommonJS.
+
+Turning it on immediately found dead code: an unused `readNdjson` helper in the worker's own test file. The rest were `useOptionalChain` rewrites in crash handlers, applied and reviewed one at a time — `err && err.stack ? err.stack : err` and `err?.stack ? err.stack : err` take the same branch for every input, including a non-`Error` throw.
+
+`noConsole` is off for these two directories. They are standalone processes, not modules this package imports, and stdout is their only channel: the host's readiness path and the test harness both wait on the worker's `listening on` line, and the crash handlers exist so an unhandled rejection is diagnosable rather than a silent exit. A logger abstraction would mean a dependency in files that deliberately have none. (The reason lives here and in the commit rather than beside the setting, because `biome.json` is strict JSON and rejects both comments and unknown keys.)
+
+Two documentation debts from earlier changes are cleared in the same pass:
+
+- The README's `--cap-drop=ALL` bullet carried only one of its two reasons. It also stops an `--internal` network's egress denial from being undone by a single `ip route add`, which is refused only because `NET_ADMIN` is absent.
+- The README said nothing about the environment a spawned command sees, which changed materially when the worker stopped passing on its own configuration. It now says what is stripped, what is inherited and why the proxy variables and `options.env` must be.
+
+No behaviour change.

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -138,9 +138,13 @@ doesn't have to forward identity through `provider.create`.
 
 Every container is launched with:
 
-- `--cap-drop=ALL` — `CAP_DAC_OVERRIDE` alone walks past the read-only bind
-  mounts the layout sets up, so the default capability set makes the mount
-  layout advisory rather than enforced.
+- `--cap-drop=ALL` — two independent reasons, and the second is easy to lose.
+  `CAP_DAC_OVERRIDE` alone walks past the read-only bind mounts the layout
+  sets up, so the default capability set makes the mount layout advisory
+  rather than enforced. Separately, an `--internal` network denies egress by
+  giving the container no route out — and restoring one is a single
+  `ip route add`, refused only because `NET_ADMIN` is absent. The network
+  removes the route; this flag removes the ability to put it back.
 - `--security-opt=no-new-privileges` — without it a setuid binary in the
   image re-escalates after the drop.
 - the configured network, which defaults to `none` (see the egress table
@@ -155,6 +159,27 @@ uid depends on the image's own filesystem ownership and forcing one breaks
 every image that expects root at startup. Set it whenever the image
 supports a non-root user — a container running as root is one bind-mount
 misconfiguration away from writing the host.
+
+### The environment a command runs in
+
+The worker strips every variable prefixed `NAMZU_SANDBOX_` before spawning
+a command. Those are its own configuration — the workspace root and both
+root lists among them — and passing them on handed the confinement layout
+to the code being confined.
+
+Everything else is inherited, which is deliberate and not an oversight:
+
+- `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` are set on the container so
+  tooling inside routes through the egress boundary. A workload that never
+  received them would stop being proxied, which looks exactly like the
+  policy working.
+- Anything you passed as `options.env` is meant to reach commands, and once
+  it is in the worker's environment the prefix is the only thing separating
+  it from the worker's own settings.
+
+Per-call `env` is applied after the strip and is **not** filtered, so a
+caller that deliberately sets a prefixed name still gets it. If a workload
+needs the workspace root, note that it is also the command's `cwd`.
 
 ## Status
 

--- a/packages/sandbox/agent/agent.cjs
+++ b/packages/sandbox/agent/agent.cjs
@@ -387,7 +387,7 @@ function handleConnection(socket) {
 }
 
 function dispatch(socket, req) {
-	const op = req && req.op
+	const op = req?.op
 	if (op === 'healthz') {
 		writeFrame(socket, { ok: true })
 		socket.end()
@@ -484,7 +484,7 @@ async function main() {
 	// never lands on a connection severed by the resume.
 	process.on('SIGUSR1', () => {
 		reListenOnResume().catch((err) => {
-			console.error('[namzu-fc-agent] re-listen on resume failed:', err && err.message)
+			console.error('[namzu-fc-agent] re-listen on resume failed:', err?.message)
 		})
 	})
 }
@@ -504,7 +504,7 @@ module.exports = {
 
 if (require.main === module) {
 	main().catch((err) => {
-		console.error('[namzu-fc-agent] fatal:', err && err.stack ? err.stack : err)
+		console.error('[namzu-fc-agent] fatal:', err?.stack ? err.stack : err)
 		process.exit(1)
 	})
 }

--- a/packages/sandbox/biome.json
+++ b/packages/sandbox/biome.json
@@ -52,9 +52,19 @@
     }
   },
   "files": {
-    "include": ["src/**/*.ts"]
+    "include": ["src/**/*.ts", "worker/**/*.js", "agent/**/*.cjs"]
   },
   "overrides": [
+    {
+      "include": ["worker/**/*.js", "agent/**/*.cjs"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
+    },
     {
       "include": ["src/**/__tests__/**/*.ts"],
       "linter": {

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "build": "tsc --build",
     "dev": "tsc --build --watch",
-    "lint": "biome check src/",
+    "lint": "biome check src/ worker/ agent/",
     "lint:fix": "biome check --write src/",
     "format": "biome format --write src/",
     "test": "vitest run --passWithNoTests",

--- a/packages/sandbox/worker/__tests__/server.test.js
+++ b/packages/sandbox/worker/__tests__/server.test.js
@@ -98,15 +98,6 @@ function getFreePort() {
 	})
 }
 
-async function readNdjson(res) {
-	const text = await res.text()
-	return text
-		.split('\n')
-		.map((line) => line.trim())
-		.filter(Boolean)
-		.map((line) => JSON.parse(line))
-}
-
 describe('worker /execute — timeoutMs ceiling', () => {
 	let worker
 

--- a/packages/sandbox/worker/__tests__/the-worker-does-not-hand-over-its-own-config.test.js
+++ b/packages/sandbox/worker/__tests__/the-worker-does-not-hand-over-its-own-config.test.js
@@ -133,74 +133,98 @@ describe('the environment a sandboxed command runs in', () => {
 		worker = undefined
 	}, NEEDS_TWO_PROCESSES)
 
-	it('does not describe the confinement layout to the confined code', async () => {
-		// The concrete case. A command could read the workspace root and both
-		// root lists straight out of its own environment.
-		worker = await spawnWorker()
+	it(
+		'does not describe the confinement layout to the confined code',
+		async () => {
+			// The concrete case. A command could read the workspace root and both
+			// root lists straight out of its own environment.
+			worker = await spawnWorker()
 
-		const seen = await environmentSeenByChild(worker)
+			const seen = await environmentSeenByChild(worker)
 
-		expect(seen.NAMZU_SANDBOX_WORKSPACE).toBeUndefined()
-		expect(seen.NAMZU_SANDBOX_READ_ROOTS).toBeUndefined()
-		expect(seen.NAMZU_SANDBOX_WRITE_ROOTS).toBeUndefined()
-	}, NEEDS_TWO_PROCESSES)
+			expect(seen.NAMZU_SANDBOX_WORKSPACE).toBeUndefined()
+			expect(seen.NAMZU_SANDBOX_READ_ROOTS).toBeUndefined()
+			expect(seen.NAMZU_SANDBOX_WRITE_ROOTS).toBeUndefined()
+		},
+		NEEDS_TWO_PROCESSES,
+	)
 
-	it('strips by prefix, so a setting added later is covered without being listed', async () => {
-		// A deny-list of known names would leak whatever is added next. The
-		// prefix is the boundary, which is why the constant carries a docblock
-		// saying so.
-		worker = await spawnWorker({ NAMZU_SANDBOX_SOME_FUTURE_SECRET: 'must-not-propagate' })
+	it(
+		'strips by prefix, so a setting added later is covered without being listed',
+		async () => {
+			// A deny-list of known names would leak whatever is added next. The
+			// prefix is the boundary, which is why the constant carries a docblock
+			// saying so.
+			worker = await spawnWorker({ NAMZU_SANDBOX_SOME_FUTURE_SECRET: 'must-not-propagate' })
 
-		const seen = await environmentSeenByChild(worker)
+			const seen = await environmentSeenByChild(worker)
 
-		expect(seen.NAMZU_SANDBOX_SOME_FUTURE_SECRET).toBeUndefined()
-		expect(Object.keys(seen).filter((k) => k.startsWith('NAMZU_SANDBOX_'))).toEqual([])
-	}, NEEDS_TWO_PROCESSES)
+			expect(seen.NAMZU_SANDBOX_SOME_FUTURE_SECRET).toBeUndefined()
+			expect(Object.keys(seen).filter((k) => k.startsWith('NAMZU_SANDBOX_'))).toEqual([])
+		},
+		NEEDS_TWO_PROCESSES,
+	)
 
-	it('still passes the proxy variables, which are set on purpose', async () => {
-		// The half that makes an allowlist wrong. The egress boundary works by
-		// tooling inside honouring these; dropping them stops every workload
-		// being proxied, which looks exactly like the policy working.
-		worker = await spawnWorker({
-			HTTP_PROXY: 'http://namzu-egress:8080',
-			HTTPS_PROXY: 'http://namzu-egress:8080',
-			NO_PROXY: 'localhost,127.0.0.1',
-		})
+	it(
+		'still passes the proxy variables, which are set on purpose',
+		async () => {
+			// The half that makes an allowlist wrong. The egress boundary works by
+			// tooling inside honouring these; dropping them stops every workload
+			// being proxied, which looks exactly like the policy working.
+			worker = await spawnWorker({
+				HTTP_PROXY: 'http://namzu-egress:8080',
+				HTTPS_PROXY: 'http://namzu-egress:8080',
+				NO_PROXY: 'localhost,127.0.0.1',
+			})
 
-		const seen = await environmentSeenByChild(worker)
+			const seen = await environmentSeenByChild(worker)
 
-		expect(seen.HTTP_PROXY).toBe('http://namzu-egress:8080')
-		expect(seen.HTTPS_PROXY).toBe('http://namzu-egress:8080')
-		expect(seen.NO_PROXY).toBe('localhost,127.0.0.1')
-	}, NEEDS_TWO_PROCESSES)
+			expect(seen.HTTP_PROXY).toBe('http://namzu-egress:8080')
+			expect(seen.HTTPS_PROXY).toBe('http://namzu-egress:8080')
+			expect(seen.NO_PROXY).toBe('localhost,127.0.0.1')
+		},
+		NEEDS_TWO_PROCESSES,
+	)
 
-	it('still passes the host’s own environment, which is meant to reach commands', async () => {
-		// A host's `options.env` arrives on the same channel as the worker's
-		// config and is indistinguishable from it once both are in
-		// `process.env`. Only the prefix tells them apart.
-		worker = await spawnWorker({ MY_APP_TOKEN: 'host-supplied' })
+	it(
+		'still passes the host’s own environment, which is meant to reach commands',
+		async () => {
+			// A host's `options.env` arrives on the same channel as the worker's
+			// config and is indistinguishable from it once both are in
+			// `process.env`. Only the prefix tells them apart.
+			worker = await spawnWorker({ MY_APP_TOKEN: 'host-supplied' })
 
-		const seen = await environmentSeenByChild(worker)
+			const seen = await environmentSeenByChild(worker)
 
-		expect(seen.MY_APP_TOKEN).toBe('host-supplied')
-	}, NEEDS_TWO_PROCESSES)
+			expect(seen.MY_APP_TOKEN).toBe('host-supplied')
+		},
+		NEEDS_TWO_PROCESSES,
+	)
 
-	it('still passes PATH, or nothing would run at all', async () => {
-		worker = await spawnWorker()
+	it(
+		'still passes PATH, or nothing would run at all',
+		async () => {
+			worker = await spawnWorker()
 
-		const seen = await environmentSeenByChild(worker)
+			const seen = await environmentSeenByChild(worker)
 
-		expect(seen.PATH ?? seen.Path).toBeTruthy()
-	}, NEEDS_TWO_PROCESSES)
+			expect(seen.PATH ?? seen.Path).toBeTruthy()
+		},
+		NEEDS_TWO_PROCESSES,
+	)
 
-	it('lets an explicit per-call value through, including a prefixed one', async () => {
-		// Inheritance is implicit and gets the default; `body.env` is a caller
-		// deciding. Filtering that too would silently drop a value the caller
-		// asked for by name.
-		worker = await spawnWorker()
+	it(
+		'lets an explicit per-call value through, including a prefixed one',
+		async () => {
+			// Inheritance is implicit and gets the default; `body.env` is a caller
+			// deciding. Filtering that too would silently drop a value the caller
+			// asked for by name.
+			worker = await spawnWorker()
 
-		const seen = await environmentSeenByChild(worker, { NAMZU_SANDBOX_WORKSPACE: 'chosen' })
+			const seen = await environmentSeenByChild(worker, { NAMZU_SANDBOX_WORKSPACE: 'chosen' })
 
-		expect(seen.NAMZU_SANDBOX_WORKSPACE).toBe('chosen')
-	}, NEEDS_TWO_PROCESSES)
+			expect(seen.NAMZU_SANDBOX_WORKSPACE).toBe('chosen')
+		},
+		NEEDS_TWO_PROCESSES,
+	)
 })

--- a/packages/sandbox/worker/server.js
+++ b/packages/sandbox/worker/server.js
@@ -541,12 +541,17 @@ const server = http.createServer(async (req, res) => {
 		// see a socket close on that one request and retry whatever
 		// it was doing, but the next request lands on a still-alive
 		// worker.
-		console.error('[namzu-sandbox-worker] uncaught handler error:', err && err.stack ? err.stack : err)
+		console.error('[namzu-sandbox-worker] uncaught handler error:', err?.stack ? err.stack : err)
 		try {
 			if (!res.headersSent) {
-				writeJson(res, 500, { error: 'internal', message: err && err.message ? err.message : String(err) })
+				writeJson(res, 500, {
+					error: 'internal',
+					message: err?.message ? err.message : String(err),
+				})
 			} else {
-				try { res.end() } catch {}
+				try {
+					res.end()
+				} catch {}
 			}
 		} catch {}
 	}
@@ -558,10 +563,10 @@ const server = http.createServer(async (req, res) => {
 // exit produces the catastrophic "every subsequent tool call fetch
 // fails because the container is gone" pattern.
 process.on('unhandledRejection', (err) => {
-	console.error('[namzu-sandbox-worker] unhandledRejection:', err && err.stack ? err.stack : err)
+	console.error('[namzu-sandbox-worker] unhandledRejection:', err?.stack ? err.stack : err)
 })
 process.on('uncaughtException', (err) => {
-	console.error('[namzu-sandbox-worker] uncaughtException:', err && err.stack ? err.stack : err)
+	console.error('[namzu-sandbox-worker] uncaughtException:', err?.stack ? err.stack : err)
 })
 
 // Bind address picks `0.0.0.0` by default so a sibling container


### PR DESCRIPTION
Closes #430.

## The gap

`biome.json` restricted `files.include` to `src/**/*.ts`, and the lint script ran `biome check src/`. Two independent exclusions of the same directories, so `worker/server.js` and `agent/agent.cjs` were checked by **nothing** — including the worker, which is the HTTP surface that executes commands inside the container, and which has no type checking either, being plain CommonJS.

Naming the path explicitly did not help. `biome check worker/` reports `Checked 0 files` and then errors with `No files were processed in the specified paths`: the config's `include` wins over the argument. That is the same shape as the smoke suite in #425 — a filter cannot re-add what discovery excluded — which is why this looked like a script problem and was a config problem.

## What turning it on found

**Dead code, on the first run**: an unused `readNdjson` helper in the worker's own test file. Removed.

**Seven `useOptionalChain` rewrites**, which biome classifies as *unsafe* and which land in crash handlers — so they were applied and read one at a time rather than taken on trust. All are `err && err.stack ? err.stack : err` → `err?.stack ? err.stack : err`, plus one `req && req.op` → `req?.op`. Both forms take the same branch for every input including a non-`Error` throw: when the subject is nullish the old form yields it and the new yields `undefined`, and both are falsy at the point that decides.

**Formatting was 11 lines of rewrapping, not a rewrite.** The file was already close to biome's style, so the diff is small enough to read — which is why it is in this PR rather than split out to keep the review clean.

## `noConsole` is off for these two directories

They are standalone processes, not modules this package imports, and stdout is their **only** channel: the host's readiness path and the test harness both wait on the worker's `listening on` line, and the crash handlers exist so an unhandled rejection is diagnosable rather than a silent exit. A logger abstraction would mean a dependency in files that deliberately have none.

The reason lives in the commit, the changeset and here rather than beside the setting, because `biome.json` is **strict JSON** — it rejects an unknown `//` key *and* a `//` comment line. I tried both.

## Two documentation debts cleared in the same pass

Both are about this package and neither had a home:

- The README's `--cap-drop=ALL` bullet carried one of its two reasons. It also stops an `--internal` network's egress denial from being undone by a single `ip route add`, which is refused only because `NET_ADMIN` is absent (measured in #428).
- **The README said nothing about the environment a spawned command sees**, which changed materially in #429 when the worker stopped handing over its own configuration. It now says what is stripped, what is inherited, and why the proxy variables and `options.env` have to be — the part a consumer hitting the breaking change will look for.

## Scope

No behaviour change. `patch`.

## Gates

sandbox lint 0 (33 files, up from 28) · sandbox build 0 · sandbox suite 168 passed / 25 skipped · external-name audit 0 · docs gate 0.
