### PR TITLE
feat(runtime): complete sandbox host and guest contracts

### DIFF
--- a/.changeset/bright-firecracker-networks.md
+++ b/.changeset/bright-firecracker-networks.md
@@ -1,0 +1,7 @@
+---
+'@namzu/sandbox': minor
+---
+
+Carry explicit Firecracker network intent on the orchestrator create request.
+`allow-all`, `deny-all`, and resolved allowlists now have distinct wire shapes;
+an absent policy keeps the legacy request unchanged.

--- a/.changeset/calm-firecracker-streams.md
+++ b/.changeset/calm-firecracker-streams.md
@@ -1,0 +1,8 @@
+---
+'@namzu/sdk': minor
+'@namzu/sandbox': minor
+---
+
+Add guest-owned pseudo-terminal and loopback TCP stream capabilities to the
+Firecracker sandbox, including lifecycle ownership and bidirectional
+backpressure.

--- a/.changeset/calm-plans-find-workers.md
+++ b/.changeset/calm-plans-find-workers.md
@@ -1,0 +1,7 @@
+---
+'@namzu/sdk': minor
+---
+
+Carry optional approved-plan and plan-step identities through delegated task
+scheduling and `agent.pending` SSE payloads, allowing hosts to correlate live
+workers with exact plan progress without label or launch-order inference.

--- a/.changeset/exact-remote-sandbox-protocol.md
+++ b/.changeset/exact-remote-sandbox-protocol.md
@@ -1,0 +1,5 @@
+---
+"@namzu/sandbox": major
+---
+
+Require container workers and Firecracker guests to publish the exact remote-execution protocol during readiness, refuse missing or mismatched peers before command admission, remove identity-less legacy execution, and export the Firecracker guest protocol version for host warm-pool admission checks. Rebuild worker images, standby-pool profiles, and microVM goldens from the same release before deploying the matching host.

--- a/.changeset/quiet-anthropic-tracing.md
+++ b/.changeset/quiet-anthropic-tracing.md
@@ -1,0 +1,6 @@
+---
+'@namzu/anthropic': patch
+---
+
+Keep the optional Claude Code version probe out of framework filesystem
+tracing so server bundles do not include the consumer's entire project.

--- a/.changeset/steady-plan-listeners.md
+++ b/.changeset/steady-plan-listeners.md
@@ -1,0 +1,6 @@
+---
+'@namzu/sdk': patch
+---
+
+Wait for asynchronous plan approval listeners before resolving the approval,
+so hosts can finish persisting the decision before disposing run storage.

--- a/.changeset/valid-consumer-fixture-ids.md
+++ b/.changeset/valid-consumer-fixture-ids.md
@@ -1,0 +1,7 @@
+---
+'@namzu/sdk': patch
+---
+
+Export deterministic UUID entity fixtures from `@namzu/sdk/testing` so
+consumer test suites can migrate away from removed prefixed IDs without
+copying the SDK's identity rules.

--- a/docs/cli/delegated-work.md
+++ b/docs/cli/delegated-work.md
@@ -60,6 +60,14 @@ inside a model batch, so a following verification read sees completed foreground
 mutations. A background shell command releases that barrier after job launch;
 wait for the job before reading its eventual output.
 
+When an `Agent` call is associated with the active plan step, the scheduler
+retains that optional plan and step identity while the child is queued and after
+it is admitted. SDK hosts receive the same `planId` and `planStepId` on the
+initial `agent_pending` event, and SSE consumers receive `plan_id` and
+`plan_step_id`. This lets a host correlate pending delegated work before the
+child starts without treating display-oriented workflow or phase labels as plan
+dependencies.
+
 
 For parallel work, send the independent Agent calls in the same response or
 launch them with `run_in_background: true` before waiting. One blocking call

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,5 +1,9 @@
 # Documentation update log
 
+## 2026-09-11
+
+- **Fix** Waited for asynchronous plan approval listeners before resolving the approval, preventing durable plan events from outliving run storage while preserving listener-failure isolation.
+
 ## 2026-09-10
 
 - **Update** Shortened exit resume commands for matching PATH installations and omitted redundant working-directory changes.

--- a/docs/log.md
+++ b/docs/log.md
@@ -4,6 +4,8 @@
 
 - **Update** Shortened exit resume commands for matching PATH installations and omitted redundant working-directory changes.
 
+- **Update** Published deterministic valid entity-ID fixtures through the SDK's testing subpath for consumer test suites migrating from removed prefixed IDs.
+
 - **Update** Documented exact host/guest rollout, guest-owned PTY and loopback TCP channels, explicit Firecracker network-policy admission, and plan-step identity on pending delegated work.
 
 - **Update** Removed bundled OAuth application credentials from the Google integration; expired borrowed sessions require owner renewal or explicit matching application configuration.

--- a/docs/log.md
+++ b/docs/log.md
@@ -4,6 +4,8 @@
 
 - **Update** Shortened exit resume commands for matching PATH installations and omitted redundant working-directory changes.
 
+- **Update** Scoped the Anthropic provider's optional Claude Code version probe out of framework filesystem tracing so server bundles do not absorb the consumer's complete project tree.
+
 - **Update** Published deterministic valid entity-ID fixtures through the SDK's testing subpath for consumer test suites migrating from removed prefixed IDs.
 
 - **Update** Documented exact host/guest rollout, guest-owned PTY and loopback TCP channels, explicit Firecracker network-policy admission, and plan-step identity on pending delegated work.

--- a/docs/log.md
+++ b/docs/log.md
@@ -4,6 +4,8 @@
 
 - **Update** Shortened exit resume commands for matching PATH installations and omitted redundant working-directory changes.
 
+- **Update** Documented exact host/guest rollout, guest-owned PTY and loopback TCP channels, explicit Firecracker network-policy admission, and plan-step identity on pending delegated work.
+
 - **Update** Removed bundled OAuth application credentials from the Google integration; expired borrowed sessions require owner renewal or explicit matching application configuration.
 
 - **Update** Recorded live CLI creation, external-edit preservation after resume, and approved parallel-agent checks; prepared an example-only terminal capture for the READMEs.

--- a/docs/sdk/ids.md
+++ b/docs/sdk/ids.md
@@ -38,6 +38,18 @@ Constructors accept canonical hyphenated UUIDs with an RFC variant and version
 1–8, preserving their case. Prefixed strings, arbitrary names, path segments
 and malformed UUIDs are rejected. Constructors never trim or rewrite keys.
 
+Tests in a consuming package can import `fixtureId` from
+`@namzu/sdk/testing`. Each entity-kind function maps a readable label to a
+stable UUID v4 fixture, so assertions stay deterministic without reviving the
+removed prefix format or sharing one identity across unrelated cases.
+
+```ts
+import { fixtureId } from '@namzu/sdk/testing'
+
+const runId = fixtureId.run('retries-after-approval')
+const sessionId = fixtureId.session('retries-after-approval')
+```
+
 `ProjectIdSchema`, `RunIdSchema` and `MessageIdSchema` use the same spelling
 rules as their constructors. They remain Zod string schemas and expose their
 validation patterns when converted to JSON Schema.

--- a/packages/cli/src/__tests__/__fixtures__/installer-not-on-path.sh
+++ b/packages/cli/src/__tests__/__fixtures__/installer-not-on-path.sh
@@ -58,7 +58,9 @@ ls -1A "$W/home/.namzu/bin" 2>/dev/null || echo "(nothing)"
 # Matches the current wording and the one it replaced, so a regression to the
 # old phrasing is reported as "named the wrong directory" rather than as "named
 # nothing" — the failure should name the defect, not the rename.
-NAMED="$(printf '%s' "$OUT" | sed -n 's/.*\(The binary is in\|The files are in\) \(.*\)\. Add it to your PATH.*/\2/p')"
+NAMED="$(printf '%s' "$OUT" | sed -n \
+	-e 's/.*The binary is in \(.*\)\. Add it to your PATH.*/\1/p' \
+	-e 's/.*The files are in \(.*\)\. Add it to your PATH.*/\1/p')"
 echo "--- directory the installer named: ${NAMED:-<none>}"
 
 if [ -z "$NAMED" ]; then

