### PR TITLE
feat(sdk): correlate delegated work with plan steps

### DIFF
--- a/.changeset/bright-firecracker-networks.md
+++ b/.changeset/bright-firecracker-networks.md
@@ -1,0 +1,7 @@
+---
+'@namzu/sandbox': minor
+---
+
+Carry explicit Firecracker network intent on the orchestrator create request.
+`allow-all`, `deny-all`, and resolved allowlists now have distinct wire shapes;
+an absent policy keeps the legacy request unchanged.

--- a/.changeset/calm-firecracker-streams.md
+++ b/.changeset/calm-firecracker-streams.md
@@ -1,0 +1,8 @@
+---
+'@namzu/sdk': minor
+'@namzu/sandbox': minor
+---
+
+Add guest-owned pseudo-terminal and loopback TCP stream capabilities to the
+Firecracker sandbox, including lifecycle ownership and bidirectional
+backpressure.

--- a/.changeset/calm-plans-find-workers.md
+++ b/.changeset/calm-plans-find-workers.md
@@ -1,0 +1,7 @@
+---
+'@namzu/sdk': minor
+---
+
+Carry optional approved-plan and plan-step identities through delegated task
+scheduling and `agent.pending` SSE payloads, allowing hosts to correlate live
+workers with exact plan progress without label or launch-order inference.

--- a/.github/scripts/public-surface-baseline.json
+++ b/.github/scripts/public-surface-baseline.json
@@ -2399,6 +2399,8 @@
         "SandboxProvider",
         "SandboxProviderFactory",
         "SandboxStatus",
+        "SandboxTcpConnectOptions",
+        "SandboxTcpConnection",
         "SandboxWorkspaceMode",
         "ScopeChain",
         "ScopeRef",

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -59,8 +59,11 @@ sessions=$(awk -F'|' '
 # an epoch. That silently broke this gate on Git Bash / Windows, where
 # every comparison below then failed with "integer expected".
 mtime() {
-  m=$(stat -c %Y "$1" 2>/dev/null)
-  case "$m" in ''|*[!0-9]*) m=$(stat -f %m "$1" 2>/dev/null) ;; esac
+  # Both probes are expected to fail on the other platform. Keep `set -e`
+  # from treating that feature detection as a fatal hook error before the
+  # portable fallback can run.
+  m=$(stat -c %Y "$1" 2>/dev/null || true)
+  case "$m" in ''|*[!0-9]*) m=$(stat -f %m "$1" 2>/dev/null || true) ;; esac
   case "$m" in ''|*[!0-9]*) m='' ;; esac
   printf '%s' "$m"
 }

--- a/docs/packages/sandbox.md
+++ b/docs/packages/sandbox.md
@@ -6,8 +6,8 @@ type: Reference
 diataxis: reference
 owner: cogitave/namzu
 status: active
-timestamp: 2026-08-30T00:00:00Z
-lastReviewed: 2026-09-01
+timestamp: 2026-09-02T00:00:00Z
+lastReviewed: 2026-09-02
 resource: packages/sandbox/src/index.ts
 tags: [sandbox, isolation, reference]
 ---
@@ -623,10 +623,24 @@ under a shorter one.
 One separate gap remains, written down rather than implied away because it
 would otherwise look like a feature that works.
 
-`Sandbox.openTerminal` is not implemented by any backend in this package. The
-contract's rule is that a backend which cannot open a real pseudo-terminal must
-throw rather than hand back a pipe, and leaving the optional method absent is
-how that reads here.
+`Sandbox.openTerminal` and `Sandbox.openTcpConnection` are implemented only by
+the Firecracker backend. The terminal is a real guest-owned pseudo-terminal;
+input, output, resize, signal, and exit events travel over the agent transport,
+and sandbox teardown kills and awaits every open session before it releases the
+microVM. If the guest stops answering, the host severs the PTY transport after
+five seconds and proceeds with microVM reclamation rather than waiting forever.
+
+The TCP capability reaches guest loopback only: it validates a non-reserved
+port, connects to `127.0.0.1` inside the guest, and exposes a byte stream whose
+`write()` result plus `onDrain`, `pause`, and `resume` carry backpressure in
+both directions. It exists so a host can publish a development server from the
+same writable sandbox without creating a second checkout or granting the guest
+another external listener.
+
+Container, standby-pool, and local backends leave both optional methods absent.
+The contract's rule remains that a backend which cannot provide a real PTY or
+an owned loopback stream must omit the capability rather than substitute a pipe
+or host process.
 
 ## Exports
 