--- a/packages/cli/src/doctor/checks/__tests__/chain.test.ts
+++ b/packages/cli/src/doctor/checks/__tests__/chain.test.ts
@@ -27,7 +27,7 @@ function writePrefs(body: unknown): void {
  * running the suite.
  */
 function check(env: Record<string, string> = {}) {
-	return describeProviderChain({ home, env, skipProbes: true })
+	return describeProviderChain({ home, env, skipKeychain: true, skipProbes: true })
 }
 
 describe('the provider chain check', () => {

--- a/packages/cli/src/doctor/checks/chain.ts
+++ b/packages/cli/src/doctor/checks/chain.ts
@@ -17,6 +17,8 @@ export interface ProviderChainCheckOptions {
 	/** Explicit OS home seam. Production defaults honor `NAMZU_HOME`. */
 	readonly home?: string
 	readonly env?: DiscoverOptions['env']
+	/** Skip the macOS Keychain read so a hermetic caller sees only its inputs. */
+	readonly skipKeychain?: boolean
 	/** Skip localhost probes. Off in production: a local server being up is the answer. */
 	readonly skipProbes?: boolean
 }
@@ -108,6 +110,7 @@ export async function describeProviderChain(
 		detected = await discoverProviders({
 			...(options.env ? { env: options.env } : {}),
 			...(options.home ? { home: options.home } : {}),
+			...(options.skipKeychain ? { skipKeychain: true } : {}),
 			...(options.skipProbes ? { skipProbes: true } : {}),
 		})
 	} catch (err) {

--- a/packages/cli/src/test-setup.ts
+++ b/packages/cli/src/test-setup.ts
@@ -17,9 +17,18 @@
  * Only set when unset, so a contributor debugging a specific test with
  * `NAMZU_LOG_LEVEL=debug pnpm test` gets what they asked for.
  */
-import { mkdtempSync } from 'node:fs'
+import { mkdtempSync, realpathSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+
+// macOS commonly exposes one temporary directory through both `/var/...` and
+// `/private/var/...`. The product canonicalizes filesystem authority paths, so
+// let fixtures begin from the same spelling rather than turning correct
+// containment and freshness checks into path-string failures.
+const canonicalTemporaryRoot = realpathSync(tmpdir())
+process.env.TMPDIR = canonicalTemporaryRoot
+process.env.TMP = canonicalTemporaryRoot
+process.env.TEMP = canonicalTemporaryRoot
 
 if (process.env.NAMZU_LOG_LEVEL === undefined) {
 	process.env.NAMZU_LOG_LEVEL = 'silent'

--- a/packages/cli/src/tui/__tests__/goal-continuation-reaches-app.test.tsx
+++ b/packages/cli/src/tui/__tests__/goal-continuation-reaches-app.test.tsx
@@ -162,7 +162,11 @@ function deferred(): {
 
 async function until(check: () => boolean, why: string): Promise<void> {
 	const started = performance.now()
-	while (!check() && performance.now() - started < 5_000) await tick()
+	// The full CLI suite transforms and renders many integration-shaped tests
+	// concurrently. Leave enough observation time for the expected frame under
+	// that measured contention while the enclosing 15-second test budget still
+	// catches a real hang.
+	while (!check() && performance.now() - started < 8_000) await tick()
 	expect(check(), why).toBe(true)
 }
 

--- a/packages/cli/src/tui/__tests__/goal-continuation-reaches-app.test.tsx
+++ b/packages/cli/src/tui/__tests__/goal-continuation-reaches-app.test.tsx
@@ -162,11 +162,7 @@ function deferred(): {
 
 async function until(check: () => boolean, why: string): Promise<void> {
 	const started = performance.now()
-	// The full CLI suite transforms and renders many integration-shaped tests
-	// concurrently. Leave enough observation time for the expected frame under
-	// that measured contention while the enclosing 15-second test budget still
-	// catches a real hang.
-	while (!check() && performance.now() - started < 8_000) await tick()
+	while (!check() && performance.now() - started < 5_000) await tick()
 	expect(check(), why).toBe(true)
 }
 
@@ -424,13 +420,19 @@ it('disarms after an abnormal turn and requires an explicit /goal resume', async
 		yield { kind: 'done', stopReason: 'end_turn' }
 	}
 
-	const { harness } = await mountedApp('namzu-goal-app-failure-')
+	const { root, harness } = await mountedApp('namzu-goal-app-failure-')
 	await submit(harness, '/goal recover only when asked')
 	await until(() => calls === 1, 'the first goal round never started')
 	await tick(120)
 	expect(calls).toBe(1)
 
+	const sessions = await openSessions(root)
 	await submit(harness, '/goal pause')
+	await untilAsync(
+		async () =>
+			(await sessions.goals.getGoal(scope!.sessionId, sessions.tenantId))?.phase === 'paused',
+		'the pause command did not reach durable goal state',
+	)
 	await until(
 		() => harness.lastFrame()?.includes('Goal paused (/goal resume)') === true,
 		'the durable paused goal did not reach the footer',

--- a/packages/providers/anthropic/src/client.ts
+++ b/packages/providers/anthropic/src/client.ts
@@ -61,7 +61,7 @@ function detectClaudeCodeVersion(): string {
 	if (claudeCodeVersionCache !== null) return claudeCodeVersionCache
 	for (const bin of ['claude', 'claude-code']) {
 		try {
-			const out = execFileSync(bin, ['--version'], {
+			const out = execFileSync(/* turbopackIgnore: true */ bin, ['--version'], {
 				encoding: 'utf8',
 				timeout: 5_000,
 				stdio: ['ignore', 'pipe', 'ignore'],

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -63,7 +63,7 @@ const provider = createSandboxProvider({
 })
 ```
 
-## Cancellation and worker compatibility
+## Protocol readiness and cancellation
 
 Pass `SandboxExecOptions.signal` to stop a command on any shipped backend. A
 remote host reserves every command before admission and the container worker or
@@ -84,12 +84,15 @@ Concurrent destroy and automatic-retirement calls share one checked teardown;
 Docker removal is never reported as accepted after a non-zero or aborted
 `docker rm -f`.
 
-The cancellation path requires a worker or guest image built from the same
-release. A current host explicitly detects an older peer and remains compatible
-with legacy no-signal execution, but a signal sent to that peer is refused with
-a rebuild instruction. For a standby pool, publish a new container group
-profile revision containing the current worker before enabling cancellation;
-for a microVM deployment, rebuild its golden guest image.
+Every worker and microVM guest publishes its wire-protocol version in the
+readiness response. The host admits only the exact version implemented by its
+release; missing, older, and newer versions fail before a sandbox handle or
+command is returned. There is no identity-less legacy execution path. For a
+standby pool, publish a new container group profile revision containing the
+matching worker before deploying the host; for a microVM deployment, rebuild
+and validate its golden guest image from the same release. Firecracker hosts
+can import `FIRECRACKER_AGENT_PROTOCOL_VERSION` to apply the same admission
+check in their own warm-pool probe.
 
 ## Documentation
 

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -94,6 +94,43 @@ and validate its golden guest image from the same release. Firecracker hosts
 can import `FIRECRACKER_AGENT_PROTOCOL_VERSION` to apply the same admission
 check in their own warm-pool probe.
 
+Roll the coupled Firecracker artifacts in this order: build the guest agent
+from the target Namzu release, publish and canary a golden image containing
+that agent, then deploy hosts that require its protocol version. Keep the
+previous host and golden-image pair available together for rollback. Rolling
+back only one side is intentionally rejected at readiness, so a mismatched
+guest never accepts work under an unverified wire contract.
+
+## Firecracker workspace channels
+
+The Firecracker backend exposes two optional same-sandbox channels. Call
+`sandbox.openTerminal()` for an interactive pseudo-terminal whose process tree
+is owned by the guest. The returned `TerminalSession` supports input, output,
+resize and close without substituting host pipes for terminal semantics. Call
+`sandbox.openTcpConnection()` to reach an IPv4 or IPv6 loopback service inside
+that same guest. Its `SandboxTcpConnection` exposes bounded write/backpressure,
+incoming-data pause and resume, half-close and final closure. This channel can
+publish a development server or WebSocket preview without moving the checkout
+to another runtime or widening guest egress.
+
+Both methods are capability-checked. A backend that cannot preserve the same
+isolation and ownership boundary omits them; callers must not fall back to a
+host process or a different sandbox.
+
+## Firecracker network policy
+
+At microVM creation, the Firecracker backend maps the resolved egress decision
+to an explicit orchestrator policy: deny-all becomes `none`, allow-all becomes
+`open`, and a static or resolved host list becomes `allowlist` with the exact
+allowed hosts. An omitted egress setting retains the orchestrator's legacy
+no-interface behavior. In particular, an empty resolved allowlist remains an
+explicit deny-all decision rather than collapsing to an absent policy.
+
+`sandbox.setNetworkPolicy()` remains the live-sandbox contract for backends
+that can change egress after admission. A backend must throw when it cannot
+enforce a requested live policy; accepting without applying it would erase the
+security boundary the host relied on.
+
 ## Documentation
 
 - [Namzu docs](https://github.com/cogitave/namzu/tree/main/docs)

--- a/packages/sandbox/agent/agent.cjs
+++ b/packages/sandbox/agent/agent.cjs
@@ -54,6 +54,7 @@ const net = require('node:net')
 const { spawn } = require('node:child_process')
 const { randomUUID } = require('node:crypto')
 const fs = require('node:fs/promises')
+const { constants: osConstants } = require('node:os')
 const path = require('node:path')
 
 // --- config (mirrors worker/server.js env contract) -----------------------
@@ -115,7 +116,7 @@ function frame(payload) {
 }
 
 function writeFrame(socket, obj) {
-	socket.write(frame(JSON.stringify(obj)))
+	return socket.write(frame(JSON.stringify(obj)))
 }
 
 function writeTerminator(socket) {
@@ -742,11 +743,284 @@ async function handleWriteFile(socket, body) {
 	}
 }
 
+// --- guest-owned pseudo-terminal ------------------------------------------
+
+const MAX_TERMINAL_COLS = 1000
+const MAX_TERMINAL_ROWS = 1000
+const TERMINAL_SIGNALS = new Set(['SIGTERM', 'SIGKILL', 'SIGINT', 'SIGHUP'])
+
+/** Quote one argv token for the shell command accepted by util-linux script. */
+function shellQuote(value) {
+	return `'${String(value).replaceAll("'", "'\\''")}'`
+}
+
+function terminalDimension(value, max, name) {
+	const parsed = Number(value)
+	if (!Number.isInteger(parsed) || parsed < 1 || parsed > max) {
+		throw new Error(`${name} must be an integer in [1, ${max}]`)
+	}
+	return parsed
+}
+
+function delay(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function processChildren(pid) {
+	try {
+		const raw = await fs.readFile(`/proc/${pid}/task/${pid}/children`, 'utf8')
+		return raw
+			.trim()
+			.split(/\s+/)
+			.map(Number)
+			.filter((value) => Number.isInteger(value) && value > 0)
+	} catch {
+		return []
+	}
+}
+
+/**
+ * Resolve the slave allocated by util-linux `script`.
+ *
+ * `script` owns the PTY master and the login shell is its child. The child's
+ * fd 0 is therefore the authoritative slave path; discovering it through proc
+ * lets resize use the real TIOCSWINSZ ioctl through `stty -F`, including the
+ * SIGWINCH programs expect. No pipe is represented as a terminal.
+ */
+async function findPtySlave(scriptPid) {
+	for (let attempt = 0; attempt < 200; attempt += 1) {
+		const queue = await processChildren(scriptPid)
+		while (queue.length > 0) {
+			const pid = queue.shift()
+			try {
+				const target = await fs.readlink(`/proc/${pid}/fd/0`)
+				if (/^\/dev\/pts\/\d+$/.test(target)) return target
+			} catch {}
+			queue.push(...(await processChildren(pid)))
+		}
+		await delay(5)
+	}
+	throw new Error('terminal PTY slave did not appear')
+}
+
+function resizePty(slavePath, cols, rows) {
+	return new Promise((resolve, reject) => {
+		const child = spawn(
+			'/usr/bin/stty',
+			['-F', slavePath, 'rows', String(rows), 'cols', String(cols)],
+			{
+				stdio: 'ignore',
+			},
+		)
+		child.once('error', reject)
+		child.once('close', (code) => {
+			if (code === 0) resolve()
+			else reject(new Error(`stty resize failed with code ${String(code)}`))
+		})
+	})
+}
+
+/**
+ * Start one interactive PTY inside the guest and bind it to this framed
+ * connection. The runtime gateway owns the connection; disconnect/kill tears
+ * down the complete detached process group before the microVM can be released.
+ */
+function handleTerminal(socket, body) {
+	let child
+	let slavePath
+	let ready = false
+	let settled = false
+	const pending = []
+
+	const kill = (signal = 'SIGTERM') => {
+		if (!child?.pid || settled) return
+		const safeSignal = TERMINAL_SIGNALS.has(signal) ? signal : 'SIGTERM'
+		try {
+			// detached:true makes the script process the process-group leader;
+			// negative pid reaches the shell and every descendant, not just script.
+			process.kill(-child.pid, safeSignal)
+		} catch {}
+	}
+
+	const apply = (event) => {
+		if (!event || typeof event !== 'object') return
+		if (event.type === 'input') {
+			if (
+				typeof event.data === 'string' &&
+				child?.stdin?.writable &&
+				!child.stdin.write(event.data)
+			) {
+				socket.pause()
+				child.stdin.once('drain', () => {
+					if (!settled) socket.resume()
+				})
+			}
+			return
+		}
+		if (event.type === 'resize') {
+			try {
+				const cols = terminalDimension(event.cols, MAX_TERMINAL_COLS, 'cols')
+				const rows = terminalDimension(event.rows, MAX_TERMINAL_ROWS, 'rows')
+				if (slavePath) void resizePty(slavePath, cols, rows).catch(() => {})
+			} catch {}
+			return
+		}
+		if (event.type === 'kill') kill(typeof event.signal === 'string' ? event.signal : 'SIGTERM')
+	}
+
+	const start = async () => {
+		if (!body || typeof body !== 'object') throw new Error('missing_terminal_options')
+		const cols = terminalDimension(body.cols, MAX_TERMINAL_COLS, 'cols')
+		const rows = terminalDimension(body.rows, MAX_TERMINAL_ROWS, 'rows')
+		const cwd = body.cwd ? resolveWithinWorkspace(body.cwd, WORKSPACE_ROOT) : WORKSPACE_ROOT
+		await fs.mkdir(cwd, { recursive: true })
+
+		const command = typeof body.command === 'string' && body.command ? body.command : '/bin/sh'
+		const args = Array.isArray(body.args) ? body.args.map(String) : []
+		const commandLine = ['exec', shellQuote(command), ...args.map(shellQuote)].join(' ')
+		child = spawn('/usr/bin/script', ['-qefc', commandLine, '/dev/null'], {
+			cwd,
+			env: { ...process.env, TERM: 'xterm-256color', ...(body.env || {}) },
+			detached: true,
+			stdio: ['pipe', 'pipe', 'pipe'],
+		})
+		const forward = (source, chunk) => {
+			if (!writeFrame(socket, { type: 'data', data: chunk.toString('utf8') })) {
+				source.pause()
+				socket.once('drain', () => {
+					if (!settled) source.resume()
+				})
+			}
+		}
+		child.stdout.on('data', (chunk) => forward(child.stdout, chunk))
+		child.stderr.on('data', (chunk) => forward(child.stderr, chunk))
+		child.once('error', (error) => {
+			if (settled) return
+			settled = true
+			writeFrame(socket, { type: 'error', error: error.message })
+			socket.end()
+		})
+		child.once('close', (exitCode, signal) => {
+			if (settled) return
+			settled = true
+			writeFrame(socket, {
+				type: 'exit',
+				exitCode: typeof exitCode === 'number' ? exitCode : -1,
+				...(signal && osConstants.signals[signal] ? { signal: osConstants.signals[signal] } : {}),
+			})
+			socket.end()
+		})
+
+		slavePath = await findPtySlave(child.pid)
+		await resizePty(slavePath, cols, rows)
+		ready = true
+		writeFrame(socket, { type: 'ready' })
+		for (const event of pending.splice(0)) apply(event)
+	}
+
+	void start().catch((error) => {
+		if (settled) return
+		writeFrame(socket, {
+			type: 'error',
+			error: error instanceof Error ? error.message : String(error),
+		})
+		kill('SIGKILL')
+		settled = true
+		socket.end()
+	})
+
+	return {
+		onFrame(payload) {
+			let event
+			try {
+				event = JSON.parse(payload)
+			} catch {
+				return
+			}
+			if (ready) apply(event)
+			else pending.push(event)
+		},
+		onClose() {
+			kill('SIGKILL')
+		},
+	}
+}
+
+// --- guest-loopback TCP forwarding ---------------------------------------
+
+function handleTcpConnect(socket, body) {
+	const host = body?.host || '127.0.0.1'
+	const port = Number(body?.port)
+	if (
+		(host !== '127.0.0.1' && host !== '::1') ||
+		!Number.isInteger(port) ||
+		port < 1 ||
+		port > 65535
+	) {
+		writeFrame(socket, { type: 'error', error: 'invalid_loopback_target' })
+		socket.end()
+		return
+	}
+
+	let settled = false
+	const upstream = net.createConnection({ host, port })
+	const finish = (event) => {
+		if (settled) return
+		settled = true
+		if (event) writeFrame(socket, event)
+		upstream.destroy()
+		socket.end()
+	}
+
+	upstream.once('connect', () => writeFrame(socket, { type: 'ready' }))
+	upstream.on('data', (chunk) => {
+		if (!writeFrame(socket, { type: 'data', data: chunk.toString('base64') })) {
+			upstream.pause()
+			socket.once('drain', () => {
+				if (!settled) upstream.resume()
+			})
+		}
+	})
+	upstream.once('end', () => finish({ type: 'end' }))
+	upstream.once('error', (error) => finish({ type: 'error', error: error.message }))
+
+	return {
+		onFrame(payload) {
+			let event
+			try {
+				event = JSON.parse(payload)
+			} catch {
+				return
+			}
+			if (event?.type === 'data' && typeof event.data === 'string') {
+				const bytes = Buffer.from(event.data, 'base64')
+				if (bytes.byteLength <= 8 * 1024 * 1024 && !upstream.write(bytes)) {
+					socket.pause()
+					upstream.once('drain', () => {
+						if (!settled) socket.resume()
+					})
+				}
+				return
+			}
+			if (event?.type === 'end') {
+				upstream.end()
+				return
+			}
+			if (event?.type === 'destroy') finish()
+		},
+		onClose() {
+			settled = true
+			upstream.destroy()
+		},
+	}
+}
+
 // --- connection dispatch ---------------------------------------------------
 
 function handleConnection(socket) {
 	const reader = new FrameReader()
 	let dispatched = false
+	let activeStream
 	socket.on('data', (chunk) => {
 		let frames
 		try {
@@ -755,21 +1029,23 @@ function handleConnection(socket) {
 			socket.destroy()
 			return
 		}
-		// One request per connection (matches the host dialer, which
-		// opens a fresh connection per request — the resume-survivable
-		// shape).
-		if (dispatched || frames.length === 0) return
-		const first = frames[0]
-		dispatched = true
-		let req
-		try {
-			req = JSON.parse(first)
-		} catch {
-			socket.destroy()
-			return
+		for (const payload of frames) {
+			if (dispatched) {
+				activeStream?.onFrame(payload)
+				continue
+			}
+			dispatched = true
+			let req
+			try {
+				req = JSON.parse(payload)
+			} catch {
+				socket.destroy()
+				return
+			}
+			activeStream = dispatch(socket, req)
 		}
-		dispatch(socket, req)
 	})
+	socket.on('close', () => activeStream?.onClose())
 	socket.on('error', () => {
 		// A severed connection is not fatal — the listener stays up and
 		// the next dial lands fresh (resume invariant).
@@ -810,6 +1086,12 @@ function dispatch(socket, req) {
 			} catch {}
 		})
 		return
+	}
+	if (op === 'terminal') {
+		return handleTerminal(socket, req.body)
+	}
+	if (op === 'tcp-connect') {
+		return handleTcpConnect(socket, req.body)
 	}
 	if (op === 'read-file') {
 		handleReadFile(socket, req.body).finally(() => socket.end())

--- a/packages/sandbox/agent/agent.cjs
+++ b/packages/sandbox/agent/agent.cjs
@@ -762,10 +762,6 @@ function terminalDimension(value, max, name) {
 	return parsed
 }
 
-function delay(ms) {
-	return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
 async function processChildren(pid) {
 	try {
 		const raw = await fs.readFile(`/proc/${pid}/task/${pid}/children`, 'utf8')

--- a/packages/sandbox/agent/agent.cjs
+++ b/packages/sandbox/agent/agent.cjs
@@ -57,6 +57,8 @@ const fs = require('node:fs/promises')
 const { constants: osConstants } = require('node:os')
 const path = require('node:path')
 
+const FIRECRACKER_AGENT_PROTOCOL_VERSION = 2
+
 // --- config (mirrors worker/server.js env contract) -----------------------
 
 const WORKSPACE_ROOT = process.env.NAMZU_SANDBOX_WORKSPACE || '/workspace'
@@ -438,7 +440,7 @@ function handleReserveExecution(socket) {
 	})
 	writeFrame(socket, {
 		ok: true,
-		protocolVersion: 2,
+		protocolVersion: FIRECRACKER_AGENT_PROTOCOL_VERSION,
 		executionId,
 		leaseExpiresAt,
 	})
@@ -1053,6 +1055,7 @@ function dispatch(socket, req) {
 	if (op === 'healthz') {
 		writeFrame(socket, {
 			ok: !agentRetiring,
+			protocolVersion: FIRECRACKER_AGENT_PROTOCOL_VERSION,
 			...(agentRetiring ? { retiring: true } : {}),
 		})
 		socket.end()
@@ -1182,6 +1185,7 @@ async function main() {
 // Export the pure pieces so the vitest loopback peer can drive the
 // agent in-process without spawning a separate node binary.
 module.exports = {
+	FIRECRACKER_AGENT_PROTOCOL_VERSION,
 	frame,
 	FrameReader,
 	handleConnection,

--- a/packages/sandbox/src/backends/aci-standby-pool/__tests__/readiness-deadline.test.ts
+++ b/packages/sandbox/src/backends/aci-standby-pool/__tests__/readiness-deadline.test.ts
@@ -4,6 +4,7 @@ import type { ResolvedContainerSandboxLayout } from '@namzu/sdk'
 
 import { checkFileWalkOwnership, fileWalkExec } from '../../__tests__/fixtures/file-walk-exec.js'
 import { HttpWorkerClient } from '../../http-worker-client.js'
+import { REMOTE_EXECUTION_PROTOCOL_VERSION } from '../../remote-execution-controller.js'
 import { buildAciStandbyPoolBackend } from '../index.js'
 
 const realFetch = globalThis.fetch
@@ -18,6 +19,15 @@ afterEach(() => {
 	vi.restoreAllMocks()
 	globalThis.fetch = realFetch
 })
+
+function workerHealthResponse(
+	protocolVersion: number | undefined = REMOTE_EXECUTION_PROTOCOL_VERSION,
+): Response {
+	return new Response(JSON.stringify({ ok: true, protocolVersion }), {
+		status: 200,
+		headers: { 'content-type': 'application/json' },
+	})
+}
 
 function backend(timeoutMs = 25) {
 	return buildAciStandbyPoolBackend({
@@ -73,7 +83,7 @@ function stubClaim(
 		}
 		if (url === 'http://10.0.0.8:2024/healthz') {
 			healthSignal = init?.signal ?? undefined
-			if (options.ready) return new Response('ok', { status: 200 })
+			if (options.ready) return workerHealthResponse()
 			return await new Promise<Response>(() => undefined)
 		}
 		if (url.startsWith('https://management.azure.com') && method === 'DELETE') {
@@ -142,7 +152,7 @@ describe('standby worker readiness deadline', () => {
 				return new Response(null, { status: 204 })
 			}
 			workerPaths.push(url)
-			if (url.endsWith('/healthz')) return new Response('ok', { status: 200 })
+			if (url.endsWith('/healthz')) return workerHealthResponse()
 			if (url.endsWith('/executions/reserve')) {
 				return new Response(
 					JSON.stringify({
@@ -189,8 +199,9 @@ describe('standby worker readiness deadline', () => {
 		expect(performance.now() - startedAt).toBeLessThan(500)
 	})
 
-	it('retires and fences an old worker after an identity-less execution outcome becomes unknown', async () => {
+	it('refuses an older worker before command admission and releases the container group', async () => {
 		let deleteCalls = 0
+		let commandCalls = 0
 		globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
 			const url = String(input)
 			const method = init?.method ?? 'GET'
@@ -209,27 +220,25 @@ describe('standby worker readiness deadline', () => {
 				deleteCalls += 1
 				return new Response(null, { status: 410 })
 			}
-			if (url.endsWith('/healthz')) return new Response('ok', { status: 200 })
-			if (url.endsWith('/executions/reserve')) {
-				return new Response(JSON.stringify({ error: 'not_found' }), { status: 404 })
+			if (url.endsWith('/healthz')) {
+				return workerHealthResponse(REMOTE_EXECUTION_PROTOCOL_VERSION - 1)
 			}
-			if (url.endsWith('/execute')) return new Response('not-json\n', { status: 200 })
+			if (url.endsWith('/executions/reserve')) {
+				commandCalls += 1
+				return new Response(null, { status: 500 })
+			}
+			if (url.endsWith('/execute')) {
+				commandCalls += 1
+				return new Response(null, { status: 500 })
+			}
 			throw new Error(`unexpected URL ${url}`)
 		}) as typeof fetch
-		const sandbox = await backend(100).create({ workingDirectory: '/workspace' })
 
-		try {
-			await sandbox.exec('ambiguous')
-			expect.unreachable('an identity-less remote outcome must retire its container group')
-		} catch (error) {
-			expect(error).toMatchObject({ retirement: { accepted: true } })
-			expect((error as Error).message).toMatch(/outcome is unknown/i)
-		}
-		expect(sandbox.status).toBe('destroyed')
+		await expect(backend(100).create({ workingDirectory: '/workspace' })).rejects.toThrow(
+			/protocol version/i,
+		)
 		expect(deleteCalls).toBe(1)
-		await expect(sandbox.writeFile('anything', 'nope')).rejects.toThrow(/no new worker operation/)
-		await sandbox.destroy()
-		expect(deleteCalls).toBe(1)
+		expect(commandCalls).toBe(0)
 	})
 
 	it('uses the same total clock while waiting for an IP address', async () => {

--- a/packages/sandbox/src/backends/aci-standby-pool/index.ts
+++ b/packages/sandbox/src/backends/aci-standby-pool/index.ts
@@ -63,7 +63,10 @@ import {
 	resolveReadinessOptions,
 	runFailureCleanup,
 } from '../readiness.js'
-import { RemoteCancellationUnknownError } from '../remote-execution-controller.js'
+import {
+	RemoteCancellationUnknownError,
+	RemoteProtocolError,
+} from '../remote-execution-controller.js'
 
 /**
  * Authentication callback. Caller returns a fresh Azure Resource
@@ -748,6 +751,7 @@ async function waitForWorkerReady(
 			if (result.ok) return
 		} catch (err) {
 			if (err instanceof OperationDeadlineExpired) break
+			if (err instanceof RemoteProtocolError) throw err
 			// Network not ready yet, try again.
 		}
 		try {

--- a/packages/sandbox/src/backends/docker/__tests__/readiness-deadline.test.ts
+++ b/packages/sandbox/src/backends/docker/__tests__/readiness-deadline.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { checkFileWalkOwnership, fileWalkExec } from '../../__tests__/fixtures/file-walk-exec.js'
 import { HttpWorkerClient } from '../../http-worker-client.js'
+import { REMOTE_EXECUTION_PROTOCOL_VERSION } from '../../remote-execution-controller.js'
 import { buildDockerBackend, resolveLayout } from '../index.js'
 
 const realFetch = globalThis.fetch
@@ -36,6 +37,7 @@ beforeEach(() => {
 
 afterEach(() => {
 	vi.restoreAllMocks()
+	vi.useRealTimers()
 	globalThis.fetch = realFetch
 	process.env.NAMZU_TEST_DOCKER_LOG = undefined
 	process.env.NAMZU_TEST_HOLD_DOCKER_RM = undefined
@@ -58,6 +60,21 @@ function backend(timeoutMs = 25) {
 
 function cleanupCalls(): number {
 	return readFileSync(dockerLog, 'utf8').trim().split('\n').length
+}
+
+function workerHealthResponse(
+	protocolVersion: number | 'missing' = REMOTE_EXECUTION_PROTOCOL_VERSION,
+): Response {
+	return new Response(
+		JSON.stringify({
+			ok: true,
+			...(protocolVersion === 'missing' ? {} : { protocolVersion }),
+		}),
+		{
+			status: 200,
+			headers: { 'content-type': 'application/json' },
+		},
+	)
 }
 
 describe('docker worker readiness deadline', () => {
@@ -83,7 +100,7 @@ describe('docker worker readiness deadline', () => {
 		globalThis.fetch = vi.fn(async (input) => {
 			const url = String(input)
 			paths.push(url)
-			if (url.endsWith('/healthz')) return new Response('ok', { status: 200 })
+			if (url.endsWith('/healthz')) return workerHealthResponse()
 			if (url.endsWith('/executions/reserve')) {
 				return new Response(
 					JSON.stringify({
@@ -123,7 +140,7 @@ describe('docker worker readiness deadline', () => {
 		let reservation = 0
 		globalThis.fetch = vi.fn(async (input) => {
 			const url = String(input)
-			if (url.endsWith('/healthz')) return new Response('ok', { status: 200 })
+			if (url.endsWith('/healthz')) return workerHealthResponse()
 			if (url.endsWith('/executions/reserve')) {
 				reservation += 1
 				return new Response(
@@ -173,32 +190,33 @@ describe('docker worker readiness deadline', () => {
 		expect(sandbox.status).toBe('destroyed')
 	})
 
-	it('retires and fences an old worker after an identity-less execution outcome becomes unknown', async () => {
+	it('refuses an unversioned worker before command admission and tears the container down', async () => {
+		let reserveCalls = 0
+		let executeCalls = 0
 		globalThis.fetch = vi.fn(async (input) => {
 			const url = String(input)
-			if (url.endsWith('/healthz')) return new Response('ok', { status: 200 })
+			if (url.endsWith('/healthz')) return workerHealthResponse('missing')
 			if (url.endsWith('/executions/reserve')) {
+				reserveCalls += 1
 				return new Response(JSON.stringify({ error: 'not_found' }), {
 					status: 404,
 				})
 			}
-			if (url.endsWith('/execute')) return new Response('not-json\n', { status: 200 })
+			if (url.endsWith('/execute')) {
+				executeCalls += 1
+				return new Response('not-json\n', { status: 200 })
+			}
 			throw new Error(`unexpected URL ${url}`)
 		}) as typeof fetch
-		const sandbox = await backend(100).create({ workingDirectory: workDir })
 
-		try {
-			await sandbox.exec('ambiguous')
-			expect.unreachable('an identity-less remote outcome must retire its container')
-		} catch (error) {
-			expect(error).toMatchObject({ retirement: { accepted: true } })
-			expect((error as Error).message).toMatch(/outcome is unknown/i)
-		}
-		expect(sandbox.status).toBe('destroyed')
+		const startedAt = performance.now()
+		await expect(backend(100).create({ workingDirectory: workDir })).rejects.toThrow(
+			/protocol version/i,
+		)
+		expect(performance.now() - startedAt).toBeLessThan(500)
 		expect(cleanupCalls()).toBe(1)
-		await expect(sandbox.readFile('anything')).rejects.toThrow(/no new worker operation/)
-		await sandbox.destroy()
-		expect(cleanupCalls()).toBe(1)
+		expect(reserveCalls).toBe(0)
+		expect(executeCalls).toBe(0)
 	})
 
 	it('settles and aborts a health fetch implementation that ignores cancellation', async () => {
@@ -259,7 +277,7 @@ describe('docker worker readiness deadline', () => {
 	})
 
 	it('passes teardown authority to a held docker rm child', async () => {
-		globalThis.fetch = vi.fn(async () => new Response('ok', { status: 200 })) as typeof fetch
+		globalThis.fetch = vi.fn(async () => workerHealthResponse()) as typeof fetch
 		const sandbox = await backend().create({ workingDirectory: workDir })
 		process.env.NAMZU_TEST_HOLD_DOCKER_RM = '1'
 		const owner = new AbortController()
@@ -275,24 +293,59 @@ describe('docker worker readiness deadline', () => {
 		expect(performance.now() - startedAt).toBeLessThan(500)
 	})
 
+	it('refuses a future worker protocol before returning a sandbox handle', async () => {
+		let commandCalls = 0
+		globalThis.fetch = vi.fn(async (input) => {
+			const url = String(input)
+			if (url.endsWith('/healthz')) {
+				return workerHealthResponse(REMOTE_EXECUTION_PROTOCOL_VERSION + 1)
+			}
+			if (url.endsWith('/executions/reserve')) {
+				commandCalls += 1
+				return new Response(null, { status: 500 })
+			}
+			if (url.endsWith('/execute')) {
+				commandCalls += 1
+				return new Response(null, { status: 500 })
+			}
+			throw new Error(`unexpected URL ${url}`)
+		}) as typeof fetch
+
+		await expect(backend(100).create({ workingDirectory: workDir })).rejects.toThrow(
+			/protocol version/i,
+		)
+		expect(cleanupCalls()).toBe(1)
+		expect(commandCalls).toBe(0)
+	})
+
 	it('reports a failed security retirement instead of claiming the container was removed', async () => {
 		globalThis.fetch = vi.fn(async (input) => {
 			const url = String(input)
-			if (url.endsWith('/healthz')) return new Response('ok', { status: 200 })
+			if (url.endsWith('/healthz')) return workerHealthResponse()
 			if (url.endsWith('/executions/reserve')) {
-				return new Response(JSON.stringify({ error: 'not_found' }), {
-					status: 404,
-				})
+				return new Response(
+					JSON.stringify({
+						ok: true,
+						protocolVersion: REMOTE_EXECUTION_PROTOCOL_VERSION,
+						executionId: 'exec_00000000-0000-4000-8000-000000000001',
+						leaseExpiresAt: Date.now() + 30_000,
+					}),
+					{ status: 201 },
+				)
 			}
 			if (url.endsWith('/execute')) return new Response('not-json\n', { status: 200 })
+			if (url.endsWith('/cancel')) return new Response('unavailable', { status: 503 })
 			throw new Error(`unexpected URL ${url}`)
 		}) as typeof fetch
 		const sandbox = await backend(100).create({ workingDirectory: workDir })
 		process.env.NAMZU_TEST_FAIL_DOCKER_RM = '1'
+		vi.useFakeTimers()
+		const execution = sandbox.exec('ambiguous')
+		await vi.advanceTimersByTimeAsync(8_100)
 
 		try {
-			await sandbox.exec('ambiguous')
-			expect.unreachable('an unconfirmed removal must remain observable')
+			await execution
+			expect.unreachable('an unreconciled remote outcome must retire its container')
 		} catch (error) {
 			expect(error).toMatchObject({
 				retirement: { accepted: false, error: expect.any(Error) },
@@ -301,5 +354,9 @@ describe('docker worker readiness deadline', () => {
 		expect(sandbox.status).toBe('destroyed')
 		expect(cleanupCalls()).toBe(1)
 		await expect(sandbox.readFile('anything')).rejects.toThrow(/no new worker operation/)
+		process.env.NAMZU_TEST_FAIL_DOCKER_RM = undefined
+		await sandbox.destroy()
+		expect(cleanupCalls()).toBe(2)
+		expect(sandbox.status).toBe('destroyed')
 	})
 })

--- a/packages/sandbox/src/backends/docker/__tests__/readiness-deadline.test.ts
+++ b/packages/sandbox/src/backends/docker/__tests__/readiness-deadline.test.ts
@@ -81,7 +81,7 @@ describe('docker worker readiness deadline', () => {
 	it.each(['complete', 'return', 'caller', 'unknown'] as const)(
 		'owns a lazy file walk until worker termination after %s',
 		async (stop) => {
-			globalThis.fetch = vi.fn(async () => new Response('ok', { status: 200 })) as typeof fetch
+			globalThis.fetch = vi.fn(async () => workerHealthResponse()) as typeof fetch
 			const sandbox = await backend(100).create({ workingDirectory: workDir })
 			const entry = { path: `${sandbox.rootDir}/first.ts`, size: 3 }
 			const worker = fileWalkExec(entry)

--- a/packages/sandbox/src/backends/docker/index.ts
+++ b/packages/sandbox/src/backends/docker/index.ts
@@ -66,7 +66,10 @@ import {
 	resolveReadinessOptions,
 	runFailureCleanup,
 } from '../readiness.js'
-import { RemoteCancellationUnknownError } from '../remote-execution-controller.js'
+import {
+	RemoteCancellationUnknownError,
+	RemoteProtocolError,
+} from '../remote-execution-controller.js'
 
 /**
  * Backend-specific tuning. Most hosts use the defaults; advanced
@@ -911,6 +914,7 @@ async function waitForWorkerReady(
 			lastError = new Error(`healthz HTTP ${result.status}`)
 		} catch (err) {
 			lastError = err
+			if (err instanceof RemoteProtocolError) throw err
 			if (err instanceof OperationDeadlineExpired) break
 		}
 		try {

--- a/packages/sandbox/src/backends/firecracker/__tests__/backend.test.ts
+++ b/packages/sandbox/src/backends/firecracker/__tests__/backend.test.ts
@@ -19,6 +19,7 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { checkFileWalkOwnership, fileWalkExec } from '../../__tests__/fixtures/file-walk-exec.js'
+import { createSandboxProvider } from '../../../index.js'
 import { buildFirecrackerBackend, normalizeHandle } from '../index.js'
 import { VsockAgentTransport, type WireSandboxAgentHandle, __framing } from '../transport.js'
 import { localIpcPath } from './fixtures/ipc-path.js'
@@ -207,14 +208,17 @@ describe.skipIf(IS_WINDOWS)('buildFirecrackerBackend (loopback agent)', () => {
 		expect(sandbox.environment).toBe('linux-namespace')
 		expect(sandbox.status).toBe('ready')
 
-		// Create body forwarded the resolved knobs + egress allowlist.
+		// Create body forwarded the resolved knobs + explicit network policy.
 		const createCall = calls.find((c) => c.method === 'POST')
 		expect(createCall?.body).toMatchObject({
 			template: 'golden-rev-7',
 			memoryLimitMb: 512,
 			maxProcesses: 64,
 			timeoutMs: 60_000,
-			egressAllowlist: ['api.example.com'],
+			networkPolicy: {
+				mode: 'allowlist',
+				allowedHosts: ['api.example.com'],
+			},
 		})
 
 		// exec over the wire.
@@ -245,6 +249,27 @@ describe.skipIf(IS_WINDOWS)('buildFirecrackerBackend (loopback agent)', () => {
 		await Promise.all([sandbox.destroy(), sandbox.destroy()])
 		expect(sandbox.status).toBe('destroyed')
 		expect(calls.filter((c) => c.method === 'DELETE' && c.url.includes(':delete'))).toHaveLength(1)
+	})
+
+	it('carries open egress through the public provider front door', async () => {
+		server = await startAgent()
+		const { calls } = stubOrchestrator({ kind: 'unix', path: sockPath })
+		const provider = createSandboxProvider({
+			backend: {
+				tier: 'microvm',
+				service: 'self-hosted',
+				orchestratorEndpoint: 'https://orchestrator.test/',
+				getToken: async () => 'tok',
+				readyTimeoutMs: 3_000,
+				readyPollIntervalMs: 50,
+			},
+			defaultEgress: { kind: 'allow-all' },
+		})
+
+		const sandbox = await provider.create({ workingDirectory: workDir })
+		const createCall = calls.find((call) => call.method === 'POST')
+		expect(createCall?.body).toEqual({ networkPolicy: { mode: 'open' } })
+		await sandbox.destroy()
 	})
 
 	it('tears down the microVM when the readiness fence times out (no orphan)', async () => {

--- a/packages/sandbox/src/backends/firecracker/__tests__/backend.test.ts
+++ b/packages/sandbox/src/backends/firecracker/__tests__/backend.test.ts
@@ -645,6 +645,34 @@ describe.skipIf(IS_WINDOWS)('buildFirecrackerBackend (loopback agent)', () => {
 	})
 })
 
+describe.skipIf(process.platform !== 'linux')('buildFirecrackerBackend terminal ownership', () => {
+	it('kills and awaits every guest terminal before deleting the microVM', async () => {
+		server = await startAgent()
+		const { calls } = stubOrchestrator({ kind: 'unix', path: sockPath })
+		const backend = buildFirecrackerBackend({
+			orchestratorEndpoint: 'https://orchestrator.test/',
+			getToken: async () => 'tok',
+			readyTimeoutMs: 3_000,
+			readyPollIntervalMs: 50,
+		})
+		const sandbox = await backend.create({ workingDirectory: workDir })
+		expect(sandbox.openTerminal).toBeTypeOf('function')
+		const terminal = await sandbox.openTerminal?.({
+			command: '/bin/sh',
+			args: ['-lc', 'sleep 30'],
+			cwd: workDir,
+			size: { cols: 80, rows: 24 },
+		})
+		expect(terminal).toBeDefined()
+
+		await sandbox.destroy()
+		await expect(terminal?.exited).resolves.toMatchObject({
+			exitCode: expect.any(Number),
+		})
+		expect(calls.some((call) => call.method === 'DELETE')).toBe(true)
+	})
+})
+
 // ---------------------------------------------------------------------------
 // Cert-injection seam (ses_051 P4 Track C) — the orchestrator returns a WIRE
 // `mtls` handle (host/port/sandboxId, NO certs); the consumer injects the

--- a/packages/sandbox/src/backends/firecracker/__tests__/backend.test.ts
+++ b/packages/sandbox/src/backends/firecracker/__tests__/backend.test.ts
@@ -10,7 +10,7 @@
  * the agent's healthz (not the orchestrator 2xx).
  */
 
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { type Server, type Socket, createServer } from 'node:net'
 import { tmpdir } from 'node:os'
@@ -18,8 +18,8 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { checkFileWalkOwnership, fileWalkExec } from '../../__tests__/fixtures/file-walk-exec.js'
 import { createSandboxProvider } from '../../../index.js'
+import { checkFileWalkOwnership, fileWalkExec } from '../../__tests__/fixtures/file-walk-exec.js'
 import { buildFirecrackerBackend, normalizeHandle } from '../index.js'
 import { VsockAgentTransport, type WireSandboxAgentHandle, __framing } from '../transport.js'
 import { localIpcPath } from './fixtures/ipc-path.js'
@@ -54,7 +54,7 @@ const realFetch = globalThis.fetch
 let realPath: string | undefined
 
 beforeEach(() => {
-	workDir = mkdtempSync(join(tmpdir(), 'fc-backend-test-'))
+	workDir = realpathSync(mkdtempSync(join(tmpdir(), 'fc-backend-test-')))
 	sockPath = localIpcPath(workDir)
 	realPath = process.env.PATH
 	process.env.NAMZU_SANDBOX_WORKSPACE = workDir

--- a/packages/sandbox/src/backends/firecracker/__tests__/backend.test.ts
+++ b/packages/sandbox/src/backends/firecracker/__tests__/backend.test.ts
@@ -41,6 +41,7 @@ const IS_WINDOWS = process.platform === 'win32'
 const require_ = createRequire(import.meta.url)
 
 interface AgentModule {
+	FIRECRACKER_AGENT_PROTOCOL_VERSION: number
 	handleConnection(socket: Socket): void
 }
 
@@ -293,6 +294,29 @@ describe.skipIf(IS_WINDOWS)('buildFirecrackerBackend (loopback agent)', () => {
 		expect(calls.some((c) => c.method === 'DELETE')).toBe(true)
 	})
 
+	it('tears down an unversioned guest immediately instead of admitting a stale golden', async () => {
+		server = await startAgentServer((socket) => {
+			const reader = new __framing.FrameReader()
+			socket.on('data', (chunk: Buffer) => {
+				if (reader.push(chunk)[0] !== undefined) {
+					socket.end(__framing.frame(JSON.stringify({ ok: true })))
+				}
+			})
+		})
+		const { calls } = stubOrchestrator({ kind: 'unix', path: sockPath })
+		const backend = buildFirecrackerBackend({
+			orchestratorEndpoint: 'https://orchestrator.test/',
+			getToken: async () => 'tok',
+			readyTimeoutMs: 2_000,
+			readyPollIntervalMs: 100,
+		})
+
+		const startedAt = performance.now()
+		await expect(backend.create({ workingDirectory: workDir })).rejects.toThrow(/protocol version/i)
+		expect(performance.now() - startedAt).toBeLessThan(500)
+		expect(calls.filter((call) => call.method === 'DELETE')).toHaveLength(1)
+	})
+
 	it('honours public exec cancellation and keeps a confirmed-quiescent microVM reusable', async () => {
 		server = await startAgent()
 		stubOrchestrator({ kind: 'unix', path: sockPath })
@@ -347,7 +371,14 @@ describe.skipIf(IS_WINDOWS)('buildFirecrackerBackend (loopback agent)', () => {
 				if (payload === undefined) return
 				const request = JSON.parse(payload) as { op?: string }
 				if (request.op === 'healthz') {
-					socket.end(__framing.frame(JSON.stringify({ ok: true })))
+					socket.end(
+						__framing.frame(
+							JSON.stringify({
+								ok: true,
+								protocolVersion: agent.FIRECRACKER_AGENT_PROTOCOL_VERSION,
+							}),
+						),
+					)
 					return
 				}
 				if (request.op === 'reserve-execution') {
@@ -390,7 +421,14 @@ describe.skipIf(IS_WINDOWS)('buildFirecrackerBackend (loopback agent)', () => {
 				if (payload === undefined) return
 				const request = JSON.parse(payload) as { op?: string }
 				if (request.op === 'healthz') {
-					socket.end(__framing.frame(JSON.stringify({ ok: true })))
+					socket.end(
+						__framing.frame(
+							JSON.stringify({
+								ok: true,
+								protocolVersion: agent.FIRECRACKER_AGENT_PROTOCOL_VERSION,
+							}),
+						),
+					)
 					return
 				}
 				if (request.op === 'reserve-execution') {

--- a/packages/sandbox/src/backends/firecracker/__tests__/egress-policy.test.ts
+++ b/packages/sandbox/src/backends/firecracker/__tests__/egress-policy.test.ts
@@ -1,19 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import type { SandboxBackendOptions } from '../../../index.js'
-import { resolveEgressAllowlist } from '../index.js'
+import { resolveNetworkPolicy } from '../index.js'
 
 /**
- * Omitting the allowlist means "no allowlist to apply", which the
- * orchestrator reads as unrestricted. That makes omission the encoding for
- * `allow-all` and only for `allow-all`.
- *
- * `resolver` used to be omitted too — so two opposite intentions shared one
- * encoding, the tenant-scoped allowlist the variant exists for was silently
- * absent, and the callback that would have produced it was never called
- * anywhere in the repo. Whichever way the orchestrator reads an omitted
- * field, one of the two variants was always mis-enforced, and the one that
- * failed OPEN was the one whose entire purpose is restriction.
+ * Omission means the caller supplied no policy and preserves the legacy
+ * no-NIC request. Every explicit policy gets its own discriminated encoding.
  */
 
 const opts = (egress?: SandboxBackendOptions['egress']): SandboxBackendOptions => ({
@@ -22,35 +14,35 @@ const opts = (egress?: SandboxBackendOptions['egress']): SandboxBackendOptions =
 })
 
 describe('each policy gets its own encoding', () => {
-	it('allow-all omits the field', async () => {
-		expect(await resolveEgressAllowlist(opts({ kind: 'allow-all' }))).toBeUndefined()
+	it('allow-all requests open networking explicitly', async () => {
+		expect(await resolveNetworkPolicy(opts({ kind: 'allow-all' }))).toEqual({ mode: 'open' })
 	})
 
-	it('deny-all sends an explicitly empty list, not an absent one', async () => {
-		expect(await resolveEgressAllowlist(opts({ kind: 'deny-all' }))).toEqual([])
+	it('deny-all requests no network explicitly', async () => {
+		expect(await resolveNetworkPolicy(opts({ kind: 'deny-all' }))).toEqual({ mode: 'none' })
 	})
 
 	it('static forwards the hosts as given', async () => {
 		expect(
-			await resolveEgressAllowlist(opts({ kind: 'static', allowedHosts: ['a.example'] })),
-		).toEqual(['a.example'])
+			await resolveNetworkPolicy(opts({ kind: 'static', allowedHosts: ['a.example'] })),
+		).toEqual({ mode: 'allowlist', allowedHosts: ['a.example'] })
 	})
 
 	it('resolver calls the callback and forwards what it returned', async () => {
 		const resolve = vi.fn(async () => ['tenant-a.example', 'tenant-b.example'])
-		expect(await resolveEgressAllowlist(opts({ kind: 'resolver', resolve }))).toEqual([
-			'tenant-a.example',
-			'tenant-b.example',
-		])
+		expect(await resolveNetworkPolicy(opts({ kind: 'resolver', resolve }))).toEqual({
+			mode: 'allowlist',
+			allowedHosts: ['tenant-a.example', 'tenant-b.example'],
+		})
 		// The callback IS the feature. It was declared and never invoked.
 		expect(resolve).toHaveBeenCalledOnce()
 	})
 
 	it('never encodes resolver the same way as allow-all', async () => {
-		const restrictive = await resolveEgressAllowlist(
+		const restrictive = await resolveNetworkPolicy(
 			opts({ kind: 'resolver', resolve: async () => ['only-this.example'] }),
 		)
-		const unrestricted = await resolveEgressAllowlist(opts({ kind: 'allow-all' }))
+		const unrestricted = await resolveNetworkPolicy(opts({ kind: 'allow-all' }))
 		expect(restrictive).not.toEqual(unrestricted)
 	})
 
@@ -58,19 +50,19 @@ describe('each policy gets its own encoding', () => {
 		// An empty allowlist is a decision, not an absence. Collapsing it
 		// back to omission would turn "this tenant may reach nothing" into
 		// "this tenant may reach everything".
-		expect(
-			await resolveEgressAllowlist(opts({ kind: 'resolver', resolve: async () => [] })),
-		).toEqual([])
+		expect(await resolveNetworkPolicy(opts({ kind: 'resolver', resolve: async () => [] }))).toEqual(
+			{ mode: 'allowlist', allowedHosts: [] },
+		)
 	})
 
 	it('omits the field when the host set no policy at all', async () => {
-		expect(await resolveEgressAllowlist(opts())).toBeUndefined()
+		expect(await resolveNetworkPolicy(opts())).toBeUndefined()
 	})
 })
 
 describe('an unknown policy', () => {
 	it('refuses rather than defaulting to unrestricted', async () => {
-		await expect(resolveEgressAllowlist(opts({ kind: 'something-new' } as never))).rejects.toThrow(
+		await expect(resolveNetworkPolicy(opts({ kind: 'something-new' } as never))).rejects.toThrow(
 			/Refusing rather than defaulting to unrestricted/,
 		)
 	})
@@ -78,7 +70,7 @@ describe('an unknown policy', () => {
 	it('propagates a failing resolver instead of falling back to open', async () => {
 		// A resolver that cannot answer must not become "allow everything".
 		await expect(
-			resolveEgressAllowlist(
+			resolveNetworkPolicy(
 				opts({
 					kind: 'resolver',
 					resolve: async () => {

--- a/packages/sandbox/src/backends/firecracker/__tests__/transport.test.ts
+++ b/packages/sandbox/src/backends/firecracker/__tests__/transport.test.ts
@@ -246,6 +246,38 @@ describe.skipIf(IS_WINDOWS)('VsockAgentTransport over a unix-socket loopback age
 		expect(await transport.healthz()).toBe(true)
 	})
 
+	it('forwards a bidirectional guest-loopback TCP stream', async () => {
+		server = await startAgentServer(agent.handleConnection)
+		const upstream = createServer((socket) => {
+			socket.once('data', (chunk) => socket.end(Buffer.concat([Buffer.from('reply:'), chunk])))
+		})
+		await new Promise<void>((resolve, reject) => {
+			upstream.once('error', reject)
+			upstream.listen(0, '127.0.0.1', resolve)
+		})
+		try {
+			const address = upstream.address()
+			if (!address || typeof address === 'string') throw new Error('missing TCP test address')
+			const transport = new VsockAgentTransport({
+				kind: 'unix',
+				path: sockPath,
+			})
+			const connection = await transport.openTcpConnection({
+				port: address.port,
+			})
+			let output = ''
+			const dispose = connection.onData((chunk) => {
+				output += Buffer.from(chunk).toString('utf8')
+			})
+			expect(connection.write('hello')).toBe(true)
+			await expect(connection.closed).resolves.toBeUndefined()
+			expect(output).toBe('reply:hello')
+			dispose()
+		} finally {
+			await new Promise<void>((resolve) => upstream.close(() => resolve()))
+		}
+	})
+
 	it('fits a connected peer that never replies inside the readiness deadline', async () => {
 		let peerClosed = false
 		server = createServer((socket) => {
@@ -478,6 +510,42 @@ describe.skipIf(IS_WINDOWS)('VsockAgentTransport over a unix-socket loopback age
 		await expect(transport.readFile('x')).rejects.toThrow(/could not connect to agent/)
 	})
 })
+
+describe.skipIf(process.platform !== 'linux')(
+	'VsockAgentTransport guest PTY over a unix-socket loopback agent',
+	() => {
+		it('provides a real TTY with ordered input, resize, output, and exit', async () => {
+			server = await startAgentServer(agent.handleConnection)
+			const transport = new VsockAgentTransport({
+				kind: 'unix',
+				path: sockPath,
+			})
+			const terminal = await transport.openTerminal({
+				command: '/bin/sh',
+				args: ['-l'],
+				cwd: workDir,
+				size: { cols: 101, rows: 31 },
+			})
+			let output = ''
+			const unsubscribe = terminal.onData((chunk) => {
+				output += chunk
+			})
+
+			terminal.write(
+				'if [ -t 0 ] && [ -t 1 ]; then echo __REAL_PTY__; else echo __NOT_A_PTY__; fi; stty size\n',
+			)
+			await vi.waitFor(() => expect(output).toContain('__REAL_PTY__'))
+			await vi.waitFor(() => expect(output).toContain('31 101'))
+
+			terminal.resize({ cols: 120, rows: 40 })
+			terminal.write('sleep 0.1; stty size; echo __RESIZED__; exit 7\n')
+			await vi.waitFor(() => expect(output).toContain('__RESIZED__'))
+			await vi.waitFor(() => expect(output).toContain('40 120'))
+			await expect(terminal.exited).resolves.toMatchObject({ exitCode: 7 })
+			unsubscribe()
+		})
+	},
+)
 
 // ---------------------------------------------------------------------------
 // Ring-0 mTLS arm — pure-local TLS loopback "relay" (no Azure, no FC host)

--- a/packages/sandbox/src/backends/firecracker/__tests__/transport.test.ts
+++ b/packages/sandbox/src/backends/firecracker/__tests__/transport.test.ts
@@ -43,6 +43,7 @@ const IS_WINDOWS = process.platform === 'win32'
 const require_ = createRequire(import.meta.url)
 
 interface AgentModule {
+	FIRECRACKER_AGENT_PROTOCOL_VERSION: number
 	handleConnection(socket: Socket): void
 }
 
@@ -243,7 +244,55 @@ describe.skipIf(IS_WINDOWS)('VsockAgentTransport over a unix-socket loopback age
 			kind: 'unix',
 			path: sockPath,
 		})
+		await expect(transport.request({ op: 'healthz' })).resolves.toMatchObject({
+			ok: true,
+			protocolVersion: agent.FIRECRACKER_AGENT_PROTOCOL_VERSION,
+		})
 		expect(await transport.healthz()).toBe(true)
+	})
+
+	it.each([
+		['missing', { ok: true }],
+		['older', { ok: true, protocolVersion: 1 }],
+		['newer', { ok: true, protocolVersion: 3 }],
+	])('refuses a %s guest protocol before readiness', async (_label, reply) => {
+		server = await startAgentServer((socket) => {
+			const reader = new __framing.FrameReader()
+			socket.on('data', (chunk: Buffer) => {
+				if (reader.push(chunk)[0] !== undefined) {
+					socket.end(__framing.frame(JSON.stringify(reply)))
+				}
+			})
+		})
+		const transport = new VsockAgentTransport({ kind: 'unix', path: sockPath })
+
+		const startedAt = performance.now()
+		await expect(transport.waitForReady(2_000, 100)).rejects.toThrow(/protocol version/i)
+		expect(performance.now() - startedAt).toBeLessThan(500)
+	})
+
+	it('never downgrades an unsupported reservation into identity-less execution', async () => {
+		let executeCalls = 0
+		server = await startAgentServer((socket) => {
+			const reader = new __framing.FrameReader()
+			socket.on('data', (chunk: Buffer) => {
+				const payload = reader.push(chunk)[0]
+				if (payload === undefined) return
+				const request = JSON.parse(payload) as { op?: string }
+				if (request.op === 'reserve-execution') {
+					socket.end(
+						__framing.frame(JSON.stringify({ ok: false, error: 'unknown_op:reserve-execution' })),
+					)
+					return
+				}
+				if (request.op === 'execute') executeCalls += 1
+				socket.end(__framing.frame(JSON.stringify({ ok: false, error: 'unexpected_op' })))
+			})
+		})
+		const transport = new VsockAgentTransport({ kind: 'unix', path: sockPath })
+
+		await expect(transport.exec('/bin/true')).rejects.toThrow(/protocol/i)
+		expect(executeCalls).toBe(0)
 	})
 
 	it('forwards a bidirectional guest-loopback TCP stream', async () => {

--- a/packages/sandbox/src/backends/firecracker/index.ts
+++ b/packages/sandbox/src/backends/firecracker/index.ts
@@ -47,6 +47,7 @@
 import https from 'node:https'
 
 import type {
+	OpenTerminalOptions,
 	Sandbox,
 	SandboxDestroyOptions,
 	SandboxEnvironment,
@@ -56,6 +57,9 @@ import type {
 	SandboxId,
 	SandboxStatus,
 	SandboxWalkFilesOptions,
+	SandboxTcpConnectOptions,
+	SandboxTcpConnection,
+	TerminalSession,
 } from '@namzu/sdk'
 import { walkFilesViaExec } from '@namzu/sdk'
 
@@ -456,6 +460,7 @@ async function spawnFirecrackerSandbox(
 	let retirementPromise: Promise<{ readonly accepted: boolean; readonly error?: Error }> | undefined
 	let teardownPromise: Promise<void> | undefined
 	let teardownComplete = false
+	const terminals = new Set<TerminalSession>()
 
 	const assertActive = (): void => {
 		if (lifecycle !== 'active') {
@@ -526,7 +531,6 @@ async function spawnFirecrackerSandbox(
 			activeExecutions = Math.max(0, activeExecutions - 1)
 		}
 	}
-
 	return {
 		id,
 		get status(): SandboxStatus {
@@ -553,6 +557,19 @@ async function spawnFirecrackerSandbox(
 		async readFile(path: string): Promise<Buffer> {
 			assertActive()
 			return await transport.readFile(path)
+		},
+
+		async openTerminal(options: OpenTerminalOptions): Promise<TerminalSession> {
+			assertActive()
+			const terminal = await transport.openTerminal(options)
+			terminals.add(terminal)
+			void terminal.exited.finally(() => terminals.delete(terminal))
+			return terminal
+		},
+
+		async openTcpConnection(options: SandboxTcpConnectOptions): Promise<SandboxTcpConnection> {
+			assertActive()
+			return await transport.openTcpConnection(options)
 		},
 
 		async listFiles(rootPath: string): Promise<readonly SandboxFileEntry[]> {
@@ -601,6 +618,13 @@ async function spawnFirecrackerSandbox(
 				if (observation.accepted) return
 				retirementPromise = undefined
 			}
+			// A terminal owns an interactive process tree in this microVM. Stop and
+			// await every one before releasing the VM so the SDK's ownership
+			// contract is real rather than best-effort bookkeeping.
+			const activeTerminals = [...terminals]
+			for (const terminal of activeTerminals) terminal.kill('SIGKILL')
+			await Promise.allSettled(activeTerminals.map((terminal) => terminal.exited))
+			terminals.clear()
 			// Let the orchestrator DELETE failure propagate — the
 			// Vandal-side lifecycle wraps this with logging, and a
 			// swallowed error here means orphaned microVMs (and their

--- a/packages/sandbox/src/backends/firecracker/index.ts
+++ b/packages/sandbox/src/backends/firecracker/index.ts
@@ -56,9 +56,9 @@ import type {
 	SandboxFileEntry,
 	SandboxId,
 	SandboxStatus,
-	SandboxWalkFilesOptions,
 	SandboxTcpConnectOptions,
 	SandboxTcpConnection,
+	SandboxWalkFilesOptions,
 	TerminalSession,
 } from '@namzu/sdk'
 import { walkFilesViaExec } from '@namzu/sdk'

--- a/packages/sandbox/src/backends/firecracker/index.ts
+++ b/packages/sandbox/src/backends/firecracker/index.ts
@@ -186,11 +186,11 @@ interface OrchestratorCreateRequest {
 	readonly maxProcesses?: number
 	readonly timeoutMs?: number
 	/**
-	 * Resolved egress allowlist for the run, materialised by the host
-	 * into per-VM nftables rules (deny-all default). The backend just
-	 * forwards the resolved hostnames; it does not own the firewall.
+	 * Explicit guest-network intent. Omitted only when the caller supplied no
+	 * egress policy, preserving the legacy no-NIC create body. The owner-run
+	 * host either enforces this exact shape or rejects it.
 	 */
-	readonly egressAllowlist?: readonly string[]
+	readonly networkPolicy?: OrchestratorNetworkPolicy
 	/**
 	 * Per-agent captured snapshot to resume (layered on the base golden).
 	 * Optional + additive: omitted from the POST body when undefined (the
@@ -201,6 +201,12 @@ interface OrchestratorCreateRequest {
 	 */
 	readonly agentSnapshot?: AgentSnapshotRef
 }
+
+/** Network policy carried on the owned orchestrator create wire. */
+export type OrchestratorNetworkPolicy =
+	| { readonly mode: 'none' }
+	| { readonly mode: 'open' }
+	| { readonly mode: 'allowlist'; readonly allowedHosts: readonly string[] }
 
 /**
  * Orchestrator `create` response. Carries the sandbox id, the
@@ -361,7 +367,7 @@ async function spawnFirecrackerSandbox(
 ): Promise<Sandbox> {
 	options.signal?.throwIfAborted()
 	const endpoint = config.orchestratorEndpoint
-	const egressAllowlist = await resolveEgressAllowlist(options)
+	const networkPolicy = await resolveNetworkPolicy(options)
 	options.signal?.throwIfAborted()
 	const createBody: OrchestratorCreateRequest = {
 		...(config.template !== undefined ? { template: config.template } : {}),
@@ -369,10 +375,9 @@ async function spawnFirecrackerSandbox(
 		...(options.memoryLimitMb !== undefined ? { memoryLimitMb: options.memoryLimitMb } : {}),
 		...(options.maxProcesses !== undefined ? { maxProcesses: options.maxProcesses } : {}),
 		...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
-		// Resolved once. It used to be called twice — harmless for the pure
-		// kinds, and once the resolver variant actually runs its callback,
-		// twice means two round-trips and two chances to disagree.
-		...(egressAllowlist !== undefined ? { egressAllowlist } : {}),
+		// Resolved once. The explicit discriminator keeps a caller that supplied
+		// `allow-all` distinct from a legacy caller that supplied no policy.
+		...(networkPolicy !== undefined ? { networkPolicy } : {}),
 	}
 
 	let created: OrchestratorCreateResponse | undefined
@@ -639,44 +644,33 @@ async function spawnFirecrackerSandbox(
 // ---------------------------------------------------------------------------
 
 /**
- * Materialise an egress policy into the allowlist the orchestrator turns
- * into firewall rules.
- *
- * Omitting the field means "no allowlist to apply", which the orchestrator
- * reads as unrestricted. That makes omission the encoding for `allow-all`
- * and ONLY for `allow-all`.
- *
- * `resolver` used to be omitted too, so two opposite intentions shared one
- * encoding and the tenant-scoped allowlist the variant exists for was
- * silently absent — with the callback that would have produced it never
- * called anywhere in the repo. Whichever way the orchestrator reads an
- * omitted field, one of the two variants was always mis-enforced, and the
- * one that failed open was the one whose entire purpose is restriction.
+ * Materialise a caller-supplied egress policy into an explicit orchestrator
+ * network policy. Omission means exactly one thing: the caller supplied no
+ * policy, so an older owner-run host keeps its historical no-NIC behaviour.
+ * `allow-all` therefore travels as `{mode:'open'}` rather than sharing the
+ * omitted encoding with legacy callers.
  *
  * The switch is exhaustive on purpose: a new variant should fail to
  * compile here rather than fall through to "unrestricted".
  */
-export async function resolveEgressAllowlist(
+export async function resolveNetworkPolicy(
 	options: SandboxBackendOptions,
-): Promise<readonly string[] | undefined> {
+): Promise<OrchestratorNetworkPolicy | undefined> {
 	const egress = options.egress
 	if (!egress) return undefined
 
 	switch (egress.kind) {
 		case 'allow-all':
-			// The one intent omission is allowed to mean.
-			return undefined
+			return { mode: 'open' }
 		case 'deny-all':
-			// Explicitly empty, not absent.
-			return []
+			return { mode: 'none' }
 		case 'static':
-			return egress.allowedHosts
+			return { mode: 'allowlist', allowedHosts: egress.allowedHosts }
 		case 'resolver': {
-			// The callback exists to produce this list. Calling it is the
-			// whole feature; an empty result is a real deny-all and travels
-			// as one rather than collapsing back to omission.
+			// The callback exists to produce this list. An empty result remains
+			// an explicit allowlist and can be enforced as deny-all by the host.
 			const resolved = await egress.resolve()
-			return resolved
+			return { mode: 'allowlist', allowedHosts: resolved }
 		}
 		default: {
 			const exhaustive: never = egress

--- a/packages/sandbox/src/backends/firecracker/protocol.ts
+++ b/packages/sandbox/src/backends/firecracker/protocol.ts
@@ -86,6 +86,57 @@ export interface ReadFileRequest {
 	readonly encoding: 'base64'
 }
 
+// ---------------------------------------------------------------------------
+// Terminal — a real guest-owned PTY over the same framed stream
+// ---------------------------------------------------------------------------
+
+/** Initial request for one interactive terminal process in the guest. */
+export interface TerminalOpenRequest {
+	readonly command?: string
+	readonly args?: readonly string[]
+	readonly cwd?: string
+	readonly env?: Record<string, string>
+	readonly cols: number
+	readonly rows: number
+}
+
+/** Host → guest messages after the terminal stream reports ready. */
+export type TerminalInputEvent =
+	| { readonly type: 'input'; readonly data: string }
+	| { readonly type: 'resize'; readonly cols: number; readonly rows: number }
+	| { readonly type: 'kill'; readonly signal?: string }
+
+/** Guest → host events carried for the lifetime of the terminal stream. */
+export type TerminalOutputEvent =
+	| { readonly type: 'ready' }
+	| { readonly type: 'data'; readonly data: string }
+	| {
+			readonly type: 'exit'
+			readonly exitCode: number
+			readonly signal?: number
+	  }
+	| { readonly type: 'error'; readonly error: string }
+
+// ---------------------------------------------------------------------------
+// Loopback TCP — publish a service without moving it out of the sandbox
+// ---------------------------------------------------------------------------
+
+export interface TcpConnectRequest {
+	readonly host: '127.0.0.1' | '::1'
+	readonly port: number
+}
+
+export type TcpInputEvent =
+	| { readonly type: 'data'; readonly data: string }
+	| { readonly type: 'end' }
+	| { readonly type: 'destroy' }
+
+export type TcpOutputEvent =
+	| { readonly type: 'ready' }
+	| { readonly type: 'data'; readonly data: string }
+	| { readonly type: 'end' }
+	| { readonly type: 'error'; readonly error: string }
+
 /** `/read-file` response. `content` is base64 on success. */
 export interface ReadFileResponse {
 	readonly ok: boolean

--- a/packages/sandbox/src/backends/firecracker/transport.ts
+++ b/packages/sandbox/src/backends/firecracker/transport.ts
@@ -66,8 +66,8 @@ import type {
 } from '@namzu/sdk'
 import { OperationDeadline, OperationDeadlineExpired } from '../readiness.js'
 import {
+	REMOTE_EXECUTION_PROTOCOL_VERSION,
 	RemoteCancellationUnknownError,
-	RemoteCancellationUnsupportedError,
 	type RemoteExecutionAdapter,
 	RemoteExecutionController,
 	RemoteProtocolError,
@@ -216,6 +216,9 @@ const DEFAULT_EXECUTION_TIMEOUT_MS = 5 * 60_000
 const EXECUTION_TRANSPORT_GRACE_MS = 10_000
 const POST_RESPONSE_CLOSE_TIMEOUT_MS = 1_000
 const MAX_TIMER_DELAY_MS = 2_147_483_647
+
+/** Exact guest wire version accepted by this Firecracker transport. */
+export const FIRECRACKER_AGENT_PROTOCOL_VERSION = REMOTE_EXECUTION_PROTOCOL_VERSION
 
 /** Framing: 8 hex digits of payload byte length, then `\n`, then payload. */
 const LENGTH_PREFIX_HEX = 8
@@ -739,8 +742,8 @@ export class VsockAgentTransport {
 			typeof response.error === 'string' &&
 			response.error.startsWith('unknown_op:')
 		) {
-			throw new RemoteCancellationUnsupportedError(
-				'This microVM agent does not support the execution-cancellation lease protocol. Rebuild the guest image before passing SandboxExecOptions.signal; refusing rather than pretending cancellation is active.',
+			throw new RemoteProtocolError(
+				`The microVM guest does not implement Firecracker agent protocol ${FIRECRACKER_AGENT_PROTOCOL_VERSION}. Rebuild the golden image from the same Namzu release before admitting commands.`,
 			)
 		}
 		if (response.ok === false && response.error === 'agent_retiring') {
@@ -755,13 +758,25 @@ export class VsockAgentTransport {
 		return await this.request<unknown>({ op: 'cancel-execution', body: { executionId } }, signal)
 	}
 
-	/** Liveness probe. Returns true on an `{ ok: true }` healthz reply. */
+	/** Readiness probe. A healthy guest must also speak the exact host protocol. */
 	async healthz(signal?: AbortSignal): Promise<boolean> {
 		try {
-			const res = await this.request<{ ok?: boolean }>({ op: 'healthz' }, signal)
-			return res.ok === true
-		} catch {
+			const res = await this.request<{ ok?: boolean; protocolVersion?: unknown }>(
+				{ op: 'healthz' },
+				signal,
+			)
+			if (res.ok !== true) return false
+			if (res.protocolVersion !== FIRECRACKER_AGENT_PROTOCOL_VERSION) {
+				const actual =
+					res.protocolVersion === undefined ? 'missing' : JSON.stringify(res.protocolVersion)
+				throw new RemoteProtocolError(
+					`Firecracker guest protocol version mismatch: expected ${FIRECRACKER_AGENT_PROTOCOL_VERSION}, received ${actual}. Rebuild the golden image from the same Namzu release.`,
+				)
+			}
+			return true
+		} catch (error) {
 			if (signal?.aborted) throw signal.reason
+			if (error instanceof RemoteProtocolError) throw error
 			return false
 		}
 	}
@@ -785,6 +800,7 @@ export class VsockAgentTransport {
 				lastErr = new Error('healthz returned not-ok')
 			} catch (err) {
 				lastErr = err
+				if (err instanceof RemoteProtocolError) throw err
 				if (err instanceof OperationDeadlineExpired) break
 			}
 			try {

--- a/packages/sandbox/src/backends/firecracker/transport.ts
+++ b/packages/sandbox/src/backends/firecracker/transport.ts
@@ -56,7 +56,14 @@
 import net from 'node:net'
 import tls from 'node:tls'
 
-import type { SandboxExecOptions, SandboxExecResult } from '@namzu/sdk'
+import type {
+	OpenTerminalOptions,
+	SandboxExecOptions,
+	SandboxExecResult,
+	SandboxTcpConnectOptions,
+	SandboxTcpConnection,
+	TerminalSession,
+} from '@namzu/sdk'
 import { OperationDeadline, OperationDeadlineExpired } from '../readiness.js'
 import {
 	RemoteCancellationUnknownError,
@@ -70,6 +77,12 @@ import {
 	ExecResultAccumulator,
 	type ReadFileRequest,
 	type ReadFileResponse,
+	type TcpConnectRequest,
+	type TcpInputEvent,
+	type TcpOutputEvent,
+	type TerminalInputEvent,
+	type TerminalOpenRequest,
+	type TerminalOutputEvent,
 	type WriteFileRequest,
 	type WriteFileResponse,
 	parseExecLine,
@@ -170,6 +183,8 @@ export type AgentRequest =
 	  }
 	| { readonly op: 'read-file'; readonly body: ReadFileRequest }
 	| { readonly op: 'write-file'; readonly body: WriteFileRequest }
+	| { readonly op: 'terminal'; readonly body: TerminalOpenRequest }
+	| { readonly op: 'tcp-connect'; readonly body: TcpConnectRequest }
 	| { readonly op: 'healthz' }
 
 export interface VsockTransportOptions {
@@ -805,6 +820,306 @@ export class VsockAgentTransport {
 			throw new Error(res.error ?? 'read-file: no content')
 		}
 		return Buffer.from(res.content, 'base64')
+	}
+
+	/**
+	 * Open a real PTY owned by the in-VM agent.
+	 *
+	 * Unlike `execute`, this keeps one framed connection open for the complete
+	 * interactive lifetime: guest output and exit events flow toward the host,
+	 * while input/resize/kill events flow back on the same ordered stream. The
+	 * browser never reaches this transport directly; the runtime gateway owns
+	 * the session and its authenticated WebSocket attachment.
+	 */
+	async openTerminal(options: OpenTerminalOptions): Promise<TerminalSession> {
+		const socket = await this.dial()
+		const request: TerminalOpenRequest = {
+			...(options.command !== undefined ? { command: options.command } : {}),
+			...(options.args !== undefined ? { args: options.args } : {}),
+			...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
+			...(options.env !== undefined ? { env: { ...options.env } } : {}),
+			cols: options.size.cols,
+			rows: options.size.rows,
+		}
+
+		return await new Promise<TerminalSession>((resolve, reject) => {
+			const KILL_GRACE_MS = 5_000
+			const reader = new FrameReader()
+			const listeners = new Set<(chunk: string) => void>()
+			const buffered: string[] = []
+			let bufferedBytes = 0
+			let ready = false
+			let settled = false
+			let killTimer: ReturnType<typeof setTimeout> | undefined
+			let resolveExit!: (event: { exitCode: number; signal?: number }) => void
+			const exited = new Promise<{ exitCode: number; signal?: number }>((done) => {
+				resolveExit = done
+			})
+			const idle = new IdleTimer(this.readIdleTimeoutMs, () => {
+				finish(
+					new Error(
+						`vsock transport: terminal read idle timeout after ${this.readIdleTimeoutMs}ms`,
+					),
+				)
+			})
+
+			const finish = (
+				error: Error | null,
+				exit: { exitCode: number; signal?: number } = { exitCode: -1 },
+			) => {
+				if (settled) return
+				settled = true
+				idle.clear()
+				if (killTimer) clearTimeout(killTimer)
+				socket.destroy()
+				listeners.clear()
+				resolveExit(exit)
+				if (!ready) reject(error ?? new Error('terminal exited before readiness'))
+			}
+
+			const send = (event: TerminalInputEvent) => {
+				if (settled) return
+				socket.write(frame(JSON.stringify(event)))
+			}
+
+			const session: TerminalSession = {
+				write(data) {
+					send({ type: 'input', data })
+				},
+				resize(size) {
+					send({ type: 'resize', cols: size.cols, rows: size.rows })
+				},
+				onData(listener) {
+					listeners.add(listener)
+					if (buffered.length > 0) {
+						const pending = buffered.splice(0)
+						bufferedBytes = 0
+						queueMicrotask(() => {
+							if (!listeners.has(listener)) return
+							for (const chunk of pending) listener(chunk)
+						})
+					}
+					return () => listeners.delete(listener)
+				},
+				exited,
+				kill(signal) {
+					send({ type: 'kill', ...(signal !== undefined ? { signal } : {}) })
+					// A wedged guest must not pin sandbox.destroy() forever. The normal
+					// path reports the real exit; the deadline only severs an
+					// unresponsive transport so the owning microVM can be reclaimed.
+					if (!settled && !killTimer) {
+						killTimer = setTimeout(() => finish(null), KILL_GRACE_MS)
+						killTimer.unref?.()
+					}
+				},
+			}
+
+			socket.on('data', (chunk: Buffer) => {
+				if (!ready) idle.bump()
+				let payloads: string[]
+				try {
+					payloads = reader.push(chunk)
+				} catch (err) {
+					finish(err instanceof Error ? err : new Error(String(err)))
+					return
+				}
+				for (const payload of payloads) {
+					let event: TerminalOutputEvent
+					try {
+						event = JSON.parse(payload) as TerminalOutputEvent
+					} catch (err) {
+						finish(err instanceof Error ? err : new Error(String(err)))
+						return
+					}
+					if (event.type === 'ready') {
+						if (!ready) {
+							ready = true
+							// Once ready, an interactive shell may legitimately sit silent
+							// for hours. Runtime/session TTL owns idle cleanup; a transport
+							// read timer would incorrectly kill a healthy quiet terminal.
+							idle.clear()
+							resolve(session)
+						}
+						continue
+					}
+					if (event.type === 'data') {
+						if (listeners.size === 0) {
+							buffered.push(event.data)
+							bufferedBytes += Buffer.byteLength(event.data)
+							while (bufferedBytes > 1024 * 1024 && buffered.length > 1) {
+								bufferedBytes -= Buffer.byteLength(buffered.shift() ?? '')
+							}
+						} else {
+							for (const listener of listeners) listener(event.data)
+						}
+						continue
+					}
+					if (event.type === 'exit') {
+						finish(null, {
+							exitCode: event.exitCode,
+							...(event.signal !== undefined ? { signal: event.signal } : {}),
+						})
+						return
+					}
+					finish(new Error(event.error))
+					return
+				}
+			})
+			socket.once('error', (err) => finish(err))
+			socket.once('close', () =>
+				finish(new Error('vsock transport: terminal socket closed before exit')),
+			)
+			idle.bump()
+			socket.write(
+				frame(
+					JSON.stringify({
+						op: 'terminal',
+						body: request,
+					} satisfies AgentRequest),
+				),
+			)
+		})
+	}
+
+	/** Open one TCP stream to a service listening on guest loopback. */
+	async openTcpConnection(options: SandboxTcpConnectOptions): Promise<SandboxTcpConnection> {
+		if (!Number.isInteger(options.port) || options.port < 1 || options.port > 65_535) {
+			throw new Error('tcp connection port must be an integer in [1, 65535]')
+		}
+		const host = options.host ?? '127.0.0.1'
+		if (host !== '127.0.0.1' && host !== '::1') {
+			throw new Error('firecracker TCP connections are restricted to guest loopback')
+		}
+		const socket = await this.dial()
+		const request: TcpConnectRequest = { host, port: options.port }
+
+		return await new Promise<SandboxTcpConnection>((resolve, reject) => {
+			const reader = new FrameReader()
+			const listeners = new Set<(chunk: Uint8Array) => void>()
+			const buffered: Buffer[] = []
+			let bufferedBytes = 0
+			let ready = false
+			let settled = false
+			let resolveClosed!: () => void
+			const closed = new Promise<void>((done) => {
+				resolveClosed = done
+			})
+			const idle = new IdleTimer(this.readIdleTimeoutMs, () => {
+				finish(
+					new Error(`vsock transport: TCP connect idle timeout after ${this.readIdleTimeoutMs}ms`),
+				)
+			})
+
+			const finish = (error: Error | null) => {
+				if (settled) return
+				settled = true
+				idle.clear()
+				socket.destroy()
+				listeners.clear()
+				resolveClosed()
+				if (!ready) reject(error ?? new Error('TCP stream closed before readiness'))
+			}
+
+			const send = (event: TcpInputEvent): boolean => {
+				return !settled && socket.write(frame(JSON.stringify(event)))
+			}
+
+			const connection: SandboxTcpConnection = {
+				write(data) {
+					const bytes = typeof data === 'string' ? Buffer.from(data) : Buffer.from(data)
+					return send({ type: 'data', data: bytes.toString('base64') })
+				},
+				end() {
+					send({ type: 'end' })
+				},
+				destroy() {
+					send({ type: 'destroy' })
+					finish(null)
+				},
+				pause() {
+					socket.pause()
+				},
+				resume() {
+					if (!settled) socket.resume()
+				},
+				onData(listener) {
+					listeners.add(listener)
+					if (buffered.length > 0) {
+						const pending = buffered.splice(0)
+						bufferedBytes = 0
+						queueMicrotask(() => {
+							if (!listeners.has(listener)) return
+							for (const chunk of pending) listener(chunk)
+						})
+					}
+					return () => listeners.delete(listener)
+				},
+				onDrain(listener) {
+					socket.on('drain', listener)
+					return () => socket.off('drain', listener)
+				},
+				closed,
+			}
+
+			socket.on('data', (chunk: Buffer) => {
+				if (!ready) idle.bump()
+				let payloads: string[]
+				try {
+					payloads = reader.push(chunk)
+				} catch (error) {
+					finish(error instanceof Error ? error : new Error(String(error)))
+					return
+				}
+				for (const payload of payloads) {
+					let event: TcpOutputEvent
+					try {
+						event = JSON.parse(payload) as TcpOutputEvent
+					} catch (error) {
+						finish(error instanceof Error ? error : new Error(String(error)))
+						return
+					}
+					if (event.type === 'ready') {
+						if (!ready) {
+							ready = true
+							idle.clear()
+							resolve(connection)
+						}
+						continue
+					}
+					if (event.type === 'data') {
+						const bytes = Buffer.from(event.data, 'base64')
+						if (listeners.size === 0) {
+							buffered.push(bytes)
+							bufferedBytes += bytes.byteLength
+							while (bufferedBytes > 1024 * 1024 && buffered.length > 1) {
+								bufferedBytes -= buffered.shift()?.byteLength ?? 0
+							}
+						} else {
+							for (const listener of listeners) listener(bytes)
+						}
+						continue
+					}
+					if (event.type === 'end') {
+						finish(null)
+						continue
+					}
+					finish(new Error(event.error))
+				}
+			})
+			socket.once('error', (error) => finish(error))
+			socket.once('close', () =>
+				finish(ready ? null : new Error('vsock TCP socket closed before readiness')),
+			)
+			idle.bump()
+			socket.write(
+				frame(
+					JSON.stringify({
+						op: 'tcp-connect',
+						body: request,
+					} satisfies AgentRequest),
+				),
+			)
+		})
 	}
 }
 

--- a/packages/sandbox/src/backends/http-worker-client.test.ts
+++ b/packages/sandbox/src/backends/http-worker-client.test.ts
@@ -99,7 +99,7 @@ describe('the shared HTTP worker execution client', () => {
 		])
 	})
 
-	it('falls back only after an explicit old-worker response and caches that peer capability', async () => {
+	it('refuses an old worker without starting identity-less execution', async () => {
 		const paths: string[] = []
 		const fetch_ = vi.fn(async (input: string | URL | Request) => {
 			const url = String(input)
@@ -113,14 +113,8 @@ describe('the shared HTTP worker execution client', () => {
 		vi.stubGlobal('fetch', fetch_)
 		const client = new HttpWorkerClient('http://old-worker')
 
-		await expect(client.exec('true', [], undefined)).resolves.toMatchObject({ exitCode: 0 })
-		await expect(client.exec('true', [], undefined)).resolves.toMatchObject({ exitCode: 0 })
-
-		expect(paths).toEqual([
-			'http://old-worker/executions/reserve',
-			'http://old-worker/execute',
-			'http://old-worker/execute',
-		])
+		await expect(client.exec('true', [], undefined)).rejects.toThrow(/protocol/i)
+		expect(paths).toEqual(['http://old-worker/executions/reserve'])
 	})
 
 	it('admits nothing for an already-aborted caller', async () => {

--- a/packages/sandbox/src/backends/http-worker-client.ts
+++ b/packages/sandbox/src/backends/http-worker-client.ts
@@ -1,7 +1,6 @@
 import { type SandboxExecOptions, type SandboxExecResult, withHint } from '@namzu/sdk'
 
 import {
-	RemoteCancellationUnsupportedError,
 	RemoteCommandError,
 	type RemoteExecutionAdapter,
 	RemoteExecutionController,
@@ -162,8 +161,8 @@ async function readExecution(
 }
 
 /**
- * A per-sandbox HTTP worker client. The controller caches protocol support for
- * that worker and gives every v2 command an identity before it can be admitted.
+ * A per-sandbox HTTP worker client. Every command must reserve an identity
+ * through the exact worker protocol before it can be admitted.
  */
 export class HttpWorkerClient {
 	private readonly controller: RemoteExecutionController
@@ -177,8 +176,8 @@ export class HttpWorkerClient {
 					signal,
 				})
 				if (response.status === 404) {
-					throw new RemoteCancellationUnsupportedError(
-						'This sandbox worker does not support the execution-cancellation lease protocol. Rebuild the worker image or standby-pool profile before passing SandboxExecOptions.signal; refusing rather than pretending cancellation is active.',
+					throw new RemoteProtocolError(
+						'The sandbox worker does not implement the required execution protocol. Rebuild the worker image or standby-pool profile from the same Namzu release before admitting commands.',
 					)
 				}
 				if (!response.ok) {
@@ -215,11 +214,7 @@ export class HttpWorkerClient {
 	}
 }
 
-/**
- * Compatibility entry point for focused consumers. Sandbox backends keep one
- * {@link HttpWorkerClient} per remote sandbox so capability state is not shared
- * across peers and is not re-probed for every command.
- */
+/** Convenience entry point for focused consumers. */
 export async function execViaHttpWorker(
 	baseUrl: string,
 	command: string,

--- a/packages/sandbox/src/backends/readiness.test.ts
+++ b/packages/sandbox/src/backends/readiness.test.ts
@@ -3,9 +3,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
 	OperationDeadline,
 	OperationDeadlineExpired,
+	probeHttpHealth,
 	resolveReadinessOptions,
 	runFailureCleanup,
 } from './readiness.js'
+import { REMOTE_EXECUTION_PROTOCOL_VERSION } from './remote-execution-controller.js'
 
 afterEach(() => {
 	vi.useRealTimers()
@@ -70,6 +72,38 @@ describe('OperationDeadline', () => {
 		await expect(deadline.run(async () => 'late-ready')).rejects.toBeInstanceOf(
 			OperationDeadlineExpired,
 		)
+	})
+})
+
+describe('HTTP worker protocol readiness', () => {
+	it('accepts only the exact remote execution protocol', async () => {
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					ok: true,
+					protocolVersion: REMOTE_EXECUTION_PROTOCOL_VERSION,
+				}),
+				{ status: 200 },
+			),
+		)
+
+		await expect(
+			probeHttpHealth('http://worker.test/healthz', new AbortController().signal),
+		).resolves.toEqual({ ok: true, status: 200 })
+	})
+
+	it.each([
+		['missing', { ok: true }],
+		['older', { ok: true, protocolVersion: REMOTE_EXECUTION_PROTOCOL_VERSION - 1 }],
+		['newer', { ok: true, protocolVersion: REMOTE_EXECUTION_PROTOCOL_VERSION + 1 }],
+	])('refuses a %s worker protocol', async (_label, payload) => {
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response(JSON.stringify(payload), { status: 200 }),
+		)
+
+		await expect(
+			probeHttpHealth('http://worker.test/healthz', new AbortController().signal),
+		).rejects.toThrow(/protocol version/i)
 	})
 })
 

--- a/packages/sandbox/src/backends/readiness.ts
+++ b/packages/sandbox/src/backends/readiness.ts
@@ -7,6 +7,11 @@
  * transports can release their sockets too.
  */
 
+import {
+	REMOTE_EXECUTION_PROTOCOL_VERSION,
+	RemoteProtocolError,
+} from './remote-execution-controller.js'
+
 const MAX_NODE_TIMER_MS = 2_147_483_647
 
 /**
@@ -142,15 +147,42 @@ export async function probeHttpHealth(
 ): Promise<{ readonly ok: boolean; readonly status: number }> {
 	signal.throwIfAborted()
 	const response = await fetch(url, { signal })
-	const result = { ok: response.ok, status: response.status }
+	if (!response.ok) {
+		try {
+			await response.body?.cancel()
+		} catch {
+			// The status is already known. A body cancellation failure must not
+			// hide it; the owning deadline still aborts the transport if needed.
+		}
+		signal.throwIfAborted()
+		return { ok: false, status: response.status }
+	}
+
+	let payload: unknown
 	try {
-		await response.body?.cancel()
-	} catch {
-		// The status is already known. A body cancellation failure must not
-		// hide it; the owning deadline still aborts the transport if needed.
+		payload = await response.json()
+	} catch (error) {
+		throw new RemoteProtocolError(
+			`Sandbox worker health response is not valid JSON for protocol ${REMOTE_EXECUTION_PROTOCOL_VERSION}: ${error instanceof Error ? error.message : String(error)}`,
+		)
 	}
 	signal.throwIfAborted()
-	return result
+	const health = payload as { ok?: unknown; protocolVersion?: unknown }
+	if (
+		!health ||
+		typeof health !== 'object' ||
+		health.ok !== true ||
+		health.protocolVersion !== REMOTE_EXECUTION_PROTOCOL_VERSION
+	) {
+		const actual =
+			health && typeof health === 'object' && health.protocolVersion !== undefined
+				? JSON.stringify(health.protocolVersion)
+				: 'missing'
+		throw new RemoteProtocolError(
+			`Sandbox worker protocol version mismatch: expected ${REMOTE_EXECUTION_PROTOCOL_VERSION}, received ${actual}. Rebuild the worker image from the same Namzu release.`,
+		)
+	}
+	return { ok: true, status: response.status }
 }
 
 /**

--- a/packages/sandbox/src/backends/remote-execution-controller.ts
+++ b/packages/sandbox/src/backends/remote-execution-controller.ts
@@ -9,9 +9,12 @@ const MAX_TIMER_DELAY_MS = 2_147_483_647
 const EXECUTION_ID_PATTERN =
 	/^exec_[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
+/** Exact wire version implemented by the shipped worker and microVM guest. */
+export const REMOTE_EXECUTION_PROTOCOL_VERSION = 2 as const
+
 export interface RemoteReservation {
 	readonly ok: true
-	readonly protocolVersion: 2
+	readonly protocolVersion: typeof REMOTE_EXECUTION_PROTOCOL_VERSION
 	readonly executionId: string
 	readonly leaseExpiresAt: number
 }
@@ -36,8 +39,6 @@ export interface RemoteCancellationAcknowledgement {
 export class RemoteCommandError extends Error {}
 
 export class RemoteProtocolError extends Error {}
-
-export class RemoteCancellationUnsupportedError extends Error {}
 
 export interface SandboxRetirementObservation {
 	readonly accepted: boolean
@@ -106,7 +107,7 @@ function parseReservation(value: unknown): RemoteReservation {
 	const reservation = value as Record<string, unknown>
 	if (
 		reservation.ok !== true ||
-		reservation.protocolVersion !== 2 ||
+		reservation.protocolVersion !== REMOTE_EXECUTION_PROTOCOL_VERSION ||
 		!EXECUTION_ID_PATTERN.test(String(reservation.executionId ?? '')) ||
 		!Number.isFinite(reservation.leaseExpiresAt)
 	) {
@@ -223,17 +224,13 @@ async function bounded<T>(
 	}
 }
 
-type Capability = 'unknown' | 'supported' | 'unsupported'
-
 /**
- * One state machine for remote command ownership. A v2 peer reserves every
- * command, even when the caller supplied no signal, so transport loss can be
- * reconciled by identity. Legacy execution is entered only after an explicit
- * unsupported response from the peer and is fenced as unknown on any failure.
+ * One state machine for remote command ownership. Every supported peer reserves
+ * every command before admission, even when the caller supplied no signal, so
+ * transport loss can be reconciled by identity. An old peer is refused; an
+ * identity-less remote command is never started.
  */
 export class RemoteExecutionController<Context = undefined> {
-	private capability: Capability = 'unknown'
-	private unsupportedError: RemoteCancellationUnsupportedError | undefined
 	private readonly controlRequestTimeoutMs: number
 	private readonly cancelConfirmTimeoutMs: number
 	private readonly resultDrainTimeoutMs: number
@@ -261,17 +258,6 @@ export class RemoteExecutionController<Context = undefined> {
 	): Promise<SandboxExecResult> {
 		const startedAt = Date.now()
 		if (opts?.signal?.aborted) return cancelledBeforeStart(startedAt)
-		if (this.capability === 'unsupported') {
-			if (opts?.signal) {
-				throw (
-					this.unsupportedError ??
-					new RemoteCancellationUnsupportedError(
-						`${this.adapter.label} was classified as cancellation-unsupported`,
-					)
-				)
-			}
-			return await this.executeLegacy(command, argv, opts, context)
-		}
 
 		let reservation: RemoteReservation
 		try {
@@ -283,44 +269,12 @@ export class RemoteExecutionController<Context = undefined> {
 					opts?.signal,
 				),
 			)
-			this.capability = 'supported'
 		} catch (error) {
 			if (opts?.signal?.aborted) return cancelledBeforeStart(startedAt)
-			if (error instanceof RemoteCancellationUnsupportedError) {
-				this.capability = 'unsupported'
-				this.unsupportedError = error
-				if (opts?.signal) throw error
-				return await this.executeLegacy(command, argv, opts, context)
-			}
 			throw error
 		}
 
 		return await this.executeReserved(reservation, command, argv, opts, startedAt, context)
-	}
-
-	private async executeLegacy(
-		command: string,
-		argv: string[] | undefined,
-		opts: SandboxExecOptions | undefined,
-		context: Context | undefined,
-	): Promise<SandboxExecResult> {
-		const timeoutMs = observationDeadlineMs(
-			opts?.timeout,
-			this.defaultExecutionTimeoutMs,
-			this.executionObservationGraceMs,
-		)
-		try {
-			return await bounded(
-				`${this.adapter.label} legacy execution observation`,
-				timeoutMs,
-				(signal) => this.adapter.execute(undefined, command, argv, opts, signal, context),
-			)
-		} catch (error) {
-			throw new RemoteCancellationUnknownError(
-				`The legacy ${this.adapter.label} execution failed after admission without an execution id: ${error instanceof Error ? error.message : String(error)}. The remote outcome is unknown and the sandbox must not be reused.`,
-				{ cause: error },
-			)
-		}
 	}
 
 	private async requestCancellation(

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -78,6 +78,7 @@ export type {
 	OrchestratorTokenProvider,
 } from './backends/firecracker/index.js'
 export {
+	FIRECRACKER_AGENT_PROTOCOL_VERSION,
 	type SandboxAgentHandle,
 	type VsockTransportOptions,
 	VsockAgentTransport,

--- a/packages/sandbox/worker/__tests__/server.test.js
+++ b/packages/sandbox/worker/__tests__/server.test.js
@@ -5,6 +5,8 @@ import os from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
+import { REMOTE_EXECUTION_PROTOCOL_VERSION } from '../../src/backends/remote-execution-controller.js'
+
 /**
  * `worker/server.js` is a plain CommonJS script meant to run standalone
  * inside the sandbox container (see the Dockerfile `CMD`), not a module
@@ -136,6 +138,27 @@ function getFreePort() {
 		})
 	})
 }
+
+describe('worker protocol readiness', () => {
+	let worker
+
+	afterEach(async () => {
+		if (worker) await worker.stop()
+		worker = undefined
+	})
+
+	it('publishes the same exact protocol version the host accepts', async () => {
+		worker = await spawnWorker({})
+
+		const response = await fetch(`${worker.baseUrl}/healthz`)
+
+		expect(response.status).toBe(200)
+		await expect(response.json()).resolves.toEqual({
+			ok: true,
+			protocolVersion: REMOTE_EXECUTION_PROTOCOL_VERSION,
+		})
+	})
+})
 
 describe('worker /execute — timeoutMs ceiling', () => {
 	let worker

--- a/packages/sandbox/worker/server.js
+++ b/packages/sandbox/worker/server.js
@@ -16,7 +16,7 @@
  * host picks the `microvm` tier instead.)
  *
  * Endpoints:
- *   GET  /healthz       — liveness probe.
+ *   GET  /healthz       — exact-protocol readiness probe.
  *   POST /execute       — run a command inside the workspace.
  *                         body: { executionId?, command, args, cwd, env, stdin,
  *                                 timeoutMs, maxOutputBytes }
@@ -57,6 +57,8 @@ const { spawn } = require('node:child_process')
 const { randomUUID } = require('node:crypto')
 const fs = require('node:fs/promises')
 const path = require('node:path')
+
+const REMOTE_EXECUTION_PROTOCOL_VERSION = 2
 
 /**
  * Prefix every variable this worker reads its own configuration from.
@@ -416,7 +418,7 @@ async function handleReserveExecution(_req, res) {
 	})
 	writeJson(res, 201, {
 		ok: true,
-		protocolVersion: 2,
+		protocolVersion: REMOTE_EXECUTION_PROTOCOL_VERSION,
 		executionId,
 		leaseExpiresAt,
 	})
@@ -939,7 +941,10 @@ const server = http.createServer(async (req, res) => {
 			return
 		}
 		if (req.method === 'GET' && req.url === '/healthz') {
-			writeJson(res, 200, { ok: true })
+			writeJson(res, 200, {
+				ok: true,
+				protocolVersion: REMOTE_EXECUTION_PROTOCOL_VERSION,
+			})
 			return
 		}
 		if (req.method === 'POST' && req.url === '/execute') {

--- a/packages/sdk/src/__fixtures__/sdk-test-working-directory-probe.test.ts
+++ b/packages/sdk/src/__fixtures__/sdk-test-working-directory-probe.test.ts
@@ -1,10 +1,12 @@
 import { mkdir, realpath, rename } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { expect, it } from 'vitest'
 
 it('runs inside the working directory verified by the SDK test boundary', async () => {
 	const workingDirectory = await realpath(process.cwd())
 	expect(process.env.NAMZU_SDK_TEST_ROOT).toBe(workingDirectory)
 	expect(process.env.NAMZU_SDK_TEST_WORKER_VERIFIED).toBe(workingDirectory)
+	expect(await realpath(tmpdir())).toBe(tmpdir())
 
 	if (process.env.NAMZU_SDK_TEST_PROBE_FAIL === '1') {
 		expect.fail('deliberate SDK test-runner child failure')

--- a/packages/sdk/src/__tests__/the-testing-subpath.test.ts
+++ b/packages/sdk/src/__tests__/the-testing-subpath.test.ts
@@ -26,4 +26,14 @@ describe('the testing subpath', () => {
 		expect(typeof testing.defineProviderDriverConformance).toBe('function')
 		expect(typeof testing.PROVIDER_DRIVER_CONTRACT_VERSION).toBe('number')
 	})
+
+	it('exports deterministic valid entity ids for consumer fixtures', async () => {
+		const testing = await import('../testing.js')
+
+		expect(testing.fixtureId.run('consumer')).toBe(testing.fixtureId.run('consumer'))
+		expect(testing.fixtureId.run('consumer')).not.toBe(testing.fixtureId.run('other'))
+		expect(testing.fixtureId.run('consumer')).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+		)
+	})
 })

--- a/packages/sdk/src/bridge/sse/mapper.test.ts
+++ b/packages/sdk/src/bridge/sse/mapper.test.ts
@@ -305,6 +305,27 @@ describe('mapRunToStreamEvent — mapped variants', () => {
 		).toBe('agent.canceled')
 	})
 
+	it('agent.pending carries an approved plan edge when present', () => {
+		const pending = mapRunToStreamEvent(
+			{
+				type: 'agent_pending',
+				runId: RID,
+				taskId: 'task_1' as TaskId,
+				parentAgentId: 'supervisor',
+				childAgentId: 'worker',
+				depth: 1,
+				planId: 'plan_1',
+				planStepId: 'step_2',
+			},
+			RID,
+		)
+
+		expect(pending?.data).toMatchObject({
+			plan_id: 'plan_1',
+			plan_step_id: 'step_2',
+		})
+	})
+
 	it('task_created / task_updated map cleanly', () => {
 		const a = mapRunToStreamEvent(
 			{

--- a/packages/sdk/src/bridge/sse/mapper.ts
+++ b/packages/sdk/src/bridge/sse/mapper.ts
@@ -435,6 +435,8 @@ const MAPPING: {
 			parent_agent_id: e.parentAgentId,
 			child_agent_id: e.childAgentId,
 			depth: e.depth,
+			...(e.planId ? { plan_id: e.planId } : {}),
+			...(e.planStepId ? { plan_step_id: e.planStepId } : {}),
 		}),
 	},
 

--- a/packages/sdk/src/manager/agent/lifecycle.ts
+++ b/packages/sdk/src/manager/agent/lifecycle.ts
@@ -252,6 +252,8 @@ export class AgentManager {
 				parentAgentId: context.parentAgentId,
 				childAgentId: options.agentId,
 				depth: context.depth,
+				...(options.planId ? { planId: options.planId } : {}),
+				...(options.planStepId ? { planStepId: options.planStepId } : {}),
 			})
 			entry.ready = true
 		} catch (error) {
@@ -544,6 +546,8 @@ export class AgentManager {
 						parentAgentId: context.parentAgentId,
 						childAgentId: options.agentId,
 						depth: context.depth,
+						...(options.planId ? { planId: options.planId } : {}),
+						...(options.planStepId ? { planStepId: options.planStepId } : {}),
 					})
 
 				const lineage: Lineage = {

--- a/packages/sdk/src/manager/plan/__tests__/a-plan-that-succeeded-is-not-failed.test.ts
+++ b/packages/sdk/src/manager/plan/__tests__/a-plan-that-succeeded-is-not-failed.test.ts
@@ -86,3 +86,47 @@ describe('a plan settles on what its steps actually reported', () => {
 		expect(new PlanManager(RUN).completePlan()).toBeNull()
 	})
 })
+
+describe('plan approval event settlement', () => {
+	it('does not resolve an approval while an async listener is still persisting it', async () => {
+		let releaseListener!: () => void
+		let reportListenerStarted!: () => void
+		const listenerGate = new Promise<void>((resolve) => {
+			releaseListener = resolve
+		})
+		const listenerStarted = new Promise<void>((resolve) => {
+			reportListenerStarted = resolve
+		})
+		const manager = new PlanManager(RUN, async () => ({ approved: true }))
+		manager.startGenerating('a plan')
+		manager.markReady()
+		manager.on(async (event) => {
+			if (event.type !== 'plan.approved') return
+			reportListenerStarted()
+			await listenerGate
+		})
+		let approvalResolved = false
+
+		const approval = manager.requestApproval().then((response) => {
+			approvalResolved = true
+			return response
+		})
+		await listenerStarted
+
+		expect(approvalResolved).toBe(false)
+		releaseListener()
+		await expect(approval).resolves.toEqual({ approved: true })
+		expect(approvalResolved).toBe(true)
+	})
+
+	it('keeps listener failures isolated from the approval decision', async () => {
+		const manager = new PlanManager(RUN, async () => ({ approved: true }))
+		manager.startGenerating('a plan')
+		manager.markReady()
+		manager.on(async () => {
+			throw new Error('observer unavailable')
+		})
+
+		await expect(manager.requestApproval()).resolves.toEqual({ approved: true })
+	})
+})

--- a/packages/sdk/src/manager/plan/lifecycle.ts
+++ b/packages/sdk/src/manager/plan/lifecycle.ts
@@ -22,7 +22,7 @@ export interface PlanEvent {
 	step?: PlanStep
 }
 
-export type PlanEventListener = (event: PlanEvent) => void
+export type PlanEventListener = (event: PlanEvent) => void | Promise<void>
 
 export type PlanApprovalHandler = (request: PlanApprovalRequest) => Promise<PlanApprovalResponse>
 
@@ -75,12 +75,14 @@ export class PlanManager {
 		}
 	}
 
-	private emit(event: PlanEvent): void {
+	private async emit(event: PlanEvent): Promise<void> {
+		const pending: Promise<void>[] = []
 		for (const listener of this.listeners) {
 			try {
-				listener(event)
+				pending.push(Promise.resolve(listener(event)).catch(() => {}))
 			} catch {}
 		}
+		await Promise.all(pending)
 	}
 
 	get active(): Plan | null {
@@ -120,7 +122,7 @@ export class PlanManager {
 		}
 
 		this.currentPlan = plan
-		this.emit({ type: 'plan.generating', plan })
+		void this.emit({ type: 'plan.generating', plan })
 		return plan
 	}
 
@@ -144,7 +146,7 @@ export class PlanManager {
 		this.currentPlan.status = 'ready'
 		this.currentPlan.summary = summary
 		this.currentPlan.readyAt = Date.now()
-		this.emit({ type: 'plan.ready', plan: this.currentPlan })
+		void this.emit({ type: 'plan.ready', plan: this.currentPlan })
 		return this.currentPlan
 	}
 
@@ -159,7 +161,7 @@ export class PlanManager {
 			this.currentPlan.status = 'rejected'
 			this.currentPlan.rejectedAt = Date.now()
 			this.currentPlan.rejectionReason = 'No approval handler configured'
-			this.emit({ type: 'plan.rejected', plan: this.currentPlan })
+			await this.emit({ type: 'plan.rejected', plan: this.currentPlan })
 			return { approved: false, feedback: 'No approval handler configured' }
 		}
 
@@ -179,12 +181,12 @@ export class PlanManager {
 			}
 			this.currentPlan.status = 'approved'
 			this.currentPlan.approvedAt = Date.now()
-			this.emit({ type: 'plan.approved', plan: this.currentPlan })
+			await this.emit({ type: 'plan.approved', plan: this.currentPlan })
 		} else {
 			this.currentPlan.status = 'rejected'
 			this.currentPlan.rejectedAt = Date.now()
 			this.currentPlan.rejectionReason = response.feedback
-			this.emit({ type: 'plan.rejected', plan: this.currentPlan })
+			await this.emit({ type: 'plan.rejected', plan: this.currentPlan })
 		}
 
 		return response
@@ -200,7 +202,7 @@ export class PlanManager {
 		}
 		this.currentPlan.status = 'approved'
 		this.currentPlan.approvedAt = Date.now()
-		this.emit({ type: 'plan.approved', plan: this.currentPlan })
+		void this.emit({ type: 'plan.approved', plan: this.currentPlan })
 		return this.currentPlan
 	}
 
@@ -209,7 +211,7 @@ export class PlanManager {
 		if (this.currentPlan.status !== 'approved') return null
 
 		this.currentPlan.status = 'executing'
-		this.emit({ type: 'plan.executing', plan: this.currentPlan })
+		void this.emit({ type: 'plan.executing', plan: this.currentPlan })
 		return this.currentPlan
 	}
 
@@ -222,7 +224,7 @@ export class PlanManager {
 		step.status = status
 		if (error) step.error = error
 
-		this.emit({ type: 'plan.step_updated', plan: this.currentPlan, step })
+		void this.emit({ type: 'plan.step_updated', plan: this.currentPlan, step })
 		return step
 	}
 
@@ -269,7 +271,7 @@ export class PlanManager {
 
 		this.currentPlan.status = allDone ? 'completed' : 'failed'
 		this.currentPlan.completedAt = Date.now()
-		this.emit({
+		void this.emit({
 			type: allDone ? 'plan.completed' : 'plan.failed',
 			plan: this.currentPlan,
 		})
@@ -293,7 +295,7 @@ export class PlanManager {
 			}
 		}
 
-		this.emit({ type: 'plan.failed', plan: this.currentPlan })
+		void this.emit({ type: 'plan.failed', plan: this.currentPlan })
 		return this.currentPlan
 	}
 

--- a/packages/sdk/src/runtime/query/__tests__/a-job-does-not-outlive-its-run.proc-test.ts
+++ b/packages/sdk/src/runtime/query/__tests__/a-job-does-not-outlive-its-run.proc-test.ts
@@ -61,6 +61,7 @@ const explodes = (): AsyncIterable<never> => ({
 async function runStartingAJob(
 	backgroundJobs: BackgroundJobRegistry,
 	command: string,
+	responseDelayMs = 0,
 ): Promise<Run | { error: unknown }> {
 	const workingDirectory = await mkdtemp(join(tmpdir(), 'namzu-runjobs-'))
 	dirs.push(workingDirectory)
@@ -69,6 +70,7 @@ async function runStartingAJob(
 	tools.register(BashTool)
 
 	const provider = new MockLLMProvider({
+		responseDelayMs,
 		turns: [
 			{
 				toolCalls: [
@@ -118,13 +120,17 @@ describe('a run takes its background jobs with it', () => {
 		// it is the one that keeps holding a port or a file lock.
 		const registry = new BackgroundJobRegistry()
 
-		const run = (await runStartingAJob(registry, 'sleep 30 & echo $!; wait')) as Run
+		// Hold the final model turn briefly so the shell has emitted the PID.
+		// Without this synchronization the run can finish before the spawned
+		// shell gets scheduled; `Number('')` then produces the valid-looking PID
+		// zero and `kill(0, 0)` probes this test process's own group.
+		const run = (await runStartingAJob(registry, 'sleep 30 & echo $!; wait', 100)) as Run
 		const job = registry.list(run.id)[0]
 		if (!job) throw new Error('the run started no job')
 		const printed = registry.read(job.id).chunk.trim().split('\n')[0]
 		const grandchild = Number(printed)
 
-		expect(Number.isFinite(grandchild)).toBe(true)
+		expect(Number.isSafeInteger(grandchild) && grandchild > 0).toBe(true)
 		await settle(300)
 		expect(alive(grandchild)).toBe(false)
 	})

--- a/packages/sdk/src/scheduler/local.ts
+++ b/packages/sdk/src/scheduler/local.ts
@@ -112,6 +112,8 @@ export class LocalTaskScheduler implements TaskScheduler {
 			{
 				agentId: options.agentId,
 				beforeStart: options.beforeStart,
+				...(options.planId ? { planId: options.planId } : {}),
+				...(options.planStepId ? { planStepId: options.planStepId } : {}),
 				input: {
 					messages: [createUserMessage(options.prompt)],
 					workingDirectory: options.workingDirectory,

--- a/packages/sdk/src/store/__tests__/snapshot-hydration.test.ts
+++ b/packages/sdk/src/store/__tests__/snapshot-hydration.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, symlink } from 'node:fs/promises'
+import { mkdtemp, realpath, symlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -111,6 +111,7 @@ describe('hydration attaches isolated work to established project and topic iden
 	it('canonicalizes hydrated roots and enforces uniqueness within each tenant', async () => {
 		const root = await mkdtemp(join(tmpdir(), 'namzu-hydrated-root-'))
 		temporaryDirectories.push(root)
+		const canonicalRoot = await realpath(root)
 		const alias = `${root}-alias`
 		await symlink(root, alias, 'junction')
 		temporaryDirectories.push(alias)
@@ -118,7 +119,7 @@ describe('hydration attaches isolated work to established project and topic iden
 		const bound = { ...project, rootPath: alias }
 		const sessions = new InMemorySessionStore([bound])
 		expect((await sessions.findProjectByRootPath(root, project.tenantId))?.id).toBe(project.id)
-		expect((await sessions.getProject(project.id, project.tenantId))?.rootPath).toBe(root)
+		expect((await sessions.getProject(project.id, project.tenantId))?.rootPath).toBe(canonicalRoot)
 		expect(
 			() =>
 				new InMemorySessionStore([bound, { ...project, id: generateProjectId(), rootPath: root }]),

--- a/packages/sdk/src/testing.ts
+++ b/packages/sdk/src/testing.ts
@@ -38,3 +38,5 @@ export {
 	defineProviderDriverConformance,
 } from './provider/conformance.js'
 export type { ProviderDriverConformanceOptions } from './provider/conformance.js'
+
+export { fixtureId } from './test-support/ids.js'

--- a/packages/sdk/src/tools/coordinator/__tests__/a-plan-step-reports-its-own-outcome.test.ts
+++ b/packages/sdk/src/tools/coordinator/__tests__/a-plan-step-reports-its-own-outcome.test.ts
@@ -101,6 +101,25 @@ const stepStatus = (pm: PlanManager, id: string) =>
 	pm.active?.steps.find((s) => s.id === id)?.status
 
 describe('a delegated step reports through the launch that carries it out', () => {
+	it('carries the plan edge on the live worker launch', async () => {
+		const pm = approvedPlan()
+		const gateway = gatewayReturning('ok')
+		let launched: Parameters<TaskScheduler['createTask']>[0] | undefined
+		const createTask = gateway.createTask.bind(gateway)
+		gateway.createTask = async (options) => {
+			launched = options
+			return createTask(options)
+		}
+		const named = toolsOver(pm, gateway)
+
+		await named('create_task').execute(
+			{ agent_id: 'worker', prompt: 'go', description: 'do it', plan_step_id: 'step_1' },
+			ctx(),
+		)
+
+		expect(launched).toMatchObject({ planId: pm.active?.id, planStepId: 'step_1' })
+	})
+
 	it('completes the step when the worker succeeded', async () => {
 		const pm = approvedPlan()
 		const named = toolsOver(pm, gatewayReturning('ok'))

--- a/packages/sdk/src/tools/coordinator/index.ts
+++ b/packages/sdk/src/tools/coordinator/index.ts
@@ -566,6 +566,7 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 			// could report `failed` or stay `executing` forever but never
 			// `completed`.
 			const planStepId = plan_step_id
+			const planId = planStepId ? getPlanManager?.()?.active?.id : undefined
 			const reportStep = (status: 'running' | 'completed' | 'failed', error?: string): void => {
 				if (!planStepId) return
 				getPlanManager?.()?.updateStepStatus(planStepId, status, error)
@@ -595,6 +596,8 @@ export function buildCoordinatorTools(opts: CoordinatorToolsOptions): ToolDefini
 				prompt,
 				workingDirectory: cwd,
 				runtimeContext: opts.runtimeContext,
+				...(planStepId ? { planStepId } : {}),
+				...(planId ? { planId } : {}),
 				// Hang the child run off THIS tool's span, so the delegation
 				// shows up inside the turn that asked for it.
 				...(_context.parentSpan ? { parentSpan: _context.parentSpan } : {}),

--- a/packages/sdk/src/types/agent/scheduler.ts
+++ b/packages/sdk/src/types/agent/scheduler.ts
@@ -54,6 +54,10 @@ export interface CreateTaskOptions {
 	 */
 	readonly parentSpan?: import('@opentelemetry/api').Span
 
+	/** Approved plan edge for live worker/progress correlation. */
+	readonly planId?: string
+	readonly planStepId?: string
+
 	agentId: string
 
 	/**

--- a/packages/sdk/src/types/agent/task.ts
+++ b/packages/sdk/src/types/agent/task.ts
@@ -154,6 +154,10 @@ export interface SendMessageOptions {
 	/** See {@link import('./scheduler.js').CreateTaskOptions.personaOverride}. */
 	readonly personaOverride?: import('../persona/index.js').AgentPersona
 
+	/** Approved plan edge inherited from the delegation tool, when present. */
+	readonly planId?: string
+	readonly planStepId?: string
+
 	agentId: string
 
 	input: AgentInput

--- a/packages/sdk/src/types/run/events.ts
+++ b/packages/sdk/src/types/run/events.ts
@@ -807,6 +807,9 @@ type CoreRunEvent =
 			parentAgentId: string
 			childAgentId: string
 			depth: number
+			/** Approved plan edge carried while the blocking tool is still live. */
+			planId?: string
+			planStepId?: string
 	  }
 	| {
 			type: 'agent_completed'

--- a/packages/sdk/src/types/sandbox/index.ts
+++ b/packages/sdk/src/types/sandbox/index.ts
@@ -233,6 +233,34 @@ export interface SandboxSpawnOptions {
 	readonly env?: Record<string, string>
 }
 
+/**
+ * One host-side end of a TCP connection opened from inside the sandbox.
+ *
+ * The connection is intentionally narrower than general sandbox networking:
+ * callers may reach a loopback service already running in the sandbox, while
+ * the sandbox's egress policy remains unchanged. This is the primitive a
+ * development-workspace gateway uses to publish an HTTP/WebSocket preview
+ * without copying the checkout into a second container.
+ */
+export interface SandboxTcpConnection {
+	/** Queue bytes for the guest. False means pause the producer until onDrain. */
+	write(data: string | Uint8Array): boolean
+	end(): void
+	destroy(): void
+	/** Pause/resume bytes arriving from the guest without closing the stream. */
+	pause(): void
+	resume(): void
+	onData(listener: (chunk: Uint8Array) => void): () => void
+	onDrain(listener: () => void): () => void
+	readonly closed: Promise<void>
+}
+
+export interface SandboxTcpConnectOptions {
+	readonly port: number
+	/** Only guest loopback addresses are supported by the built-in backend. */
+	readonly host?: '127.0.0.1' | '::1'
+}
+
 export interface Sandbox {
 	readonly id: SandboxId
 	readonly status: SandboxStatus
@@ -281,11 +309,18 @@ export interface Sandbox {
 	 * with `rootDir` as its working directory does not satisfy either the
 	 * confinement or the ownership contract.
 	 *
-	 * @deprecated No built-in backend currently satisfies both guarantees.
-	 * Use a separately owned terminal backend; this member will be removed in
-	 * a future major release after the repository's deprecation window.
+	 * The Firecracker backend satisfies both guarantees by owning the PTY in the
+	 * guest and awaiting its exit before the microVM is released. Backends that
+	 * cannot provide that boundary omit the capability.
 	 */
 	openTerminal?(options: OpenTerminalOptions): Promise<TerminalSession>
+	/**
+	 * Connect to a loopback TCP service owned by this same sandbox.
+	 *
+	 * Optional. A backend that cannot preserve the same-workspace boundary must
+	 * omit this capability rather than proxying to a different filesystem.
+	 */
+	openTcpConnection?(options: SandboxTcpConnectOptions): Promise<SandboxTcpConnection>
 	writeFile(path: string, content: string | Buffer): Promise<void>
 	readFile(path: string): Promise<Buffer>
 	/**
@@ -476,7 +511,10 @@ export interface ContainerSandboxLayout {
  * can inspect the post-default layout the model actually sees.
  */
 export interface ResolvedContainerSandboxLayout {
-	readonly outputs: { readonly source: ContainerSandboxMountSource; readonly containerPath: string }
+	readonly outputs: {
+		readonly source: ContainerSandboxMountSource
+		readonly containerPath: string
+	}
 	readonly uploads?: {
 		readonly source: ContainerSandboxMountSource
 		readonly containerPath: string

--- a/scripts/__tests__/audit-external-names.test.ts
+++ b/scripts/__tests__/audit-external-names.test.ts
@@ -152,6 +152,19 @@ test('commissioned research may attribute its source without exempting other pro
 	assert.match(result.stderr, /docs\/sdk\/unrelated.md/)
 })
 
+test('an exact release-history attribution does not exempt adjacent log prose', () => {
+	const root = repository()
+	mkdirSync(join(root, 'docs'), { recursive: true })
+	const attribution =
+		"- **Update** Scoped the Anthropic provider's optional Claude Code version probe out of framework filesystem tracing so server bundles do not absorb the consumer's complete project tree.\n"
+	writeFileSync(join(root, 'docs/log.md'), attribution)
+	assert.equal(runAudit(root).status, 0)
+	writeFileSync(join(root, 'docs/log.md'), `${attribution}- **Update** Claude shapes this project.\n`)
+	const result = runAudit(root)
+	assert.equal(result.status, 1)
+	assert.match(result.stderr, /docs\/log\.md/)
+})
+
 test('provider selection fixtures may name wire keys without exempting adjacent code', () => {
 	const root = repository()
 	mkdirSync(join(root, 'packages/cli/src/tui'), { recursive: true })

--- a/scripts/__tests__/audit-external-names.test.ts
+++ b/scripts/__tests__/audit-external-names.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { execFileSync, spawnSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, test } from 'node:test'
@@ -10,6 +10,18 @@ const here = dirname(fileURLToPath(import.meta.url))
 const audit = join(here, '..', 'audit-external-names.mjs')
 const roots: string[] = []
 const forbiddenProse = '# We copied Gemini to shape this interface.\n'
+
+function caseVariantsAreDistinct(): boolean {
+	const root = mkdtempSync(join(tmpdir(), 'namzu-name-case-'))
+	try {
+		mkdirSync(join(root, '.namzu'))
+		return !existsSync(join(root, '.NAMZU'))
+	} finally {
+		rmSync(root, { recursive: true, force: true })
+	}
+}
+
+const CASE_VARIANTS_ARE_DISTINCT = caseVariantsAreDistinct()
 
 afterEach(() => {
 	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
@@ -42,19 +54,28 @@ test('ignored runtime state is outside the authored-file inventory', () => {
 })
 
 for (const directory of ['.namzu-cache', '.NAMZU']) {
-	test(`a similarly named ${directory} directory remains auditable`, () => {
-		const root = repository()
-		const path = join(root, 'packages/sdk', directory)
-		mkdirSync(path, { recursive: true })
-		writeFileSync(join(path, 'authored.md'), forbiddenProse, 'utf8')
+	test(
+		`a similarly named ${directory} directory remains auditable`,
+		{
+			skip:
+				directory === '.NAMZU' && !CASE_VARIANTS_ARE_DISTINCT
+					? 'the filesystem resolves .NAMZU to the ignored .namzu directory'
+					: false,
+		},
+		() => {
+			const root = repository()
+			const path = join(root, 'packages/sdk', directory)
+			mkdirSync(path, { recursive: true })
+			writeFileSync(join(path, 'authored.md'), forbiddenProse, 'utf8')
 
-		const result = runAudit(root)
-		assert.equal(result.status, 1, result.stderr)
-		assert.match(
-			result.stderr,
-			new RegExp(`packages/sdk/${directory.replace('.', '\\.')}\\/authored\\.md`),
-		)
-	})
+			const result = runAudit(root)
+			assert.equal(result.status, 1, result.stderr)
+			assert.match(
+				result.stderr,
+				new RegExp(`packages/sdk/${directory.replace('.', '\\.')}\\/authored\\.md`),
+			)
+		},
+	)
 }
 
 test('force-tracked prose remains auditable below an ignored directory', () => {

--- a/scripts/audit-external-names.mjs
+++ b/scripts/audit-external-names.mjs
@@ -477,6 +477,26 @@ const RESEARCH_SOURCE_DOCS = new Map([
 	],
 ])
 
+// Historical release notes may identify the external executable whose
+// integration changed. Keep these exceptions exact by term, path and line so
+// they cannot become a general licence for product positioning in the log.
+const HISTORY_SOURCE_LINES = new Map([
+	[
+		'claude',
+		new Map([
+			[
+				'docs/log.md',
+				new Set([
+					"- **Update** Scoped the Anthropic provider's optional Claude Code version probe out of framework filesystem tracing so server bundles do not absorb the consumer's complete project tree.",
+				]),
+			],
+		]),
+	],
+])
+
+const isHistorySourceLine = (term, path, line) =>
+	HISTORY_SOURCE_LINES.get(term)?.get(path)?.has(line.trim()) ?? false
+
 /**
  * Strip what markdown uses for the same job a string literal does in code.
  *
@@ -830,6 +850,7 @@ function findings(source, path) {
 			for (const term of TERMS) {
 				if (DRIVEN_SERVICES.has(term.name)) continue
 				if (RESEARCH_SOURCE_DOCS.get(term.name)?.has(path)) continue
+				if (isHistorySourceLine(term.name, path, line)) continue
 				if (matches(term, prose)) {
 					hits.push({ path, line: index + 1, name: term.name, text: line.trim() })
 				}

--- a/scripts/run-sdk-tests.mjs
+++ b/scripts/run-sdk-tests.mjs
@@ -203,7 +203,19 @@ async function main() {
 		validateOwnedRoot(ownedRoot, temporaryRoot);
 
 		if (!requestedSignal) {
-			const childEnvironment = { ...process.env, [TEST_ROOT_ENV]: ownedRoot };
+			// macOS commonly exposes the temporary directory as `/var/...` while
+			// `realpath` returns `/private/var/...`. Product code intentionally
+			// canonicalizes filesystem authority paths, so fixtures created through
+			// the alias otherwise compare two spellings of the same directory and
+			// report false containment, freshness, and ownership failures. Give every
+			// test process the already-resolved root used by this runner.
+			const childEnvironment = {
+				...process.env,
+				TMPDIR: temporaryRoot,
+				TMP: temporaryRoot,
+				TEMP: temporaryRoot,
+				[TEST_ROOT_ENV]: ownedRoot,
+			};
 			delete childEnvironment[WORKER_VERIFIED_ENV];
 			delete childEnvironment[DEBUG_ROOT_ENV];
 


### PR DESCRIPTION
The remote sandbox path lacked the complete host/guest contract needed by a real consumer: interactive PTY and loopback TCP streams, explicit Firecracker network-policy admission, exact protocol compatibility, and durable correlation between delegated work and plan steps. This change carries those contracts through the worker agent, sandbox backends, SDK types and events, tests, package documentation, and changesets.

It also closes the integration defects found while validating that surface: deterministic public entity-ID fixtures, portable test/runtime behavior across case-insensitive filesystems and macOS, bounded provider filesystem tracing, and plan approvals that wait for asynchronous event persistence before run storage can be disposed.

The PR touches 56 files because the wire protocol, public types, runtime adapters, guest agent, fixtures, package docs, and release notes must move together. The 15 commits remain scoped rollback boundaries; the streaming, network policy, exact protocol, plan correlation, fixture, portability, tracing, and listener-settlement changes can each be reverted by commit. They ship as one integration unit because selecting only part of the host/guest and SDK contract would create an incompatible consumer pin.

Validation:

- `pnpm lint`
- workflow gate parity and project-reference checks
- `pnpm typecheck`
- `pnpm -r build`
- `pnpm -r test`
- `pnpm --filter @namzu/sdk test:proc` (239 passed, 4 platform skips)
- external-name audit and adjacent audit tests
- log-standard audit and adjacent tests
- model-price catalogue check
- POSIX `sh` and `dash` syntax checks
- all 4 eval suites passed
- SDK coverage: 5,927 passed, 3 platform skips; every module floor passed
- SDK test-presence, publish-metadata, and signature-export checks
- packaged consumer installs for all 18 SDK-dependent packages
- publint for all 20 publishable packages
- OKF documentation and 38 compiled documentation fences

An adversarial review checked the asynchronous listener lifecycle and the exact release-history attribution exception. It found no blocking issue; the exception is restricted to one term, path, and exact line, and adjacent prose remains audited.