--- a/docs/packages/sandbox.md
+++ b/docs/packages/sandbox.md
@@ -281,9 +281,9 @@ type EgressPolicy =
 ```
 
 **Omitting `defaultEgress` is not `deny-all`.** No policy reaches the backend at
-all: the container keeps whatever network you named, and the microVM
-orchestrator receives no allowlist, which it reads as unrestricted. If you want
-nothing to leave, say so.
+all: the container keeps whatever network you named, while the microVM
+orchestrator receives no network-policy field and keeps its deployment's legacy
+behavior. If you want nothing to leave, say so.
 
 Every backend takes the same shape and they do **not** all enforce every
 variant. A backend that cannot enforce one throws rather than accepting it
@@ -293,7 +293,7 @@ quietly:
 |---|---|---|---|---|
 | `container:docker`, `container:runsc` | Enforced by an `--internal` network, checked against the daemon rather than trusted. Impossible under `hostReachability: 'host-port'`, and refused. | The configured network, unfiltered. | Enforced at a loopback egress proxy the backend starts and tears down with the sandbox. | Same, and `resolve()` is called per request so a rotating allowlist is honoured. |
 | `container:aci-standby-pool` | Refused | Refused | Refused | Refused |
-| `microvm:self-hosted` | An explicitly empty allowlist is forwarded | No allowlist is forwarded | The allowlist is forwarded | `resolve()` is called and its result forwarded |
+| `microvm:self-hosted` | `{ mode: 'none' }` is forwarded | `{ mode: 'open' }` is forwarded | `{ mode: 'allowlist', allowedHosts }` is forwarded | `resolve()` is called and its result forwarded as an allowlist policy |
 
 Three rows, three versions of the same lesson.
 
@@ -304,11 +304,11 @@ failure found later — its claim API rejects every property override except a
 config map, so an egress policy, a memory cap, a process cap and environment
 variables had nowhere to ride through, and all four were accepted and dropped.
 Set them on the container group profile the pool is built from. The microVM row
-is a third variant: `allow-all` and `resolver` both used to encode as an omitted
-allowlist, so one encoding carried two opposite intentions and the callback that
-produces the tenant-scoped list was never called anywhere. Whichever way the
-orchestrator reads an omitted field, one of the two was always mis-enforced —
-and the one that failed **open** was the one whose entire purpose is restriction.
+is a third variant: `allow-all` and an absent policy once both encoded as an
+omitted allowlist, so a deployment whose legacy omission meant no NIC could not
+distinguish a development workspace requesting public package access. Explicit
+policy objects now preserve each intent; an owner-run host that cannot enforce
+one must refuse it.
 
 ### The network has to be able to carry the policy
 

--- a/docs/sdk/architecture.md
+++ b/docs/sdk/architecture.md
@@ -7,7 +7,7 @@ diataxis: explanation
 owner: cogitave/namzu
 status: active
 timestamp: 2026-09-02T00:00:00Z
-lastReviewed: 2026-09-02
+lastReviewed: 2026-09-04
 resource: packages/sdk/src/public-runtime.ts
 tags: [sdk, architecture, explanation]
 ---
@@ -229,7 +229,9 @@ These exist because the moment you have more than one agent running in parallel 
 - Builds a child config via the agent definition's `configBuilder(factoryOptions)`
 - Stamps the child with manager-owned `parentRunId` and `depth` **after** the builder returns, so a fixed builder or per-call override cannot turn a child back into the root; `topicId`, project, tenant, and child session scope are stamped at the same boundary
 - Registers the child task in an internal `TaskRegistry` keyed by `TaskId`
-- Emits `agent_pending` on the bus with parent/child/depth metadata
+- Emits `agent_pending` on the bus with parent/child/depth metadata and, when
+  the launch belongs to an approved plan step, its exact optional `planId` /
+  `planStepId` edge
 - Forwards every child event to the parent's run listener so the supervisor sees what its subtree is doing
 
 When the parent is cancelled — by HITL, by a limit breach, or by an external signal — `cancelAll(parentRunId)` walks the subtree and aborts every descendant. This is the equivalent of signalling a whole process group.
@@ -604,6 +606,10 @@ Plugins are how a community ecosystem grows around the kernel without the kernel
 child-task request into the agent manager, preserves the parent task context,
 tracks lightweight settled handles after the heavy run state is evicted, and
 delivers each observer's events in order without blocking the child stream.
+`CreateTaskOptions.planId` and `planStepId` carry an optional approved-plan
+edge through that translation so the manager can publish it on the live child
+lifecycle. Both are absent for ordinary delegation; a scheduler must not infer
+either identity from task order or agent names.
 External transports remain host concerns built over the kernel's bridge and
 run APIs; there is no kernel-owned gateway directory.
 

--- a/docs/sdk/architecture.md
+++ b/docs/sdk/architecture.md
@@ -6,8 +6,8 @@ type: Explanation
 diataxis: explanation
 owner: cogitave/namzu
 status: active
-timestamp: 2026-08-24T00:00:00Z
-lastReviewed: 2026-09-01
+timestamp: 2026-09-02T00:00:00Z
+lastReviewed: 2026-09-02
 resource: packages/sdk/src/public-runtime.ts
 tags: [sdk, architecture, explanation]
 ---
@@ -189,7 +189,22 @@ answer or reporting a destruction that was not established.
 
 Background jobs are a separate host-process capability, not a mode of sandbox execution. `BackgroundJobRegistry` can be supplied to an unsandboxed run, where `bash` may start work that outlives its tool call and the run later tears that work down. A run that creates a sandbox does not expose that host registry in `ToolContext`, and `bash run_in_background` refuses with that reason. Otherwise changing only `run_in_background` would move the same command from `sandbox.exec()` to a host child process and turn a scheduling option into an isolation bypass. A sandboxed persistent process requires a backend that owns both its lifetime and its confinement; the host registry does not claim to be one.
 
-The same boundary applies to pseudo-terminals. `LocalSandboxProvider` does not implement `Sandbox.openTerminal`: setting a host PTY's working directory to `rootDir` neither applies the provider's isolation tier nor makes `destroy()` kill and await its descendant tree. The optional method is deprecated while its removal observes the public deprecation window; any external backend that still implements it must provide both guarantees. The exported `loadPty` and `openTerminalWith` utilities are host-scoped primitives, not sandbox or lifecycle owners. A future persistent-terminal service needs an owner-scoped registry, a process substrate that owns complete session teardown, and confinement applied to the exact argv before spawn.
+The same boundary applies to pseudo-terminals. `LocalSandboxProvider` does not
+implement `Sandbox.openTerminal`: setting a host PTY's working directory to
+`rootDir` neither applies the provider's isolation tier nor makes `destroy()`
+kill and await its descendant tree. The Firecracker backend does implement the
+optional capability: the PTY is created inside the guest, the sandbox owns its
+lifecycle, and teardown waits for its exit before releasing the microVM. A
+wedged guest transport is severed after five seconds so it cannot prevent the
+owning microVM from being reclaimed. The exported `loadPty` and
+`openTerminalWith` utilities remain host-scoped primitives, not sandbox or
+lifecycle owners.
+
+Firecracker also exposes an optional guest-loopback TCP stream for publishing a
+process that is already running inside that same sandbox. `write()` reports
+backpressure and `onDrain`, `pause`, and `resume` let a host bound buffering in
+both directions. This is a transport primitive, not a network-policy bypass:
+the guest may connect only to `127.0.0.1` on a validated non-reserved port.
 
 ### 2. Interprocess Communication: Bridge (`bridge/`) and Bus (`bus/`)
 

--- a/docs/sdk/integrations/event-bridges.md
+++ b/docs/sdk/integrations/event-bridges.md
@@ -7,7 +7,7 @@ diataxis: explanation
 owner: cogitave/namzu
 status: active
 timestamp: 2026-08-24T00:00:00Z
-lastReviewed: 2026-08-31
+lastReviewed: 2026-09-04
 tags: [sdk]
 ---
 
@@ -118,6 +118,15 @@ things arrive that way:
   transient write failure, and no retry or reconnect will produce one.
 
 A client must not advance its cursor onto any of them.
+
+When `create_task` launches work for an approved plan step, `agent.pending`
+also carries the exact plan edge as optional `plan_id` and `plan_step_id`
+fields. They are absent for delegation outside a plan. Use these identities to
+paint live plan progress; do not infer ownership from an agent label, launch
+order, or the first incomplete step. The correlation remains live-only for the
+same reason as the surrounding lifecycle event, so a host that needs restored
+progress must persist its own projection or settle from the durable plan
+events.
 
 `tool.progress` is a bounded latest-state signal, not a lossless output log.
 Each message is at most 8 KiB of UTF-8; when a live consumer is slower than the

--- a/packages/sandbox/agent/agent.cjs
+++ b/packages/sandbox/agent/agent.cjs
@@ -54,6 +54,7 @@ const net = require('node:net')
 const { spawn } = require('node:child_process')
 const { randomUUID } = require('node:crypto')
 const fs = require('node:fs/promises')
+const { constants: osConstants } = require('node:os')
 const path = require('node:path')
 
 // --- config (mirrors worker/server.js env contract) -----------------------
@@ -115,7 +116,7 @@ function frame(payload) {
 }
 
 function writeFrame(socket, obj) {
-	socket.write(frame(JSON.stringify(obj)))
+	return socket.write(frame(JSON.stringify(obj)))
 }
 
 function writeTerminator(socket) {
@@ -742,11 +743,284 @@ async function handleWriteFile(socket, body) {
 	}
 }
 
+// --- guest-owned pseudo-terminal ------------------------------------------
+
+const MAX_TERMINAL_COLS = 1000
+const MAX_TERMINAL_ROWS = 1000
+const TERMINAL_SIGNALS = new Set(['SIGTERM', 'SIGKILL', 'SIGINT', 'SIGHUP'])
+
+/** Quote one argv token for the shell command accepted by util-linux script. */
+function shellQuote(value) {
+	return `'${String(value).replaceAll("'", "'\\''")}'`
+}
+
+function terminalDimension(value, max, name) {
+	const parsed = Number(value)
+	if (!Number.isInteger(parsed) || parsed < 1 || parsed > max) {
+		throw new Error(`${name} must be an integer in [1, ${max}]`)
+	}
+	return parsed
+}
+
+function delay(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function processChildren(pid) {
+	try {
+		const raw = await fs.readFile(`/proc/${pid}/task/${pid}/children`, 'utf8')
+		return raw
+			.trim()
+			.split(/\s+/)
+			.map(Number)
+			.filter((value) => Number.isInteger(value) && value > 0)
+	} catch {
+		return []
+	}
+}
+
+/**
+ * Resolve the slave allocated by util-linux `script`.
+ *
+ * `script` owns the PTY master and the login shell is its child. The child's
+ * fd 0 is therefore the authoritative slave path; discovering it through proc
+ * lets resize use the real TIOCSWINSZ ioctl through `stty -F`, including the
+ * SIGWINCH programs expect. No pipe is represented as a terminal.
+ */
+async function findPtySlave(scriptPid) {
+	for (let attempt = 0; attempt < 200; attempt += 1) {
+		const queue = await processChildren(scriptPid)
+		while (queue.length > 0) {
+			const pid = queue.shift()
+			try {
+				const target = await fs.readlink(`/proc/${pid}/fd/0`)
+				if (/^\/dev\/pts\/\d+$/.test(target)) return target
+			} catch {}
+			queue.push(...(await processChildren(pid)))
+		}
+		await delay(5)
+	}
+	throw new Error('terminal PTY slave did not appear')
+}
+
+function resizePty(slavePath, cols, rows) {
+	return new Promise((resolve, reject) => {
+		const child = spawn(
+			'/usr/bin/stty',
+			['-F', slavePath, 'rows', String(rows), 'cols', String(cols)],
+			{
+				stdio: 'ignore',
+			},
+		)
+		child.once('error', reject)
+		child.once('close', (code) => {
+			if (code === 0) resolve()
+			else reject(new Error(`stty resize failed with code ${String(code)}`))
+		})
+	})
+}
+
+/**
+ * Start one interactive PTY inside the guest and bind it to this framed
+ * connection. The runtime gateway owns the connection; disconnect/kill tears
+ * down the complete detached process group before the microVM can be released.
+ */
+function handleTerminal(socket, body) {
+	let child
+	let slavePath
+	let ready = false
+	let settled = false
+	const pending = []
+
+	const kill = (signal = 'SIGTERM') => {
+		if (!child?.pid || settled) return
+		const safeSignal = TERMINAL_SIGNALS.has(signal) ? signal : 'SIGTERM'
+		try {
+			// detached:true makes the script process the process-group leader;
+			// negative pid reaches the shell and every descendant, not just script.
+			process.kill(-child.pid, safeSignal)
+		} catch {}
+	}
+
+	const apply = (event) => {
+		if (!event || typeof event !== 'object') return
+		if (event.type === 'input') {
+			if (
+				typeof event.data === 'string' &&
+				child?.stdin?.writable &&
+				!child.stdin.write(event.data)
+			) {
+				socket.pause()
+				child.stdin.once('drain', () => {
+					if (!settled) socket.resume()
+				})
+			}
+			return
+		}
+		if (event.type === 'resize') {
+			try {
+				const cols = terminalDimension(event.cols, MAX_TERMINAL_COLS, 'cols')
+				const rows = terminalDimension(event.rows, MAX_TERMINAL_ROWS, 'rows')
+				if (slavePath) void resizePty(slavePath, cols, rows).catch(() => {})
+			} catch {}
+			return
+		}
+		if (event.type === 'kill') kill(typeof event.signal === 'string' ? event.signal : 'SIGTERM')
+	}
+
+	const start = async () => {
+		if (!body || typeof body !== 'object') throw new Error('missing_terminal_options')
+		const cols = terminalDimension(body.cols, MAX_TERMINAL_COLS, 'cols')
+		const rows = terminalDimension(body.rows, MAX_TERMINAL_ROWS, 'rows')
+		const cwd = body.cwd ? resolveWithinWorkspace(body.cwd, WORKSPACE_ROOT) : WORKSPACE_ROOT
+		await fs.mkdir(cwd, { recursive: true })
+
+		const command = typeof body.command === 'string' && body.command ? body.command : '/bin/sh'
+		const args = Array.isArray(body.args) ? body.args.map(String) : []
+		const commandLine = ['exec', shellQuote(command), ...args.map(shellQuote)].join(' ')
+		child = spawn('/usr/bin/script', ['-qefc', commandLine, '/dev/null'], {
+			cwd,
+			env: { ...process.env, TERM: 'xterm-256color', ...(body.env || {}) },
+			detached: true,
+			stdio: ['pipe', 'pipe', 'pipe'],
+		})
+		const forward = (source, chunk) => {
+			if (!writeFrame(socket, { type: 'data', data: chunk.toString('utf8') })) {
+				source.pause()
+				socket.once('drain', () => {
+					if (!settled) source.resume()
+				})
+			}
+		}
+		child.stdout.on('data', (chunk) => forward(child.stdout, chunk))
+		child.stderr.on('data', (chunk) => forward(child.stderr, chunk))
+		child.once('error', (error) => {
+			if (settled) return
+			settled = true
+			writeFrame(socket, { type: 'error', error: error.message })
+			socket.end()
+		})
+		child.once('close', (exitCode, signal) => {
+			if (settled) return
+			settled = true
+			writeFrame(socket, {
+				type: 'exit',
+				exitCode: typeof exitCode === 'number' ? exitCode : -1,
+				...(signal && osConstants.signals[signal] ? { signal: osConstants.signals[signal] } : {}),
+			})
+			socket.end()
+		})
+
+		slavePath = await findPtySlave(child.pid)
+		await resizePty(slavePath, cols, rows)
+		ready = true
+		writeFrame(socket, { type: 'ready' })
+		for (const event of pending.splice(0)) apply(event)
+	}
+
+	void start().catch((error) => {
+		if (settled) return
+		writeFrame(socket, {
+			type: 'error',
+			error: error instanceof Error ? error.message : String(error),
+		})
+		kill('SIGKILL')
+		settled = true
+		socket.end()
+	})
+
+	return {
+		onFrame(payload) {
+			let event
+			try {
+				event = JSON.parse(payload)
+			} catch {
+				return
+			}
+			if (ready) apply(event)
+			else pending.push(event)
+		},
+		onClose() {
+			kill('SIGKILL')
+		},
+	}
+}
+
+// --- guest-loopback TCP forwarding ---------------------------------------
+
+function handleTcpConnect(socket, body) {
+	const host = body?.host || '127.0.0.1'
+	const port = Number(body?.port)
+	if (
+		(host !== '127.0.0.1' && host !== '::1') ||
+		!Number.isInteger(port) ||
+		port < 1 ||
+		port > 65535
+	) {
+		writeFrame(socket, { type: 'error', error: 'invalid_loopback_target' })
+		socket.end()
+		return
+	}
+
+	let settled = false
+	const upstream = net.createConnection({ host, port })
+	const finish = (event) => {
+		if (settled) return
+		settled = true
+		if (event) writeFrame(socket, event)
+		upstream.destroy()
+		socket.end()
+	}
+
+	upstream.once('connect', () => writeFrame(socket, { type: 'ready' }))
+	upstream.on('data', (chunk) => {
+		if (!writeFrame(socket, { type: 'data', data: chunk.toString('base64') })) {
+			upstream.pause()
+			socket.once('drain', () => {
+				if (!settled) upstream.resume()
+			})
+		}
+	})
+	upstream.once('end', () => finish({ type: 'end' }))
+	upstream.once('error', (error) => finish({ type: 'error', error: error.message }))
+
+	return {
+		onFrame(payload) {
+			let event
+			try {
+				event = JSON.parse(payload)
+			} catch {
+				return
+			}
+			if (event?.type === 'data' && typeof event.data === 'string') {
+				const bytes = Buffer.from(event.data, 'base64')
+				if (bytes.byteLength <= 8 * 1024 * 1024 && !upstream.write(bytes)) {
+					socket.pause()
+					upstream.once('drain', () => {
+						if (!settled) socket.resume()
+					})
+				}
+				return
+			}
+			if (event?.type === 'end') {
+				upstream.end()
+				return
+			}
+			if (event?.type === 'destroy') finish()
+		},
+		onClose() {
+			settled = true
+			upstream.destroy()
+		},
+	}
+}
+
 // --- connection dispatch ---------------------------------------------------
 
 function handleConnection(socket) {
 	const reader = new FrameReader()
 	let dispatched = false
+	let activeStream
 	socket.on('data', (chunk) => {
 		let frames
 		try {
@@ -755,21 +1029,23 @@ function handleConnection(socket) {
 			socket.destroy()
 			return
 		}
-		// One request per connection (matches the host dialer, which
-		// opens a fresh connection per request — the resume-survivable
-		// shape).
-		if (dispatched || frames.length === 0) return
-		const first = frames[0]
-		dispatched = true
-		let req
-		try {
-			req = JSON.parse(first)
-		} catch {
-			socket.destroy()
-			return
+		for (const payload of frames) {
+			if (dispatched) {
+				activeStream?.onFrame(payload)
+				continue
+			}
+			dispatched = true
+			let req
+			try {
+				req = JSON.parse(payload)
+			} catch {
+				socket.destroy()
+				return
+			}
+			activeStream = dispatch(socket, req)
 		}
-		dispatch(socket, req)
 	})
+	socket.on('close', () => activeStream?.onClose())
 	socket.on('error', () => {
 		// A severed connection is not fatal — the listener stays up and
 		// the next dial lands fresh (resume invariant).
@@ -810,6 +1086,12 @@ function dispatch(socket, req) {
 			} catch {}
 		})
 		return
+	}
+	if (op === 'terminal') {
+		return handleTerminal(socket, req.body)
+	}
+	if (op === 'tcp-connect') {
+		return handleTcpConnect(socket, req.body)
 	}
 	if (op === 'read-file') {
 		handleReadFile(socket, req.body).finally(() => socket.end())

--- a/packages/sandbox/agent/agent.cjs
+++ b/packages/sandbox/agent/agent.cjs
@@ -762,10 +762,6 @@ function terminalDimension(value, max, name) {
 	return parsed
 }
 
-function delay(ms) {
-	return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
 async function processChildren(pid) {
 	try {
 		const raw = await fs.readFile(`/proc/${pid}/task/${pid}/children`, 'utf8')

--- a/packages/sandbox/src/backends/firecracker/__tests__/backend.test.ts
+++ b/packages/sandbox/src/backends/firecracker/__tests__/backend.test.ts
@@ -577,6 +577,34 @@ describe.skipIf(IS_WINDOWS)('buildFirecrackerBackend (loopback agent)', () => {
 	})
 })
 
+describe.skipIf(process.platform !== 'linux')('buildFirecrackerBackend terminal ownership', () => {
+	it('kills and awaits every guest terminal before deleting the microVM', async () => {
+		server = await startAgent()
+		const { calls } = stubOrchestrator({ kind: 'unix', path: sockPath })
+		const backend = buildFirecrackerBackend({
+			orchestratorEndpoint: 'https://orchestrator.test/',
+			getToken: async () => 'tok',
+			readyTimeoutMs: 3_000,
+			readyPollIntervalMs: 50,
+		})
+		const sandbox = await backend.create({ workingDirectory: workDir })
+		expect(sandbox.openTerminal).toBeTypeOf('function')
+		const terminal = await sandbox.openTerminal?.({
+			command: '/bin/sh',
+			args: ['-lc', 'sleep 30'],
+			cwd: workDir,
+			size: { cols: 80, rows: 24 },
+		})
+		expect(terminal).toBeDefined()
+
+		await sandbox.destroy()
+		await expect(terminal?.exited).resolves.toMatchObject({
+			exitCode: expect.any(Number),
+		})
+		expect(calls.some((call) => call.method === 'DELETE')).toBe(true)
+	})
+})
+
 // ---------------------------------------------------------------------------
 // Cert-injection seam (ses_051 P4 Track C) — the orchestrator returns a WIRE
 // `mtls` handle (host/port/sandboxId, NO certs); the consumer injects the

--- a/packages/sandbox/src/backends/firecracker/__tests__/backend.test.ts
+++ b/packages/sandbox/src/backends/firecracker/__tests__/backend.test.ts
@@ -18,6 +18,7 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { createSandboxProvider } from '../../../index.js'
 import { buildFirecrackerBackend, normalizeHandle } from '../index.js'
 import { type WireSandboxAgentHandle, __framing } from '../transport.js'
 import { localIpcPath } from './fixtures/ipc-path.js'
@@ -153,14 +154,17 @@ describe.skipIf(IS_WINDOWS)('buildFirecrackerBackend (loopback agent)', () => {
 		expect(sandbox.environment).toBe('linux-namespace')
 		expect(sandbox.status).toBe('ready')
 
-		// Create body forwarded the resolved knobs + egress allowlist.
+		// Create body forwarded the resolved knobs + explicit network policy.
 		const createCall = calls.find((c) => c.method === 'POST')
 		expect(createCall?.body).toMatchObject({
 			template: 'golden-rev-7',
 			memoryLimitMb: 512,
 			maxProcesses: 64,
 			timeoutMs: 60_000,
-			egressAllowlist: ['api.example.com'],
+			networkPolicy: {
+				mode: 'allowlist',
+				allowedHosts: ['api.example.com'],
+			},
 		})
 
 		// exec over the wire.
@@ -191,6 +195,27 @@ describe.skipIf(IS_WINDOWS)('buildFirecrackerBackend (loopback agent)', () => {
 		await Promise.all([sandbox.destroy(), sandbox.destroy()])
 		expect(sandbox.status).toBe('destroyed')
 		expect(calls.filter((c) => c.method === 'DELETE' && c.url.includes(':delete'))).toHaveLength(1)
+	})
+
+	it('carries open egress through the public provider front door', async () => {
+		server = await startAgent()
+		const { calls } = stubOrchestrator({ kind: 'unix', path: sockPath })
+		const provider = createSandboxProvider({
+			backend: {
+				tier: 'microvm',
+				service: 'self-hosted',
+				orchestratorEndpoint: 'https://orchestrator.test/',
+				getToken: async () => 'tok',
+				readyTimeoutMs: 3_000,
+				readyPollIntervalMs: 50,
+			},
+			defaultEgress: { kind: 'allow-all' },
+		})
+
+		const sandbox = await provider.create({ workingDirectory: workDir })
+		const createCall = calls.find((call) => call.method === 'POST')
+		expect(createCall?.body).toEqual({ networkPolicy: { mode: 'open' } })
+		await sandbox.destroy()
 	})
 
 	it('tears down the microVM when the readiness fence times out (no orphan)', async () => {

--- a/packages/sandbox/src/backends/firecracker/__tests__/egress-policy.test.ts
+++ b/packages/sandbox/src/backends/firecracker/__tests__/egress-policy.test.ts
@@ -1,19 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import type { SandboxBackendOptions } from '../../../index.js'
-import { resolveEgressAllowlist } from '../index.js'
+import { resolveNetworkPolicy } from '../index.js'
 
 /**
- * Omitting the allowlist means "no allowlist to apply", which the
- * orchestrator reads as unrestricted. That makes omission the encoding for
- * `allow-all` and only for `allow-all`.
- *
- * `resolver` used to be omitted too — so two opposite intentions shared one
- * encoding, the tenant-scoped allowlist the variant exists for was silently
- * absent, and the callback that would have produced it was never called
- * anywhere in the repo. Whichever way the orchestrator reads an omitted
- * field, one of the two variants was always mis-enforced, and the one that
- * failed OPEN was the one whose entire purpose is restriction.
+ * Omission means the caller supplied no policy and preserves the legacy
+ * no-NIC request. Every explicit policy gets its own discriminated encoding.
  */
 
 const opts = (egress?: SandboxBackendOptions['egress']): SandboxBackendOptions => ({
@@ -22,35 +14,35 @@ const opts = (egress?: SandboxBackendOptions['egress']): SandboxBackendOptions =
 })
 
 describe('each policy gets its own encoding', () => {
-	it('allow-all omits the field', async () => {
-		expect(await resolveEgressAllowlist(opts({ kind: 'allow-all' }))).toBeUndefined()
+	it('allow-all requests open networking explicitly', async () => {
+		expect(await resolveNetworkPolicy(opts({ kind: 'allow-all' }))).toEqual({ mode: 'open' })
 	})
 
-	it('deny-all sends an explicitly empty list, not an absent one', async () => {
-		expect(await resolveEgressAllowlist(opts({ kind: 'deny-all' }))).toEqual([])
+	it('deny-all requests no network explicitly', async () => {
+		expect(await resolveNetworkPolicy(opts({ kind: 'deny-all' }))).toEqual({ mode: 'none' })
 	})
 
 	it('static forwards the hosts as given', async () => {
 		expect(
-			await resolveEgressAllowlist(opts({ kind: 'static', allowedHosts: ['a.example'] })),
-		).toEqual(['a.example'])
+			await resolveNetworkPolicy(opts({ kind: 'static', allowedHosts: ['a.example'] })),
+		).toEqual({ mode: 'allowlist', allowedHosts: ['a.example'] })
 	})
 
 	it('resolver calls the callback and forwards what it returned', async () => {
 		const resolve = vi.fn(async () => ['tenant-a.example', 'tenant-b.example'])
-		expect(await resolveEgressAllowlist(opts({ kind: 'resolver', resolve }))).toEqual([
-			'tenant-a.example',
-			'tenant-b.example',
-		])
+		expect(await resolveNetworkPolicy(opts({ kind: 'resolver', resolve }))).toEqual({
+			mode: 'allowlist',
+			allowedHosts: ['tenant-a.example', 'tenant-b.example'],
+		})
 		// The callback IS the feature. It was declared and never invoked.
 		expect(resolve).toHaveBeenCalledOnce()
 	})
 
 	it('never encodes resolver the same way as allow-all', async () => {
-		const restrictive = await resolveEgressAllowlist(
+		const restrictive = await resolveNetworkPolicy(
 			opts({ kind: 'resolver', resolve: async () => ['only-this.example'] }),
 		)
-		const unrestricted = await resolveEgressAllowlist(opts({ kind: 'allow-all' }))
+		const unrestricted = await resolveNetworkPolicy(opts({ kind: 'allow-all' }))
 		expect(restrictive).not.toEqual(unrestricted)
 	})
 
@@ -58,19 +50,19 @@ describe('each policy gets its own encoding', () => {
 		// An empty allowlist is a decision, not an absence. Collapsing it
 		// back to omission would turn "this tenant may reach nothing" into
 		// "this tenant may reach everything".
-		expect(
-			await resolveEgressAllowlist(opts({ kind: 'resolver', resolve: async () => [] })),
-		).toEqual([])
+		expect(await resolveNetworkPolicy(opts({ kind: 'resolver', resolve: async () => [] }))).toEqual(
+			{ mode: 'allowlist', allowedHosts: [] },
+		)
 	})
 
 	it('omits the field when the host set no policy at all', async () => {
-		expect(await resolveEgressAllowlist(opts())).toBeUndefined()
+		expect(await resolveNetworkPolicy(opts())).toBeUndefined()
 	})
 })
 
 describe('an unknown policy', () => {
 	it('refuses rather than defaulting to unrestricted', async () => {
-		await expect(resolveEgressAllowlist(opts({ kind: 'something-new' } as never))).rejects.toThrow(
+		await expect(resolveNetworkPolicy(opts({ kind: 'something-new' } as never))).rejects.toThrow(
 			/Refusing rather than defaulting to unrestricted/,
 		)
 	})
@@ -78,7 +70,7 @@ describe('an unknown policy', () => {
 	it('propagates a failing resolver instead of falling back to open', async () => {
 		// A resolver that cannot answer must not become "allow everything".
 		await expect(
-			resolveEgressAllowlist(
+			resolveNetworkPolicy(
 				opts({
 					kind: 'resolver',
 					resolve: async () => {

--- a/packages/sandbox/src/backends/firecracker/__tests__/transport.test.ts
+++ b/packages/sandbox/src/backends/firecracker/__tests__/transport.test.ts
@@ -246,6 +246,38 @@ describe.skipIf(IS_WINDOWS)('VsockAgentTransport over a unix-socket loopback age
 		expect(await transport.healthz()).toBe(true)
 	})
 
+	it('forwards a bidirectional guest-loopback TCP stream', async () => {
+		server = await startAgentServer(agent.handleConnection)
+		const upstream = createServer((socket) => {
+			socket.once('data', (chunk) => socket.end(Buffer.concat([Buffer.from('reply:'), chunk])))
+		})
+		await new Promise<void>((resolve, reject) => {
+			upstream.once('error', reject)
+			upstream.listen(0, '127.0.0.1', resolve)
+		})
+		try {
+			const address = upstream.address()
+			if (!address || typeof address === 'string') throw new Error('missing TCP test address')
+			const transport = new VsockAgentTransport({
+				kind: 'unix',
+				path: sockPath,
+			})
+			const connection = await transport.openTcpConnection({
+				port: address.port,
+			})
+			let output = ''
+			const dispose = connection.onData((chunk) => {
+				output += Buffer.from(chunk).toString('utf8')
+			})
+			expect(connection.write('hello')).toBe(true)
+			await expect(connection.closed).resolves.toBeUndefined()
+			expect(output).toBe('reply:hello')
+			dispose()
+		} finally {
+			await new Promise<void>((resolve) => upstream.close(() => resolve()))
+		}
+	})
+
 	it('fits a connected peer that never replies inside the readiness deadline', async () => {
 		let peerClosed = false
 		server = createServer((socket) => {
@@ -478,6 +510,42 @@ describe.skipIf(IS_WINDOWS)('VsockAgentTransport over a unix-socket loopback age
 		await expect(transport.readFile('x')).rejects.toThrow(/could not connect to agent/)
 	})
 })
+
+describe.skipIf(process.platform !== 'linux')(
+	'VsockAgentTransport guest PTY over a unix-socket loopback agent',
+	() => {
+		it('provides a real TTY with ordered input, resize, output, and exit', async () => {
+			server = await startAgentServer(agent.handleConnection)
+			const transport = new VsockAgentTransport({
+				kind: 'unix',
+				path: sockPath,
+			})
+			const terminal = await transport.openTerminal({
+				command: '/bin/sh',
+				args: ['-l'],
+				cwd: workDir,
+				size: { cols: 101, rows: 31 },
+			})
+			let output = ''
+			const unsubscribe = terminal.onData((chunk) => {
+				output += chunk
+			})
+
+			terminal.write(
+				'if [ -t 0 ] && [ -t 1 ]; then echo __REAL_PTY__; else echo __NOT_A_PTY__; fi; stty size\n',
+			)
+			await vi.waitFor(() => expect(output).toContain('__REAL_PTY__'))
+			await vi.waitFor(() => expect(output).toContain('31 101'))
+
+			terminal.resize({ cols: 120, rows: 40 })
+			terminal.write('sleep 0.1; stty size; echo __RESIZED__; exit 7\n')
+			await vi.waitFor(() => expect(output).toContain('__RESIZED__'))
+			await vi.waitFor(() => expect(output).toContain('40 120'))
+			await expect(terminal.exited).resolves.toMatchObject({ exitCode: 7 })
+			unsubscribe()
+		})
+	},
+)
 
 // ---------------------------------------------------------------------------
 // Ring-0 mTLS arm — pure-local TLS loopback "relay" (no Azure, no FC host)

--- a/packages/sandbox/src/backends/firecracker/index.ts
+++ b/packages/sandbox/src/backends/firecracker/index.ts
@@ -184,11 +184,11 @@ interface OrchestratorCreateRequest {
 	readonly maxProcesses?: number
 	readonly timeoutMs?: number
 	/**
-	 * Resolved egress allowlist for the run, materialised by the host
-	 * into per-VM nftables rules (deny-all default). The backend just
-	 * forwards the resolved hostnames; it does not own the firewall.
+	 * Explicit guest-network intent. Omitted only when the caller supplied no
+	 * egress policy, preserving the legacy no-NIC create body. The owner-run
+	 * host either enforces this exact shape or rejects it.
 	 */
-	readonly egressAllowlist?: readonly string[]
+	readonly networkPolicy?: OrchestratorNetworkPolicy
 	/**
 	 * Per-agent captured snapshot to resume (layered on the base golden).
 	 * Optional + additive: omitted from the POST body when undefined (the
@@ -199,6 +199,12 @@ interface OrchestratorCreateRequest {
 	 */
 	readonly agentSnapshot?: AgentSnapshotRef
 }
+
+/** Network policy carried on the owned orchestrator create wire. */
+export type OrchestratorNetworkPolicy =
+	| { readonly mode: 'none' }
+	| { readonly mode: 'open' }
+	| { readonly mode: 'allowlist'; readonly allowedHosts: readonly string[] }
 
 /**
  * Orchestrator `create` response. Carries the sandbox id, the
@@ -359,7 +365,7 @@ async function spawnFirecrackerSandbox(
 ): Promise<Sandbox> {
 	options.signal?.throwIfAborted()
 	const endpoint = config.orchestratorEndpoint
-	const egressAllowlist = await resolveEgressAllowlist(options)
+	const networkPolicy = await resolveNetworkPolicy(options)
 	options.signal?.throwIfAborted()
 	const createBody: OrchestratorCreateRequest = {
 		...(config.template !== undefined ? { template: config.template } : {}),
@@ -367,10 +373,9 @@ async function spawnFirecrackerSandbox(
 		...(options.memoryLimitMb !== undefined ? { memoryLimitMb: options.memoryLimitMb } : {}),
 		...(options.maxProcesses !== undefined ? { maxProcesses: options.maxProcesses } : {}),
 		...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
-		// Resolved once. It used to be called twice — harmless for the pure
-		// kinds, and once the resolver variant actually runs its callback,
-		// twice means two round-trips and two chances to disagree.
-		...(egressAllowlist !== undefined ? { egressAllowlist } : {}),
+		// Resolved once. The explicit discriminator keeps a caller that supplied
+		// `allow-all` distinct from a legacy caller that supplied no policy.
+		...(networkPolicy !== undefined ? { networkPolicy } : {}),
 	}
 
 	let created: OrchestratorCreateResponse | undefined
@@ -622,44 +627,33 @@ async function spawnFirecrackerSandbox(
 // ---------------------------------------------------------------------------
 
 /**
- * Materialise an egress policy into the allowlist the orchestrator turns
- * into firewall rules.
- *
- * Omitting the field means "no allowlist to apply", which the orchestrator
- * reads as unrestricted. That makes omission the encoding for `allow-all`
- * and ONLY for `allow-all`.
- *
- * `resolver` used to be omitted too, so two opposite intentions shared one
- * encoding and the tenant-scoped allowlist the variant exists for was
- * silently absent — with the callback that would have produced it never
- * called anywhere in the repo. Whichever way the orchestrator reads an
- * omitted field, one of the two variants was always mis-enforced, and the
- * one that failed open was the one whose entire purpose is restriction.
+ * Materialise a caller-supplied egress policy into an explicit orchestrator
+ * network policy. Omission means exactly one thing: the caller supplied no
+ * policy, so an older owner-run host keeps its historical no-NIC behaviour.
+ * `allow-all` therefore travels as `{mode:'open'}` rather than sharing the
+ * omitted encoding with legacy callers.
  *
  * The switch is exhaustive on purpose: a new variant should fail to
  * compile here rather than fall through to "unrestricted".
  */
-export async function resolveEgressAllowlist(
+export async function resolveNetworkPolicy(
 	options: SandboxBackendOptions,
-): Promise<readonly string[] | undefined> {
+): Promise<OrchestratorNetworkPolicy | undefined> {
 	const egress = options.egress
 	if (!egress) return undefined
 
 	switch (egress.kind) {
 		case 'allow-all':
-			// The one intent omission is allowed to mean.
-			return undefined
+			return { mode: 'open' }
 		case 'deny-all':
-			// Explicitly empty, not absent.
-			return []
+			return { mode: 'none' }
 		case 'static':
-			return egress.allowedHosts
+			return { mode: 'allowlist', allowedHosts: egress.allowedHosts }
 		case 'resolver': {
-			// The callback exists to produce this list. Calling it is the
-			// whole feature; an empty result is a real deny-all and travels
-			// as one rather than collapsing back to omission.
+			// The callback exists to produce this list. An empty result remains
+			// an explicit allowlist and can be enforced as deny-all by the host.
 			const resolved = await egress.resolve()
-			return resolved
+			return { mode: 'allowlist', allowedHosts: resolved }
 		}
 		default: {
 			const exhaustive: never = egress

--- a/packages/sandbox/src/backends/firecracker/index.ts
+++ b/packages/sandbox/src/backends/firecracker/index.ts
@@ -47,6 +47,7 @@
 import https from 'node:https'
 
 import type {
+	OpenTerminalOptions,
 	Sandbox,
 	SandboxDestroyOptions,
 	SandboxEnvironment,
@@ -55,6 +56,9 @@ import type {
 	SandboxFileEntry,
 	SandboxId,
 	SandboxStatus,
+	SandboxTcpConnectOptions,
+	SandboxTcpConnection,
+	TerminalSession,
 } from '@namzu/sdk'
 
 import type { AgentSnapshotRef, SandboxBackend, SandboxBackendOptions } from '../../index.js'
@@ -459,6 +463,7 @@ async function spawnFirecrackerSandbox(
 	let retirementPromise: Promise<{ readonly accepted: boolean; readonly error?: Error }> | undefined
 	let teardownPromise: Promise<void> | undefined
 	let teardownComplete = false
+	const terminals = new Set<TerminalSession>()
 
 	const assertActive = (): void => {
 		if (lifecycle !== 'active') {
@@ -529,7 +534,6 @@ async function spawnFirecrackerSandbox(
 			activeExecutions = Math.max(0, activeExecutions - 1)
 		}
 	}
-
 	return {
 		id,
 		get status(): SandboxStatus {
@@ -558,6 +562,19 @@ async function spawnFirecrackerSandbox(
 			return await transport.readFile(path)
 		},
 
+		async openTerminal(options: OpenTerminalOptions): Promise<TerminalSession> {
+			assertActive()
+			const terminal = await transport.openTerminal(options)
+			terminals.add(terminal)
+			void terminal.exited.finally(() => terminals.delete(terminal))
+			return terminal
+		},
+
+		async openTcpConnection(options: SandboxTcpConnectOptions): Promise<SandboxTcpConnection> {
+			assertActive()
+			return await transport.openTcpConnection(options)
+		},
+
 		async listFiles(rootPath: string): Promise<readonly SandboxFileEntry[]> {
 			return await runExecution(async () => {
 				// Same wire as docker/aci: `find -printf '%p\t%s\n'`, parse
@@ -584,6 +601,13 @@ async function spawnFirecrackerSandbox(
 				if (observation.accepted) return
 				retirementPromise = undefined
 			}
+			// A terminal owns an interactive process tree in this microVM. Stop and
+			// await every one before releasing the VM so the SDK's ownership
+			// contract is real rather than best-effort bookkeeping.
+			const activeTerminals = [...terminals]
+			for (const terminal of activeTerminals) terminal.kill('SIGKILL')
+			await Promise.allSettled(activeTerminals.map((terminal) => terminal.exited))
+			terminals.clear()
 			// Let the orchestrator DELETE failure propagate — the
 			// Vandal-side lifecycle wraps this with logging, and a
 			// swallowed error here means orphaned microVMs (and their

--- a/packages/sandbox/src/backends/firecracker/protocol.ts
+++ b/packages/sandbox/src/backends/firecracker/protocol.ts
@@ -86,6 +86,57 @@ export interface ReadFileRequest {
 	readonly encoding: 'base64'
 }
 
+// ---------------------------------------------------------------------------
+// Terminal — a real guest-owned PTY over the same framed stream
+// ---------------------------------------------------------------------------
+
+/** Initial request for one interactive terminal process in the guest. */
+export interface TerminalOpenRequest {
+	readonly command?: string
+	readonly args?: readonly string[]
+	readonly cwd?: string
+	readonly env?: Record<string, string>
+	readonly cols: number
+	readonly rows: number
+}
+
+/** Host → guest messages after the terminal stream reports ready. */
+export type TerminalInputEvent =
+	| { readonly type: 'input'; readonly data: string }
+	| { readonly type: 'resize'; readonly cols: number; readonly rows: number }
+	| { readonly type: 'kill'; readonly signal?: string }
+
+/** Guest → host events carried for the lifetime of the terminal stream. */
+export type TerminalOutputEvent =
+	| { readonly type: 'ready' }
+	| { readonly type: 'data'; readonly data: string }
+	| {
+			readonly type: 'exit'
+			readonly exitCode: number
+			readonly signal?: number
+	  }
+	| { readonly type: 'error'; readonly error: string }
+
+// ---------------------------------------------------------------------------
+// Loopback TCP — publish a service without moving it out of the sandbox
+// ---------------------------------------------------------------------------
+
+export interface TcpConnectRequest {
+	readonly host: '127.0.0.1' | '::1'
+	readonly port: number
+}
+
+export type TcpInputEvent =
+	| { readonly type: 'data'; readonly data: string }
+	| { readonly type: 'end' }
+	| { readonly type: 'destroy' }
+
+export type TcpOutputEvent =
+	| { readonly type: 'ready' }
+	| { readonly type: 'data'; readonly data: string }
+	| { readonly type: 'end' }
+	| { readonly type: 'error'; readonly error: string }
+
 /** `/read-file` response. `content` is base64 on success. */
 export interface ReadFileResponse {
 	readonly ok: boolean

--- a/packages/sandbox/src/backends/firecracker/transport.ts
+++ b/packages/sandbox/src/backends/firecracker/transport.ts
@@ -56,7 +56,14 @@
 import net from 'node:net'
 import tls from 'node:tls'
 
-import type { SandboxExecOptions, SandboxExecResult } from '@namzu/sdk'
+import type {
+	OpenTerminalOptions,
+	SandboxExecOptions,
+	SandboxExecResult,
+	SandboxTcpConnectOptions,
+	SandboxTcpConnection,
+	TerminalSession,
+} from '@namzu/sdk'
 import { OperationDeadline, OperationDeadlineExpired } from '../readiness.js'
 import {
 	RemoteCancellationUnknownError,
@@ -70,6 +77,12 @@ import {
 	ExecResultAccumulator,
 	type ReadFileRequest,
 	type ReadFileResponse,
+	type TcpConnectRequest,
+	type TcpInputEvent,
+	type TcpOutputEvent,
+	type TerminalInputEvent,
+	type TerminalOpenRequest,
+	type TerminalOutputEvent,
 	type WriteFileRequest,
 	type WriteFileResponse,
 	parseExecLine,
@@ -170,6 +183,8 @@ export type AgentRequest =
 	  }
 	| { readonly op: 'read-file'; readonly body: ReadFileRequest }
 	| { readonly op: 'write-file'; readonly body: WriteFileRequest }
+	| { readonly op: 'terminal'; readonly body: TerminalOpenRequest }
+	| { readonly op: 'tcp-connect'; readonly body: TcpConnectRequest }
 	| { readonly op: 'healthz' }
 
 export interface VsockTransportOptions {
@@ -805,6 +820,306 @@ export class VsockAgentTransport {
 			throw new Error(res.error ?? 'read-file: no content')
 		}
 		return Buffer.from(res.content, 'base64')
+	}
+
+	/**
+	 * Open a real PTY owned by the in-VM agent.
+	 *
+	 * Unlike `execute`, this keeps one framed connection open for the complete
+	 * interactive lifetime: guest output and exit events flow toward the host,
+	 * while input/resize/kill events flow back on the same ordered stream. The
+	 * browser never reaches this transport directly; the runtime gateway owns
+	 * the session and its authenticated WebSocket attachment.
+	 */
+	async openTerminal(options: OpenTerminalOptions): Promise<TerminalSession> {
+		const socket = await this.dial()
+		const request: TerminalOpenRequest = {
+			...(options.command !== undefined ? { command: options.command } : {}),
+			...(options.args !== undefined ? { args: options.args } : {}),
+			...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
+			...(options.env !== undefined ? { env: { ...options.env } } : {}),
+			cols: options.size.cols,
+			rows: options.size.rows,
+		}
+
+		return await new Promise<TerminalSession>((resolve, reject) => {
+			const KILL_GRACE_MS = 5_000
+			const reader = new FrameReader()
+			const listeners = new Set<(chunk: string) => void>()
+			const buffered: string[] = []
+			let bufferedBytes = 0
+			let ready = false
+			let settled = false
+			let killTimer: ReturnType<typeof setTimeout> | undefined
+			let resolveExit!: (event: { exitCode: number; signal?: number }) => void
+			const exited = new Promise<{ exitCode: number; signal?: number }>((done) => {
+				resolveExit = done
+			})
+			const idle = new IdleTimer(this.readIdleTimeoutMs, () => {
+				finish(
+					new Error(
+						`vsock transport: terminal read idle timeout after ${this.readIdleTimeoutMs}ms`,
+					),
+				)
+			})
+
+			const finish = (
+				error: Error | null,
+				exit: { exitCode: number; signal?: number } = { exitCode: -1 },
+			) => {
+				if (settled) return
+				settled = true
+				idle.clear()
+				if (killTimer) clearTimeout(killTimer)
+				socket.destroy()
+				listeners.clear()
+				resolveExit(exit)
+				if (!ready) reject(error ?? new Error('terminal exited before readiness'))
+			}
+
+			const send = (event: TerminalInputEvent) => {
+				if (settled) return
+				socket.write(frame(JSON.stringify(event)))
+			}
+
+			const session: TerminalSession = {
+				write(data) {
+					send({ type: 'input', data })
+				},
+				resize(size) {
+					send({ type: 'resize', cols: size.cols, rows: size.rows })
+				},
+				onData(listener) {
+					listeners.add(listener)
+					if (buffered.length > 0) {
+						const pending = buffered.splice(0)
+						bufferedBytes = 0
+						queueMicrotask(() => {
+							if (!listeners.has(listener)) return
+							for (const chunk of pending) listener(chunk)
+						})
+					}
+					return () => listeners.delete(listener)
+				},
+				exited,
+				kill(signal) {
+					send({ type: 'kill', ...(signal !== undefined ? { signal } : {}) })
+					// A wedged guest must not pin sandbox.destroy() forever. The normal
+					// path reports the real exit; the deadline only severs an
+					// unresponsive transport so the owning microVM can be reclaimed.
+					if (!settled && !killTimer) {
+						killTimer = setTimeout(() => finish(null), KILL_GRACE_MS)
+						killTimer.unref?.()
+					}
+				},
+			}
+
+			socket.on('data', (chunk: Buffer) => {
+				if (!ready) idle.bump()
+				let payloads: string[]
+				try {
+					payloads = reader.push(chunk)
+				} catch (err) {
+					finish(err instanceof Error ? err : new Error(String(err)))
+					return
+				}
+				for (const payload of payloads) {
+					let event: TerminalOutputEvent
+					try {
+						event = JSON.parse(payload) as TerminalOutputEvent
+					} catch (err) {
+						finish(err instanceof Error ? err : new Error(String(err)))
+						return
+					}
+					if (event.type === 'ready') {
+						if (!ready) {
+							ready = true
+							// Once ready, an interactive shell may legitimately sit silent
+							// for hours. Runtime/session TTL owns idle cleanup; a transport
+							// read timer would incorrectly kill a healthy quiet terminal.
+							idle.clear()
+							resolve(session)
+						}
+						continue
+					}
+					if (event.type === 'data') {
+						if (listeners.size === 0) {
+							buffered.push(event.data)
+							bufferedBytes += Buffer.byteLength(event.data)
+							while (bufferedBytes > 1024 * 1024 && buffered.length > 1) {
+								bufferedBytes -= Buffer.byteLength(buffered.shift() ?? '')
+							}
+						} else {
+							for (const listener of listeners) listener(event.data)
+						}
+						continue
+					}
+					if (event.type === 'exit') {
+						finish(null, {
+							exitCode: event.exitCode,
+							...(event.signal !== undefined ? { signal: event.signal } : {}),
+						})
+						return
+					}
+					finish(new Error(event.error))
+					return
+				}
+			})
+			socket.once('error', (err) => finish(err))
+			socket.once('close', () =>
+				finish(new Error('vsock transport: terminal socket closed before exit')),
+			)
+			idle.bump()
+			socket.write(
+				frame(
+					JSON.stringify({
+						op: 'terminal',
+						body: request,
+					} satisfies AgentRequest),
+				),
+			)
+		})
+	}
+
+	/** Open one TCP stream to a service listening on guest loopback. */
+	async openTcpConnection(options: SandboxTcpConnectOptions): Promise<SandboxTcpConnection> {
+		if (!Number.isInteger(options.port) || options.port < 1 || options.port > 65_535) {
+			throw new Error('tcp connection port must be an integer in [1, 65535]')
+		}
+		const host = options.host ?? '127.0.0.1'
+		if (host !== '127.0.0.1' && host !== '::1') {
+			throw new Error('firecracker TCP connections are restricted to guest loopback')
+		}
+		const socket = await this.dial()
+		const request: TcpConnectRequest = { host, port: options.port }
+
+		return await new Promise<SandboxTcpConnection>((resolve, reject) => {
+			const reader = new FrameReader()
+			const listeners = new Set<(chunk: Uint8Array) => void>()
+			const buffered: Buffer[] = []
+			let bufferedBytes = 0
+			let ready = false
+			let settled = false
+			let resolveClosed!: () => void
+			const closed = new Promise<void>((done) => {
+				resolveClosed = done
+			})
+			const idle = new IdleTimer(this.readIdleTimeoutMs, () => {
+				finish(
+					new Error(`vsock transport: TCP connect idle timeout after ${this.readIdleTimeoutMs}ms`),
+				)
+			})
+
+			const finish = (error: Error | null) => {
+				if (settled) return
+				settled = true
+				idle.clear()
+				socket.destroy()
+				listeners.clear()
+				resolveClosed()
+				if (!ready) reject(error ?? new Error('TCP stream closed before readiness'))
+			}
+
+			const send = (event: TcpInputEvent): boolean => {
+				return !settled && socket.write(frame(JSON.stringify(event)))
+			}
+
+			const connection: SandboxTcpConnection = {
+				write(data) {
+					const bytes = typeof data === 'string' ? Buffer.from(data) : Buffer.from(data)
+					return send({ type: 'data', data: bytes.toString('base64') })
+				},
+				end() {
+					send({ type: 'end' })
+				},
+				destroy() {
+					send({ type: 'destroy' })
+					finish(null)
+				},
+				pause() {
+					socket.pause()
+				},
+				resume() {
+					if (!settled) socket.resume()
+				},
+				onData(listener) {
+					listeners.add(listener)
+					if (buffered.length > 0) {
+						const pending = buffered.splice(0)
+						bufferedBytes = 0
+						queueMicrotask(() => {
+							if (!listeners.has(listener)) return
+							for (const chunk of pending) listener(chunk)
+						})
+					}
+					return () => listeners.delete(listener)
+				},
+				onDrain(listener) {
+					socket.on('drain', listener)
+					return () => socket.off('drain', listener)
+				},
+				closed,
+			}
+
+			socket.on('data', (chunk: Buffer) => {
+				if (!ready) idle.bump()
+				let payloads: string[]
+				try {
+					payloads = reader.push(chunk)
+				} catch (error) {
+					finish(error instanceof Error ? error : new Error(String(error)))
+					return
+				}
+				for (const payload of payloads) {
+					let event: TcpOutputEvent
+					try {
+						event = JSON.parse(payload) as TcpOutputEvent
+					} catch (error) {
+						finish(error instanceof Error ? error : new Error(String(error)))
+						return
+					}
+					if (event.type === 'ready') {
+						if (!ready) {
+							ready = true
+							idle.clear()
+							resolve(connection)
+						}
+						continue
+					}
+					if (event.type === 'data') {
+						const bytes = Buffer.from(event.data, 'base64')
+						if (listeners.size === 0) {
+							buffered.push(bytes)
+							bufferedBytes += bytes.byteLength
+							while (bufferedBytes > 1024 * 1024 && buffered.length > 1) {
+								bufferedBytes -= buffered.shift()?.byteLength ?? 0
+							}
+						} else {
+							for (const listener of listeners) listener(bytes)
+						}
+						continue
+					}
+					if (event.type === 'end') {
+						finish(null)
+						continue
+					}
+					finish(new Error(event.error))
+				}
+			})
+			socket.once('error', (error) => finish(error))
+			socket.once('close', () =>
+				finish(ready ? null : new Error('vsock TCP socket closed before readiness')),
+			)
+			idle.bump()
+			socket.write(
+				frame(
+					JSON.stringify({
+						op: 'tcp-connect',
+						body: request,
+					} satisfies AgentRequest),
+				),
+			)
+		})
 	}
 }
 

--- a/packages/sdk/src/bridge/sse/mapper.test.ts
+++ b/packages/sdk/src/bridge/sse/mapper.test.ts
@@ -280,6 +280,27 @@ describe('mapRunToStreamEvent — mapped variants', () => {
 		).toBe('agent.canceled')
 	})
 
+	it('agent.pending carries an approved plan edge when present', () => {
+		const pending = mapRunToStreamEvent(
+			{
+				type: 'agent_pending',
+				runId: RID,
+				taskId: 'task_1' as TaskId,
+				parentAgentId: 'supervisor',
+				childAgentId: 'worker',
+				depth: 1,
+				planId: 'plan_1',
+				planStepId: 'step_2',
+			},
+			RID,
+		)
+
+		expect(pending?.data).toMatchObject({
+			plan_id: 'plan_1',
+			plan_step_id: 'step_2',
+		})
+	})
+
 	it('task_created / task_updated map cleanly', () => {
 		const a = mapRunToStreamEvent(
 			{

--- a/packages/sdk/src/bridge/sse/mapper.ts
+++ b/packages/sdk/src/bridge/sse/mapper.ts
@@ -398,6 +398,8 @@ const MAPPING: {
 			parent_agent_id: e.parentAgentId,
 			child_agent_id: e.childAgentId,
 			depth: e.depth,
+			...(e.planId ? { plan_id: e.planId } : {}),
+			...(e.planStepId ? { plan_step_id: e.planStepId } : {}),
 		}),
 	},
 

--- a/packages/sdk/src/manager/agent/lifecycle.ts
+++ b/packages/sdk/src/manager/agent/lifecycle.ts
@@ -301,6 +301,8 @@ export class AgentManager {
 				parentAgentId: context.parentAgentId,
 				childAgentId: options.agentId,
 				depth: context.depth,
+				...(options.planId ? { planId: options.planId } : {}),
+				...(options.planStepId ? { planStepId: options.planStepId } : {}),
 			})
 
 			const lineage: Lineage = {

--- a/packages/sdk/src/scheduler/local.ts
+++ b/packages/sdk/src/scheduler/local.ts
@@ -107,6 +107,8 @@ export class LocalTaskScheduler implements TaskScheduler {
 		const task = await this.agentManager.sendMessage(
 			{
 				agentId: options.agentId,
+				...(options.planId ? { planId: options.planId } : {}),
+				...(options.planStepId ? { planStepId: options.planStepId } : {}),
 				input: {
 					messages: [createUserMessage(options.prompt)],
 					workingDirectory: options.workingDirectory,

--- a/packages/sdk/src/tools/coordinator/__tests__/a-plan-step-reports-its-own-outcome.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/a-plan-step-reports-its-own-outcome.test.ts
@@ -101,6 +101,25 @@ const stepStatus = (pm: PlanManager, id: string) =>
 	pm.active?.steps.find((s) => s.id === id)?.status
 
 describe('a delegated step reports through the launch that carries it out', () => {
+	it('carries the plan edge on the live worker launch', async () => {
+		const pm = approvedPlan()
+		const gateway = gatewayReturning('ok')
+		let launched: Parameters<TaskScheduler['createTask']>[0] | undefined
+		const createTask = gateway.createTask.bind(gateway)
+		gateway.createTask = async (options) => {
+			launched = options
+			return createTask(options)
+		}
+		const named = toolsOver(pm, gateway)
+
+		await named('create_task').execute(
+			{ agent_id: 'worker', prompt: 'go', description: 'do it', plan_step_id: 'step_1' },
+			ctx(),
+		)
+
+		expect(launched).toMatchObject({ planId: pm.active?.id, planStepId: 'step_1' })
+	})
+
 	it('completes the step when the worker succeeded', async () => {
 		const pm = approvedPlan()
 		const named = toolsOver(pm, gatewayReturning('ok'))

--- a/packages/sdk/src/tools/coordinator/index.ts
+++ b/packages/sdk/src/tools/coordinator/index.ts
@@ -620,6 +620,7 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 			// could report `failed` or stay `executing` forever but never
 			// `completed`.
 			const planStepId = plan_step_id
+			const planId = planStepId ? getPlanManager?.()?.active?.id : undefined
 			const reportStep = (status: 'running' | 'completed' | 'failed', error?: string): void => {
 				if (!planStepId) return
 				getPlanManager?.()?.updateStepStatus(planStepId, status, error)
@@ -649,6 +650,8 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 				prompt,
 				workingDirectory: cwd,
 				runtimeContext: opts.runtimeContext,
+				...(planStepId ? { planStepId } : {}),
+				...(planId ? { planId } : {}),
 				// Hang the child run off THIS tool's span, so the delegation
 				// shows up inside the turn that asked for it.
 				...(_context.parentSpan ? { parentSpan: _context.parentSpan } : {}),

--- a/packages/sdk/src/types/agent/scheduler.ts
+++ b/packages/sdk/src/types/agent/scheduler.ts
@@ -47,6 +47,10 @@ export interface CreateTaskOptions {
 	 */
 	readonly parentSpan?: import('@opentelemetry/api').Span
 
+	/** Approved plan edge for live worker/progress correlation. */
+	readonly planId?: string
+	readonly planStepId?: string
+
 	agentId: string
 
 	/**

--- a/packages/sdk/src/types/agent/task.ts
+++ b/packages/sdk/src/types/agent/task.ts
@@ -160,6 +160,10 @@ export interface SendMessageOptions {
 	/** See {@link import('./scheduler.js').CreateTaskOptions.personaOverride}. */
 	readonly personaOverride?: import('../persona/index.js').AgentPersona
 
+	/** Approved plan edge inherited from the delegation tool, when present. */
+	readonly planId?: string
+	readonly planStepId?: string
+
 	agentId: string
 
 	input: AgentInput

--- a/packages/sdk/src/types/run/events.ts
+++ b/packages/sdk/src/types/run/events.ts
@@ -750,6 +750,9 @@ type CoreRunEvent =
 			parentAgentId: string
 			childAgentId: string
 			depth: number
+			/** Approved plan edge carried while the blocking tool is still live. */
+			planId?: string
+			planStepId?: string
 	  }
 	| {
 			type: 'agent_completed'

--- a/packages/sdk/src/types/sandbox/index.ts
+++ b/packages/sdk/src/types/sandbox/index.ts
@@ -206,6 +206,34 @@ export interface SandboxNetworkPolicy {
 	readonly allowedHosts: readonly string[]
 }
 
+/**
+ * One host-side end of a TCP connection opened from inside the sandbox.
+ *
+ * The connection is intentionally narrower than general sandbox networking:
+ * callers may reach a loopback service already running in the sandbox, while
+ * the sandbox's egress policy remains unchanged. This is the primitive a
+ * development-workspace gateway uses to publish an HTTP/WebSocket preview
+ * without copying the checkout into a second container.
+ */
+export interface SandboxTcpConnection {
+	/** Queue bytes for the guest. False means pause the producer until onDrain. */
+	write(data: string | Uint8Array): boolean
+	end(): void
+	destroy(): void
+	/** Pause/resume bytes arriving from the guest without closing the stream. */
+	pause(): void
+	resume(): void
+	onData(listener: (chunk: Uint8Array) => void): () => void
+	onDrain(listener: () => void): () => void
+	readonly closed: Promise<void>
+}
+
+export interface SandboxTcpConnectOptions {
+	readonly port: number
+	/** Only guest loopback addresses are supported by the built-in backend. */
+	readonly host?: '127.0.0.1' | '::1'
+}
+
 export interface Sandbox {
 	readonly id: SandboxId
 	readonly status: SandboxStatus
@@ -241,11 +269,18 @@ export interface Sandbox {
 	 * with `rootDir` as its working directory does not satisfy either the
 	 * confinement or the ownership contract.
 	 *
-	 * @deprecated No built-in backend currently satisfies both guarantees.
-	 * Use a separately owned terminal backend; this member will be removed in
-	 * a future major release after the repository's deprecation window.
+	 * The Firecracker backend satisfies both guarantees by owning the PTY in the
+	 * guest and awaiting its exit before the microVM is released. Backends that
+	 * cannot provide that boundary omit the capability.
 	 */
 	openTerminal?(options: OpenTerminalOptions): Promise<TerminalSession>
+	/**
+	 * Connect to a loopback TCP service owned by this same sandbox.
+	 *
+	 * Optional. A backend that cannot preserve the same-workspace boundary must
+	 * omit this capability rather than proxying to a different filesystem.
+	 */
+	openTcpConnection?(options: SandboxTcpConnectOptions): Promise<SandboxTcpConnection>
 	writeFile(path: string, content: string | Buffer): Promise<void>
 	readFile(path: string): Promise<Buffer>
 	/**
@@ -428,7 +463,10 @@ export interface ContainerSandboxLayout {
  * can inspect the post-default layout the model actually sees.
  */
 export interface ResolvedContainerSandboxLayout {
-	readonly outputs: { readonly source: ContainerSandboxMountSource; readonly containerPath: string }
+	readonly outputs: {
+		readonly source: ContainerSandboxMountSource
+		readonly containerPath: string
+	}
 	readonly uploads?: {
 		readonly source: ContainerSandboxMountSource
 		readonly containerPath: string


### PR DESCRIPTION
## Summary

- carry approved plan and step identities through delegated task scheduling
- expose the exact edge on live `agent.pending` SSE payloads
- document the live-only correlation boundary and add a minor SDK changeset

## Verification

- lint, workflow parity, project references, typecheck, and build
- focused SDK tests: 35 passed
- docs and TypeScript fence checks
- signature export and public-surface checks
- both new assertions killed by targeted hop-removal mutations

The full local SDK suite also completed 5,206 tests; 15 existing macOS canonical-path cases compare `/var` with `/private/var`. Linux CI is the authoritative full-suite result for this pull request.
